### PR TITLE
#32: Name thread in threadpools for easier jstack reading.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
@@ -159,7 +159,7 @@ public class CoapClient {
 	 * @return the CoAP client
 	 */
 	public CoapClient useExecutor() {
-		this.executor = Executors.newSingleThreadExecutor();
+		this.executor = Executors.newSingleThreadExecutor(new Utils.NamedThreadFactory("CoapClient#")); //$NON-NLS-1$
 		
 		// activates the executor so that this user thread starts deterministically
 		executor.execute(new Runnable() {

--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
@@ -36,9 +36,10 @@ import org.eclipse.californium.core.observe.ObserveNotificationOrderer;
  * successfully established and to cancel or refresh the relation.
  */
 public class CoapObserveRelation {
-	
+
 	/** A executor service to schedule re-registrations */
-	private static ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(new Utils.DaemonThreadFactory());
+	private static ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(//
+			new Utils.DaemonThreadFactory("CoapObserveRelation#")); //$NON-NLS-1$
 
 	/** The request. */
 	private Request request;

--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
@@ -156,7 +156,9 @@ public class CoapServer implements ServerInterface {
 		// endpoints
 		this.endpoints = new ArrayList<Endpoint>();
 		// sets the central thread pool for the protocol stage over all endpoints
-		this.executor = Executors.newScheduledThreadPool( config.getInt(NetworkConfig.Keys.PROTOCOL_STAGE_THREAD_COUNT) );
+		this.executor = Executors.newScheduledThreadPool(//
+				config.getInt(NetworkConfig.Keys.PROTOCOL_STAGE_THREAD_COUNT), //
+				new Utils.NamedThreadFactory("CoapServer#")); //$NON-NLS-1$
 		// create endpoint for each port
 		for (int port:ports)
 			addEndpoint(new CoapEndpoint(port, this.config));

--- a/californium-core/src/main/java/org/eclipse/californium/core/Utils.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/Utils.java
@@ -22,6 +22,7 @@
 package org.eclipse.californium.core;
 
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.Request;
@@ -143,15 +144,93 @@ public class Utils {
 	
 	        return sb.toString();
 	}
-	
+
+	static final ThreadGroup COAP_THREAD_GROUP = new ThreadGroup("Californium"); //$NON-NLS-1$
+
 	/**
 	 * A factory to create executor services with daemon threads.
 	 */
-	public static class DaemonThreadFactory implements ThreadFactory {
-	    public Thread newThread(Runnable r) {
-	        Thread thread = new Thread(r);
-	        thread.setDaemon(true);
-	        return thread;
-	    }
+	public static class DaemonThreadFactory extends NamedThreadFactory {
+
+		/**
+		 * Creates a new factory and sets the thread group to Californium
+		 * default group.
+		 *
+		 * @param threadPrefix the prefix, that becomes part of the name of all
+		 *            threads, created by this factory.
+		 */
+		public DaemonThreadFactory(final String threadPrefix) {
+			super(threadPrefix, null);
+		}
+
+		/**
+		 * Creates a new factory.
+		 *
+		 * @param threadPrefix the prefix, that becomes part of the name of all
+		 *            threads, created by this factory.
+		 * @param threadGroup the thread group or <code>null</code>
+		 */
+		public DaemonThreadFactory(final String threadPrefix, final ThreadGroup threadGroup) {
+			super(threadPrefix, threadGroup);
+		}
+
+		/**
+		 * @see java.util.concurrent.ThreadFactory#newThread(java.lang.Runnable)
+		 */
+		@Override
+		public Thread newThread(Runnable runnable) {
+			final Thread thread = super.newThread(runnable);
+			thread.setDaemon(true);
+			return thread;
+		}
 	}
+
+	/**
+	 * The default thread factory
+	 */
+	public static class NamedThreadFactory implements ThreadFactory {
+
+		private final ThreadGroup group;
+		private final AtomicInteger index = new AtomicInteger(1);
+		private final String prefix;
+
+		/**
+		 * Creates a new factory and sets the thread group to Californium
+		 * default group.
+		 *
+		 * @param threadPrefix the prefix, that becomes part of the name of all
+		 *            threads, created by this factory.
+		 */
+		public NamedThreadFactory(final String threadPrefix) {
+			this(threadPrefix, null);
+		}
+
+		/**
+		 * Creates a new factory.
+		 *
+		 * @param threadPrefix the prefix, that becomes part of the name of all
+		 *            threads, created by this factory.
+		 * @param threadGroup the thread group or <code>null</code>
+		 */
+		public NamedThreadFactory(final String threadPrefix, final ThreadGroup threadGroup) {
+			group = null == threadGroup ? COAP_THREAD_GROUP : threadGroup;
+			prefix = threadPrefix;
+		}
+
+		/**
+		 * @see java.util.concurrent.ThreadFactory#newThread(java.lang.Runnable)
+		 */
+		@Override
+		public Thread newThread(Runnable runnable) {
+			final Thread ret = new Thread(group, runnable, prefix + index.getAndIncrement(), 0);
+			if (ret.isDaemon()) {
+				ret.setDaemon(false);
+			}
+			if (ret.getPriority() != Thread.NORM_PRIORITY) {
+				ret.setPriority(Thread.NORM_PRIORITY);
+			}
+			return ret;
+		}
+	}
+
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -247,7 +247,8 @@ public class CoapEndpoint implements Endpoint {
 		if (this.executor == null) {
 			LOGGER.log(Level.CONFIG, "Endpoint [{0}] requires an executor to start, using default single-threaded daemon executor", getAddress());
 
-			final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(new Utils.DaemonThreadFactory());
+			final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(//
+					new Utils.DaemonThreadFactory("CoapEndpoint-" + connector.getAddress() + '#')); //$NON-NLS-1$
 			setExecutor(executor);
 			addObserver(new EndpointObserver() {
 				public void started(Endpoint endpoint) { }

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/ConcurrentCoapResource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/ConcurrentCoapResource.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.core.network.Exchange;
 
 /**
@@ -101,7 +102,8 @@ public class ConcurrentCoapResource extends CoapResource {
 	public ConcurrentCoapResource(String name) {
 		super(name);
 		this.threads = getAvailableProcessors();
-		setExecutor(Executors.newFixedThreadPool(threads));
+		setExecutor(Executors.newFixedThreadPool(threads,
+				new Utils.NamedThreadFactory("ConcurrentCoapResource-" + name + '#'))); //$NON-NLS-1$
 	}
 	
 	/**
@@ -114,7 +116,8 @@ public class ConcurrentCoapResource extends CoapResource {
 	public ConcurrentCoapResource(String name, int threads) {
 		super(name);
 		this.threads = threads;
-		setExecutor(Executors.newFixedThreadPool(threads));
+		setExecutor(Executors.newFixedThreadPool(threads,
+				new Utils.NamedThreadFactory("ConcurrentCoapResource-" + name + '#'))); //$NON-NLS-1$
 	}
 	
 	/**

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
@@ -49,7 +49,9 @@ public class UDPConnector implements Connector {
 	public final static Logger LOGGER = Logger.getLogger(UDPConnector.class.getName());
 	
 	public static final int UNDEFINED = 0;
-	
+
+	static final ThreadGroup ELEMENTS_THREAD_GROUP = new ThreadGroup("Californium/Elements"); //$NON-NLS-1$
+
 	private boolean running;
 	
 	private DatagramSocket socket;
@@ -207,8 +209,8 @@ public class UDPConnector implements Connector {
 		 *
 		 * @param name the name
 		 */
-		private NetworkStageThread(String name) {
-			super(name);
+		protected NetworkStageThread(String name) {
+			super(ELEMENTS_THREAD_GROUP, name);
 			setDaemon(true);
 		}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -117,6 +117,8 @@ public class DTLSConnector implements Connector {
 			+ 13 // DTLS record headers
 			+ MAX_CIPHERTEXT_EXPANSION;
 
+	static final ThreadGroup SCANDIUM_THREAD_GROUP = new ThreadGroup("Californium/Scandium"); //$NON-NLS-1$
+
 	private InetSocketAddress lastBindAddress;
 	private int maximumTransmissionUnit = 1280; // min. IPv6 MTU
 	private int inboundDatagramBufferSize = MAX_DATAGRAM_BUFFER_SIZE;
@@ -1490,8 +1492,8 @@ public class DTLSConnector implements Connector {
 		 *
 		 * @param name the name, e.g., of the transport protocol
 		 */
-		private Worker(String name) {
-			super(name);
+		protected Worker(String name) {
+			super(SCANDIUM_THREAD_GROUP, name);
 		}
 
 		@Override


### PR DESCRIPTION
This commit:
- introduces a new Utils.NamedThreadFactory class
- makes all executor services to use this factory, so theads can receive meaningful names
- in addition, all threads are created using thread group
- the following thread groups are available: Californium, Californium/Elements, Californium/Scandium

Bug: https://github.com/eclipse/californium/issues/32
Signed-off-by: Valentin Valchev <v.valchev@prosyst.bg>