### PR TITLE
Set Request.scheme variable based on RawData.isSecure()

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -38,6 +38,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.californium.core.Utils;
+import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Message;
@@ -633,6 +634,10 @@ public class CoapEndpoint implements Endpoint {
 					}
 					return;
 				}
+
+				// set request attributes from raw data
+				request.setScheme(raw.isSecure()?
+						CoAP.COAP_SECURE_URI_SCHEME:CoAP.COAP_URI_SCHEME);
 				request.setSource(raw.getAddress());
 				request.setSourcePort(raw.getPort());
 				request.setSenderIdentity(raw.getSenderIdentity());

--- a/element-connector/src/main/java/org/eclipse/californium/elements/RawData.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/RawData.java
@@ -360,4 +360,14 @@ public final class RawData {
 	public MessageCallback getMessageCallback() {
 		return callback;
 	}
+
+	/**
+	 * Determines if the correlation context of this object is secure.
+	 *
+	 * @return <code>true</code> if context is secure, <code>false</code> otherwise
+	 */
+	public boolean isSecure() {
+		return (correlationContext != null &&
+				correlationContext.get(DtlsCorrelationContext.KEY_SESSION_ID) != null);
+	}
 }


### PR DESCRIPTION
Set scheme variable of Request object when it is created in the CoapEndpoint.InboxImpl.  This helps applications to inspect the scheme just as source address, port or principle.  New method RawData.isSecure() inspects the CorrelationContext to determine if it is from a secure context.

Signed-off-by: Vinod Mukkamala <vmukkamala@hotmail.com>