### PR TITLE
ping: using timeout param instead of magic number

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
@@ -278,7 +278,7 @@ public class CoapClient {
 			request.setType(Type.CON);
 			request.setToken(new byte[0]);
 			request.setURI(uri);
-			request.send().waitForResponse(5000);
+			request.send().waitForResponse(timeout);
 			request.cancel();
 			return request.isRejected();
 		} catch (InterruptedException e) {


### PR DESCRIPTION
The CoapClient:ping(long timeout) method wasn't using it's parameter, it uses a magic number for the timeout instead.