### PR TITLE
Fix TD_COAP_CORE_11 to request /separate and expect CON

### DIFF
--- a/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CC11.java
+++ b/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CC11.java
@@ -24,11 +24,12 @@ import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.plugtests.PlugtestChecker.TestClientAbstract;
 
 /**
- * TD_COAP_CORE_11: Handle request not containing Token option.
+ * TD_COAP_CORE_11: Perform GET transaction containing non-empty Token
+ * with a separate response (CON mode)
  */
 public class CC11 extends TestClientAbstract {
 
-	public static final String RESOURCE_URI = "/test";
+	public static final String RESOURCE_URI = "/separate";
 	public final ResponseCode EXPECTED_RESPONSE_CODE = ResponseCode.CONTENT;
 
 	public CC11(String serverURI) {
@@ -46,7 +47,7 @@ public class CC11 extends TestClientAbstract {
 	protected boolean checkResponse(Request request, Response response) {
 		boolean success = true;
 
-		success &= checkType(Type.ACK, response.getType());
+		success &= checkType(Type.CON, response.getType());
 		success &= checkInt(EXPECTED_RESPONSE_CODE.value,
 				response.getCode().value, "code");
 		// Token value = the same value as in the request sent by the client


### PR DESCRIPTION
Correct me if I'm wrong, but whenever I had a look on these test specifications, test 11 should be verified like in this commit. See https://rawgit.com/cabo/td-coap4/master/base.html