### PR TITLE
Observe clustering (no changes to CoapClient)

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
@@ -96,18 +96,18 @@ public class CoapServer implements ServerInterface {
 
 	/** The root resource. */
 	private final Resource root;
-	
+
 	/** The message deliverer. */
 	private MessageDeliverer deliverer;
-	
+
 	/** The list of endpoints the server connects to the network. */
 	private final List<Endpoint> endpoints;
-	
+
 	/** The executor of the server for its endpoints (can be null). */
 	private ScheduledExecutorService executor;
-	
+
 	private final NetworkConfig config;
-	
+
 	/**
 	 * Constructs a default server. The server starts after the method
 	 * {@link #start()} is called. If a server starts and has no specific ports
@@ -116,7 +116,7 @@ public class CoapServer implements ServerInterface {
 	public CoapServer() {
 		this(NetworkConfig.getStandard());
 	}
-	
+
 	/**
 	 * Constructs a server that listens to the specified port(s) after method
 	 * {@link #start()} is called.
@@ -126,7 +126,7 @@ public class CoapServer implements ServerInterface {
 	public CoapServer(final int... ports) {
 		this(NetworkConfig.getStandard(), ports);
 	}
-	
+
 	/**
 	 * Constructs a server with the specified configuration that listens to the
 	 * specified ports after method {@link #start()} is called.
@@ -136,23 +136,23 @@ public class CoapServer implements ServerInterface {
 	 * @param ports the ports to bind to
 	 */
 	public CoapServer(final NetworkConfig config, final int... ports) {
-		
+
 		// global configuration that is passed down (can be observed for changes)
 		if (config != null) {
 			this.config = config;
 		} else {
 			this.config = NetworkConfig.getStandard();
 		}
-		
+
 		// resources
 		this.root = createRoot();
 		this.deliverer = new ServerMessageDeliverer(root);
-		
+
 		CoapResource wellKnown = new CoapResource(".well-known");
 		wellKnown.setVisible(false);
 		wellKnown.add(new DiscoveryResource(root));
 		root.add(wellKnown);
-		
+
 		// endpoints
 		this.endpoints = new ArrayList<>();
 		// sets the central thread pool for the protocol stage over all endpoints
@@ -164,19 +164,19 @@ public class CoapServer implements ServerInterface {
 			addEndpoint(new CoapEndpoint(port, this.config));
 		}
 	}
-	
+
 	public void setExecutor(final ScheduledExecutorService executor) {
-		
+
 		if (this.executor != null) {
 			this.executor.shutdown();
 		}
-		
+
 		this.executor = executor;
 		for (Endpoint ep : endpoints) {
 			ep.setExecutor(executor);
 		}
 	}
-	
+
 	/**
 	 * Starts the server by starting all endpoints this server is assigned to.
 	 * Each endpoint binds to its port. If no endpoint is assigned to the
@@ -184,18 +184,18 @@ public class CoapServer implements ServerInterface {
 	 */
 	@Override
 	public void start() {
-		
+
 		LOGGER.info("Starting server");
-		
+
 		if (endpoints.isEmpty()) {
 			// servers should bind to the configured port (while clients should use an ephemeral port through the default endpoint)
 			int port = config.getInt(NetworkConfig.Keys.COAP_PORT);
 			LOGGER.log(Level.INFO, "No endpoints have been defined for server, setting up server endpoint on default port {0}", port);
 			addEndpoint(new CoapEndpoint(port, this.config));
 		}
-		
+
 		int started = 0;
-		for (Endpoint ep:endpoints) {
+		for (Endpoint ep : endpoints) {
 			try {
 				ep.start();
 				// only reached on success
@@ -204,7 +204,7 @@ public class CoapServer implements ServerInterface {
 				LOGGER.log(Level.SEVERE, "Cannot start server endpoint [" + ep.getAddress() + "]", e);
 			}
 		}
-		if (started==0) {
+		if (started == 0) {
 			throw new IllegalStateException("None of the server endpoints could be started");
 		}
 	}
@@ -249,7 +249,7 @@ public class CoapServer implements ServerInterface {
 			endpoint.setMessageDeliverer(deliverer);
 		}
 	}
-	
+
 	/**
 	 * Gets the message deliverer.
 	 *
@@ -274,7 +274,7 @@ public class CoapServer implements ServerInterface {
 		endpoint.setExecutor(executor);
 		endpoints.add(endpoint);
 	}
-	
+
 	/**
 	 * Gets the list of endpoints this server is connected to.
 	 *

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
@@ -29,6 +29,7 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
+import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.server.MessageDeliverer;
 
 /**
@@ -101,6 +102,22 @@ public interface Endpoint {
 	void removeObserver(EndpointObserver obs);
 
 	/**
+	 * Adds a listener for observe notification (This is related to CoAP
+	 * observe)
+	 * 
+	 * @param lis the listener
+	 */
+	void addNotificationListener(NotificationListener lis);
+
+	/**
+	 * Removes a listener for observe notification (This is related to CoAP
+	 * observe)
+	 * 
+	 * @param lis the listener
+	 */
+	void removeNotificationListener(NotificationListener lis);
+
+	/**
 	 * Adds a message interceptor to this endpoint.
 	 *
 	 * @param interceptor the interceptor
@@ -165,4 +182,11 @@ public interface Endpoint {
 	 */
 	NetworkConfig getConfig();
 
+	/**
+	 * Cancels an observation this endpoint has for a remote resource.
+	 * 
+	 * @param token
+	 *            the token used in the original request to establish the observation.
+	 */
+	void cancelObservation(byte[] token);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -160,6 +160,18 @@ public class Exchange {
 		this.origin = origin;
 		this.timestamp = System.currentTimeMillis();
 	}
+	
+	/**
+	 * Creates a new exchange with the specified request, origin and context.
+	 * 
+	 * @param request the request that starts the exchange
+	 * @param origin the origin of the request (LOCAL or REMOTE)
+	 * @param ctx the correlation context of this exchange
+	 */
+	public Exchange(final Request request, final Origin origin, final CorrelationContext ctx) {
+		this(request, origin);
+		this.correlationContext = ctx;
+	}
 
 	/**
 	 * Accept this exchange and therefore the request. Only if the request's

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/ExchangeObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/ExchangeObserver.java
@@ -40,5 +40,4 @@ public interface ExchangeObserver {
 	 * @param exchange the exchange
 	 */
 	void contextEstablished(Exchange exchange);
-
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/InMemoryObservationStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/InMemoryObservationStore.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ ******************************************************************************/
+package org.eclipse.californium.core.observe;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.Exchange.KeyToken;
+import org.eclipse.californium.core.network.serialization.DataParser;
+import org.eclipse.californium.core.network.serialization.Serializer;
+import org.eclipse.californium.elements.CorrelationContext;
+import org.eclipse.californium.elements.RawData;
+
+public class InMemoryObservationStore implements ObservationStore {
+
+	private Map<KeyToken, Observation> map = new ConcurrentHashMap<>();
+
+	@Override
+	public void add(Observation obs) {
+		if (obs != null) {
+			map.put(new KeyToken(obs.getRequest().getToken()), obs);
+		}
+	}
+
+	@Override
+	public Observation get(byte[] token) {
+		Observation obs = map.get(new KeyToken(token));
+		if (obs != null) {
+			RawData serialize = Serializer.serialize(obs.getRequest(), null);
+			DataParser parser = new DataParser(serialize.getBytes());
+			Request newRequest = parser.parseRequest();
+			return new Observation(newRequest, obs.getContext());
+		}
+		return null;
+	}
+
+	@Override
+	public Observation remove(byte[] token) {
+		return map.remove(new KeyToken(token));
+	}
+
+	public boolean isEmpty(){
+		return map.isEmpty();
+	}
+
+	public int getSize() {
+		return map.size();
+	}
+
+	public void clear() {
+		map.clear();
+	}
+
+	@Override
+	public void setContext(byte[] token, CorrelationContext ctx) {
+		Observation obs = map.get(new KeyToken(token));
+		if (obs != null) {
+			map.put(new KeyToken(token), new Observation(obs.getRequest(), ctx));
+		}
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/NotificationListener.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/NotificationListener.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ ******************************************************************************/
+package org.eclipse.californium.core.observe;
+
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+
+/**
+ * Client code can register a notification listener on an {@code Endpoint} in order to
+ * be called back when notifications for observed resources are received from peers.
+ * <p>
+ * Notification listeners are registered at a <em>global</em> level only, i.e. the listener
+ * will be invoked for all notifications for all observed resources. This is in contrast
+ * to the {@code CoapHandler} that client code can register when invoking one of {@code CoapClient}'s
+ * methods and which is called back for notifications for a particular observed resource only.
+ * </p>
+ */
+public interface NotificationListener {
+
+	/**
+	 * Invoked when a notification for an observed resource has been
+	 * received.
+	 * 
+	 * @param exchange the message exchange that the notification has been reserved in.
+	 *         The exchange also holds a reference to the original request that was used
+	 *         to establish the observation.
+	 * @param response the notification.
+	 */
+	void onNotification(Exchange exchange, Response response);
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/Observation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/Observation.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ ******************************************************************************/
+package org.eclipse.californium.core.observe;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.elements.CorrelationContext;
+
+/**
+ * An observation initiated by a given request, for a particular correlation
+ * context.
+ */
+public final class Observation {
+
+	private final Request request;
+	private final CorrelationContext context;
+
+	public Observation(final Request request) {
+		this(request, null);
+	}
+
+	public Observation(final Request request, final CorrelationContext context) {
+		if (request == null) {
+			throw new NullPointerException("Request must not be null");
+		}
+		this.request = request;
+		this.context = context;
+	}
+
+	/**
+	 * @return the request which initiated the observation
+	 */
+	public Request getRequest() {
+		return request;
+	}
+
+	/**
+	 * @return the correlation context for this observation
+	 */
+	public CorrelationContext getContext() {
+		return context;
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationStore.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ ******************************************************************************/
+package org.eclipse.californium.core.observe;
+
+import org.eclipse.californium.elements.CorrelationContext;
+
+/**
+ * A registry for keeping information about resources observed on other peers.
+ * <p>
+ * The information kept in this registry is particularly intended to be shared
+ * with other instances (running on other nodes) to support failing over the
+ * processing of notifications received by another node after the original
+ * node (that initially registered the observation) has crashed.
+ * </p>
+ */
+public interface ObservationStore {
+
+	/**
+	 * Adds an observation to the store.
+	 */
+	void add(Observation obs);
+
+	/**
+	 * Removes the observation initiated by the request with the given token.
+	 * 
+	 * @return the removed observation or {@code null} if the store does not contain
+	 *          an observation for the given token.
+	 */
+	Observation remove(byte[] token);
+
+	/**
+	 * Gets the observation initiated by the request with the given token.
+	 */
+	Observation get(byte[] token);
+
+	/**
+	 * Sets the correlation context on the observation initiated by the
+	 * request with the given token.
+	 * <p>
+	 * This method is necessary because the correlation context may not be
+	 * known when the observation is originally registered. This is due to
+	 * the fact that the information contained in the correlation context is
+	 * gathered by the transport layer when the request establishing the observation
+	 * is sent to the peer.
+	 * </p>
+	 */
+	void setContext(byte[] token, CorrelationContext correlationContext);
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
@@ -72,7 +72,7 @@ public final class ServerMessageDeliverer implements MessageDeliverer {
 		final Resource resource = findResource(path);
 		if (resource != null) {
 			checkForObserveOption(exchange, resource);
-			
+
 			// Get the executor and let it process the request
 			Executor executor = resource.getExecutor();
 			if (executor != null) {
@@ -113,7 +113,7 @@ public final class ServerMessageDeliverer implements MessageDeliverer {
 		InetSocketAddress source = new InetSocketAddress(request.getSource(), request.getSourcePort());
 
 		if (request.getOptions().hasObserve() && resource.isObservable()) {
-			
+
 			if (request.getOptions().getObserve()==0) {
 				// Requests wants to observe and resource allows it :-)
 				LOGGER.log(Level.FINER,

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
@@ -15,15 +15,9 @@ package org.eclipse.californium.core.test.lockstep;
 
 import static org.eclipse.californium.core.coap.CoAP.Code.GET;
 import static org.eclipse.californium.core.coap.CoAP.ResponseCode.CONTENT;
-import static org.eclipse.californium.core.coap.CoAP.Type.ACK;
-import static org.eclipse.californium.core.coap.CoAP.Type.CON;
-import static org.eclipse.californium.core.coap.CoAP.Type.RST;
-import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.createLockstepEndpoint;
-import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.createRequest;
-import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.generateRandomPayload;
-import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.printServerLog;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.eclipse.californium.core.coap.CoAP.Type.*;
+import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.*;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -287,7 +281,6 @@ public class ClusteringTest {
 
 		// WHEN sends notification to client 1
 		System.out.println("Server sends Observe response to client 1...");
-		respPayload = generateRandomPayload(10); // changed
 		respPayload = generateRandomPayload(10); // changed
 		server.setDestination(client1.getAddress());
 		server.sendResponse(CON, CONTENT).loadToken(TOKEN_ID).payload(respPayload).mid(++mid).observe(observeCounter).go();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
@@ -1,0 +1,288 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ ******************************************************************************/
+package org.eclipse.californium.core.test.lockstep;
+
+import static org.eclipse.californium.core.coap.CoAP.Code.GET;
+import static org.eclipse.californium.core.coap.CoAP.ResponseCode.CONTENT;
+import static org.eclipse.californium.core.coap.CoAP.Type.*;
+import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.*;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+import org.eclipse.californium.category.Medium;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.interceptors.MessageTracer;
+import org.eclipse.californium.core.observe.InMemoryObservationStore;
+import org.eclipse.californium.core.observe.NotificationListener;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Medium.class)
+public class ClusteringTest {
+
+	private static final String TOKEN_ID = "T";
+	private static final String path = "test";
+	private static NetworkConfig CONFIG;
+
+	private ClientBlockwiseInterceptor clientInterceptor;
+	private LockstepEndpoint server;
+
+	private Endpoint client1;
+	private Endpoint client2;
+
+	private int mid = 8000;
+	private int observeCounter;
+
+	private InMemoryObservationStore store;
+
+	private SynchronousNotificationListener notificationListener1;
+	private SynchronousNotificationListener notificationListener2;
+
+	@BeforeClass
+	public static void init() {
+		System.out.println(System.lineSeparator() + "Start " + ClusteringTest.class.getSimpleName());
+		CONFIG = new NetworkConfig()
+				.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 16)
+				.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 16)
+				.setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200) // client retransmits after 200 ms
+				.setFloat(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1f)
+				.setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f);
+	}
+
+	@Before
+	public void setupClient() throws IOException {
+
+		store = new InMemoryObservationStore();
+		clientInterceptor = new ClientBlockwiseInterceptor();
+
+		notificationListener1 = new SynchronousNotificationListener();
+		client1 = createAndStartClientEndpoint(notificationListener1, clientInterceptor);
+		System.out.println("Client 1 binds to port " + client1.getAddress().getPort());
+
+		notificationListener2 = new SynchronousNotificationListener();
+		client2 = createAndStartClientEndpoint(notificationListener2, clientInterceptor);
+		System.out.println("Client 2 binds to port " + client2.getAddress().getPort());
+	}
+
+	@After
+	public void shutdownClient() {
+		System.out.println();
+		client1.destroy();
+		client2.destroy();
+	}
+
+	@AfterClass
+	public static void finish() {
+		System.out.println("End " + ClusteringTest.class.getSimpleName());
+	}
+
+	private Endpoint createAndStartClientEndpoint(final NotificationListener listener, final ClientBlockwiseInterceptor interceptor) throws IOException {
+		Endpoint client = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), CONFIG, store);
+		client.addNotificationListener(listener);
+		client.addInterceptor(interceptor);
+		client.addInterceptor(new MessageTracer());
+		client.start();
+		return client;
+	}
+
+	@Test
+	public void testNotificationFailOver() throws Exception {
+		System.out.println(System.lineSeparator() + "Fail over notifications from client 1 to client 2 and back");
+
+		// GIVEN a resource on server observed by client 1
+		givenAResourceObservedByClient1(generateRandomPayload(10));
+
+		// WHEN client 1 fails and server sends notification to client 2 instead
+		System.out.println(System.lineSeparator() + "Crashing client 1...");
+		client1.destroy();
+		System.out.println("Failing over notifications to client 2...");
+		String respPayload = generateRandomPayload(10); // changed
+		sendNotificationToClient(client2, respPayload);
+
+		// THEN client 2 delivers the payload to the registered notification listener
+		assertClientDeliversNotificationToListener(notificationListener2, respPayload);
+		printServerLog(clientInterceptor);
+		System.out.println("Client 2 received notification");
+
+		// WHEN client 2 fails and client 1 recovers and server sends notification to client 1 again
+		System.out.println(System.lineSeparator() + "Crashing client 2...");
+		client2.destroy();
+		System.out.println(System.lineSeparator() + "Recovering client 1...");
+		client1 = createAndStartClientEndpoint(notificationListener1, clientInterceptor);
+		System.out.println();
+		System.out.println(System.lineSeparator() + "Failing over notifications back to client 1");
+		respPayload = generateRandomPayload(10); // changed
+		sendNotificationToClient(client1, respPayload);
+
+		// THEN client1 delivers the payload to the registered notification listener
+		assertClientDeliversNotificationToListener(notificationListener1, respPayload);
+		printServerLog(clientInterceptor);
+		System.out.println("Client 1 received notification");
+	}
+
+	@Test
+	public void testBlockwiseNotificationFailOver() throws Exception {
+		System.out.println(System.lineSeparator() + "Fail over blockwise notifications from client 1 to client 2 and back");
+
+		// GIVEN a resource on server observed by client 1
+		givenAResourceObservedByClient1(generateRandomPayload(10));
+
+		// WHEN the server sends a notification using blockwise transfer to client 1
+		String respPayload = generateRandomPayload(40); // changed
+		System.out.println();
+		System.out.println(System.lineSeparator() + "Server sends blockwise observe response to client 1 [" + respPayload + "]");
+		server.setDestination(client1.getAddress());
+		server.sendResponse(CON, CONTENT).loadToken(TOKEN_ID).mid(++mid).observe(observeCounter++).block2(0, true, 16)
+				.payload(respPayload.substring(0, 16)).go();
+		server.expectEmpty(ACK, mid).go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 16).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 16).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 16).payload(respPayload.substring(32, 40)).go();
+		Thread.sleep(200);
+
+		// THEN client 1 delivers the payload to the registered notification listener
+		assertClientDeliversNotificationToListener(notificationListener1, respPayload);
+		printServerLog(clientInterceptor);
+		System.out.println("Client 1 received blockwise notification");
+
+		// WHEN client 1 fails and server sends next notification using blockwise transfer to client 2
+		System.out.println(System.lineSeparator() + "Crashing client 1...");
+		client1.destroy();
+		System.out.println("Failing over notifications to client 2...");
+		respPayload = generateRandomPayload(40); // changed
+		System.out.println(System.lineSeparator() + "Server sends blockwise observe response to client 2 [" + respPayload + "]");
+		server.setDestination(client2.getAddress());
+		server.sendResponse(CON, CONTENT).loadToken(TOKEN_ID).mid(++mid).observe(observeCounter++).block2(0, true, 16)
+				.payload(respPayload.substring(0, 16)).go();
+		server.expectEmpty(ACK, mid).go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 16).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 16).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 16).payload(respPayload.substring(32, 40)).go();
+		Thread.sleep(200);
+
+		// THEN client 2 delivers the payload to the registered notification listener
+		assertClientDeliversNotificationToListener(notificationListener2, respPayload);
+		printServerLog(clientInterceptor);
+		System.out.println("Client 2 received blockwise notification");
+	}
+
+	@Test
+	public void testCancellingNotification() throws Exception {
+		System.out.println(System.lineSeparator() + "Cancel failed over observation:");
+
+		// GIVEN a resource on server observed by client 1
+		byte[] requestToken = givenAResourceObservedByClient1(generateRandomPayload(10));
+
+		// WHEN client 1 fails and server sends notification to client 2 instead
+		System.out.println(System.lineSeparator() + "Crashing client 1...");
+		client1.destroy();
+		System.out.println(System.lineSeparator() + "Failing over to client 2...");
+		// server send new response to client 2
+		System.out.println("Server sends Observe response to client 2...");
+		String respPayload = generateRandomPayload(10); // changed
+		sendNotificationToClient(client2, respPayload);
+
+		// THEN client 2 successfully delivers the payload to the registered notification listener
+		assertClientDeliversNotificationToListener(notificationListener2, respPayload);
+		printServerLog(clientInterceptor);
+		System.out.println("Client 2 received notification");
+
+		// WHEN client 2 cancels observation and next notification arrives from server
+		System.out.println();
+		System.out.println(System.lineSeparator() + "Now cancelling observation from client 2");
+		client2.cancelObservation(requestToken);
+
+		System.out.println();
+		System.out.println(System.lineSeparator() + "Server sends notification to client 2...");
+		respPayload = generateRandomPayload(10); // changed
+		server.setDestination(client2.getAddress());
+		server.sendResponse(CON, CONTENT).loadToken(TOKEN_ID).payload(respPayload).mid(++mid).observe(observeCounter).go();
+
+		// THEN client 2 rejects the notification and cancels the observation on the server
+		server.expectEmpty(RST, mid).go();
+		printServerLog(clientInterceptor);
+		System.out.println("Client 2 has rejected received notification");
+
+		// WHEN client 1 recovers and the next notification arrives from server
+		client2.destroy();
+		System.out.println(System.lineSeparator() + "Recovering client 1...");
+		client1 = createAndStartClientEndpoint(notificationListener1, clientInterceptor);
+
+		// server send new response to client 1
+		System.out.println();
+		System.out.println(System.lineSeparator() + "Server sends notification to recovered client 1...");
+		respPayload = generateRandomPayload(10); // changed
+		server.setDestination(client1.getAddress());
+		server.sendResponse(CON, CONTENT).loadToken(TOKEN_ID).payload(respPayload).mid(++mid).observe(++observeCounter).go();
+		server.expectEmpty(RST, mid).go();
+		printServerLog(clientInterceptor);
+		System.out.println("Recovered client 1 has rejected received notification");
+	}
+
+	private byte[] givenAResourceObservedByClient1(final String expectedResponse) throws Exception {
+		server = createLockstepEndpoint(client1.getAddress());
+		observeCounter = 100;
+
+		// send observe request from client 1
+		System.out.println(System.lineSeparator() + "Establishing observation from client 1 ...");
+		Request request = createRequest(GET, path, server);
+		request.setObserve();
+		client1.sendRequest(request);
+
+		// server wait for request and send response
+		System.out.println(System.lineSeparator() + "Server sends Observe response to client 1.");
+		server.expectRequest(CON, GET, path).storeMID("MID").storeToken(TOKEN_ID).observe(0).go();
+		server.sendEmpty(ACK).loadMID("MID").go();
+		server.sendResponse(CON, CONTENT).loadToken(TOKEN_ID).payload(expectedResponse).mid(++mid).observe(++observeCounter).go();
+		server.expectEmpty(ACK, mid).go();
+		Response response = request.waitForResponse(1000);
+
+		printServerLog(clientInterceptor);
+		assertClientReceivedExpectedPayload(expectedResponse, response);
+		assertNotNull("ObservationStore does not contain token for new observation: ", store.get(response.getToken()));
+		System.out.println("Observe relation established with client 1");
+		return request.getToken();
+	}
+
+	private void assertClientDeliversNotificationToListener(final SynchronousNotificationListener listener,
+			final String expectedPayload) throws Exception {
+		Response receivedResponse =  listener.waitForResponse(1000);
+		assertClientReceivedExpectedPayload(expectedPayload, receivedResponse);
+	}
+
+	private void assertClientReceivedExpectedPayload(final String expectedPayload, final Response receivedResponse) {
+		assertNotNull("Client received no response", receivedResponse);
+		assertEquals("Client received wrong response code", CONTENT, receivedResponse.getCode());
+		assertEquals("Client received wrong payload", expectedPayload, receivedResponse.getPayloadString());
+	}
+
+	private void sendNotificationToClient(final Endpoint client, final String payload) throws Exception {
+		server.setDestination(client.getAddress());
+		server.sendResponse(CON, CONTENT).loadToken(TOKEN_ID).payload(payload).mid(++mid).observe(++observeCounter).go();
+		server.expectEmpty(ACK, mid).go();
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
@@ -161,7 +161,7 @@ public class ClusteringTest {
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
 		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 16).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 16).payload(respPayload.substring(32, 40)).go();
-		Thread.sleep(100);
+		Thread.sleep(200);
 
 		// THEN client 1 delivers the payload to the registered notification listener
 		assertClientDeliversNotificationToListener(notificationListener1, respPayload);
@@ -182,7 +182,7 @@ public class ClusteringTest {
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
 		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 16).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 16).payload(respPayload.substring(32, 40)).go();
-		Thread.sleep(100);
+		Thread.sleep(200);
 
 		// THEN client 2 delivers the payload to the registered notification listener
 		assertClientDeliversNotificationToListener(notificationListener2, respPayload);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/SynchronousNotificationListener.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/SynchronousNotificationListener.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2016 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Matthias Kovatsch - creator and main architect
+ ******************************************************************************/
+package org.eclipse.californium.core.test.lockstep;
+
+import java.util.Arrays;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.observe.NotificationListener;
+
+public class SynchronousNotificationListener implements NotificationListener {
+
+	private Request request; // request to listen
+	private Response currentResponse;
+	private Object lock = new Object();
+
+	public SynchronousNotificationListener() {
+	}
+
+	public SynchronousNotificationListener(final Request req) {
+		request = req;
+	}
+
+	/**
+	 * Wait until a response is received or the request was cancelled/rejected.
+	 * 
+	 * @return the response or null if waiting time elapses or if request is
+	 *         cancelled/rejected.
+	 */
+	public Response waitForResponse(long timeoutInMs) throws InterruptedException {
+		Response r;
+		synchronized (lock) {
+			if (currentResponse != null)
+				r = currentResponse;
+			else {
+				lock.wait(timeoutInMs);
+				r = currentResponse;
+			}
+			currentResponse = null;
+		}
+		return r;
+	}
+
+	@Override
+	public void onNotification(final Exchange exchange, final Response response) {
+		if (request == null || Arrays.equals(request.getToken(), response.getToken())) {
+			synchronized (lock) {
+				currentResponse = response;
+				lock.notifyAll();
+			}
+		}
+	}
+}


### PR DESCRIPTION
The main difference between this approach and the original `observe_clustering` branch is that no changes to CoapClient have been made and the NotificationListener is only used for delivering notifications.

@Simon: I have incorporated (and refactored) a lot of your testing code but I still think that this approach is a little more lightweight ... ;-)

I have also tidied up a lot of the classes I needed to touch so that the overall amoutn of changes is larger than would have been necessary. But I thought: if I am already on it ...
