### PR TITLE
Use destination in getURI, if host is missing.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -22,6 +22,8 @@
  *    												  from toString() to
  *                                                    Message.getPayloadTracingString(). 
  *                                                    (for message tracing)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use destination in getURI, if
+ *                                                    host is not available
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
@@ -285,7 +287,13 @@ public class Request extends Message {
 		else builder.append("coap://");
 		String host = getOptions().getUriHost();
 		if (host != null) builder.append(host);
-		else builder.append("localhost");
+		else {
+			InetAddress dest = getDestination();
+			if (null == dest || dest.isLoopbackAddress())
+				builder.append("localhost");
+			else 
+				builder.append(getDestination());
+		}
 		Integer port = getOptions().getUriPort();
 		if (port != null) builder.append(":").append(port);
 		String path = getOptions().getUriPathString();


### PR DESCRIPTION
Fixes bugs.eclipse.org #475816

Note: this implementation would return "localhost" even when using the
loopback address as literal (e.g. "127.0.0.1").

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>