### PR TITLE
Compare mime types directly in HttpTranslator

### DIFF
--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
@@ -14,6 +14,7 @@
  *    Matthias Kovatsch - creator and main architect
  *    Martin Lanter - architect and re-implementation
  *    Francesco Corazza - HTTP cross-proxy
+ *    Paul LeMarquand - fix content type returned from getHttpEntity(), cleanup
  ******************************************************************************/
 package org.eclipse.californium.proxy;
 
@@ -482,7 +483,6 @@ public final class HttpTranslator {
 
 		// translate the http headers in coap options
 		List<Option> coapOptions = getCoapOptions(httpRequest.getAllHeaders());
-//		coapRequest.setOptions(coapOptions);
 		for (Option option:coapOptions)
 			coapRequest.getOptions().addOption(option);
 
@@ -565,7 +565,7 @@ public final class HttpTranslator {
 
 		// translate the http headers in coap options
 		List<Option> coapOptions = getCoapOptions(httpResponse.getAllHeaders());
-//		coapResponse.addop(coapOptions);
+
 		for (Option option:coapOptions)
 			coapResponse.getOptions().addOption(option);
 
@@ -627,12 +627,9 @@ public final class HttpTranslator {
 		byte[] payload = coapMessage.getPayload();
 		if (payload != null && payload.length != 0) {
 
-			// get the coap content-type
-//			Integer coapContentType = coapMessage.getOptions().getContentFormat();
 			ContentType contentType = null;
 
 			// if the content type is not set, translate with octect-stream
-//			if (coapContentType == MediaTypeRegistry.UNDEFINED) {
 			if (! coapMessage.getOptions().hasContentFormat()) {
 				contentType = ContentType.APPLICATION_OCTET_STREAM;
 			} else {
@@ -655,9 +652,6 @@ public final class HttpTranslator {
 				// parse the content type
 				try {
 					contentType = ContentType.parse(coapContentTypeString);
-//				} catch (ParseException e) {
-//					LOGGER.finer("Cannot convert string to ContentType: " + e.getMessage());
-//					contentType = ContentType.APPLICATION_OCTET_STREAM;
 				} catch (UnsupportedCharsetException e) {
 					LOGGER.finer("Cannot convert string to ContentType: " + e.getMessage());
 					contentType = ContentType.APPLICATION_OCTET_STREAM;
@@ -666,14 +660,14 @@ public final class HttpTranslator {
 
 			// get the charset
 			Charset charset = contentType.getCharset();
+
 			// if there is a charset, means that the content is not binary
 			if (charset != null) {
 
 				// according to the class ContentType the default content-type
-				// with
-				// UTF-8 charset is application/json. If the content-type
-				// parsed is different, or is not iso encoded, it is needed a
-				// translation
+				// with UTF-8 charset is application/json. If the content-type
+				// parsed is different and is not iso encoded, a translation is
+				// needed
 				Charset isoCharset = ISO_8859_1;
 				if (!charset.equals(isoCharset) && !contentType.getMimeType().equals(ContentType.APPLICATION_JSON.getMimeType())) {
 					byte[] newPayload = changeCharset(payload, charset, isoCharset);
@@ -702,7 +696,7 @@ public final class HttpTranslator {
 
 			// set the content-type
 			((AbstractHttpEntity) httpEntity).setContentType(contentType.toString());
-		} // if (payload != null && payload.length != 0)
+		}
 
 		return httpEntity;
 	}
@@ -791,8 +785,6 @@ public final class HttpTranslator {
 
 		HttpRequest httpRequest = null;
 
-		// get the coap method
-//		String coapMethod = CodeRegistry.toString(coapRequest.getCode());
 		String coapMethod = null;
 		switch (coapRequest.getCode()) {
 		case GET: coapMethod = "GET"; break;
@@ -818,11 +810,6 @@ public final class HttpTranslator {
 			LOGGER.warning("Cannot translate the server uri" + e);
 			throw new InvalidFieldException("Cannot get the proxy-uri from the coap message", e);
 		}
-		
-//		if (proxyUri == null) {
-//			LOGGER.warning("proxyUri == null");
-//			throw new InvalidFieldException("proxyUri == null");
-//		}
 
 		// create the requestLine
 		RequestLine requestLine = new BasicRequestLine(coapMethod, proxyUri.toString(), HttpVersion.HTTP_1_1);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
@@ -675,7 +675,7 @@ public final class HttpTranslator {
 				// parsed is different, or is not iso encoded, it is needed a
 				// translation
 				Charset isoCharset = ISO_8859_1;
-				if (!charset.equals(isoCharset) && contentType != ContentType.APPLICATION_JSON) {
+				if (!charset.equals(isoCharset) && !contentType.getMimeType().equals(ContentType.APPLICATION_JSON.getMimeType())) {
 					byte[] newPayload = changeCharset(payload, charset, isoCharset);
 
 					// since ISO-8859-1 is a subset of UTF-8, it is needed to

--- a/californium-proxy/src/test/java/org/eclipse/californium/proxy/HttpTranslatorTest.java
+++ b/californium-proxy/src/test/java/org/eclipse/californium/proxy/HttpTranslatorTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Paul LeMarquand - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.proxy;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.nio.charset.Charset;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ContentType;
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.coap.Request;
+import org.junit.Test;
+
+public class HttpTranslatorTest {
+
+	@Test
+	public void testGetHttpEntity() throws Exception {
+		Request req = new Request(Code.GET);
+		req.setPayload("payload");
+		req.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
+
+		validateCharset(req, "ISO_8859_1");
+	}
+
+	@Test
+	public void testGetHttpEntityWithJSON() throws Exception {
+		Request req = new Request(Code.GET);
+		req.setPayload("{}");
+		req.getOptions().setContentFormat(MediaTypeRegistry.APPLICATION_JSON);
+
+		// Charset should be modified to be ISO_8859_1 unless the contentFormat
+		// is APPLICATION_JSON, in which case it should stay UTF-8
+		validateCharset(req, "UTF-8");
+	}
+
+	private void validateCharset(Message request, String charset) throws TranslationException {
+		HttpEntity httpEntity = HttpTranslator.getHttpEntity(request);
+		Charset httpEntityCharset = ContentType.parse(httpEntity.getContentType().getValue()).getCharset();
+
+		assertThat(httpEntityCharset, equalTo(Charset.forName(charset)));
+	}
+}


### PR DESCRIPTION
When translating HTTP requests in the proxy, if the contentType was created via ContentType.parse the charset of the translated request would always be modified to be ISO_8859_1 even if the content type was application/json. The newly created content type was compared to the existing static instance using object equality instead of .equals().

Fixes the issue by comparing mime types directly.