### PR TITLE
Use SessionListener to trigger sending of pending APPLICATION messages.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordLayer.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordLayer.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Kai Hudalla (Bosch Software Innovations GmbH) - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+/**
+ * An abstraction of the DTLS record layer's capabilities for sending records to peers.
+ * 
+ */
+public interface RecordLayer {
+
+	/**
+	 * Sends a DTLS record to a peer.
+	 * 
+	 * @param record the record to send
+	 */
+	void sendRecord(Record record);
+
+	/**
+	 * Sends a set of records containing DTLS handshake messages to a peer.
+	 * <p>
+	 * The records are sent <em>as a whole</em>. In particular this means that all
+	 * records will be re-transmitted in case of a missing acknowledgement from the peer.
+	 * </p>
+	 * 
+	 * @param flight the records to send. The properties of the flight are used to control the
+	 *                  timespan to wait between re-transmissions. 
+	 */
+	void sendFlight(DTLSFlight flight);
+}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/SimpleRecordLayer.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/SimpleRecordLayer.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Kai Hudalla (Bosch Software Innovations GmbH) - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+public class SimpleRecordLayer implements RecordLayer {
+	private DTLSFlight sentFlight;
+	private Record sentRecord;
+
+	@Override
+	public void sendFlight(DTLSFlight flight) {
+		sentFlight = flight;
+	}
+
+	@Override
+	public void sendRecord(Record record) {
+		sentRecord = record;
+	}
+
+	public DTLSFlight getSentFlight() {
+		return sentFlight;
+	}
+
+	public Record getSentRecord() {
+		return sentRecord;
+	}
+}


### PR DESCRIPTION
Sending an APPLICATION message to a peer for which no DTLS session
exists yet triggers a new handshake with the peer. Previously it was the
responsibility of the `Handshaker` class to send the (pending) APPLICATION layer
message to the peer once the handshake has been completed.

Handshakers signal the establishment of a session by means of the
`SessionLifecycle.sessionEstablished()` callback method. In order to
improve separation of concerns pending APPLICATION layer messages are
now sent by the `DTLSConnector` on invocation of this callback method.

This PR is the first step towards fixing #1 in that it hands back control over the message sending to `DTLSConnector`. The approach to fixing #1 then is to include a callback handler in the `RawData` instance passed in to `DTLSConnector.send(RawData)` which will be called back with the *ID*, *epoch* and *cipher* of the `DTLSSession` used for sending the message to the peer.