### PR TITLE
Add clustering support for observe

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.californium.core.coap.MessageObserver;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.observe.ObserveNotificationOrderer;
 
 /**
@@ -58,7 +59,9 @@ public class CoapObserveRelation {
 
 	/** The handle to re-register for Observe notifications */
 	private ScheduledFuture<?> reregistrationHandle = null;
-	
+
+	private NotificationListener notificationListener;
+
 	/**
 	 * Constructs a new CoapObserveRelation with the specified request.
 	 *
@@ -125,6 +128,7 @@ public class CoapObserveRelation {
 		
 		// cancel old ongoing request
 		request.cancel();
+		endpoint.cancelObservation(request.getToken());
 		setCanceled(true);
 	}
 	
@@ -134,6 +138,7 @@ public class CoapObserveRelation {
 	 */
 	public void reactiveCancel() {
 		request.cancel();
+		endpoint.cancelObservation(request.getToken());
 		setCanceled(true);
 	}
 	
@@ -165,9 +170,17 @@ public class CoapObserveRelation {
 		
 		if (this.canceled) {
 			setReregistrationHandle(null);
+
+			if (notificationListener != null) {
+				endpoint.removeNotificationListener(notificationListener);
+			}
 		}
 	}
 	
+	public void setNotificationListener(NotificationListener listener) {
+		notificationListener = listener;
+	}
+
 	/**
 	 * Sets the current notification.
 	 *

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
@@ -29,6 +29,7 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
+import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.server.MessageDeliverer;
 
 /**
@@ -99,6 +100,22 @@ public interface Endpoint {
 	 * @param obs the observer
 	 */
 	void removeObserver(EndpointObserver obs);
+	
+	/**
+	 * Adds a listener for observe notification (This is related to CoAP
+	 * observe)
+	 * 
+	 * @param lis the listener
+	 */
+	void addNotificationListener(NotificationListener lis);
+
+	/**
+	 * Removes a listener for observe notification (This is related to CoAP
+	 * observe)
+	 * 
+	 * @param lis the listener
+	 */
+	void removeNotificationListener(NotificationListener lis);
 
 	/**
 	 * Adds a message interceptor to this endpoint.
@@ -165,4 +182,12 @@ public interface Endpoint {
 	 */
 	NetworkConfig getConfig();
 
+	/**
+	 * Cancel observation for this request.
+	 * 
+	 * @param token
+	 *            the token of the original request which establishes the
+	 *            observe relation to cancel.
+	 */
+	void cancelObservation(byte[] token);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -160,6 +160,21 @@ public class Exchange {
 		this.origin = origin;
 		this.timestamp = System.currentTimeMillis();
 	}
+	
+	/**
+	 * Creates a new exchange with the specified request, origin and context.
+	 * 
+	 * @param request the request that starts the exchange
+	 * @param origin the origin of the request (LOCAL or REMOTE)
+	 * @param ctx the correlation context of this exchange
+	 */
+	public Exchange(Request request, Origin origin, CorrelationContext ctx) {
+		INSTANCE_COUNTER.incrementAndGet();
+		this.currentRequest = request; // might only be the first block of the whole request
+		this.origin = origin;
+		this.correlationContext = ctx;
+		this.timestamp = System.currentTimeMillis();
+	}
 
 	/**
 	 * Accept this exchange and therefore the request. Only if the request's

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/ExchangeObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/ExchangeObserver.java
@@ -33,7 +33,7 @@ public interface ExchangeObserver {
 	 * @param exchange the exchange
 	 */
 	void completed(Exchange exchange);
-	
+
 	/**
 	 * Invoked when a new correlation context is set.
 	 * 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -461,6 +461,9 @@ public class BlockwiseLayer extends AbstractLayer {
 					}
 
 					LOGGER.log(Level.FINE, "Assembled response: {0}", assembled);
+					// Set the original request as current request.
+					exchange.setCurrentRequest(exchange.getRequest());
+					// Set the assembled response as current response
 					exchange.setResponse(assembled);
 					super.receiveResponse(exchange, assembled);
 				}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapStack.java
@@ -190,8 +190,7 @@ public class CoapStack {
 
 		@Override
 		public void receiveResponse(Exchange exchange, Response response) {
-			if (!response.getOptions().hasObserve())
-				exchange.setComplete();
+			exchange.setComplete();
 			if (deliverer != null) {
 				deliverer.deliverResponse(exchange, response); // notify request that response has arrived
 			} else {

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/InMemoryObservationStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/InMemoryObservationStore.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ ******************************************************************************/
+package org.eclipse.californium.core.observe;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.Exchange.KeyToken;
+import org.eclipse.californium.core.network.serialization.DataParser;
+import org.eclipse.californium.core.network.serialization.Serializer;
+import org.eclipse.californium.elements.CorrelationContext;
+import org.eclipse.californium.elements.RawData;
+
+public class InMemoryObservationStore implements ObservationStore {
+
+	private Map<KeyToken, Observation> map = new ConcurrentHashMap<>();
+
+	@Override
+	public void add(Observation obs) {
+		if (obs != null) {
+			map.put(new KeyToken(obs.getRequest().getToken()), obs);
+		}
+	}
+
+	@Override
+	public Observation get(byte[] token) {
+		Observation obs = map.get(new KeyToken(token));
+		if (obs != null) {
+			RawData serialize = Serializer.serialize(obs.getRequest(), null);
+			DataParser parser = new DataParser(serialize.getBytes());
+			Request newRequest = parser.parseRequest();
+			return new Observation(newRequest, obs.getContext());
+		}
+		return null;
+	}
+
+	@Override
+	public void remove(byte[] token) {
+		map.remove(new KeyToken(token));
+	}
+
+	public boolean isEmpty(){
+		return map.isEmpty();
+	}
+
+	public int getSize() {
+		return map.size();
+	}
+
+	public void clear() {
+		map.clear();
+	}
+
+	@Override
+	public void setContext(byte[] token, CorrelationContext ctx) {
+		Observation obs = map.get(new KeyToken(token));
+		if (obs != null) {
+			map.put(new KeyToken(token), new Observation(obs.getRequest(), ctx));
+		}
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/NotificationListener.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/NotificationListener.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ ******************************************************************************/
+package org.eclipse.californium.core.observe;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+
+/**
+ * Client code can register a notification listener on an {@code Endpoint} in
+ * order to be called back when notifications for observed resources are
+ * received from peers.
+ * <p>
+ * Notification listeners are registered at a <em>global</em> level only, i.e.
+ * the listener will be invoked for all notifications for all observed
+ * resources. This is in contrast to the {@code CoapHandler} that client code
+ * can register when invoking one of {@code CoapClient}'s methods and which is
+ * called back for notifications for a particular observed resource only.
+ * </p>
+ */
+public interface NotificationListener {
+
+	/**
+	 * Invoked when a notification for an observed resource has been received.
+	 * 
+	 * @param Request
+	 *            The original request that was used to establish the
+	 *            observation.
+	 * @param response
+	 *            the notification.
+	 */
+	void onNotification(Request request, Response response);
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/Observation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/Observation.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ ******************************************************************************/
+package org.eclipse.californium.core.observe;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.elements.CorrelationContext;
+
+/**
+ * An observation initiated by a given request, for a particular correlation
+ * context.
+ */
+public class Observation {
+
+	private final Request request;
+	private final CorrelationContext context;
+
+	public Observation(Request request, CorrelationContext context) {
+		this.request = request;
+		this.context = context;
+	}
+
+	/**
+	 * @return the request which initiated the observation
+	 */
+	public Request getRequest() {
+		return request;
+	}
+
+	/**
+	 * @return the correlation context for this observation
+	 */
+	public CorrelationContext getContext() {
+		return context;
+	}
+
+
+
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationStore.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ ******************************************************************************/
+package org.eclipse.californium.core.observe;
+
+import org.eclipse.californium.elements.CorrelationContext;
+
+/**
+ * A registry for keeping information about resources observed on other peers.
+ * <p>
+ * The information kept in this registry is particularly intended to be shared
+ * with other instances (running on other nodes) to support failing over the
+ * processing of notifications received by another node after the original node
+ * (that initially registered the observation) has crashed.
+ * </p>
+ */
+public interface ObservationStore {
+
+	/**
+	 * Adds an observation to the store.
+	 */
+	void add(Observation obs);
+
+	/**
+	 * Removes the observation initiated by the request with the given token.
+	 */
+	void remove(byte[] token);
+
+	/**
+	 * Gets the observation initiated by the request with the given token.
+	 */
+	Observation get(byte[] token);
+
+	/**
+	 * Sets the correlation context on the observation initiated by the request
+	 * with the given token.
+	 * <p>
+	 * This method is necessary because the correlation context may not be known
+	 * when the observation is originally registered. This is due to the fact
+	 * that the information contained in the correlation context is gathered by
+	 * the transport layer when the request establishing the observation is sent
+	 * to the peer.
+	 * </p>
+	 */
+	void setContext(byte[] token, CorrelationContext correlationContext);
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -416,6 +416,8 @@ public class BlockwiseClientSideTest {
 
 		Request request = createRequest(GET, path, server);
 		request.setObserve();
+		SynchronousNotificationListener notificationListener = new SynchronousNotificationListener(request);
+		client.addNotificationListener(notificationListener);
 		client.sendRequest(request);
 
 		System.out.println("Establish observe relation to " + path);
@@ -446,7 +448,7 @@ public class BlockwiseClientSideTest {
 		server.expectRequest(CON, GET, path).storeBoth("E").noOption(OBSERVE).block2(2, false, 128).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("E").block2(2, false, 128).payload(respPayload.substring(256, 280)).go();
 
-		Response notification1 = request.waitForResponse(1000);
+		Response notification1 = notificationListener.waitForResponse(1000);
 		assertResponseContainsExpectedPayload(notification1, respPayload);
 
 		System.out.println("Server sends second notification...");
@@ -469,13 +471,14 @@ public class BlockwiseClientSideTest {
 		System.out.println("Send old notification during transfer");
 		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(18).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
 		server.expectEmpty(ACK, mid).go();
+		server.expectRequest(CON, GET, path).storeBoth("H").noOption(OBSERVE).block2(1, false, 128).go();
 
 		server.sendResponse(ACK, CONTENT).loadBoth("G").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
 
-		server.expectRequest(CON, GET, path).storeBoth("H").noOption(OBSERVE).block2(2, false, 128).go();
-		server.sendResponse(ACK, CONTENT).loadBoth("H").block2(2, false, 128).payload(respPayload.substring(256, 290)).go();
+		server.expectRequest(CON, GET, path).storeBoth("I").noOption(OBSERVE).block2(2, false, 128).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("I").block2(2, false, 128).payload(respPayload.substring(256, 290)).go();
 
-		Response notification2 = request.waitForResponse(1000);
+		Response notification2 = notificationListener.waitForResponse(1000);
 		assertResponseContainsExpectedPayload(notification2, respPayload);
 
 		printServerLog(clientInterceptor);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
@@ -1,0 +1,371 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ ******************************************************************************/
+package org.eclipse.californium.core.test.lockstep;
+
+import static org.eclipse.californium.core.coap.CoAP.Code.GET;
+import static org.eclipse.californium.core.coap.CoAP.ResponseCode.CONTENT;
+import static org.eclipse.californium.core.coap.CoAP.Type.ACK;
+import static org.eclipse.californium.core.coap.CoAP.Type.CON;
+import static org.eclipse.californium.core.coap.CoAP.Type.RST;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Random;
+
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.interceptors.MessageTracer;
+import org.eclipse.californium.core.observe.InMemoryObservationStore;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClusteringTest {
+
+	private static boolean RANDOM_PAYLOAD_GENERATION = true;
+
+	private LockstepEndpoint server;
+
+	private Endpoint client1;
+	private int clientPort1;
+
+	private int mid = 8000;
+
+	private String respPayload;
+
+	private ClientBlockwiseInterceptor clientInterceptor = new ClientBlockwiseInterceptor();
+
+	private CoapEndpoint client2;
+
+	private int clientPort2;
+
+	private InMemoryObservationStore store;
+
+	private SynchronousNotificationListener notificationListener1;
+
+	private SynchronousNotificationListener notificationListener2;
+
+	@Before
+	public void setupClient() throws IOException {
+		System.out.println("\nStart " + getClass().getSimpleName());
+
+		NetworkConfig config = new NetworkConfig().setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 16)
+				.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 16).setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200) // client
+																													// retransmits
+																													// after
+																													// 200
+																													// ms
+				.setFloat(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1f).setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f);
+
+		store = new InMemoryObservationStore();
+		notificationListener1 = new SynchronousNotificationListener();
+
+		client1 = new CoapEndpoint(new InetSocketAddress(0), config, store);
+		client1.addNotificationListener(notificationListener1);
+		client1.addInterceptor(clientInterceptor);
+		client1.addInterceptor(new MessageTracer());
+		client1.start();
+		clientPort1 = client1.getAddress().getPort();
+		System.out.println("Client 1 binds to port " + clientPort1);
+
+		notificationListener2 = new SynchronousNotificationListener();
+		client2 = new CoapEndpoint(new InetSocketAddress(0), config, store);
+		client2.addNotificationListener(notificationListener2);
+		client2.addInterceptor(clientInterceptor);
+		client2.addInterceptor(new MessageTracer());
+		client2.start();
+		clientPort2 = client2.getAddress().getPort();
+		System.out.println("Client 2 binds to port " + clientPort2);
+	}
+
+	@After
+	public void shutdownClient() {
+		System.out.println();
+		client1.destroy();
+		client2.destroy();
+		System.out.println("End " + getClass().getSimpleName());
+	}
+
+	@Test
+	public void testNotification() throws Exception {
+		System.out.println("\nObserve:");
+		respPayload = generatePayload(10);
+		String path = "test";
+		server = createLockstepEndpoint();
+		int obs = 100;
+
+		// Make sure the ObserveRequestStore is empty
+		Assert.assertTrue(store.isEmpty());
+
+		// send observe request from client 1
+		System.out.println("\nSending Observe Request to client 1 ...");
+		Request request = createRequest(GET, path);
+		request.setObserve();
+		client1.sendRequest(request);
+
+		// server wait for request and send response
+		System.out.println("\nServer send Observe response to client 1.");
+		server.expectRequest(CON, GET, path).storeMID("A").storeToken("B").observe(0).go();
+		server.sendEmpty(ACK).loadMID("A").go();
+		server.sendResponse(CON, CONTENT).loadToken("B").payload(respPayload).mid(++mid).observe(++obs).go();
+		server.expectEmpty(ACK, mid).go();
+		Thread.sleep(50);
+		Response response = request.waitForResponse(1000);
+
+		printServerLog();
+		Assert.assertNotNull("Client 1 received no response", response);
+		Assert.assertEquals("Client 1 received wrong response code:", CONTENT, response.getCode());
+		Assert.assertEquals("Client 1 received wrong payload:", respPayload, response.getPayloadString());
+		Assert.assertTrue("Store does not contain the new Observe Request:", !store.isEmpty());
+		System.out.println("Relation established with client 1");
+
+		// server send new response to client 2
+		System.out.println("\nServer send Observe response to client 2.");
+		respPayload = generatePayload(10); // changed
+		server.setDestination(client2.getAddress());
+		server.sendResponse(CON, CONTENT).loadToken("B").payload(respPayload).mid(++mid).observe(++obs).go();
+		server.expectEmpty(ACK, mid).go();
+		response = notificationListener2.waitForResponse(1000);
+
+		printServerLog();
+		Assert.assertNotNull("Client 2 received no response", response);
+		Assert.assertEquals("Client 2 received wrong response code:", CONTENT, response.getCode());
+		Assert.assertEquals("Client 2 received wrong payload:", respPayload, response.getPayloadString());
+		System.out.println("Response received");
+
+		// server send new response to client 1
+		System.out.println();
+		System.out.println("\nServer send Observe response to client 1.");
+		respPayload = generatePayload(10); // changed
+		server.setDestination(client1.getAddress());
+		server.sendResponse(CON, CONTENT).loadToken("B").payload(respPayload).mid(++mid).observe(++obs).go();
+		server.expectEmpty(ACK, mid).go();
+		response = notificationListener1.waitForResponse(1000);
+
+		printServerLog();
+		Assert.assertNotNull("Client 1 received no response", response);
+		Assert.assertEquals("Client 1 received wrong response code:", CONTENT, response.getCode());
+		Assert.assertEquals("Client 1 received wrong payload:", respPayload, response.getPayloadString());
+		System.out.println("Response received");
+	}
+
+	@Test
+	public void testNotificationWithBlockWise() throws Exception {
+		System.out.println("\nObserve with blockwise:");
+		respPayload = generatePayload(40);
+		String path = "test";
+		server = createLockstepEndpoint();
+		int obs = 100;
+
+		// Make sure the ObserveRequestStore is empty
+		store.clear();
+		Assert.assertTrue(store.isEmpty());
+
+		// send observe request from client 1
+		System.out.println("\nSending Observe Request to client 1 ...");
+		Request request = createRequest(GET, path);
+		request.setObserve();
+		client1.sendRequest(request);
+
+		// server wait for request and send response
+		System.out.println("\nServer send Observe response to client 1.");
+		server.expectRequest(CON, GET, path).storeBoth("A").storeToken("T").observe(0).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("A").observe(obs++).block2(0, true, 16).payload(respPayload.substring(0, 16)).go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 16).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 16).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 16).payload(respPayload.substring(32, 40)).go();
+		Thread.sleep(50);
+		Response response = request.waitForResponse(1000);
+
+		printServerLog();
+		Assert.assertNotNull("Client 1 received no response", response);
+		Assert.assertEquals("Client 1 received wrong response code:", CONTENT, response.getCode());
+		Assert.assertEquals("Client 1 received wrong payload:", respPayload, response.getPayloadString());
+		Assert.assertTrue("Store does not contain the new Observe Request:", !store.isEmpty());
+		System.out.println("Relation established with client 1");
+
+		// server send new response to client 2
+		System.out.println("\nServer send Observe response to client 2.");
+		respPayload = generatePayload(40); // changed
+		server.setDestination(client2.getAddress());
+		server.sendResponse(CON, CONTENT).loadToken("T").mid(++mid).observe(obs++).block2(0, true, 16)
+				.payload(respPayload.substring(0, 16)).go();
+		server.expectEmpty(ACK, mid).go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 16).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 16).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 16).payload(respPayload.substring(32, 40)).go();
+		response = notificationListener2.waitForResponse(1000);
+
+		printServerLog();
+		Assert.assertNotNull("Client 2 received no response", response);
+		Assert.assertEquals("Client 2 received wrong response code:", CONTENT, response.getCode());
+		Assert.assertEquals("Client 2 received wrong payload:", respPayload, response.getPayloadString());
+		System.out.println("Response received");
+
+		// server send new response to client 1
+		System.out.println();
+		System.out.println("\nServer send Observe response to client 1.");
+		respPayload = generatePayload(40); // changed
+		server.setDestination(client1.getAddress());
+		server.sendResponse(CON, CONTENT).loadToken("T").mid(++mid).observe(obs++).block2(0, true, 16)
+				.payload(respPayload.substring(0, 16)).go();
+		server.expectEmpty(ACK, mid).go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 16).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 16).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 16).payload(respPayload.substring(32, 40)).go();
+		response = notificationListener1.waitForResponse(1000);
+
+
+		printServerLog();
+		Assert.assertNotNull("Client 1 received no response", response);
+		Assert.assertEquals("Client 1 received wrong response code:", CONTENT, response.getCode());
+		Assert.assertEquals("Client 1 received wrong payload:", respPayload, response.getPayloadString());
+		System.out.println("Response received");
+	}
+
+	@Test
+	public void testCancellingNotification() throws Exception {
+		System.out.println("\nObserve:");
+		respPayload = generatePayload(10);
+		String path = "test";
+		server = createLockstepEndpoint();
+		int obs = 100;
+
+		// Make sure the ObserveRequestStore is empty
+		store.clear();
+		Assert.assertTrue(store.isEmpty());
+
+		// send observe request from client 1
+		System.out.println("\nSending Observe Request to client 1 ...");
+		Request request = createRequest(GET, path);
+		request.setObserve();
+		client1.sendRequest(request);
+
+		// server wait for request and send response
+		System.out.println("\nServer send Observe response to client 1.");
+		server.expectRequest(CON, GET, path).storeMID("A").storeToken("B").observe(0).go();
+		server.sendEmpty(ACK).loadMID("A").go();
+		server.sendResponse(CON, CONTENT).loadToken("B").payload(respPayload).mid(++mid).observe(++obs).go();
+		server.expectEmpty(ACK, mid).go();
+		Thread.sleep(50);
+		Response response = request.waitForResponse(1000);
+
+		printServerLog();
+		Assert.assertNotNull("Client 1 received no response", response);
+		Assert.assertEquals("Client 1 received wrong response code:", CONTENT, response.getCode());
+		Assert.assertEquals("Client 1 received wrong payload:", respPayload, response.getPayloadString());
+		Assert.assertTrue("Store does not contain the new Observe Request:", !store.isEmpty());
+		System.out.println("Relation established with client 1");
+		Thread.sleep(1000);
+
+		// server send new response to client 2
+		System.out.println("\nServer send Observe response to client 2.");
+		respPayload = generatePayload(10); // changed
+		server.setDestination(client2.getAddress());
+		server.sendResponse(CON, CONTENT).loadToken("B").payload(respPayload).mid(++mid).observe(++obs).go();
+		server.expectEmpty(ACK, mid).go();
+		response = notificationListener2.waitForResponse(1000);
+
+		printServerLog();
+		Assert.assertNotNull("Client 2 received no response", response);
+		Assert.assertEquals("Client 2 received wrong response code:", CONTENT, response.getCode());
+		Assert.assertEquals("Client 2 received wrong payload:", respPayload, response.getPayloadString());
+		System.out.println("Response received");
+
+		// server send new response to client 1
+		System.out.println();
+		System.out.println("\nServer send Observe response to client 1.");
+		respPayload = generatePayload(10); // changed
+		server.setDestination(client1.getAddress());
+		server.sendResponse(CON, CONTENT).loadToken("B").payload(respPayload).mid(++mid).observe(++obs).go();
+		server.expectEmpty(ACK, mid).go();
+		response = notificationListener1.waitForResponse(1000);
+
+		printServerLog();
+		Assert.assertNotNull("Client 1 received no response", response);
+		Assert.assertEquals("Client 1 received wrong response code:", CONTENT, response.getCode());
+		Assert.assertEquals("Client 1 received wrong payload:", respPayload, response.getPayloadString());
+		System.out.println("Response received");
+
+		// cancel observation
+		System.out.println();
+		System.out.println("\nCancel Observation.");
+		store.remove(request.getToken());
+
+		// server send new response to client 1
+		System.out.println();
+		System.out.println("\nServer send Observe response to client 1.");
+		respPayload = generatePayload(10); // changed
+		server.setDestination(client1.getAddress());
+		server.sendResponse(CON, CONTENT).loadToken("B").payload(respPayload).mid(++mid).observe(++obs).go();
+		server.expectEmpty(RST, mid).go();
+		printServerLog();
+
+		// server send new response to client 2
+		System.out.println();
+		System.out.println("\nServer send Observe response to client 2.");
+		respPayload = generatePayload(10); // changed
+		server.setDestination(client2.getAddress());
+		server.sendResponse(CON, CONTENT).loadToken("B").payload(respPayload).mid(++mid).observe(obs).go();
+		server.expectEmpty(RST, mid).go();
+		printServerLog();
+	}
+
+	private LockstepEndpoint createLockstepEndpoint() {
+		try {
+			LockstepEndpoint endpoint = new LockstepEndpoint();
+			endpoint.setDestination(new InetSocketAddress(InetAddress.getByName("localhost"), clientPort1));
+			return endpoint;
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private Request createRequest(Code code, String path) throws Exception {
+		Request request = new Request(code);
+		String uri = "coap://localhost:" + (server.getPort()) + "/" + path;
+		request.setURI(uri);
+		return request;
+	}
+
+	private void printServerLog() {
+		System.out.print(clientInterceptor.toString());
+		clientInterceptor.clear();
+	}
+
+	private static String generatePayload(int length) {
+		StringBuffer buffer = new StringBuffer();
+		if (RANDOM_PAYLOAD_GENERATION) {
+			Random rand = new Random();
+			while (buffer.length() < length) {
+				buffer.append(rand.nextInt());
+			}
+		} else { // Deterministic payload
+			int n = 1;
+			while (buffer.length() < length) {
+				buffer.append(n++);
+			}
+		}
+		return buffer.substring(0, length);
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/SynchronousNotificationListener.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/SynchronousNotificationListener.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2016 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Matthias Kovatsch - creator and main architect
+ ******************************************************************************/
+package org.eclipse.californium.core.test.lockstep;
+
+import java.util.Arrays;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.observe.NotificationListener;
+
+public class SynchronousNotificationListener implements NotificationListener {
+
+	private Request request; // request to listen
+	private Response currentResponse;
+	private Object lock = new Object();
+
+	public SynchronousNotificationListener() {
+	}
+
+	public SynchronousNotificationListener(Request req) {
+		request = req;
+	}
+
+	/**
+	 * Wait until a response is received or the request was cancelled/rejected.
+	 * 
+	 * @return the response or null if waiting time elapses or if request is
+	 *         cancelled/rejected.
+	 */
+	public Response waitForResponse(long timeoutInMs) throws InterruptedException {
+		Response r;
+		synchronized (lock) {
+			if (currentResponse != null)
+				r = currentResponse;
+			else {
+				lock.wait(timeoutInMs);
+				r = currentResponse;
+			}
+			currentResponse = null;
+		}
+		return r;
+	}
+
+	@Override
+	public void onNotification(Request req, Response resp) {
+		if (request == null || Arrays.equals(request.getToken(), req.getToken())) {
+			synchronized (lock) {
+				currentResponse = resp;
+				lock.notifyAll();
+			}
+		}
+	}
+}


### PR DESCRIPTION
The idea is to be able to handle observe notification in a cluster. (more detail available [here](https://github.com/eclipse/leshan/wiki/Cluster))

To resolve this issue, I introduce 2 new interfaces:
  1. `NotificationListener` : to be able to get notification from any Californium instance.
  1. `ObserveRequestStore`: to share the pending observation state through each instances.

The other "big" change is the `Exchange` instance lifetime for observation:
* Before, the exchange lived all along the observe relation lifetime.
* Now, we recreate an exchange for each notification. I mean a new `Exchange` instance is created from data stored in `ObserverRequestStore` each time we receive a new notification and will be completed/removed as soon as the notification is handled.

All of this is clearly a work in progress (e.g. notification over DTLS is not supported). The idea is to share my first step to know if I go in the right direction.
So feedback is welcome ;)