### PR TITLE
#1: Include DTLS session params in Request/Response matching.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
+ * Copyright (c) 2015, 2016 Institute for Pervasive Computing, ETH Zurich and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,8 @@
  *    Kai Hudalla - logging
  *    Kai Hudalla (Bosch Software Innovations GmbH) - use Logger's message formatting instead of
  *                                                    explicit String concatenation
+ *    Bosch Software Innovations GmbH - use correlation context to improve matching
+ *                                      of Response(s) to Request (fix GitHub issue #1)
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -25,6 +27,7 @@ import java.util.Iterator;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
@@ -43,35 +46,39 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.deduplication.Deduplicator;
 import org.eclipse.californium.core.network.deduplication.DeduplicatorFactory;
 import org.eclipse.californium.core.observe.ObserveRelation;
+import org.eclipse.californium.elements.DtlsCorrelationContext;
+import org.eclipse.californium.elements.CorrelationContext;
 
 public class Matcher {
 
 	private final static Logger LOGGER = Logger.getLogger(Matcher.class.getCanonicalName());
-	
+
 	private boolean started;
 	private ExchangeObserver exchangeObserver = new ExchangeObserverImpl();
-	
+
 	/* the executor, by default the one of the protocol stage */
 	private ScheduledExecutorService executor;
-	
+
 	/* managing the MID per endpoint requires remote endpoint management */
 	private AtomicInteger currendMID;
-	
+
 	/* limit the token size to save bytes in closed environments */
 	private int tokenSizeLimit;
-	
+
 	private ConcurrentHashMap<KeyMID, Exchange> exchangesByMID; // for all
 	private ConcurrentHashMap<KeyToken, Exchange> exchangesByToken; // for outgoing
 	private ConcurrentHashMap<KeyUri, Exchange> ongoingExchanges; // for blockwise
-	
+
 	// TODO: Multicast Exchanges: should not be removed from deduplicator
 	private Deduplicator deduplicator;
 	// Idea: Only store acks/rsts and not the whole exchange. Responses should be sent CON.
-	
+
 	/* Health status output */
 	private Level healthStatusLevel;
 	private int healthStatusInterval; // seconds
-	
+
+	private boolean useStrictResponseMatching = false;
+
 	public Matcher(NetworkConfig config) {
 		this.started = false;
 		this.exchangesByMID = new ConcurrentHashMap<KeyMID, Exchange>();
@@ -80,33 +87,38 @@ public class Matcher {
 
 		DeduplicatorFactory factory = DeduplicatorFactory.getDeduplicatorFactory();
 		this.deduplicator = factory.createDeduplicator(config);
-		
+
+		tokenSizeLimit = config.getInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT);
+		useStrictResponseMatching = config.getBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING);
 		boolean randomMID = config.getBoolean(NetworkConfig.Keys.USE_RANDOM_MID_START);
 		if (randomMID) {
 			currendMID = new AtomicInteger(new Random().nextInt(1<<16));
 		} else {
 			currendMID = new AtomicInteger(0);
 		}
-		
-		tokenSizeLimit = config.getInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT);
-		
-		LOGGER.log(Level.CONFIG,
-				"Matcher uses USE_RANDOM_MID_START={0} and TOKEN_SIZE_LIMIT={1}",
-				new Object[]{randomMID, tokenSizeLimit});
-		
+
+		if (LOGGER.isLoggable(Level.CONFIG)) {
+			String msg = new StringBuilder("Matcher uses ")
+					.append(NetworkConfig.Keys.USE_RANDOM_MID_START).append("=").append(randomMID).append(", ")
+					.append(NetworkConfig.Keys.TOKEN_SIZE_LIMIT).append("=").append(tokenSizeLimit).append(" and ")
+					.append(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING).append("=").append(useStrictResponseMatching)
+					.toString();
+			LOGGER.config(msg);
+		}
+
 		healthStatusLevel = Level.parse(config.getString(NetworkConfig.Keys.HEALTH_STATUS_PRINT_LEVEL));
 		healthStatusInterval = config.getInt(NetworkConfig.Keys.HEALTH_STATUS_INTERVAL);
 	}
-	
+
 	public synchronized void start() {
 		if (started) return;
 		else started = true;
-		
+
 		if (executor == null)
 			throw new IllegalStateException("Matcher has no executor to schedule exchange removal");
-		
+
 		deduplicator.start();
-		
+
 		// this is a useful health metric that could later be exported to some kind of monitoring interface
 		if (LOGGER.isLoggable(healthStatusLevel)) {
 			executor.scheduleAtFixedRate(new Runnable() {
@@ -120,40 +132,34 @@ public class Matcher {
 			}, healthStatusInterval, healthStatusInterval, TimeUnit.SECONDS);
 		}
 	}
-	
+
 	public synchronized void stop() {
 		if (!started) return;
 		else started = false;
 		deduplicator.stop();
 		clear();
 	}
-	
+
 	public synchronized void setExecutor(ScheduledExecutorService executor) {
 		deduplicator.setExecutor(executor);
 		this.executor = executor;
 		// health status runnable is not migrated at the moment
 	}
-	
+
 	public void sendRequest(Exchange exchange, Request request) {
-		
+
 		// ensure MID is set
 		if (request.getMID() == Message.NONE) {
-			request.setMID(currendMID.getAndIncrement()%(1<<16));
+			request.setMID(currendMID.getAndIncrement()%(1<<16)); // wrap at 2^16
 		}
 		// request MID is from the local namespace -- use blank address
-		KeyMID idByMID = new KeyMID(request.getMID(), null, 0);
+		KeyMID idByMID = new KeyMID(request.getMID());
 
 		// ensure Token is set
 		KeyToken idByToken;
 		if (request.getToken() == null) {
-			byte[] token;
-			do {
-				token = createNewToken();
-				idByToken = new KeyToken(token);
-			} while (exchangesByToken.get(idByToken) != null);
-			
-			request.setToken(token);
-			
+			idByToken = createUnusedToken();
+			request.setToken(idByToken.token);
 		} else {
 			idByToken = new KeyToken(request.getToken());
 			// ongoing requests may reuse token
@@ -161,21 +167,21 @@ public class Matcher {
 				LOGGER.log(Level.WARNING, "Manual token overrides existing open request: {0}", idByToken);
 			}
 		}
-		
+
 		exchange.setObserver(exchangeObserver);
-		LOGGER.log(Level.FINE, "Stored open request by {0}, {1}", new Object[]{idByMID, idByToken});
-		
+		LOGGER.log(Level.FINE, "Tracking open request using {0}, {1}", new Object[]{idByMID, idByToken});
+
 		exchangesByMID.put(idByMID, exchange);
 		exchangesByToken.put(idByToken, exchange);
 	}
 
 	public void sendResponse(Exchange exchange, Response response) {
-		
+
 		// ensure MID is set
 		if (response.getMID() == Message.NONE) {
 			response.setMID(currendMID.getAndIncrement()%(1<<16));
 		}
-		
+
 		// ensure Token is set
 		response.setToken(exchange.getCurrentRequest().getToken());
 
@@ -183,18 +189,18 @@ public class Matcher {
 		if (response.getType() == Type.CON || response.getType() == Type.ACK) {
 			ObserveRelation relation = exchange.getRelation();
 			if (relation != null) {
-				removeNotificatoinsOf(relation);
+				removeNotificationsOf(relation);
 			}
 		}
-		
+
 		// Blockwise transfers are identified by URI and remote endpoint
 		if (response.getOptions().hasBlock2()) {
 			Request request = exchange.getCurrentRequest();
 			KeyUri idByUri = new KeyUri(request.getURI(), response.getDestination().getAddress(), response.getDestinationPort());
 			// Observe notifications only send the first block, hence do not store them as ongoing
-			if (exchange.getResponseBlockStatus()!=null && !response.getOptions().hasObserve()) {
+			if (exchange.getResponseBlockStatus() != null && !response.getOptions().hasObserve()) {
 				// Remember ongoing blockwise GET requests
-				if (ongoingExchanges.put(idByUri, exchange)==null) {
+				if (ongoingExchanges.put(idByUri, exchange) == null) {
 					LOGGER.log(Level.FINE, "Ongoing Block2 started late, storing {0} for {1}",
 							new Object[]{idByUri, request});
 				} else {
@@ -207,14 +213,14 @@ public class Matcher {
 				ongoingExchanges.remove(idByUri);
 			}
 		}
-		
+
 		// Insert CON and NON to match ACKs and RSTs to the exchange.
 		// Do not insert ACKs and RSTs.
 		if (response.getType() == Type.CON || response.getType() == Type.NON) {
-			KeyMID idByMID = new KeyMID(response.getMID(), null, 0);
+			KeyMID idByMID = new KeyMID(response.getMID());
 			exchangesByMID.put(idByMID, exchange);
 		}
-		
+
 		// Only CONs and Observe keep the exchange active
 		if (response.getType() != Type.CON && response.isLast()) {
 			exchange.setComplete();
@@ -222,10 +228,10 @@ public class Matcher {
 	}
 
 	public void sendEmptyMessage(Exchange exchange, EmptyMessage message) {
-		
+
 		// ensure Token is set
 		message.setToken(new byte[0]);
-		
+
 		if (message.getType() == Type.RST && exchange != null) {
 			// We have rejected the request or response
 			exchange.setComplete();
@@ -244,9 +250,9 @@ public class Matcher {
 		 * 		if nothing has been sent yet => do nothing
 		 * (Retransmission is supposed to be done by the retransm. layer)
 		 */
-		
-		KeyMID idByMID = new KeyMID(request.getMID(), request.getSource().getAddress(), request.getSourcePort());
-		
+
+		KeyMID idByMID = KeyMID.fromInboundMessage(request);
+
 		/*
 		 * The differentiation between the case where there is a Block1 or
 		 * Block2 option and the case where there is none has the advantage that
@@ -260,36 +266,36 @@ public class Matcher {
 			if (previous == null) {
 				exchange.setObserver(exchangeObserver);
 				return exchange;
-				
+
 			} else {
-				LOGGER.log(Level.INFO, "Duplicate request: {0}", request);
+				LOGGER.log(Level.FINER, "Duplicate request: {0}", request);
 				request.setDuplicate(true);
 				return previous;
 			}
-			
+
 		} else {
-			
+
 			KeyUri idByUri = new KeyUri(request.getURI(), request.getSource().getAddress(), request.getSourcePort());
 			LOGGER.log(Level.FINE, "Looking up ongoing exchange for {0}", idByUri);
-			
+
 			Exchange ongoing = ongoingExchanges.get(idByUri);
 			if (ongoing != null) {
-				
+
 				Exchange prev = deduplicator.findPrevious(idByMID, ongoing);
 				if (prev != null) {
-					LOGGER.log(Level.INFO, "Duplicate ongoing request: {0}", request);
+					LOGGER.log(Level.FINER, "Duplicate ongoing request: {0}", request);
 					request.setDuplicate(true);
 				} else {
 					// the exchange is continuing, we can (i.e., must) clean up the previous response
 					// check for null, in case no response was created (e.g., because the resource handler crashed...)
-					if (ongoing.getCurrentResponse()!=null && ongoing.getCurrentResponse().getType() != Type.ACK && !ongoing.getCurrentResponse().getOptions().hasObserve()) {
-						idByMID = new KeyMID(ongoing.getCurrentResponse().getMID(), null, 0);
+					if (ongoing.getCurrentResponse() != null && ongoing.getCurrentResponse().getType() != Type.ACK && !ongoing.getCurrentResponse().getOptions().hasObserve()) {
+						idByMID = new KeyMID(ongoing.getCurrentResponse().getMID());
 						LOGGER.log(Level.FINE, "Ongoing exchange got new request, cleaning up {0}", idByMID);
 						exchangesByMID.remove(idByMID);
 					}
 				}
 				return ongoing;
-		
+
 			} else {
 				// We have no ongoing exchange for that request block. 
 				/*
@@ -303,12 +309,12 @@ public class Matcher {
 				Exchange exchange = new Exchange(request, Origin.REMOTE);
 				Exchange previous = deduplicator.findPrevious(idByMID, exchange);
 				if (previous == null) {
-					LOGGER.log(Level.FINE, "New ongoing request, storing {0} for {1}", new Object[]{idByUri, request});
+					LOGGER.log(Level.FINER, "New ongoing request, storing {0} for {1}", new Object[]{idByUri, request});
 					exchange.setObserver(exchangeObserver);
 					ongoingExchanges.put(idByUri, exchange);
 					return exchange;
 				} else {
-					LOGGER.log(Level.INFO, "Duplicate initial request: {0}", request);
+					LOGGER.log(Level.FINER, "Duplicate initial request: {0}", request);
 					request.setDuplicate(true);
 					return previous;
 				}
@@ -316,76 +322,118 @@ public class Matcher {
 		} // if blockwise
 	}
 
-	public Exchange receiveResponse(Response response) {
-		
+	public Exchange receiveResponse(final Response response, final CorrelationContext responseContext) {
+
 		/*
 		 * This response could be
 		 * - The first CON/NCON/ACK+response => deliver
 		 * - Retransmitted CON (because client got no ACK)
 		 * 		=> resend ACK
 		 */
-		
+
 		KeyMID idByMID;
 		if (response.getType() == Type.ACK) {
 			// own namespace
-			idByMID = new KeyMID(response.getMID(), null, 0);
+			idByMID = new KeyMID(response.getMID());
 		} else {
 			// remote namespace
-			idByMID = new KeyMID(response.getMID(), response.getSource().getAddress(), response.getSourcePort());
+			idByMID = KeyMID.fromInboundMessage(response);
 		}
-		
+
 		KeyToken idByToken = new KeyToken(response.getToken());
-		
+
 		Exchange exchange = exchangesByToken.get(idByToken);
-		
-		if (exchange != null) {
-			// There is an exchange with the given token
-			Exchange prev = deduplicator.findPrevious(idByMID, exchange);
-			if (prev != null) { // (and thus it holds: prev == exchange)
-				LOGGER.log(Level.INFO, "Duplicate response for open exchange: {0}", response);
-				response.setDuplicate(true);
-			} else {
-				idByMID = new KeyMID(exchange.getCurrentRequest().getMID(), null, 0);
-				exchangesByMID.remove(idByMID);
-				LOGGER.log(Level.FINE, "Closed open request with {0}", idByMID);
-			}
-			
-			if (response.getType() == Type.ACK && exchange.getCurrentRequest().getMID() != response.getMID()) {
-				// The token matches but not the MID.
-				LOGGER.log(Level.WARNING,
-						"Possible MID reuse before lifetime end: {0} expected MID {1} but received {2}",
-						new Object[]{response.getTokenString(), exchange.getCurrentRequest().getMID(), response.getMID()});
-			}
-			
-			return exchange;
-			
-		} else {
+
+		if (exchange == null) {
 			// There is no exchange with the given token.
 			if (response.getType() != Type.ACK) {
-				// only act upon separate responses
+				// only act upon separate (non piggy-backed) responses
 				Exchange prev = deduplicator.find(idByMID);
 				if (prev != null) {
-					LOGGER.log(Level.INFO, "Duplicate response for completed exchange: {0}", response);
+					LOGGER.log(Level.FINER, "Received response for already completed exchange: {0}", response);
 					response.setDuplicate(true);
 					return prev;
 				}
 			} else {
-				LOGGER.log(Level.INFO,
-					"Ignoring unmatchable piggy-backed response from {0}:{1}: {2}",
-					new Object[]{response.getSource(), response.getSourcePort(), response});
+				LOGGER.log(Level.FINER, "Discarding unmatchable piggy-backed response from [{0}:{1}]: {2}",
+						new Object[]{response.getSource(), response.getSourcePort(), response});
 			}
 			// ignore response
+			return null;
+		} else if (isResponseRelatedToRequest(exchange, responseContext)) {
+			// we have received a Response matching the Request of an ongoing Exchange
+			Exchange prev = deduplicator.findPrevious(idByMID, exchange);
+			if (prev != null) { // (and thus it holds: prev == exchange)
+				LOGGER.log(Level.FINER, "Received duplicate response for open exchange: {0}", response);
+				response.setDuplicate(true);
+			} else {
+				// we have received the expected response for the original request
+				idByMID = new KeyMID(exchange.getCurrentRequest().getMID());
+				exchangesByMID.remove(idByMID);
+				LOGGER.log(Level.FINE, "Closed open request [{0}]", idByMID);
+			}
+
+			if (response.getType() == Type.ACK && exchange.getCurrentRequest().getMID() != response.getMID()) {
+				// The token matches but not the MID.
+				LOGGER.log(Level.WARNING,
+						"Possible MID reuse before lifetime end for token [{0}], expected MID {1} but received {2}",
+						new Object[]{response.getTokenString(), exchange.getCurrentRequest().getMID(), response.getMID()});
+			}
+
+			return exchange;
+		} else {
+			LOGGER.log(Level.INFO, "Ignoring potentially forged response for token {0} with non-matching correlation context", idByToken);
 			return null;
 		}
 	}
 
+	private boolean isResponseRelatedToRequest(final Exchange exchange, final CorrelationContext responseContext) {
+		if (exchange.getCorrelationContext() == null) {
+			// no correlation information available for request, thus any
+			// additional correlation information available in the response is ignored
+			return true;
+		} else if (exchange.getCorrelationContext() instanceof DtlsCorrelationContext) {
+			// original request has been sent via a DTLS protected transport
+			DtlsCorrelationContext exchangeDtlsContext = (DtlsCorrelationContext) exchange.getCorrelationContext();
+			// check if the response has been received in the same DTLS session
+			if (useStrictResponseMatching) {
+				return isResponseStrictlyRelatedToDtlsRequest(exchangeDtlsContext, responseContext);
+			} else {
+				return isResponseRelatedToDtlsRequest(exchangeDtlsContext, responseContext);
+			}
+		} else {
+			// compare message context used for sending original request to context
+			// the response has been received in
+			return exchange.getCorrelationContext().equals(responseContext);
+		}
+	}
+
+	private boolean isResponseRelatedToDtlsRequest(DtlsCorrelationContext requestContext, CorrelationContext responseContext) {
+		if (responseContext == null) {
+			return false;
+		} else {
+			return requestContext.getSessionId().equals(responseContext.get(DtlsCorrelationContext.KEY_SESSION_ID))
+					&& requestContext.getCipher().equals(responseContext.get(DtlsCorrelationContext.KEY_CIPHER));
+		}
+	}
+
+	private boolean isResponseStrictlyRelatedToDtlsRequest(DtlsCorrelationContext requestContext, CorrelationContext responseContext) {
+		if (responseContext == null) {
+			return false;
+		} else {
+			return requestContext.getSessionId().equals(responseContext.get(DtlsCorrelationContext.KEY_SESSION_ID))
+					&& requestContext.getEpoch().equals(responseContext.get(DtlsCorrelationContext.KEY_EPOCH))
+					&& requestContext.getCipher().equals(responseContext.get(DtlsCorrelationContext.KEY_CIPHER));
+		}
+	}
+
 	public Exchange receiveEmptyMessage(EmptyMessage message) {
-		
+
 		// local namespace
 		KeyMID idByMID = new KeyMID(message.getMID(), null, 0);
-		
+
 		Exchange exchange = exchangesByMID.get(idByMID);
-		
+
 		if (exchange != null) {
 			LOGGER.log(Level.FINE, "Exchange got reply: Cleaning up {0}", idByMID);
 			exchangesByMID.remove(idByMID);
@@ -397,15 +445,15 @@ public class Matcher {
 			return null;
 		}
 	}
-	
+
 	public void clear() {
 		this.exchangesByMID.clear();
 		this.exchangesByToken.clear();
 		this.ongoingExchanges.clear();
 		deduplicator.clear();
 	}
-	
-	private void removeNotificatoinsOf(ObserveRelation relation) {
+
+	private void removeNotificationsOf(ObserveRelation relation) {
 		LOGGER.fine("Remove all remaining NON-notifications of observe relation");
 		for (Iterator<Response> iterator = relation.getNotificationIterator(); iterator.hasNext();) {
 			Response previous = iterator.next();
@@ -415,45 +463,50 @@ public class Matcher {
 			iterator.remove();
 		}
 	}
-	
+
 	/**
 	 * Creates a new token that is never the empty token (i.e., always 1-8 bytes).
 	 * @return the new token
 	 */
-	private byte[] createNewToken() {
-		
-		Random random = new Random();
-		
-		// random length between 1 and tokenSizeLimit
-		byte[] token = new byte[random.nextInt(tokenSizeLimit)+1];
-		// random value
-		random.nextBytes(token);
-		
-		return token;
+	private KeyToken createUnusedToken() {
+
+		Random random = ThreadLocalRandom.current();
+		byte[] token;
+		KeyToken result;
+		do {
+			// random length between 1 and tokenSizeLimit
+			// TODO: why would we want to have a random length token?
+			token = new byte[random.nextInt(tokenSizeLimit)+1];
+			// random value
+			random.nextBytes(token);
+			result = new KeyToken(token);
+		} while (exchangesByToken.get(result) != null);
+
+		return result;
 	}
-	
+
 	private class ExchangeObserverImpl implements ExchangeObserver {
 
 		@Override
 		public void completed(Exchange exchange) {
-			
+
 			/* 
 			 * Logging in this method leads to significant performance loss.
 			 * Uncomment logging code only for debugging purposes.
 			 */
-			
+
 			if (exchange.getOrigin() == Origin.LOCAL) {
 				// this endpoint created the Exchange by issuing a request
-				
+
 				KeyMID idByMID = new KeyMID(exchange.getCurrentRequest().getMID(), null, 0);
 				KeyToken idByToken = new KeyToken(exchange.getCurrentRequest().getToken());
-				
+
 //				LOGGER.log(Level.FINE, "Exchange completed: Cleaning up {0}", idByToken);
 				exchangesByToken.remove(idByToken);
-				
+
 				// in case an empty ACK was lost
 				exchangesByMID.remove(idByMID);
-			
+
 			} else { // Origin.REMOTE
 				// this endpoint created the Exchange to respond to a request
 
@@ -464,22 +517,20 @@ public class Matcher {
 //					LOGGER.log(Level.FINE, "Remote ongoing completed, cleaning up {0}", midKey);
 					exchangesByMID.remove(midKey);
 				}
-				
+
 				Request request = exchange.getCurrentRequest();
 				if (request != null && (request.getOptions().hasBlock1() || response.getOptions().hasBlock2()) ) {
 					KeyUri uriKey = new KeyUri(request.getURI(), request.getSource().getAddress(), request.getSourcePort());
 					LOGGER.log(Level.FINE, "Remote ongoing completed, cleaning up ", uriKey);
 					ongoingExchanges.remove(uriKey);
 				}
-				
+
 				// Remove all remaining NON-notifications if this exchange is an observe relation
 				ObserveRelation relation = exchange.getRelation();
 				if (relation != null) {
-					removeNotificatoinsOf(relation);
+					removeNotificationsOf(relation);
 				}
 			}
 		}
-		
 	}
-	
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
+ * Copyright (c) 2015, 2016 Institute for Pervasive Computing, ETH Zurich and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Bosch Software Innovations GmbH - add key for selecting strict request/response matching
  ******************************************************************************/
 package org.eclipse.californium.core.network.config;
 
@@ -100,6 +101,7 @@ public class NetworkConfig {
 		public static final String DEDUPLICATOR_CROP_ROTATION = "DEDUPLICATOR_CROP_ROTATION";
 		public static final String CROP_ROTATION_PERIOD = "CROP_ROTATION_PERIOD";
 		public static final String NO_DEDUPLICATOR = "NO_DEDUPLICATOR";
+		public static final String USE_STRICT_RESPONSE_MATCHING = "USE_STRICT_RESPONSE_MATCHING";
 		
 		public static final String HTTP_PORT = "HTTP_PORT";
 		public static final String HTTP_SERVER_SOCKET_TIMEOUT = "HTTP_SERVER_SOCKET_TIMEOUT";

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
+ * Copyright (c) 2015, 2016 Institute for Pervasive Computing, ETH Zurich and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Bosch Software Innovations GmbH - don't use strict request/response matching by default 
  ******************************************************************************/
 package org.eclipse.californium.core.network.config;
 
@@ -77,6 +78,7 @@ public class NetworkConfigDefaults {
 		config.setString(NetworkConfig.Keys.DEDUPLICATOR, NetworkConfig.Keys.DEDUPLICATOR_MARK_AND_SWEEP);
 		config.setLong(NetworkConfig.Keys.MARK_AND_SWEEP_INTERVAL, 10 * 1000);
 		config.setInt(NetworkConfig.Keys.CROP_ROTATION_PERIOD, 2000);
+		config.setBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING, false);
 
 		config.setInt(NetworkConfig.Keys.HTTP_PORT, 8080);
 		config.setInt(NetworkConfig.Keys.HTTP_SERVER_SOCKET_TIMEOUT, 100000);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/MessageInterceptor.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/MessageInterceptor.java
@@ -26,11 +26,11 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 
 /**
- * MessageIntercepters registers at an endpoint. When messages arrive from the
+ * MessageInterceptors register at an endpoint. When messages arrive from the
  * connector, the corresponding receive-method is called. When a message is
- * about to be sent over a connector, the corresponding send-method is called.
- * The intercepter can be sought of being placed inside a <code>CoapEndpoint</code> just
- * between the message <code>Serializer</code> and the <code>Matcher</code>.
+ * about to be sent over a connector, the corresponding send method is called.
+ * The interceptor can be thought of being placed inside an <code>CoapEndpoint</code>
+ * just between the message <code>Serializer</code> and the <code>Matcher</code>.
  * <p>
  * A <code>MessageInterceptor</code> can cancel a message to stop it. If it is
  * an outgoing message that traversed down through the <code>CoapStack</code> to the
@@ -46,43 +46,42 @@ public interface MessageInterceptor {
 	 *
 	 * @param request the request
 	 */
-	public void sendRequest(Request request);
-	
+	void sendRequest(Request request);
+
 	/**
 	 * Override this method to be notified when a response is about to be sent.
 	 *
 	 * @param response the response
 	 */
-	public void sendResponse(Response response);
-	
+	void sendResponse(Response response);
+
 	/**
 	 * Override this method to be notified when an empty message is about to be
 	 * sent.
 	 * 
 	 * @param message the empty message
 	 */
-	public void sendEmptyMessage(EmptyMessage message);
-	
+	void sendEmptyMessage(EmptyMessage message);
+
 	/**
 	 * Override this method to be notified when request has been received.
 	 *
 	 * @param request the request
 	 */
-	public void receiveRequest(Request request);
-	
+	void receiveRequest(Request request);
+
 	/**
 	 * Override this method to be notified when response has been received.
 	 *
 	 * @param response the response
 	 */
-	public void receiveResponse(Response response);
-	
+	void receiveResponse(Response response);
+
 	/**
 	 * Override this method to be notified when an empty message has been
 	 * received.
 	 * 
 	 * @param message the message
 	 */
-	public void receiveEmptyMessage(EmptyMessage message);
-	
+	void receiveEmptyMessage(EmptyMessage message);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/Serializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/Serializer.java
@@ -20,9 +20,12 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network.serialization;
 
+import java.net.InetSocketAddress;
+
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.elements.MessageCallback;
 import org.eclipse.californium.elements.RawData;
 
 
@@ -30,7 +33,10 @@ import org.eclipse.californium.elements.RawData;
  * The serializer serializes requests, responses and empty messages to bytes,
  * i.e. {@link RawData}.
  */
-public final class Serializer {
+public class Serializer {
+
+	private Serializer() {
+	}
 
 	/**
 	 * Serializes the specified request. Message identifier, message code,
@@ -48,6 +54,31 @@ public final class Serializer {
 			bytes = new DataSerializer().serializeRequest(request);
 		request.setBytes(bytes);
 		return new RawData(bytes, request.getDestination(), request.getDestinationPort());
+	}
+
+	/**
+	 * Serializes a given CoAP request.
+	 * <p>
+	 * Message identifier, message code, token, options and payload are converted
+	 * into a byte array and wrapped in a {@link RawData} object.
+	 * The request's destination address and port are stored as address and port
+	 * in the RawData object.
+	 * </p>
+	 * 
+	 * @param request
+	 *            the request
+	 * @param callback
+	 *            the callback the transport layer should invoke to signal establishment
+	 *            of message context information. This information may be used for matching a response
+	 *            to a request.
+	 * @return the request as raw data
+	 */
+	public static RawData serialize(Request request, MessageCallback callback) {
+		byte[] bytes = request.getBytes();
+		if (bytes == null)
+			bytes = new DataSerializer().serializeRequest(request);
+		request.setBytes(bytes);
+		return RawData.outbound(bytes, new InetSocketAddress(request.getDestination(), request.getDestinationPort()), callback, false);
 	}
 
 	/**

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTest.java
@@ -1,0 +1,219 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.network.Exchange.Origin;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.CorrelationContext;
+import org.eclipse.californium.elements.DtlsCorrelationContext;
+import org.eclipse.californium.elements.MapBasedCorrelationContext;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MatcherTest {
+
+	static final String SESSION_ID = "010203";
+	static final String OTHER_SESSION_ID = "567322";
+	static final String EPOCH = "1";
+	static final String OTHER_EPOCH = "2";
+	static final String CIPHER = "TLS_PSK";
+	static final String OTHER_CIPHER = "TLS_NULL";
+	InetSocketAddress dest;
+	InetSocketAddress source;
+
+	@Before
+	public void setUp() throws Exception {
+		source = new InetSocketAddress(InetAddress.getLoopbackAddress(), 12000);
+		dest = new InetSocketAddress(InetAddress.getLoopbackAddress(), 5684);
+	}
+
+	@Test
+	public void testReceiveResponseAcceptsResponseWithArbitraryCorrelationInformation() {
+		// GIVEN a request sent without any additional correlation information
+		//  using a matcher set to lax matching
+		Matcher matcher = newMatcher(false);
+		Exchange exchange = sendRequest(matcher, null);
+
+		// WHEN a response arrives with arbitrary additional correlation information
+		Exchange matchedExchange = matcher.receiveResponse(
+												responseFor(exchange.getCurrentRequest()),
+												new MapBasedCorrelationContext());
+
+		// THEN assert that the response is successfully matched against the request
+		assertThat(matchedExchange, is(exchange));
+	}
+
+	@Test
+	public void testReceiveResponseRejectsResponseWithoutCorrelationInformation() {
+		// GIVEN a request sent with some additional correlation information
+		//  using a matcher set to lax matching
+		Matcher matcher = newMatcher(false);
+		MapBasedCorrelationContext ctx = new MapBasedCorrelationContext();
+		ctx.put("key", "value");
+		Exchange exchange = sendRequest(matcher, ctx);
+
+		// WHEN a response arrives without any correlation information
+		Exchange matchedExchange = matcher.receiveResponse(responseFor(exchange.getCurrentRequest()), null);
+
+		// THEN assert that the response is not matched
+		assertThat(matchedExchange, is(nullValue()));
+	}
+
+	// tests verifying lax response matching based on SESSION ID and CIPHER only
+
+	@Test
+	public void testReceiveResponseAcceptsResponseFromDifferentEpochUsingLaxMatching() {
+		// GIVEN a request sent via a DTLS transport using a matcher set to lax matching 
+		Matcher matcher = newMatcher(false);
+		Exchange exchange = sendRequest(matcher, new DtlsCorrelationContext(SESSION_ID, EPOCH, CIPHER));
+
+		// WHEN a response arrives with the same message ID within the same DTLS session, using
+		// the same cipher but from a different epoch
+		Exchange matchedExchange = matcher.receiveResponse(
+												responseFor(exchange.getCurrentRequest()),
+												new DtlsCorrelationContext(SESSION_ID, OTHER_EPOCH, CIPHER));
+
+		// THEN assert that the response is matched successfully
+		assertThat(matchedExchange, is(exchange));
+	}
+
+	@Test
+	public void testReceiveResponseRejectsResponseFromDifferentSessionUsingLaxMatching() {
+		// GIVEN a request sent via a DTLS transport using a matcher set to lax matching
+		Matcher matcher = newMatcher(false);
+		Exchange exchange = sendRequest(matcher, new DtlsCorrelationContext(SESSION_ID, EPOCH, CIPHER));
+
+		// WHEN a response arrives with the same message ID but a different DTLS session
+		Exchange matchedExchange = matcher.receiveResponse(
+												responseFor(exchange.getCurrentRequest()),
+												new DtlsCorrelationContext(OTHER_SESSION_ID, EPOCH, CIPHER));
+
+		// THEN assert that the response is not matched
+		assertThat(matchedExchange, is(nullValue()));
+	}
+
+	@Test
+	public void testReceiveResponseRejectsResponseUsingDifferentCipherUsingLaxMatching() {
+		// GIVEN a request sent via a DTLS transport using a matcher set to lax matching
+		Matcher matcher = newMatcher(false);
+		Exchange exchange = sendRequest(matcher, new DtlsCorrelationContext(SESSION_ID, EPOCH, CIPHER));
+
+		// WHEN a response arrives with the same message ID within the same DTLS session but using another cipher
+		Exchange matchedExchange = matcher.receiveResponse(
+												responseFor(exchange.getCurrentRequest()),
+												new DtlsCorrelationContext(SESSION_ID, EPOCH, OTHER_CIPHER));
+
+		// THEN assert that the response is not matched
+		assertThat(matchedExchange, is(nullValue()));
+	}
+
+	// tests verifying strict response matching
+
+	@Test
+	public void testReceiveResponseAcceptsResponseFromSameSessionEpochAndCipherUsingStrictMatching() {
+		// GIVEN a request sent via a DTLS transport 
+		Matcher matcher = newMatcher(true);
+		Exchange exchange = sendRequest(matcher, new DtlsCorrelationContext(SESSION_ID, EPOCH, CIPHER));
+
+		// WHEN a response arrives with the same message ID, session ID, epoch and cipher
+		Exchange matchedExchange = matcher.receiveResponse(
+												responseFor(exchange.getCurrentRequest()),
+												new DtlsCorrelationContext(SESSION_ID, EPOCH, CIPHER));
+
+		// THEN assert that the response is matched successfully
+		assertThat(matchedExchange, is(exchange));
+	}
+
+	@Test
+	public void testReceiveResponseRejectsResponseFromDifferentEpochUsingStrictMatching() {
+		// GIVEN a request sent via a DTLS transport using a matcher set to strict matching
+		Matcher matcher = newMatcher(true);
+		Exchange exchange = sendRequest(matcher, new DtlsCorrelationContext(SESSION_ID, EPOCH, CIPHER));
+
+		// WHEN a response arrives with the same message ID, session ID and cipher but from a different epoch
+		Exchange matchedExchange = matcher.receiveResponse(
+												responseFor(exchange.getCurrentRequest()),
+												new DtlsCorrelationContext(SESSION_ID, OTHER_EPOCH, CIPHER));
+
+		// THEN assert that the response is not matched
+		assertThat(matchedExchange, is(nullValue()));
+	}
+
+	@Test
+	public void testReceiveResponseRejectsResponseFromDifferentSessionUsingStrictMatching() {
+		// GIVEN a request sent via a DTLS transport using a matcher set to strict matching
+		Matcher matcher = newMatcher(true);
+		Exchange exchange = sendRequest(matcher, new DtlsCorrelationContext(SESSION_ID, EPOCH, CIPHER));
+
+		// WHEN a response arrives with the same message ID, epoch and cipher but a different session ID
+		Exchange matchedExchange = matcher.receiveResponse(
+												responseFor(exchange.getCurrentRequest()),
+												new DtlsCorrelationContext(OTHER_SESSION_ID, EPOCH, CIPHER));
+
+		// THEN assert that the response is not matched
+		assertThat(matchedExchange, is(nullValue()));
+	}
+
+	@Test
+	public void testReceiveResponseRejectsResponseUsingDifferentCipherUsingStrictMatching() {
+		// GIVEN a request sent via a DTLS transport using a matcher set to strict matching
+		Matcher matcher = newMatcher(true);
+		Exchange exchange = sendRequest(matcher, new DtlsCorrelationContext(SESSION_ID, EPOCH, CIPHER));
+
+		// WHEN a response arrives with the same message ID, session ID and epoch but using a different cipher
+		Exchange matchedExchange = matcher.receiveResponse(
+												responseFor(exchange.getCurrentRequest()),
+												new DtlsCorrelationContext(SESSION_ID, EPOCH, OTHER_CIPHER));
+
+		// THEN assert that the response is not matched
+		assertThat(matchedExchange, is(nullValue()));
+	}
+
+	private Matcher newMatcher(boolean useStrictMatching) {
+		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
+		config.setBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING, useStrictMatching);
+		return new Matcher(config);
+	}
+
+	private Exchange sendRequest(final Matcher matcher, final CorrelationContext ctx) {
+		Request request = Request.newGet();
+		request.setDestination(dest.getAddress());
+		request.setDestinationPort(dest.getPort());
+		Exchange exchange = new Exchange(request, Origin.LOCAL);
+		matcher.sendRequest(exchange, request);
+		exchange.setCorrelationContext(ctx);
+		return exchange;
+	}
+
+	private Response responseFor(Request request) {
+		Response response = new Response(ResponseCode.CONTENT);
+		response.setMID(request.getMID());
+		response.setToken(request.getToken());
+		response.setBytes(new byte[]{});
+		response.setSource(source.getAddress());
+		response.setSourcePort(source.getPort());
+		return response;
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
@@ -682,7 +682,7 @@ public class LockstepEndpoint {
 				message.setDestinationPort(destination.getPort());
 			}
 			setProperties(message);
-			
+
 			RawData raw = Serializer.serialize(message);
 			send(raw);
 		}
@@ -747,7 +747,7 @@ public class LockstepEndpoint {
 				request.setDestinationPort(destination.getPort());
 			}
 			setProperties(request);
-			
+
 			RawData raw = Serializer.serialize(request);
 			send(raw);
 		}
@@ -833,7 +833,7 @@ public class LockstepEndpoint {
 				response.setDestinationPort(destination.getPort());
 			}
 			setProperties(response);
-			
+
 			RawData raw = Serializer.serialize(response);
 			send(raw);
 		}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/CorrelationContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/CorrelationContext.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - add support for correlation context to provide
+ *                                      additional information to application layer for
+ *                                      matching messages (fix GitHub issue #1)
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+/**
+ * A container for storing transport specific information about the context
+ * in which a message has been sent or received.
+ */
+public interface CorrelationContext {
+
+	/**
+	 * Gets a value from this context.
+	 * 
+	 * @param key the key to retrieve the value for.
+	 * @return the value or <code>null</code> if this context does not contain
+	 *         a value for the given key.
+	 */
+	String get(String key);
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/DtlsCorrelationContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/DtlsCorrelationContext.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - add support for correlation context to provide
+ *                                      additional information to application layer for
+ *                                      matching messages (fix GitHub issue #1)
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+/**
+ * A correlation context that explicitly supports DTLS specific properties.
+ */
+public class DtlsCorrelationContext extends MapBasedCorrelationContext {
+
+	public static final String KEY_SESSION_ID = "DTLS_SESSION_ID";
+	public static final String KEY_EPOCH = "DTLS_EPOCH";
+	public static final String KEY_CIPHER = "DTLS_CIPHER";
+
+	/**
+	 * Creates a new correlation context from DTLS session parameters.
+	 * 
+	 * @param sessionId the session's ID.
+	 * @param epoch the session's current read/write epoch.
+	 * @param cipher the cipher suite of the session's current read/write state.
+	 * @throws NullPointerException if any of the params is <code>null</code>.
+	 */
+	public DtlsCorrelationContext(String sessionId, String epoch, String cipher) {
+		if (sessionId == null) {
+			throw new NullPointerException("Session ID must not be null");
+		} else if (epoch == null) {
+			throw new NullPointerException("Epoch must not be null");
+		} else if (cipher == null) {
+			throw new NullPointerException("Cipher must not be null");
+		} else {
+			put(KEY_SESSION_ID, sessionId);
+			put(KEY_EPOCH, epoch);
+			put(KEY_CIPHER, cipher);
+		}
+	}
+
+	public String getSessionId() {
+		return get(KEY_SESSION_ID);
+	}
+
+	public String getEpoch() {
+		return get(KEY_EPOCH);
+	}
+
+	public String getCipher() {
+		return get(KEY_CIPHER);
+	}
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedCorrelationContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedCorrelationContext.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - add support for correlation context to provide
+ *                                      additional information to application layer for
+ *                                      matching messages (fix GitHub issue #1)
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A map based correlation context.
+ */
+public class MapBasedCorrelationContext implements CorrelationContext {
+
+	private Map<String, String> entries = new HashMap<>();
+
+	/**
+	 * Puts a value to the context.
+	 * 
+	 * @param key the key to put the value under.
+	 * @param value the value to put to the context.
+	 * @return the previous value for the given key or <code>null</code> if the context did
+	 *         not contain any value for the key yet.
+	 */
+	public final Object put(String key, String value) {
+		return entries.put(key, value);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String get(String key) {
+		return entries.get(key);
+	}
+
+	/**
+	 * Creates a hash code based on the entries stored in this context.
+	 * <p>
+	 * The hash code for two instances will be the same if they contain the
+	 * same keys and values.
+	 * </p>
+	 * 
+	 * @return the hash code.
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((entries == null) ? 0 : entries.hashCode());
+		return result;
+	}
+
+	/**
+	 * Checks if this correlation context has the same entries as another instance.
+	 * 
+	 * @param obj the object to compare this context to.
+	 * @return <code>true</code> if the other object also is a <code>MapBasedCorrelationContext</code>
+	 *         and has the same entries as this context.
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (!(obj instanceof MapBasedCorrelationContext)) {
+			return false;
+		}
+		MapBasedCorrelationContext other = (MapBasedCorrelationContext) obj;
+		if (entries == null) {
+			if (other.entries != null) {
+				return false;
+			}
+		} else if (!entries.equals(other.entries)) {
+			return false;
+		}
+		return true;
+	}
+
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/MessageCallback.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/MessageCallback.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - add support for correlation context to provide
+ *                                      additional information to application layer for
+ *                                      matching messages (fix GitHub issue #1)
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+public interface MessageCallback {
+
+	/**
+	 * Called when the context information for an outbound message has been
+	 * established.
+	 * <p>
+	 * The information contained in the context object depends on the particular
+	 * transport layer used to send the message. For a transport using DTLS the
+	 * context will include e.g. the DTLS session's ID, epoch number and cipher
+	 * that is used for sending the message to the peer.
+	 * </p>
+	 *  
+	 * @param context transport specific properties describing the context in
+	 *                   which the message is sent
+	 */
+	void onContextEstablished(CorrelationContext context);
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/RawData.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/RawData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
+ * Copyright (c) 2015, 2016 Institute for Pervasive Computing, ETH Zurich and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,6 +14,9 @@
  *    Matthias Kovatsch - creator and main architect
  *    Martin Lanter - architect and initial implementation
  *    Kai Hudalla (Bosch Software Innovations GmbH) - several additions and improvements
+ *    Bosch Software Innovations GmbH - add support for correlation context to provide
+ *                                      additional information to application layer for
+ *                                      matching messages (fix GitHub issue #1)
  ******************************************************************************/
 package org.eclipse.californium.elements;
 
@@ -36,19 +39,23 @@ import java.util.Arrays;
  * A message received from a client via the network may also optionally contain the
  * authenticated sender's identity as a <code>java.security.Principal</code> object.
  */
-public class RawData {
+public final class RawData {
 
 	/** The raw message. */
 	public final byte[] bytes;
-	
+
 	/** The source/destination address. */
 	private InetSocketAddress address;
-	
+
 	/** Indicates if this message is a multicast message */
 	private boolean multicast;
-	
+
 	private Principal senderIdentity;
-	
+
+	private CorrelationContext correlationContext;
+
+	private MessageCallback callback;
+
 	/**
 	 * Instantiates a new raw data.
 	 *
@@ -58,7 +65,7 @@ public class RawData {
 	public RawData(byte[] data) {
 		this(data, null, 0, null, false);
 	}
-	
+
 	/**
 	 * Instantiates a new raw data.
 	 *
@@ -69,7 +76,7 @@ public class RawData {
 	public RawData(byte[] data, InetSocketAddress address) {
 		this(data, address, null, false);
 	}
-	
+
 	/**
 	 * Instantiates a new raw data.
 	 *
@@ -82,7 +89,7 @@ public class RawData {
 	public RawData(byte[] data, InetSocketAddress address, Principal clientIdentity) {
 		this(data, address, clientIdentity, false);
 	}
-	
+
 	/**
 	 * Instantiates a new raw data.
 	 *
@@ -94,7 +101,7 @@ public class RawData {
 	public RawData(byte[] data, InetAddress address, int port) {
 		this(data, address, port, null, false);
 	}
-	
+
 	/**
 	 * Instantiates a new raw data.
 	 *
@@ -108,7 +115,7 @@ public class RawData {
 	public RawData(byte[] data, InetAddress address, int port, Principal clientIdentity) {
 		this(data, address, port, clientIdentity, false);
 	}
-	
+
 	/**
 	 * Instantiates a new raw data.
 	 *
@@ -132,18 +139,37 @@ public class RawData {
 	 * @throws NullPointerException if data or address is <code>null</code>
 	 */
 	public RawData(byte[] data, InetSocketAddress address, Principal clientIdentity, boolean multicast) {
+		this(data, address, clientIdentity, null, multicast);
+	}
+
+	/**
+	 * Instantiates a new raw data.
+	 *
+	 * @param data the data that is to be sent or has been received
+	 * @param address the IP address and port the data is to be sent to or has been received from
+	 * @param clientIdentity the identity of the authenticated sender of the message
+	 *     (or <code>null</code> if sender is not authenticated)
+	 * @param correlationContext additional information regarding the context the message has been
+	 *      received in. The information contained will usually come from the transport layer, e.g.
+	 *      the ID of the DTLS session the message has been received in, and can be used to correlate
+	 *      this message with another (previously send) message.
+	 * @param multicast indicates whether the data represents a multicast message
+	 * @throws NullPointerException if data or address is <code>null</code>
+	 */
+	private RawData(byte[] data, InetSocketAddress address, Principal clientIdentity, CorrelationContext correlationContext, boolean multicast) {
 		if (data == null) {
 			throw new NullPointerException("Data must not be null");
-		}
-		if (address == null) {
+		} else if (address == null) {
 			throw new NullPointerException("Address must not be null");
+		} else {
+			this.bytes = data;
+			this.address = address;
+			this.senderIdentity = clientIdentity;
+			this.correlationContext = correlationContext;
+			this.multicast = multicast;
 		}
-		this.bytes = data;
-		this.address = address;
-		this.senderIdentity = clientIdentity;
-		this.multicast = multicast;
 	}
-	
+
 	/**
 	 * Instantiates a new raw data.
 	 *
@@ -156,7 +182,7 @@ public class RawData {
 	public RawData(byte[] data, InetAddress address, int port, boolean multicast) {
 		this(data, address, port, null, multicast);
 	}
-	
+
 	/**
 	 * Instantiates a new raw data.
 	 *
@@ -171,7 +197,55 @@ public class RawData {
 	public RawData(byte[] data, InetAddress address, int port, Principal clientIdentity, boolean multicast) {
 		this(data, new InetSocketAddress(address, port), clientIdentity, multicast);
 	}
-	
+
+	/**
+	 * Instantiates a new raw data for a message received from a peer.
+	 *
+	 * @param data the data that is to be sent or has been received.
+	 * @param address the IP address and port the data has been received from.
+	 * @param clientIdentity the identity of the authenticated sender of the message
+	 *     (or <code>null</code> if sender is not authenticated).
+	 * @param correlationContext additional information regarding the context the message has been
+	 *      received in. The information contained will usually come from the transport layer, e.g.
+	 *      the ID of the DTLS session the message has been received in, and can be used to correlate
+	 *      this message with another (previously sent) message.
+	 * @param isMulticast indicates whether the data has been received as a multicast message.
+	 * @return the raw data object containing the inbound message.
+	 * @throws NullPointerException if data or address is <code>null</code>.
+	 */
+	public static RawData inbound(byte[] data, InetSocketAddress address, Principal clientIdentity,
+			CorrelationContext correlationContext, boolean isMulticast) {
+		return new RawData(data, address, clientIdentity, correlationContext, isMulticast);
+	}
+
+	/**
+	 * Instantiates a new raw data for a message to be sent to a peer.
+	 * <p>
+	 * The given callback handler is notified when the message has been sent by a <code>Connector</code>.
+	 * The information contained in the <code>MessageContext</code> object that is passed in to the
+	 * handler may be relevant for matching a response received via a <code>RawDataChannel</code> to a request
+	 * sent using this method, e.g. when using a DTLS based connector the context may contain the DTLS session
+	 * ID and epoch number which is required to match a response to a request as defined in the CoAP specification.
+	 * </p>
+	 * <p>
+	 * The message context is set via a callback in order to allow <code>Connector</code> implementations to
+	 * process (send) messages asynchronously.
+	 * </p>
+	 * 
+	 * @param data the data to send.
+	 * @param address the IP address and port the data is to be sent to.
+	 * @param callback the handler to call when this message has been sent (may be <code>null</code>).
+	 * @param useMulticast indicates whether the data should be sent using a multicast message.
+	 * @return the raw data object containing the outbound message.
+	 * @throws NullPointerException if data or address is <code>null</code>.
+	 */
+	public static RawData outbound(byte[] data, InetSocketAddress address, MessageCallback callback, boolean useMulticast) {
+		RawData result = new RawData(data, address);
+		result.callback = callback;
+		result.multicast = useMulticast;
+		return result;
+	}
+
 	/**
 	 * Gets the raw message.
 	 *
@@ -180,7 +254,7 @@ public class RawData {
 	public byte[] getBytes() {
 		return Arrays.copyOf(bytes, bytes.length);
 	}
-	
+
 	/**
 	 * Gets the length of the serialized message
 	 *
@@ -255,7 +329,7 @@ public class RawData {
 	public InetSocketAddress getInetSocketAddress() {
 		return address;
 	}
-	
+
 	/**
 	 * Gets the identity of the sender of the message.
 	 * 
@@ -267,5 +341,23 @@ public class RawData {
 	 */
 	public Principal getSenderIdentity() {
 		return senderIdentity;
+	}
+
+	/**
+	 * Gets additional information regarding the context this message has been 
+	 * received in.
+	 * 
+	 * @return the messageContext the correlation information or <code>null</code> if
+	 *           no additional correlation information is available
+	 */
+	public CorrelationContext getCorrelationContext() {
+		return correlationContext;
+	}
+
+	/**
+	 * @return the callback
+	 */
+	public MessageCallback getMessageCallback() {
+		return callback;
 	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
@@ -180,12 +180,14 @@ public class UDPConnector implements Connector {
 	public synchronized void destroy() {
 		stop();
 	}
-	
+
 	@Override
 	public void send(RawData msg) {
-		if (msg == null)
-			throw new NullPointerException();
-		outgoing.add(msg);
+		if (msg == null) {
+			throw new NullPointerException("Message must not be null");
+		} else {
+			outgoing.add(msg);
+		}
 	}
 
 	@Override
@@ -252,7 +254,7 @@ public class UDPConnector implements Connector {
 			}
 			byte[] bytes = Arrays.copyOfRange(datagram.getData(), datagram.getOffset(), datagram.getLength());
 			RawData msg = new RawData(bytes, datagram.getAddress(), datagram.getPort());
-			
+
 			receiver.receiveData(msg);
 		}
 		

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
+ * Copyright (c) 2015, 2016 Institute for Pervasive Computing, ETH Zurich and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -26,6 +26,8 @@
  *                                                    plaintext expansion
  *    Kai Hudalla (Bosch Software Innovations GmbH) - calculate max fragment size based on (P)MTU, explicit
  *                                                    value provided by peer and current write state
+ *    Bosch Software Innovations GmbH - add accessors for current read/write state cipher names
+ *                                      (fix GitHub issue #1)
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -434,6 +436,15 @@ public final class DTLSSession {
 	}
 
 	/**
+	 * Gets the name of the current read state's cipher suite.
+	 * 
+	 * @return the name.
+	 */
+	public String getReadStateCipher() {
+		return readState.getCipherSuite().name();
+	}
+
+	/**
 	 * Gets the current write state of the connection.
 	 * 
 	 * The information in the current write state is used to en-crypt
@@ -474,6 +485,15 @@ public final class DTLSSession {
 		// re-calculate maximum fragment length based on cipher suite from updated write state
 		determineMaxFragmentLength(maxFragmentLength);
 		LOGGER.log(Level.FINEST, "Setting current write state to\n{0}", writeState);
+	}
+
+	/**
+	 * Gets the name of the current write state's cipher suite.
+	 * 
+	 * @return the name.
+	 */
+	public String getWriteStateCipher() {
+		return writeState.getCipherSuite().name();
 	}
 
 	final KeyExchangeAlgorithm getKeyExchange() {


### PR DESCRIPTION
I have tried to follow the ideas generated during the discussion on the mailing list around issue #1.

**Element Connector**

New classes `MessageCallback` and `CorrelationContext` have been created in order to pass hence and forth correlation information between Core and Scandium as part of `RawData` objects.

**Scandium**

The idea is to pass a `MessageCallback` as part of the `RawData` object passed into `Connector.send(RawData)`. The `DTLSConnector` then invokes `MessageCallback.onContextEstablished(CorrelationContext)` with an instance of `DtlsCorrelationContext` which contains the ID, epoch and cipher name of the DTLS session used to send the message.

When the `DTLSConnector` receives a message on an established session, it creates a `DtlsCorreleationContext` object using the session's ID, epoch and cipher name and includes it in the `RawData` object handed over to the application layer, i.e. `RawDataChannel.receiveData(RawData)`.

**Core**

Within Californium's `CoapEndpoint.OutboxImpl` we *attach* the `DtlsCorrelationContext` provided by the `MessageCallback`to the ongoing `Exchange` and later, when the response is received and matched based on the token, the `Matcher` also compares the values contained in the incoming `DtlsCorrelationContext` to the values contained in the context attached to the `Exchange`.

A new configuration property in `NetworkConfig` has been created to select either *lax* (default, only checks session ID) or *strict* (also checks for matching epoch) Request/Response matching.