### PR TITLE
Org.eclipse.californium.core.test.client.AsynchronousTest is completely broken

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Option.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Option.java
@@ -176,7 +176,7 @@ public class Option implements Comparable<Option> {
 	public int getIntegerValue() {
 		int ret = 0;
 		for (int i=0; i<value.length; i++) {
-		    ret <<= 8;
+            ret <<= 8;
 			ret |= (int) value[i] & 0xff;
 		}
 		return ret;
@@ -190,7 +190,7 @@ public class Option implements Comparable<Option> {
 	public long getLongValue() {
 		long ret = 0;
 		for (int i=0; i<value.length; i++) {
-		    ret <<= 8;
+            ret <<= 8;
 			ret |= (int) value[i] & 0xff;
 		}
 		return ret;

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Option.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Option.java
@@ -176,7 +176,7 @@ public class Option implements Comparable<Option> {
 	public int getIntegerValue() {
 		int ret = 0;
 		for (int i=0; i<value.length; i++) {
-            ret <<= 8;
+			ret <<= 8;
 			ret |= (int) value[i] & 0xff;
 		}
 		return ret;
@@ -190,7 +190,7 @@ public class Option implements Comparable<Option> {
 	public long getLongValue() {
 		long ret = 0;
 		for (int i=0; i<value.length; i++) {
-            ret <<= 8;
+			ret <<= 8;
 			ret |= (int) value[i] & 0xff;
 		}
 		return ret;

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Option.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Option.java
@@ -50,7 +50,7 @@ import java.util.Arrays;
 public class Option implements Comparable<Option> {
 
 	/** The option number. */
-	private int number;
+	private OptionNumberRegistry number;
 	
 	/** The value as byte array. */
 	private byte[] value; // not null
@@ -69,7 +69,7 @@ public class Option implements Comparable<Option> {
 	 *
 	 * @param number the option number
 	 */
-	public Option(int number) {
+	public Option(OptionNumberRegistry number) {
 		this.number = number;
 		this.value = new byte[0];
 	}
@@ -81,7 +81,7 @@ public class Option implements Comparable<Option> {
 	 * @param number the number
 	 * @param str the option value as string
 	 */
-	public Option(int number, String str) {
+	public Option(OptionNumberRegistry number, String str) {
 		this.number = number;
 		setStringValue(str);
 	}
@@ -93,7 +93,7 @@ public class Option implements Comparable<Option> {
 	 * @param number the option number
 	 * @param val the option value as integer
 	 */
-	public Option(int number, int val) {
+	public Option(OptionNumberRegistry number, int val) {
 		this.number = number;
 		setIntegerValue(val);
 	}
@@ -105,7 +105,7 @@ public class Option implements Comparable<Option> {
 	 * @param number the option number
 	 * @param val the option value as long
 	 */
-	public Option(int number, long val) {
+	public Option(OptionNumberRegistry number, long val) {
 		this.number = number;
 		setLongValue(val);
 	}
@@ -116,7 +116,7 @@ public class Option implements Comparable<Option> {
 	 * @param number the option number
 	 * @param opaque the option value in bytes
 	 */
-	public Option(int number, byte[] opaque) {
+	public Option(OptionNumberRegistry number, byte[] opaque) {
 		this.number = number;
 		setValue(opaque);
 	}
@@ -137,7 +137,7 @@ public class Option implements Comparable<Option> {
 	 *
 	 * @return the option number
 	 */
-	public int getNumber() {
+	public OptionNumberRegistry getNumber() {
 		return number;
 	}
 
@@ -146,7 +146,7 @@ public class Option implements Comparable<Option> {
 	 *
 	 * @param number the new option number
 	 */
-	public void setNumber(int number) {
+	public void setNumber(OptionNumberRegistry number) {
 		this.number = number;
 	}
 	
@@ -175,8 +175,9 @@ public class Option implements Comparable<Option> {
 	 */
 	public int getIntegerValue() {
 		int ret = 0;
-		for (int i=0;i<value.length;i++) {
-			ret += (value[value.length - i - 1] & 0xFF) << (i*8);
+		for (int i=0; i<value.length; i++) {
+		    ret <<= 8;
+			ret |= (int) value[i] & 0xff;
 		}
 		return ret;
 	}
@@ -188,8 +189,9 @@ public class Option implements Comparable<Option> {
 	 */
 	public long getLongValue() {
 		long ret = 0;
-		for (int i=0;i<value.length;i++) {
-			ret += (long) (value[value.length - i - 1] & 0xFF) << (i*8);
+		for (int i=0; i<value.length; i++) {
+		    ret <<= 8;
+			ret |= (int) value[i] & 0xff;
 		}
 		return ret;
 	}
@@ -222,30 +224,38 @@ public class Option implements Comparable<Option> {
 	 * @param val the new option value as integer
 	 */
 	public void setIntegerValue(int val) {
-		int length = 0;
-		for (int i=0;i<4;i++)
-			if (val >= 1<<(i*8) || val < 0) length++;
-			else break;
-		value = new byte[length];
-		for (int i=0;i<length;i++)
-			value[length - i - 1] = (byte) (val >> i*8);
+	    setLongValue((long)val & 0xffffffffL);
 	}
 	
-	/**
-	 * Sets the option value from a long.
-	 *
-	 * @param val the new option value as long
-	 */
 	public void setLongValue(long val) {
-		int length = 0;
-		for (int i=0;i<8;i++)
-			if (val >= 1L<<(i*8) || val < 0) length++;
-			else break;
-		value = new byte[length];
-		for (int i=0;i<length;i++)
-			value[length - i - 1] = (byte) (val >> i*8);
+	    long[] tab = {
+	                         0x00L, // 0 bytes
+	                         0x01L, // 1 byte
+	                        0x100L, // 2 bytes
+	                      0x10000L,
+	                    0x1000000L,
+	                  0x100000000L,
+	                0x10000000000L,
+	              0x1000000000000L, // 7 bytes
+	    };
+	    int length = 0, b = 4;
+	    if (val < 0L || val >= 0x100000000000000L)
+	        length = 8;
+	    else {
+	        // this loop repeats four times to get log_0x100(value) rounded upwards.
+	        while (b != 0) {
+	            if (val >= tab[length + b])
+	                length += b;
+	            b >>= 1;
+	        }
+	    }
+	    value = new byte[length];
+		while (length > 0) {
+		    value[--length] = (byte) (val & 0xff);
+		    val >>>= 8;
 		}
-	
+	}
+
 	/**
 	 * Checks if is this option is critical.
 	 *
@@ -253,7 +263,7 @@ public class Option implements Comparable<Option> {
 	 */
 	public boolean isCritical() {
 		// Critical = (onum & 1);
-		return (number & 1) != 0;
+	    return number.isCritical();
 	}
 	
 	/**
@@ -263,7 +273,7 @@ public class Option implements Comparable<Option> {
 	 */
 	public boolean isUnSafe() {
 		// UnSafe = (onum & 2);
-		return (number & 2) != 0;
+		return number.isUnsafe();
 	}
 	
 	/**
@@ -273,7 +283,7 @@ public class Option implements Comparable<Option> {
 	 */
 	public boolean isNoCacheKey() {
 		// NoCacheKey = ((onum & 0x1e) == 0x1c);
-		return (number & 0x1E) == 0x1C;
+		return number.isNoCacheKey();
 	}
 	
 	/* (non-Javadoc)
@@ -281,7 +291,7 @@ public class Option implements Comparable<Option> {
 	 */
 	@Override
 	public int compareTo(Option o) {
-		return number - o.number;
+		return number.getProtocolValue() - o.number.getProtocolValue();
 	}
 	
 	/* (non-Javadoc)
@@ -303,7 +313,7 @@ public class Option implements Comparable<Option> {
 	 */
 	@Override
 	public int hashCode() {
-		return number*31 + value.hashCode();
+		return number.getProtocolValue()*31 + value.hashCode();
 	}
 	
 	/* (non-Javadoc)
@@ -312,7 +322,7 @@ public class Option implements Comparable<Option> {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append(OptionNumberRegistry.toString(number));
+		sb.append(number.toString());
 		sb.append(": ");
 		sb.append(toValueString());
 		return sb.toString();
@@ -324,7 +334,7 @@ public class Option implements Comparable<Option> {
 	 * @return the option value as string
 	 */
 	public String toValueString() {
-		switch (OptionNumberRegistry.getFormatByNr(number)) {
+		switch (number.getFormat()) {
 		case INTEGER:
 			if (number==OptionNumberRegistry.ACCEPT || number==OptionNumberRegistry.CONTENT_FORMAT) return "\""+MediaTypeRegistry.toString(getIntegerValue())+"\"";
 			else if (number==OptionNumberRegistry.BLOCK1 || number==OptionNumberRegistry.BLOCK2) return "\""+ new BlockOption(value) +"\"";

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/OptionNumberRegistry.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/OptionNumberRegistry.java
@@ -19,318 +19,211 @@
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
+import java.util.Map;
+import java.util.TreeMap;
+
 /**
- * This class describes the CoAP Option Number Registry as defined in
- * RFC 7252, Section 12.2 and other CoAP extensions.
+ * This class describes the CoAP Option Number Registry as defined in RFC 7252,
+ * Section 12.2 and other CoAP extensions.
  */
-public final class OptionNumberRegistry {
-	public static final int UNKNOWN			= -1;
-	
-	// RFC 7252
-	public static final int RESERVED_0		= 0;
-	public static final int IF_MATCH		= 1;
-	public static final int URI_HOST		= 3;
-	public static final int ETAG			= 4;
-	public static final int IF_NONE_MATCH	= 5;
-	public static final int URI_PORT		= 7;
-	public static final int LOCATION_PATH	= 8;
-	public static final int URI_PATH		= 11;
-	public static final int CONTENT_FORMAT	= 12;
-	public static final int MAX_AGE			= 14;
-	public static final int URI_QUERY		= 15;
-	public static final int ACCEPT			= 17;
-	public static final int LOCATION_QUERY	= 20;
-	public static final int PROXY_URI		= 35;
-	public static final int PROXY_SCHEME	= 39;
-	public static final int SIZE1			= 60;
-	public static final int RESERVED_1		= 128;
-	public static final int RESERVED_2		= 132;
-	public static final int RESERVED_3		= 136;
-	public static final int RESERVED_4		= 140;
+public enum OptionNumberRegistry {
+    IF_MATCH(       1, true,  false, optionFormats.OPAQUE,  "If-Match"), 
+    URI_HOST(       3, false, true,  optionFormats.STRING,  "Uri-Host"), 
+    ETAG(           4, true,  false, optionFormats.OPAQUE,  "ETag"), 
+    IF_NONE_MATCH(  5, false, false, optionFormats.INTEGER, "If-None-Match"), 
+    OBSERVE(        6, false, false, optionFormats.INTEGER, "Observe"), 
+    URI_PORT(       7, false, true,  optionFormats.INTEGER, "Uri-Port"), 
+    LOCATION_PATH(  8, true,  false, optionFormats.STRING,  "Location-Path"), 
+    URI_PATH(      11, true,  true,  optionFormats.STRING,  "Uri-Path"), 
+    CONTENT_FORMAT(12, false, false, optionFormats.INTEGER, "Content-Format"), 
+    MAX_AGE(       14, false, false, optionFormats.INTEGER, "Max-Age"), 
+    URI_QUERY(     15, true,  true,  optionFormats.STRING,  "Uri-Query"),
+    ACCEPT(        17, false, false, optionFormats.INTEGER, "Accept"),
+    LOCATION_QUERY(20, true,  false, optionFormats.STRING,  "Location-Query"),
+    BLOCK2(        23, false, false, optionFormats.INTEGER, "Block2"),
+    BLOCK1(        27, false, false, optionFormats.INTEGER, "Block1"),
+    SIZE2(         28, false, false, optionFormats.INTEGER, "Size2"),
+    PROXY_URI(     35, false, false, optionFormats.STRING,  "Proxy-Uri"),
+    PROXY_SCHEME(  39, false, false, optionFormats.STRING,  "Proxy-Scheme"),
+    SIZE1(         60, false, false, optionFormats.INTEGER, "Size1"),
+    ;
 
-	// draft-ietf-core-observe-14
-	public static final int OBSERVE			= 6;
+    private static Map<String, OptionNumberRegistry> m_mapByName;
+    private static Map<Integer, OptionNumberRegistry> m_mapByNumber;
+    
+    private int m_protocolValue;
+    private boolean m_isRepeatable;
+    private boolean m_isUriPart;
+    private String m_name;
+    private optionFormats m_format;
 
-	// draft-ietf-core-block-14
-	public static final int BLOCK2			= 23;
-	public static final int BLOCK1			= 27;
-	public static final int SIZE2			= 28;
+    OptionNumberRegistry(
+            int protocolValue,
+            boolean isRepeatable,
+            boolean isUriPart,
+            optionFormats format,
+            String name)
+    {
+        m_protocolValue = protocolValue;
+        m_isRepeatable = isRepeatable;
+        m_isUriPart = isUriPart;
+        m_name = name;
+        m_format = format;
+    }
 
-	/**
-	 * Option names.
-	 */
-	public static class Names {
-		public static final String Reserved 		= "Reserved";
-		
-		public static final String If_Match 		= "If-Match";
-		public static final String Uri_Host 		= "Uri-Host";
-		public static final String ETag 			= "ETag";
-		public static final String If_None_Match 	= "If-None-Match";
-		public static final String Uri_Port 		= "Uri-Port";
-		public static final String Location_Path 	= "Location-Path";
-		public static final String Uri_Path 		= "Uri-Path";
-		public static final String Content_Format	= "Content-Format";
-		public static final String Max_Age 			= "Max-Age";
-		public static final String Uri_Query 		= "Uri-Query";
-		public static final String Accept 			= "Accept";
-		public static final String Location_Query 	= "Location-Query";
-		public static final String Proxy_Uri 		= "Proxy-Uri";
-		public static final String Proxy_Scheme		= "Proxy-Scheme";
-		public static final String Size1			= "Size1";
+    
+     /**
+      * Option default values.
+      */
+    public static class Defaults {
 
-		public static final String Observe			= "Observe";
+        /** The default Max-Age. */
+        public static final long MAX_AGE = 60L;
+    }
 
-		public static final String Block2			= "Block2";
-		public static final String Block1			= "Block1";
-		public static final String Size2			= "Size2";
-	}
-	
-	/**
-	 * Option default values.
-	 */
-	public static class Defaults {
-		
-		/** The default Max-Age. */
-		public static final long MAX_AGE = 60L;
-	}
+    /**
+     * The format types of CoAP options.
+     */
+    public static enum optionFormats {
+        INTEGER, STRING, OPAQUE, UNKNOWN
+    }
 
-	/**
-	 * The format types of CoAP options.
-	 */
-	public static enum optionFormats {
-		INTEGER, STRING, OPAQUE, UNKNOWN
-	}
+    /**
+     * Returns the option format based on the option number.
+     * 
+     * @return The option format corresponding to the option number
+     */
+    public optionFormats getFormat() {
+        return m_format;
+    }
+    
+    /**
+     * Gets the protocol value for this {@link OptionNumberRegistry}.
+     * @return the protocol value.
+     */
+    public int getProtocolValue() {
+        return m_protocolValue;
+    }
 
-	/**
-	 * Returns the option format based on the option number.
-	 * 
-	 * @param optionNumber
-	 *            The option number
-	 * @return The option format corresponding to the option number
-	 */
-	public static optionFormats getFormatByNr(int optionNumber) {
-		switch (optionNumber) {
-		case CONTENT_FORMAT:
-		case MAX_AGE:
-		case URI_PORT:
-		case OBSERVE:
-		case BLOCK2:
-		case BLOCK1:
-		case SIZE2:
-		case SIZE1:
-		case IF_NONE_MATCH:
-		case ACCEPT:
-			return optionFormats.INTEGER;
-		case URI_HOST:
-		case URI_PATH:
-		case URI_QUERY:
-		case LOCATION_PATH:
-		case LOCATION_QUERY:
-		case PROXY_URI:
-		case PROXY_SCHEME:
-			return optionFormats.STRING;
-		case ETAG:
-		case IF_MATCH:
-			return optionFormats.OPAQUE;
-		default:
-			return optionFormats.UNKNOWN;
-		}
-	}
+    /**
+     * Checks whether an option is critical.
+     * 
+     * @return {@code true} if the option is critical
+     */
+    public boolean isCritical() {
+        return (m_protocolValue & 0x01) != 0;
+    }
 
-	/**
-	 * Checks whether an option is critical.
-	 * 
-	 * @param optionNumber
-	 *            The option number to check
-	 * @return {@code true} if the option is critical
-	 */
-	public static boolean isCritical(int optionNumber) {
-		return (optionNumber & 1) > 1;
-	}
+    /**
+     * Checks whether an option is elective.
+     * 
+     * @return {@code true} if the option is elective
+     */
+    public boolean isElective() {
+        return !isCritical();
+    }
 
-	/**
-	 * Checks whether an option is elective.
-	 * 
-	 * @param optionNumber
-	 *            The option number to check
-	 * @return {@code true} if the option is elective
-	 */
-	public static boolean isElective(int optionNumber) {
-		return (optionNumber & 1) == 0;
-	}
+    /**
+     * Checks whether an option is unsafe.
+     * 
+     * @return {@code true} if the option is unsafe
+     */
+    public boolean isUnsafe() {
+        return (m_protocolValue & 0x02) != 0;
+    }
 
-	/**
-	 * Checks whether an option is unsafe.
-	 * 
-	 * @param optionNumber
-	 *            The option number to check
-	 * @return {@code true} if the option is unsafe
-	 */
-	public static boolean isUnsafe(int optionNumber) {
-		// When bit 6 is 1, an option is Unsafe
-		return (optionNumber & 2) > 0;
-	}
-	
-	/**
-	 * Checks whether an option is safe.
-	 * 
-	 * @param optionNumber
-	 *            The option number to check
-	 * @return {@code true} if the option is safe
-	 */
-	public static boolean isSafe(int optionNumber) {
-		return !isUnsafe(optionNumber);
-	}
+    /**
+     * Checks whether an option is safe.
+     * 
+     * @return {@code true} if the option is safe
+     */
+    public boolean isSafe() {
+        return !isUnsafe();
+    }
 
-	/**
-	 * Checks whether an option is not a cache-key.
-	 * 
-	 * @param optionNumber
-	 *            The option number to check
-	 * @return {@code true} if the option is not a cache-key
-	 */
-	public static boolean isNoCacheKey(int optionNumber) {
-		/*
-		 * When an option is not Unsafe, it is not a Cache-Key (NoCacheKey) if
-		 * and only if bits 3-5 are all set to 1; all other bit combinations
-		 * mean that it indeed is a Cache-Key
-		 */
-		return (optionNumber & 0x1E) == 0x1C;
-	}
-	
-	/**
-	 * Checks whether an option is a cache-key.
-	 * 
-	 * @param optionNumber
-	 *            The option number to check
-	 * @return {@code true} if the option is a cache-key
-	 */
-	public static boolean isCacheKey(int optionNumber) {
-		return !isNoCacheKey(optionNumber);
-	}
+    /**
+     * Checks whether an option is not a cache-key.
+     * 
+     * @return {@code true} if the option is not a cache-key
+     */
+    public boolean isNoCacheKey() {
+        /*
+         * When an option is not Unsafe, it is not a Cache-Key (NoCacheKey) if
+         * and only if bits 3-5 are all set to 1; all other bit combinations
+         * mean that it indeed is a Cache-Key
+         */
+        return (m_protocolValue & 0x1E) == 0x1C;
+    }
 
-	/**
-	 * Checks if is single value.
-	 * 
-	 * @param optionNumber
-	 *            the option number
-	 * @return {@code true} if is single value
-	 */
-	public static boolean isSingleValue(int optionNumber) {
-		switch (optionNumber) {
-		case CONTENT_FORMAT:
-		case MAX_AGE:
-		case PROXY_URI:
-		case PROXY_SCHEME:
-		case URI_HOST:
-		case URI_PORT:
-		case IF_NONE_MATCH:
-			return true;
-		case ETAG:
-		case ACCEPT:
-		case IF_MATCH:
-		case URI_PATH:
-		case URI_QUERY:
-		case LOCATION_PATH:
-		case LOCATION_QUERY:
-		default:
-			return false;
-		}
-	}
+    /**
+     * Checks whether an option is a cache-key.
+     * 
+     * @param optionNumber
+     *            The option number to check
+     * @return {@code true} if the option is a cache-key
+     */
+    public boolean isCacheKey() {
+        return !isNoCacheKey();
+    }
 
-	/**
-	 * Checks if is uri option.
-	 * 
-	 * @param optionNumber
-	 *            the option number
-	 * @return {@code true} if is uri option
-	 */
-	public static boolean isUriOption(int optionNumber) {
-		boolean result = optionNumber == URI_HOST || optionNumber == URI_PATH || optionNumber == URI_PORT || optionNumber == URI_QUERY;
-		return result;
-	}
+    /**
+     * Checks if this option is repeatable.
+     * @return {@code true} if is repeatable.
+     */
+    public boolean isRepeatable() {
+        return m_isRepeatable;
+    }
+    
+    /**
+     * Checks if is single value.
+     * 
+     * @param optionNumber
+     *            the option number
+     * @return {@code true} if is single value
+     */
+    public boolean isSingleValue() {
+        return !m_isRepeatable;
+    }
 
-	/**
-	 * Returns a string representation of the option number.
-	 * 
-	 * @param optionNumber
-	 *            the option number to describe
-	 * @return a string describing the option number
-	 */
-	public static String toString(int optionNumber) {
-		switch (optionNumber) {
-		case RESERVED_0:
-		case RESERVED_1:
-		case RESERVED_2:
-		case RESERVED_3:
-		case RESERVED_4:
-			return Names.Reserved;
-		case IF_MATCH:
-			return Names.If_Match;
-		case URI_HOST:
-			return Names.Uri_Host;
-		case ETAG:
-			return Names.ETag;
-		case IF_NONE_MATCH:
-			return Names.If_None_Match;
-		case URI_PORT:
-			return Names.Uri_Port;
-		case LOCATION_PATH:
-			return Names.Location_Path;
-		case URI_PATH:
-			return Names.Uri_Path;
-		case CONTENT_FORMAT:
-			return Names.Content_Format;
-		case MAX_AGE:
-			return Names.Max_Age;
-		case URI_QUERY:
-			return Names.Uri_Query;
-		case ACCEPT:
-			return Names.Accept;
-		case LOCATION_QUERY:
-			return Names.Location_Query;
-		case PROXY_URI:
-			return Names.Proxy_Uri;
-		case PROXY_SCHEME:
-			return Names.Proxy_Scheme;
-		case OBSERVE:
-			return Names.Observe;
-		case BLOCK2:
-			return Names.Block2;
-		case BLOCK1:
-			return Names.Block1;
-		case SIZE2:
-			return Names.Size2;
-		case SIZE1:
-			return Names.Size1;
-		default:
-			return String.format("Unknown (%d)", optionNumber);
-		}
-	}
-	
-	public static int toNumber(String name) {
-		if (Names.If_Match.equals(name))			return IF_MATCH;
-		else if (Names.Uri_Host.equals(name))		return URI_HOST;
-		else if (Names.ETag.equals(name)) 			return ETAG;
-		else if (Names.If_None_Match.equals(name)) return IF_NONE_MATCH;
-		else if (Names.Uri_Port.equals(name))		return URI_PORT;
-		else if (Names.Location_Path.equals(name))	return LOCATION_PATH;
-		else if (Names.Uri_Path.equals(name))		return URI_PATH;
-		else if (Names.Content_Format.equals(name))return CONTENT_FORMAT;
-		else if (Names.Max_Age.equals(name)) 		return MAX_AGE;
-		else if (Names.Uri_Query.equals(name))		return URI_QUERY;
-		else if (Names.Accept.equals(name))		return ACCEPT;
-		else if (Names.Location_Query.equals(name))return LOCATION_QUERY;
-		else if (Names.Proxy_Uri.equals(name)) 	return PROXY_URI;
-		else if (Names.Proxy_Scheme.equals(name)) 	return PROXY_SCHEME;
-		else if (Names.Observe.equals(name))		return OBSERVE;
-		else if (Names.Block2.equals(name))		return BLOCK2;
-		else if (Names.Block1.equals(name))		return BLOCK1;
-		else if (Names.Size2.equals(name))			return SIZE2;
-		else if (Names.Size1.equals(name))			return SIZE1;
-		else return UNKNOWN;
-	}
+    /**
+     * Checks if is uri option.
+     * 
+     * @return {@code true} if is uri option
+     */
+    public boolean isUriOption() {
+        return m_isUriPart;
+    }
 
-	private OptionNumberRegistry() {
-	}
+    /**
+     * Returns a string representation of the option number.
+     * 
+     * @param optionNumber
+     *            the option number to describe
+     * @return a string describing the option number
+     */
+    @Override
+    public String toString() {
+        return m_name;
+    }
+
+    public static OptionNumberRegistry parse(String name) {
+        if (m_mapByName == null) {
+            m_mapByName = new TreeMap<String, OptionNumberRegistry>();
+            for (OptionNumberRegistry v: OptionNumberRegistry.values()) {
+                m_mapByName.put(v.toString(), v);
+            }
+        }
+        return m_mapByName.get(name);
+    }
+    
+    public static OptionNumberRegistry parse(int protocolValue) {
+        if (m_mapByNumber == null) {
+            m_mapByNumber = new TreeMap<Integer, OptionNumberRegistry>();
+            for (OptionNumberRegistry v: OptionNumberRegistry.values()) {
+                m_mapByNumber.put(v.getProtocolValue(), v);
+            }
+        }
+        return m_mapByNumber.get(protocolValue);
+    }
+
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/OptionSet.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/OptionSet.java
@@ -1251,7 +1251,7 @@ public class OptionSet {
 	 * @param number the option number
 	 * @return true if present
 	 */
-	public boolean hasOption(int number) {
+	public boolean hasOption(OptionNumberRegistry number) {
 		return Collections.binarySearch(asSortedList(), new Option(number)) >= 0;
 	}
 	
@@ -1327,25 +1327,25 @@ public class OptionSet {
 	 */
 	public OptionSet addOption(Option option) {
 		switch (option.getNumber()) {
-			case OptionNumberRegistry.IF_MATCH:       addIfMatch(option.getValue()); break;
-			case OptionNumberRegistry.URI_HOST:       setUriHost(option.getStringValue()); break;
-			case OptionNumberRegistry.ETAG:           addETag(option.getValue()); break;
-			case OptionNumberRegistry.IF_NONE_MATCH:  setIfNoneMatch(true); break;
-			case OptionNumberRegistry.URI_PORT:       setUriPort(option.getIntegerValue()); break;
-			case OptionNumberRegistry.LOCATION_PATH:  addLocationPath(option.getStringValue()); break;
-			case OptionNumberRegistry.URI_PATH:       addUriPath(option.getStringValue()); break;
-			case OptionNumberRegistry.CONTENT_FORMAT: setContentFormat(option.getIntegerValue()); break;
-			case OptionNumberRegistry.MAX_AGE:        setMaxAge(option.getLongValue()); break;
-			case OptionNumberRegistry.URI_QUERY:      addUriQuery(option.getStringValue()); break;
-			case OptionNumberRegistry.ACCEPT:         setAccept(option.getIntegerValue()); break;
-			case OptionNumberRegistry.LOCATION_QUERY: addLocationQuery(option.getStringValue()); break;
-			case OptionNumberRegistry.PROXY_URI:      setProxyUri(option.getStringValue()); break;
-			case OptionNumberRegistry.PROXY_SCHEME:   setProxyScheme(option.getStringValue()); break;
-			case OptionNumberRegistry.BLOCK1:         setBlock1(option.getValue()); break;
-			case OptionNumberRegistry.BLOCK2:         setBlock2(option.getValue()); break;
-			case OptionNumberRegistry.SIZE1:          setSize1(option.getIntegerValue()); break;
-			case OptionNumberRegistry.SIZE2:          setSize2(option.getIntegerValue()); break;
-			case OptionNumberRegistry.OBSERVE:        setObserve(option.getIntegerValue()); break;
+			case IF_MATCH:       addIfMatch(option.getValue()); break;
+			case URI_HOST:       setUriHost(option.getStringValue()); break;
+			case ETAG:           addETag(option.getValue()); break;
+			case IF_NONE_MATCH:  setIfNoneMatch(true); break;
+			case URI_PORT:       setUriPort(option.getIntegerValue()); break;
+			case LOCATION_PATH:  addLocationPath(option.getStringValue()); break;
+			case URI_PATH:       addUriPath(option.getStringValue()); break;
+			case CONTENT_FORMAT: setContentFormat(option.getIntegerValue()); break;
+			case MAX_AGE:        setMaxAge(option.getLongValue()); break;
+			case URI_QUERY:      addUriQuery(option.getStringValue()); break;
+			case ACCEPT:         setAccept(option.getIntegerValue()); break;
+			case LOCATION_QUERY: addLocationQuery(option.getStringValue()); break;
+			case PROXY_URI:      setProxyUri(option.getStringValue()); break;
+			case PROXY_SCHEME:   setProxyScheme(option.getStringValue()); break;
+			case BLOCK1:         setBlock1(option.getValue()); break;
+			case BLOCK2:         setBlock2(option.getValue()); break;
+			case SIZE1:          setSize1(option.getIntegerValue()); break;
+			case SIZE2:          setSize2(option.getIntegerValue()); break;
+			case OBSERVE:        setObserve(option.getIntegerValue()); break;
 			default: getOthers().add(option);
 		}
 		return this;
@@ -1355,14 +1355,14 @@ public class OptionSet {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		StringBuilder sbv = new StringBuilder();
-		int oldNr = -1;
+		OptionNumberRegistry oldNr = null;
 		boolean list = false;
 
 		sb.append('{');
 		
 		for (Option opt : asSortedList()) {
 			if (opt.getNumber()!=oldNr) {
-				if (oldNr!=-1) {
+				if (oldNr!=null) {
 					if (list) sbv.append(']');
 					sb.append(sbv.toString());
 					sbv = new StringBuilder();
@@ -1372,7 +1372,7 @@ public class OptionSet {
 				list = false;
 				
 				sb.append('"');
-				sb.append(OptionNumberRegistry.toString(opt.getNumber()));
+				sb.append(opt.getNumber().toString());
 				sb.append('"');
 				sb.append(':');
 			} else {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/OriginTracer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/OriginTracer.java
@@ -52,7 +52,8 @@ public class OriginTracer implements MessageInterceptor {
 			fh = new FileHandler("origin-trace/origin-trace-" + month + ".txt", true);
 			SimpleFormatter formatter = new SimpleFormatter() {
 				public String format(LogRecord record) {
-					return String.format("%s\t%s%s", dateFormat.format(new Date()), record.getMessage(), System.lineSeparator());
+					String message = formatMessage(record);
+					return String.format("%s\t%s%s", dateFormat.format(new Date()), message, System.lineSeparator());
 				}
 			};
 			fh.setFormatter(formatter);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataParser.java
@@ -35,6 +35,7 @@ import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.Option;
+import org.eclipse.californium.core.coap.OptionNumberRegistry;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.CoAP.Code;
@@ -147,7 +148,7 @@ public class DataParser {
 				int optionLength = readOptionValueFromNibble(optionLengthNibble);
 				
 				// read option
-				Option option = new Option(currentOption);
+				Option option = new Option(OptionNumberRegistry.parse(currentOption));
 				option.setValue(reader.readBytes(optionLength));
 				
 				// add option to message

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
@@ -80,7 +80,7 @@ public class DataSerializer {
 		for (Option option:options) {
 			
 			// write 4-bit option delta
-			int optionDelta = option.getNumber() - lastOptionNumber;
+			int optionDelta = option.getNumber().getProtocolValue() - lastOptionNumber;
 			int optionDeltaNibble = getOptionNibble(optionDelta);
 			writer.write(optionDeltaNibble, OPTION_DELTA_BITS);
 			
@@ -107,7 +107,7 @@ public class DataSerializer {
 			writer.writeBytes(option.getValue());
 
 			// update last option number
-			lastOptionNumber = option.getNumber();
+			lastOptionNumber = option.getNumber().getProtocolValue();
 		}
 		
 		byte[] payload = message.getPayload();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/OptionTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/OptionTest.java
@@ -143,9 +143,9 @@ public class OptionTest {
 		assertArrayEquals(option.getValue(), new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
 		assertEquals(0xFFFFFFFFL, option.getLongValue());
 
-		option.setLongValue(0x9823749837239845L);
-		assertArrayEquals(option.getValue(), new byte[] {-104, 35, 116, -104, 55, 35, -104, 69});
-		assertEquals(0x9823749837239845L, option.getLongValue());
+		//option.setLongValue(0x9823749837239845L);
+		//assertArrayEquals(option.getValue(), new byte[] {-104, 35, 116, -104, 55, 35, -104, 69});
+		//assertEquals(0x9823749837239845L, option.getLongValue());
 
 		option.setLongValue(0xFFFFFFFFFFFFFFFFL);
 		assertArrayEquals(option.getValue(), new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
@@ -211,25 +211,26 @@ public class OptionTest {
 	
 	@Test
 	public void testArbitraryOptions() {
+	    // arbitrary options not present in OptionNumberRegistry are not allowed anymore.
 		OptionSet options = new OptionSet();
 		options.addETag(new byte[] {1, 2, 3});
 		options.addLocationPath("abc");
-		options.addOption(new Option(7));
-		options.addOption(new Option(43));
-		options.addOption(new Option(33));
-		options.addOption(new Option(17));
+		options.addOption(new Option(OptionNumberRegistry.parse(7)));
+		//options.addOption(new Option(OptionNumberRegistry.parse(43)));
+		//options.addOption(new Option(OptionNumberRegistry.parse(33)));
+		options.addOption(new Option(OptionNumberRegistry.parse(17)));
 
 		// Check that options are in the set
 		Assert.assertTrue(options.hasOption(OptionNumberRegistry.ETAG));
 		Assert.assertTrue(options.hasOption(OptionNumberRegistry.LOCATION_PATH));
-		Assert.assertTrue(options.hasOption(7));
-		Assert.assertTrue(options.hasOption(17));
-		Assert.assertTrue(options.hasOption(33));
-		Assert.assertTrue(options.hasOption(43));
+		Assert.assertTrue(options.hasOption(OptionNumberRegistry.parse(7)));
+		Assert.assertTrue(options.hasOption(OptionNumberRegistry.parse(17)));
+		//Assert.assertTrue(options.hasOption(OptionNumberRegistry.parse(33)));
+		//Assert.assertTrue(options.hasOption(OptionNumberRegistry.parse(43)));
 		
 		// Check that others are not
-		Assert.assertFalse(options.hasOption(19));
-		Assert.assertFalse(options.hasOption(53));
+		//Assert.assertFalse(options.hasOption(OptionNumberRegistry.parse(19)));
+		//Assert.assertFalse(options.hasOption(OptionNumberRegistry.parse(53)));
 		
 		// Check that we can remove options
 		options.clearETags();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/OptionTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/OptionTest.java
@@ -51,8 +51,13 @@ public class OptionTest {
 	}
 
     @Test
-    public void testEnumSize() {
+    public void testEnumSizeAndOrder() {
+        int last = 0;
         assertEquals(19, OptionNumberRegistry.values().length);
+        for (OptionNumberRegistry o: OptionNumberRegistry.values()) {
+            assertTrue(last < o.getProtocolValue());
+            last = o.getProtocolValue();
+        }
     }
 
     @Test

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/OptionTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/OptionTest.java
@@ -265,9 +265,9 @@ public class OptionTest {
 		assertArrayEquals(option.getValue(), new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
 		assertEquals(0xFFFFFFFFL, option.getLongValue());
 
-		//option.setLongValue(0x9823749837239845L);
-		//assertArrayEquals(option.getValue(), new byte[] {-104, 35, 116, -104, 55, 35, -104, 69});
-		//assertEquals(0x9823749837239845L, option.getLongValue());
+		option.setLongValue(0x9823749837239845L);
+		assertArrayEquals(option.getValue(), new byte[] {-104, 35, 116, -104, 55, 35, -104, 69});
+		assertEquals(0x9823749837239845L, option.getLongValue());
 
 		option.setLongValue(0xFFFFFFFFFFFFFFFFL);
 		assertArrayEquals(option.getValue(), new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ParserTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ParserTest.java
@@ -23,12 +23,11 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.eclipse.californium.core.coap.Option;
-import org.eclipse.californium.core.coap.Request;
-import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.serialization.DataParser;
 import org.eclipse.californium.core.network.serialization.DataSerializer;
 import org.junit.Test;
@@ -70,11 +69,11 @@ public class ParserTest {
 		response.setMID(9);
 		response.setToken(new byte[] {22, -1, 0, 78, 100, 22});
 		response.getOptions().addETag(new byte[] {1, 0, 0, 0, 0, 1})
-							.addLocationPath("/one/two/three/four/five/six/seven/eight/nine/ten")
-							.addOption(new Option(57453, "Arbitrary".hashCode()))
-							.addOption(new Option(19205, "Arbitrary1"))
-							.addOption(new Option(19205, "Arbitrary2"))
-							.addOption(new Option(19205, "Arbitrary3"));
+							.addLocationPath("/one/two/three/four/five/six/seven/eight/nine/ten");
+//							.addOption(new Option(57453, "Arbitrary".hashCode()))
+//							.addOption(new Option(19205, "Arbitrary1"))
+//							.addOption(new Option(19205, "Arbitrary2"))
+//							.addOption(new Option(19205, "Arbitrary3"));
 		
 		DataSerializer serializer = new DataSerializer();
 		byte[] bytes = serializer.serializeResponse(response);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -443,11 +443,11 @@ public class BlockwiseClientSideTest {
 		server.expectRequest(CON, GET, path).storeToken("At").storeMID("Am").observe(0).go();
 		server.sendResponse(ACK, CONTENT).loadToken("At").loadMID("Am").observe(62350).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
 		
-		server.expectRequest(CON, GET, path).storeBoth("B").noOption(OBSERVE).block2(1, false, 128).go();
+		server.expectRequest(CON, GET, path).storeBoth("B").noOption(OBSERVE.getProtocolValue()).block2(1, false, 128).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
 		
 		// TODO: Is is mandatory that token C is the same as B?
-		server.expectRequest(CON, GET, path).storeBoth("C").noOption(OBSERVE).block2(2, false, 128).go();
+		server.expectRequest(CON, GET, path).storeBoth("C").noOption(OBSERVE.getProtocolValue()).block2(2, false, 128).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 128).payload(respPayload.substring(256, 300)).go();
 		
 		Response response = request.waitForResponse(1000);
@@ -463,10 +463,10 @@ public class BlockwiseClientSideTest {
 		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(62354).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
 		server.expectEmpty(ACK, mid).go();
 		
-		server.expectRequest(CON, GET, path).storeBoth("D").noOption(OBSERVE).block2(1, false, 128).go();
+		server.expectRequest(CON, GET, path).storeBoth("D").noOption(OBSERVE.getProtocolValue()).block2(1, false, 128).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("D").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
 		
-		server.expectRequest(CON, GET, path).storeBoth("E").noOption(OBSERVE).block2(2, false, 128).go();
+		server.expectRequest(CON, GET, path).storeBoth("E").noOption(OBSERVE.getProtocolValue()).block2(2, false, 128).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("E").block2(2, false, 128).payload(respPayload.substring(256, 280)).go();
 		
 		Response notification1 = request.waitForResponse(1000);
@@ -483,14 +483,14 @@ public class BlockwiseClientSideTest {
 		server.expectEmpty(ACK, mid).go();
 
 		// expect blockwise transfer for second notification
-		server.expectRequest(CON, GET, path).storeBoth("F").noOption(OBSERVE).block2(1, false, 128).go();
+		server.expectRequest(CON, GET, path).storeBoth("F").noOption(OBSERVE.getProtocolValue()).block2(1, false, 128).go();
 		
 		System.out.println("Send third notification during transfer");
 		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(19).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
 		server.expectEmpty(ACK, mid).go();
 		
 		// expect blockwise transfer for third notification
-		server.expectRequest(CON, GET, path).storeBoth("G").noOption(OBSERVE).block2(1, false, 128).go();
+		server.expectRequest(CON, GET, path).storeBoth("G").noOption(OBSERVE.getProtocolValue()).block2(1, false, 128).go();
 		
 		System.out.println("Send old notification during transfer");
 		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(18).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
@@ -498,7 +498,7 @@ public class BlockwiseClientSideTest {
 		
 		server.sendResponse(ACK, CONTENT).loadBoth("G").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
 		
-		server.expectRequest(CON, GET, path).storeBoth("H").noOption(OBSERVE).block2(2, false, 128).go();
+		server.expectRequest(CON, GET, path).storeBoth("H").noOption(OBSERVE.getProtocolValue()).block2(2, false, 128).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("H").block2(2, false, 128).payload(respPayload.substring(256, 290)).go();
 
 		Response notification2 = request.waitForResponse(1000);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
@@ -669,10 +669,10 @@ public class BlockwiseServerSideTest {
 
 		byte[] tok1 = generateNextToken();
 		client.sendRequest(CON, GET, tok1, ++mid).path(path).block2(1, false, 128).go();
-		client.expectResponse(ACK, CONTENT, tok1, mid).block2(1, true, 128).noOption(OBSERVE).payload(respPayload.substring(128, 256)).go();
+		client.expectResponse(ACK, CONTENT, tok1, mid).block2(1, true, 128).noOption(OBSERVE.getProtocolValue()).payload(respPayload.substring(128, 256)).go();
 
 		client.sendRequest(CON, GET, tok1, ++mid).path(path).block2(2, false, 128).go();
-		client.expectResponse(ACK, CONTENT, tok1, mid).block2(2, false, 128).noOption(OBSERVE).payload(respPayload.substring(256, 300)).go();
+		client.expectResponse(ACK, CONTENT, tok1, mid).block2(2, false, 128).noOption(OBSERVE.getProtocolValue()).payload(respPayload.substring(256, 300)).go();
 
 		serverInterceptor.log("\n... time passes ...");
 		System.out.println("Send first notification");
@@ -685,10 +685,10 @@ public class BlockwiseServerSideTest {
 
 		byte[] tok2 = generateNextToken();
 		client.sendRequest(CON, GET, tok2, ++mid).path(path).block2(1, false, 128).go();
-		client.expectResponse(ACK, CONTENT, tok2, mid).block2(1, true, 128).noOption(OBSERVE).payload(respPayload.substring(128, 256)).go();
+		client.expectResponse(ACK, CONTENT, tok2, mid).block2(1, true, 128).noOption(OBSERVE.getProtocolValue()).payload(respPayload.substring(128, 256)).go();
 		
 		client.sendRequest(CON, GET, tok2, ++mid).path(path).block2(2, false, 128).go();
-		client.expectResponse(ACK, CONTENT, tok2, mid).block2(2, false, 128).noOption(OBSERVE).payload(respPayload.substring(256, 280)).go();
+		client.expectResponse(ACK, CONTENT, tok2, mid).block2(2, false, 128).noOption(OBSERVE.getProtocolValue()).payload(respPayload.substring(256, 280)).go();
 		
 		System.out.println("Send second notification");
 		serverInterceptor.log("\n... time passes ...");
@@ -701,10 +701,10 @@ public class BlockwiseServerSideTest {
 
 		byte[] tok3 = generateNextToken();
 		client.sendRequest(CON, GET, tok3, ++mid).path(path).block2(1, false, 128).go();
-		client.expectResponse(ACK, CONTENT, tok3, mid).block2(1, true, 128).noOption(OBSERVE).payload(respPayload.substring(128, 256)).go();
+		client.expectResponse(ACK, CONTENT, tok3, mid).block2(1, true, 128).noOption(OBSERVE.getProtocolValue()).payload(respPayload.substring(128, 256)).go();
 		
 		client.sendRequest(CON, GET, tok3, ++mid).path(path).block2(2, false, 128).go();
-		client.expectResponse(ACK, CONTENT, tok3, mid).block2(2, false, 128).noOption(OBSERVE).payload(respPayload.substring(256, 290)).go();
+		client.expectResponse(ACK, CONTENT, tok3, mid).block2(2, false, 128).noOption(OBSERVE.getProtocolValue()).payload(respPayload.substring(256, 290)).go();
 		
 		printServerLog();
 	}
@@ -724,10 +724,10 @@ public class BlockwiseServerSideTest {
 		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 64).observe(0).block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
 		
 		client.sendRequest(CON, GET, tok, ++mid).path(path).block2(1, false, 64).go();
-		client.expectResponse(ACK, CONTENT, tok, mid).block2(1, true, 64).noOption(OBSERVE).payload(respPayload.substring(64, 128)).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(1, true, 64).noOption(OBSERVE.getProtocolValue()).payload(respPayload.substring(64, 128)).go();
 
 		client.sendRequest(CON, GET, tok, ++mid).path(path).block2(2, false, 64).go();
-		client.expectResponse(ACK, CONTENT, tok, mid).block2(2, false, 64).noOption(OBSERVE).payload(respPayload.substring(128, 150)).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(2, false, 64).noOption(OBSERVE.getProtocolValue()).payload(respPayload.substring(128, 150)).go();
 		
 		System.out.println("Send first notification");
 		serverInterceptor.log("\n... time passes ...");
@@ -740,10 +740,10 @@ public class BlockwiseServerSideTest {
 
 		byte[] tok2 = generateNextToken();
 		client.sendRequest(CON, GET, tok2, ++mid).path(path).block2(1, false, 64).go();
-		client.expectResponse(ACK, CONTENT, tok2, mid).block2(1, true, 64).noOption(OBSERVE).payload(respPayload.substring(64, 128)).go();
+		client.expectResponse(ACK, CONTENT, tok2, mid).block2(1, true, 64).noOption(OBSERVE.getProtocolValue()).payload(respPayload.substring(64, 128)).go();
 		
 		client.sendRequest(CON, GET, tok2, ++mid).path(path).block2(2, false, 64).go();
-		client.expectResponse(ACK, CONTENT, tok2, mid).block2(2, false, 64).noOption(OBSERVE).payload(respPayload.substring(128, 140)).go();
+		client.expectResponse(ACK, CONTENT, tok2, mid).block2(2, false, 64).noOption(OBSERVE.getProtocolValue()).payload(respPayload.substring(128, 140)).go();
 		
 		System.out.println("Send second notification");
 		serverInterceptor.log("\n... time passes ...");
@@ -756,10 +756,10 @@ public class BlockwiseServerSideTest {
 
 		byte[] tok3 = generateNextToken();
 		client.sendRequest(CON, GET, tok3, ++mid).path(path).block2(1, false, 64).go();
-		client.expectResponse(ACK, CONTENT, tok3, mid).block2(1, true, 64).noOption(OBSERVE).payload(respPayload.substring(64, 128)).go();
+		client.expectResponse(ACK, CONTENT, tok3, mid).block2(1, true, 64).noOption(OBSERVE.getProtocolValue()).payload(respPayload.substring(64, 128)).go();
 		
 		client.sendRequest(CON, GET, tok3, ++mid).path(path).block2(2, false, 64).go();
-		client.expectResponse(ACK, CONTENT, tok3, mid).block2(2, false, 64).noOption(OBSERVE).payload(respPayload.substring(128, 145)).go();
+		client.expectResponse(ACK, CONTENT, tok3, mid).block2(2, false, 64).noOption(OBSERVE.getProtocolValue()).payload(respPayload.substring(128, 145)).go();
 		
 		printServerLog();
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
@@ -272,7 +272,7 @@ public class LockstepEndpoint {
 					List<Option> options = message.getOptions().asSortedList();
 					for (Option option:options) {
 						for (int n:numbers) {
-							if (option.getNumber() == n) {
+							if (option.getNumber().getProtocolValue() == n) {
 								Assert.assertTrue("Must not have option number "+n+" but has", false);
 							}
 						}


### PR DESCRIPTION
Asynchronous test is broken when running on eclipse.  Eclipse asks the user to allow the test to allow the server to listen on a UDP port, and at the same time the test is running (and passes, as no assertion has ben executed).  The assertions are being made in the callbacks and no callback is called, due to no server listening.  This has to be corrected, as the number of assertions made depend strongly on the execution speed of the tests and the server being available.

Assertions must be done in the main method call (or a subroutine from it) and not in the callbacks, as the assertions can even be made from a different thread and then the test thread will not generate the proper assertion exceptions.

I don't know at this moment if there are more tests with this behaviour, so a full check seems to be necessary on all the asynchronous Cf stuff. I was only trying to devise how to configure server and client to make asynchronous calls when I discovered this bug in the testing suite.