### PR TITLE
Range for import package: org.eclipse.californium.elements should be "[1.0, 1.2)".

### DIFF
--- a/scandium-core/pom.xml
+++ b/scandium-core/pom.xml
@@ -92,6 +92,7 @@
 							org.eclipse.californium.scandium.util
 						</Private-Package>
 						<Import-Package>
+							org.eclipse.californium.elements;version="[1.0, 1.2)",
 							*
 						</Import-Package>
 						<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>

--- a/scandium-core/pom.xml
+++ b/scandium-core/pom.xml
@@ -92,7 +92,6 @@
 							org.eclipse.californium.scandium.util
 						</Private-Package>
 						<Import-Package>
-							org.eclipse.californium.elements;version="[1.0, 1.2)",
 							*
 						</Import-Package>
 						<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>

--- a/scandium-core/pom.xml
+++ b/scandium-core/pom.xml
@@ -92,7 +92,7 @@
 							org.eclipse.californium.scandium.util
 						</Private-Package>
 						<Import-Package>
-							org.eclipse.californium.elements;version="[1.0.0, 1.1)",
+							org.eclipse.californium.elements;version="[1.0, 1.2)",
 							*
 						</Import-Package>
 						<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>


### PR DESCRIPTION
This means the version 1.2.0 is not included and the actual version 1.1.0 is in this range.

Example version ranges:
[1.2.3,4.5.6) 1.2.3 ≤ x < 4.5.6
[1.2.3,4.5.6] 1.2.3 ≤ x ≤ 4.5.6