### PR TITLE
Bugfix  for #474290 (wrong payload length in tracing message of responses).

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/Utils.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/Utils.java
@@ -16,6 +16,8 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add toHexText 
+ *                                                    (for message tracing)
  ******************************************************************************/
 package org.eclipse.californium.core;
 
@@ -51,9 +53,39 @@ public class Utils {
 	}
 
 	/**
+	 * Converts the specified byte array up to the specified length into a hexadecimal text.
+	 * Separate bytes by spaces and group them in lines. Append length of array, if specified 
+	 * length is smaller then the length of the array.
+	 * 
+	 * @param bytes the array of bytes. If null, the text "null" is returned.
+	 * @param length length up to the bytes should be converted into hexadecimal text. 
+	 *               If larger then the array length, reduce it to the array length.
+	 * @return byte array as hexadecimal text
+	 */
+	public static String toHexText(byte[] bytes, int length) {
+		if (bytes == null) return "null";
+		if (length > bytes.length) length = bytes.length;
+	    StringBuilder sb = new StringBuilder();
+	    if (16 < length) sb.append('\n');
+	    for(int index = 0; index < length; ++index) {	    	
+	       sb.append(String.format("%02x", bytes[index] & 0xFF));
+	       if (31 == (31 & index)) {
+	    	   sb.append('\n');
+	       }
+	       else {
+	    	   sb.append(' ');	    	   
+	       }
+	    }
+	    if (length < bytes.length) {
+	    	sb.append(" .. ").append(bytes.length).append(" bytes");
+	    }
+	    return sb.toString();
+	}
+
+	/**
 	 * Formats a {@link Request} into a readable String representation. 
 	 * 
-	 * @param r the Resquest
+	 * @param r the Request
 	 * @return the pretty print
 	 */
 	public static String prettyPrint(Request r) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/BlockOption.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/BlockOption.java
@@ -16,6 +16,9 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add block size also in bytes
+ *                                                    to return value of toString() 
+ *                                                    (for message tracing)
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
@@ -215,7 +218,7 @@ public class BlockOption {
 	 */
 	@Override
 	public String toString() {
-		return "(szx="+szx+", m="+m+", num="+num+")";
+		return "(szx="+szx+"/"+ szx2Size(szx)+ ", m="+m+", num="+num+")";
 	}
 	
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Option.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Option.java
@@ -16,6 +16,9 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add block1/block2 options 
+ *                                                    to be decoded by toValueString 
+ *                                                    (for message tracing)
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
@@ -324,6 +327,7 @@ public class Option implements Comparable<Option> {
 		switch (OptionNumberRegistry.getFormatByNr(number)) {
 		case INTEGER:
 			if (number==OptionNumberRegistry.ACCEPT || number==OptionNumberRegistry.CONTENT_FORMAT) return "\""+MediaTypeRegistry.toString(getIntegerValue())+"\"";
+			else if (number==OptionNumberRegistry.BLOCK1 || number==OptionNumberRegistry.BLOCK2) return "\""+ new BlockOption(value) +"\"";
 			else return Integer.toString(getIntegerValue());
 		case STRING:
 			return "\""+this.getStringValue()+"\"";

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -18,6 +18,10 @@
  *    Kai Hudalla (Bosch Software Innovations GmbH) - logging
  *    Kai Hudalla (Bosch Software Innovations GmbH) - add field for sender identity
  *                                                    (465073)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - move payload string conversion
+ *    												  from toString() to
+ *                                                    Message.getPayloadTracingString(). 
+ *                                                    (for message tracing)
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
@@ -521,16 +525,7 @@ public class Request extends Message {
 	 */
 	@Override
 	public String toString() {
-		String payload = getPayloadString();
-		if (payload == null) {
-			payload = "no payload";
-		} else {
-			int len = payload.length();
-			if (payload.indexOf("\n")!=-1) payload = payload.substring(0, payload.indexOf("\n"));
-			if (payload.length() > 24) payload = payload.substring(0,20);
-			payload = "\""+payload+"\"";
-			if (payload.length() != len+2) payload += ".. " + len + " bytes";
-		}
+		String payload = getPayloadTracingString();
 		return String.format("%s-%-6s MID=%5d, Token=%s, OptionSet=%s, %s", getType(), getCode(), getMID(), getTokenString(), getOptions(), payload);
 	}
 	

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Response.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Response.java
@@ -16,6 +16,10 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - move payload string conversion
+ *    												  from toString() to
+ *                                                    Message.getPayloadTracingString(). 
+ *                                                    (for message tracing)
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
@@ -60,16 +64,7 @@ public class Response extends Message {
 	 */
 	@Override
 	public String toString() {
-		String payload = getPayloadString();
-		if (payload == null) {
-			payload = "no payload";
-		} else {
-			int len = payload.length();
-			if (payload.indexOf("\n")!=-1) payload = payload.substring(0, payload.indexOf("\n"));
-			if (payload.length() > 24) payload = payload.substring(0,20);
-			payload = "\""+payload+"\"";
-			if (payload.length() != len+2) payload += ".. " + payload.length() + " bytes";
-		}
+		String payload = getPayloadTracingString();
 		return String.format("%s-%-6s MID=%5d, Token=%s, OptionSet=%s, %s", getType(), getCode(), getMID(), getTokenString(), getOptions(), payload);
 	}
 	


### PR DESCRIPTION
Fixes bug #474290.

Additionally moves code duplicate from Request and Response to Message. 
Add textual tracing of block-options.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>