### PR TITLE
HttpProxy does not set coap request type.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -155,8 +155,10 @@ public class Exchange {
 		assert(origin == Origin.REMOTE);
 		if (request.getType() == Type.CON && !request.isAcknowledged()) {
 			request.setAcknowledged(true);
-			EmptyMessage ack = EmptyMessage.newACK(request);
-			endpoint.sendEmptyMessage(this, ack);
+			if (endpoint != null) {
+				EmptyMessage ack = EmptyMessage.newACK(request);
+				endpoint.sendEmptyMessage(this, ack);
+			}
 		}
 	}
 	
@@ -167,8 +169,10 @@ public class Exchange {
 	public void sendReject() {
 		assert(origin == Origin.REMOTE);
 		request.setRejected(true);
-		EmptyMessage rst = EmptyMessage.newRST(request);
-		endpoint.sendEmptyMessage(this, rst);
+		if (endpoint != null) {
+			EmptyMessage rst = EmptyMessage.newRST(request);
+			endpoint.sendEmptyMessage(this, rst);
+		}
 	}
 	
 	/**
@@ -181,7 +185,8 @@ public class Exchange {
 		response.setDestination(request.getSource());
 		response.setDestinationPort(request.getSourcePort());
 		setResponse(response);
-		endpoint.sendResponse(this, response);
+		if (endpoint != null)
+			endpoint.sendResponse(this, response);
 	}
 	
 	public Origin getOrigin() {

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
@@ -60,6 +60,7 @@ import org.apache.http.message.BasicRequestLine;
 import org.apache.http.message.BasicStatusLine;
 import org.apache.http.util.EntityUtils;
 import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.Message;
@@ -415,7 +416,7 @@ public final class HttpTranslator {
 
 		// create the request
 //		Request coapRequest = Request.getRequestForMethod(coapMethod);
-		Request coapRequest = new Request(Code.valueOf(coapMethod));
+		Request coapRequest = new Request(Code.valueOf(coapMethod), Type.CON);
 
 		// get the uri
 		String uriString = httpRequest.getRequestLine().getUri();

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
@@ -453,7 +453,7 @@ public final class HttpTranslator {
 
 			if (proxyingEnabled) {
 				// if the uri hasn't the indication of the scheme, add it
-				if (!uriString.matches("^coap://.*")) {
+				if (!uriString.matches("^coap://.*") && !uriString.matches("^coaps://.*")) {
 					uriString = "coap://" + uriString;
 				}
 


### PR DESCRIPTION
Requests do not have CON type set. As result they do not go through retransmission code.
The path fixes it.