### PR TITLE
Compare mime types directly in HttpTranslator

### DIFF
--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
@@ -675,7 +675,7 @@ public final class HttpTranslator {
 				// parsed is different, or is not iso encoded, it is needed a
 				// translation
 				Charset isoCharset = ISO_8859_1;
-				if (!charset.equals(isoCharset) && contentType != ContentType.APPLICATION_JSON) {
+				if (!charset.equals(isoCharset) && !contentType.getMimeType().equals(ContentType.APPLICATION_JSON.getMimeType())) {
 					byte[] newPayload = changeCharset(payload, charset, isoCharset);
 
 					// since ISO-8859-1 is a subset of UTF-8, it is needed to


### PR DESCRIPTION
When translating HTTP requests in the proxy, if the contentType was created via ContentType.parse the charset of the translated request would always be modified to be ISO_8859_1 even if the content type was application/json. The newly created content type was compared to the existing static instance using object equality instead of .equals().

Fixes the issue by comparing mime types directly.