### PR TITLE
Do resume session on restart if needed.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ConnectionStore.java
@@ -27,6 +27,8 @@ import java.net.InetSocketAddress;
  * It is also assumed that the sessions are kept in memory. Thus, no
  * explicit <code>update</code> method is provided since all instances
  * are expected to be passed-in and stored by reference.
+ * 
+ * @Deprecated use ResumptionSupportingConnectionStore
  */
 public interface ConnectionStore {
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -16,6 +16,7 @@
 package org.eclipse.californium.scandium.dtls;
 
 import java.net.InetSocketAddress;
+import java.util.Iterator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -50,7 +51,7 @@ import org.eclipse.californium.scandium.util.LeastRecentlyUsedCache;
  * 
  * Storing and reading to/from the store is thread safe.
  */
-public class InMemoryConnectionStore extends LeastRecentlyUsedCache<InetSocketAddress, Connection> implements ConnectionStore {
+public class InMemoryConnectionStore extends LeastRecentlyUsedCache<InetSocketAddress, Connection> implements ResumptionSupportingConnectionStore {
 
 	private static final Logger LOG = Logger.getLogger(InMemoryConnectionStore.class.getName());
 	
@@ -124,5 +125,14 @@ public class InMemoryConnectionStore extends LeastRecentlyUsedCache<InetSocketAd
 			});
 		}
 	}
-
+	
+	@Override
+	public synchronized void markAllAsResumptionRequired() {
+		for (Iterator<Connection> iterator = values(); iterator.hasNext();) {
+			Connection c = iterator.next();
+			if (c != null){
+				c.setResumptionRequired(true);;
+			}
+		}
+	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumptionSupportingConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumptionSupportingConnectionStore.java
@@ -1,0 +1,16 @@
+package org.eclipse.californium.scandium.dtls;
+
+/**
+ * A connection store which adds support of connection resumption.
+ * 
+ * @since 1.1
+ */
+public interface ResumptionSupportingConnectionStore extends ConnectionStore {
+
+	/**
+	 * Mark all connections as resumption required.
+	 * 
+	 */
+	void markAllAsResumptionRequired();
+	
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/util/LeastRecentlyUsedCache.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/util/LeastRecentlyUsedCache.java
@@ -16,6 +16,7 @@
 package org.eclipse.californium.scandium.util;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -324,6 +325,27 @@ public class LeastRecentlyUsedCache<K, V> {
 
 	static interface EvictionListener<V> {
 		void onEviction(V evictedValue);
+	}
+
+	protected final Iterator<V> values() {
+		final Iterator<CacheEntry<K, V>> iter = cache.values().iterator();
+
+		return new Iterator<V>() {
+			@Override
+			public boolean hasNext() {
+				return iter.hasNext();
+			}
+
+			@Override
+			public V next() {
+				return iter.next().value;
+			}
+
+			@Override
+			public void remove() {
+				throw new UnsupportedOperationException();
+			}
+		};
 	}
 
 	private static class CacheEntry<K, V> {


### PR DESCRIPTION
Currently we can not restart  a device with a different `inetAddress`. This just don't works.
The idea is to do a resume session in this case.

See more details on [this thread](https://dev.eclipse.org/mhonarc/lists/cf-dev/msg00497.html) on the mailing list.

(About the tests I didn't find a good way to check if we do a resume handshake or not, at least the test I added verify that we can do a start/stop/start)