### PR TITLE
Implementation of TCP connector for Californium per CoAP over TCP RFC.

### DIFF
--- a/element-connector/pom.xml
+++ b/element-connector/pom.xml
@@ -21,6 +21,11 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-all</artifactId>
+			<version>4.1.1.Final</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/element-connector/src/main/java/org/eclipse/californium/elements/Connector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/Connector.java
@@ -91,4 +91,12 @@ public interface Connector {
 	 * @return the address
 	 */
 	public InetSocketAddress getAddress();
+
+	/**
+	 * Returns true if this connector supports specified scheme (e.g. coap for CoAP over UDP, coaps for coap over DTLS,
+	 * coap+tcp for coap over TCP).
+	 *
+	 * @return true if connector supports 'scheme'
+     */
+	public boolean isSchemeSupported(String scheme);
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
@@ -324,4 +324,9 @@ public class UDPConnector implements Connector {
 	public int getReceiverPacketSize() {
 		return receiverPacketSize;
 	}
+
+	@Override
+	public boolean isSchemeSupported(String scheme) {
+		return "coap".equals(scheme);
+	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/CloseOnErrorHandler.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/CloseOnErrorHandler.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Amazon Web Services.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ ******************************************************************************/
+package org.eclipse.californium.elements.tcp;
+
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Channel handler that closes connection if an exception was raised.
+ */
+class CloseOnErrorHandler extends ChannelHandlerAdapter {
+
+    private final static Logger LOGGER = Logger.getLogger(CloseOnErrorHandler.class.getName());
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        // Since we use length based framing, any exception reading in TCP stream has the high likelihood of us
+        // getting out of sync on the stream, and not being able to recover. So close the connection and hope for the
+        // better luck next time.
+        LOGGER.log(Level.SEVERE, "Exception in channel handler chain for endpoint " + ctx.channel().remoteAddress() +
+                ". Closing connection.", cause);
+        ctx.close();
+    }
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/CloseOnIdleHandler.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/CloseOnIdleHandler.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Amazon Web Services.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ ******************************************************************************/
+package org.eclipse.californium.elements.tcp;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.timeout.IdleStateEvent;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Channel handler that closes connection if an idle event was raised.
+ */
+class CloseOnIdleHandler extends ChannelDuplexHandler {
+
+    private final static Logger LOGGER = Logger.getLogger(CloseOnIdleHandler.class.getName());
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof IdleStateEvent) {
+            LOGGER.log(Level.FINER, "Closing channel with {0} due to idle time.",
+                    new Object[]{ctx.channel().remoteAddress()});
+            ctx.channel().close();
+        }
+    }
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/DatagramFramer.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/DatagramFramer.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Amazon Web Services.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ ******************************************************************************/
+package org.eclipse.californium.elements.tcp;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import org.eclipse.californium.elements.RawData;
+
+import java.math.BigInteger;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+/**
+ * Converts stream of bytes over TCP connection into distinct datagrams based on CoAP over TCP spec.
+ */
+public class DatagramFramer extends ByteToMessageDecoder {
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+        while (in.readableBytes() > 0) {
+            byte firstByte = in.getByte(in.readerIndex());
+            int lengthNibble = (firstByte & 0xF0) >>> 4;
+            int tokenNibble = firstByte & 0x0F;
+
+            int lengthFieldSize = getLengthFieldSize(lengthNibble);
+            int coapHeaderSize = getCoapHeaderSize(lengthFieldSize, tokenNibble);
+            if (in.readableBytes() < coapHeaderSize) {
+                // Not enough data, no point in continuing.
+                return;
+            }
+
+            int bodyLength = getBodyLength(in, lengthNibble, lengthFieldSize);
+            if (in.readableBytes() < coapHeaderSize + bodyLength) {
+                // Whole body not available yet.
+                return;
+            }
+
+            byte[] data = new byte[coapHeaderSize + bodyLength];
+            in.readBytes(data);
+            // This is TCP connector, so we know remote address is InetSocketAddress.
+            InetSocketAddress socketAddress = (InetSocketAddress) ctx.channel().remoteAddress();
+            RawData rawData = new RawData(data, socketAddress);
+            out.add(rawData);
+        }
+    }
+
+    private int getBodyLength(ByteBuf in, int lengthNibble, int fieldSize) {
+        byte data[] = new byte[fieldSize];
+        in.getBytes(in.readerIndex() + 1, data);
+
+        switch (fieldSize) {
+            case 0:
+                return lengthNibble;
+            case 1:
+                return new BigInteger(1, data).intValue() + 13;
+            case 2:
+                return new BigInteger(1, data).intValue() + 269;
+            case 4:
+                // Possible overflow here, but is anybody reallying sending 2GB messages around?
+                return new BigInteger(1, data).intValue() + 65805;
+            default:
+                throw new IllegalArgumentException("Invalid field size: " + fieldSize);
+        }
+    }
+
+    private int getCoapHeaderSize(int lengthFieldSize, int tokenFieldSize) {
+        // https://tools.ietf.org/html/draft-ietf-core-coap-tcp-tls-02
+        // 2 4-bit nibbles (len + tlk_len) + length field + code field + token field.
+        return 2 + lengthFieldSize + tokenFieldSize;
+
+    }
+
+    public static int getLengthFieldSize(int len) {
+        if (len > 15 || len < 0) {
+            throw new IllegalArgumentException("Invalid len field: " + len);
+        }
+
+        if (len == 13) {
+            return 1;
+        } else if (len == 14) {
+            return 2;
+        } else if (len == 15) {
+            return 4;
+        } else {
+            return 0;
+        }
+    }
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/DispatchHandler.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/DispatchHandler.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Amazon Web Services.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ ******************************************************************************/
+package org.eclipse.californium.elements.tcp;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.eclipse.californium.elements.RawData;
+import org.eclipse.californium.elements.RawDataChannel;
+
+/**
+ * Channel handler that dispatches framed raw messages to coap stack.
+ */
+public class DispatchHandler extends ChannelInboundHandlerAdapter {
+
+    private final RawDataChannel rawDataChannel;
+
+    public DispatchHandler(RawDataChannel rawDataChannel) {
+        this.rawDataChannel = rawDataChannel;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        rawDataChannel.receiveData((RawData) msg);
+    }
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpClientConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpClientConnector.java
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Amazon Web Services.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ ******************************************************************************/
+package org.eclipse.californium.elements.tcp;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.pool.AbstractChannelPoolHandler;
+import io.netty.channel.pool.AbstractChannelPoolMap;
+import io.netty.channel.pool.ChannelPool;
+import io.netty.channel.pool.FixedChannelPool;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.RawData;
+import org.eclipse.californium.elements.RawDataChannel;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * TCP client connection is used by CoapEndpoint when instantiated by the CoapClient. Per RFC the client can both
+ * send and receive messages, but cannot accept new incoming connections.
+ */
+public class TcpClientConnector implements Connector {
+
+    private final static Logger LOGGER = Logger.getLogger(TcpClientConnector.class.getName());
+
+    private final int numberOfThreads;
+    private final int connectionIdleTimeoutSeconds;
+    private final int connectTimeoutMillis;
+    private EventLoopGroup workerGroup;
+    private RawDataChannel rawDataChannel;
+    private AbstractChannelPoolMap<SocketAddress, ChannelPool> poolMap;
+
+    public TcpClientConnector(int numberOfThreads, int connectTimeoutMillis, int idleTimeout) {
+        this.numberOfThreads = numberOfThreads;
+        this.connectionIdleTimeoutSeconds = idleTimeout;
+        this.connectTimeoutMillis = connectTimeoutMillis;
+    }
+
+    @Override
+    public void start() throws IOException {
+        if (rawDataChannel == null) {
+            throw new IllegalStateException("Cannot start without message handler.");
+        }
+
+        if (workerGroup != null) {
+            throw new IllegalStateException("Connector already started");
+        }
+
+        workerGroup = new NioEventLoopGroup(numberOfThreads);
+        poolMap = new AbstractChannelPoolMap<SocketAddress, ChannelPool>() {
+            @Override
+            protected ChannelPool newPool(SocketAddress key) {
+                Bootstrap bootstrap = new Bootstrap()
+                        .group(workerGroup)
+                        .channel(NioSocketChannel.class)
+                        .option(ChannelOption.SO_KEEPALIVE, true)
+                        .option(ChannelOption.AUTO_READ, true)
+                        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMillis)
+                        .remoteAddress(key);
+
+                // We multiplex over the same TCP connection, so don't acquire more than one connection per endpoint.
+                // TODO: But perhaps we could make it a configurable property.
+                return new FixedChannelPool(bootstrap, new MyChannelPoolHandler(key), 1);
+            }
+        };
+    }
+
+    @Override
+    public void stop() {
+        workerGroup.shutdownGracefully(0, 1, TimeUnit.SECONDS).syncUninterruptibly();
+        workerGroup = null;
+    }
+
+    @Override
+    public void destroy() {
+        stop();
+    }
+
+    @Override
+    public void send(final RawData msg) {
+        final ChannelPool channelPool = poolMap.get(new InetSocketAddress(msg.getAddress(), msg.getPort()));
+        Future<Channel> acquire = channelPool.acquire();
+        acquire.addListener(new GenericFutureListener<Future<Channel>>() {
+            @Override
+            public void operationComplete(Future<Channel> future) throws Exception {
+                if (future.isSuccess()) {
+                    Channel channel = future.getNow();
+                    try {
+                        channel.writeAndFlush(Unpooled.wrappedBuffer(msg.getBytes()));
+                    } finally {
+                        channelPool.release(channel);
+                    }
+                } else {
+                    LOGGER.log(Level.WARNING, "Unable to open connection to " + msg.getAddress(), future.cause());
+                }
+            }
+        });
+    }
+
+    @Override
+    public void setRawDataReceiver(RawDataChannel messageHandler) {
+        if (rawDataChannel != null) {
+            throw new IllegalStateException("Raw data channel already set.");
+        }
+
+        this.rawDataChannel = messageHandler;
+    }
+
+    @Override
+    public InetSocketAddress getAddress() {
+        // Client TCP connector doesn't really have an address it binds to.
+        return new InetSocketAddress(0);
+    }
+
+    private class MyChannelPoolHandler extends AbstractChannelPoolHandler {
+
+        private final SocketAddress key;
+
+        MyChannelPoolHandler(SocketAddress key) {
+            this.key = key;
+        }
+
+        @Override
+        public void channelCreated(Channel ch) throws Exception {
+            // Handler order:
+            // 1. Generate Idle events
+            // 2. Close idle channels
+            // 3. Remove pools when they are empty.
+            // 4. Stream-to-message decoder
+            // 5. Hand-off decoded messages to CoAP stack
+            // 6. Close connections on errors
+            ch.pipeline().addLast(new IdleStateHandler(0, 0, connectionIdleTimeoutSeconds));
+            ch.pipeline().addLast(new CloseOnIdleHandler());
+            ch.pipeline().addLast(new RemoveEmptyPoolHandler(key));
+            ch.pipeline().addLast(new DatagramFramer());
+            ch.pipeline().addLast(new DispatchHandler(rawDataChannel));
+            ch.pipeline().addLast(new CloseOnErrorHandler());
+        }
+    }
+
+    private class RemoveEmptyPoolHandler extends ChannelDuplexHandler {
+        private final SocketAddress key;
+
+        RemoveEmptyPoolHandler(SocketAddress key) {
+            this.key = key;
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+            // TODO: This only works with fixed sized pool with connection one. Otherwise it's not save to remove and
+            // close the pool as soon as a single channel is closed.
+            poolMap.remove(key);
+        }
+    }
+
+    @Override
+    public boolean isSchemeSupported(String scheme) {
+        return "coap+tcp".equals(scheme);
+    }
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpServerConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpServerConnector.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Amazon Web Services.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ ******************************************************************************/
+package org.eclipse.californium.elements.tcp;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.timeout.IdleStateHandler;
+import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.RawData;
+import org.eclipse.californium.elements.RawDataChannel;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * TCP server connection is used by CoapEndpoint when instantiated by the CoapServer. Per RFC the server can both
+ * send and receive messages, but cannot initiated new outgoing connections.
+ */
+public class TcpServerConnector implements Connector {
+
+    private final static Logger LOGGER = Logger.getLogger(TcpServerConnector.class.getName());
+
+    private final int numberOfThreads;
+    private final InetSocketAddress localAddress;
+    private final int connectionIdleTimeoutSeconds;
+    private final ConcurrentMap<SocketAddress, Channel> activeChannels = new ConcurrentHashMap<>();
+
+    private RawDataChannel rawDataChannel;
+    private EventLoopGroup bossGroup;
+    private EventLoopGroup workerGroup;
+
+    public TcpServerConnector(InetSocketAddress localAddress, int idleTimeout, int numberOfThreads) {
+        this.numberOfThreads = numberOfThreads;
+        this.connectionIdleTimeoutSeconds = idleTimeout;
+        this.localAddress = localAddress;
+    }
+
+    @Override
+    public void start() throws IOException {
+        if (rawDataChannel == null) {
+            throw new IllegalStateException("Cannot start without message handler.");
+        }
+        if (bossGroup != null) {
+            throw new IllegalStateException("Connector already started");
+        }
+        if (workerGroup != null) {
+            throw new IllegalStateException("Connector already started");
+        }
+
+        bossGroup = new NioEventLoopGroup(1);
+        workerGroup = new NioEventLoopGroup(numberOfThreads);
+
+        ServerBootstrap bootstrap = new ServerBootstrap();
+        bootstrap.group(bossGroup, workerGroup)
+                .channel(NioServerSocketChannel.class)
+                .option(ChannelOption.SO_BACKLOG, 100)
+                .option(ChannelOption.SO_KEEPALIVE, true)
+                .option(ChannelOption.AUTO_READ, true)
+                .childHandler(new ChannelRegistry());
+
+        // Start the server.
+        bootstrap.bind(localAddress).syncUninterruptibly();
+    }
+
+    @Override
+    public void stop() {
+        bossGroup.shutdownGracefully(0, 1, TimeUnit.SECONDS).syncUninterruptibly();
+        workerGroup.shutdownGracefully(0, 1, TimeUnit.SECONDS).syncUninterruptibly();
+
+        workerGroup = null;
+        bossGroup = null;
+    }
+
+    @Override
+    public void destroy() {
+        stop();
+    }
+
+    @Override
+    public void send(RawData msg) {
+        Channel channel = activeChannels.get(msg.getInetSocketAddress());
+        if (channel == null) {
+            // TODO: Is it worth allowing opening a new connection when in server mode?
+            LOGGER.log(Level.WARNING,
+                    "Attempting to send message to an address without an active connection {0}", msg.getAddress());
+            return;
+        }
+
+        channel.writeAndFlush(Unpooled.wrappedBuffer(msg.getBytes()));
+    }
+
+    @Override
+    public void setRawDataReceiver(RawDataChannel messageHandler) {
+        if (rawDataChannel != null) {
+            throw new IllegalStateException("RawDataChannel alrady set");
+        }
+
+        this.rawDataChannel = messageHandler;
+    }
+
+    @Override
+    public InetSocketAddress getAddress() {
+        return localAddress;
+    }
+
+    private class ChannelRegistry extends ChannelInitializer<SocketChannel> {
+        @Override
+        protected void initChannel(SocketChannel ch) throws Exception {
+            // Handler order:
+            // 0. Register/unregister new channel: all messages can only be sent over open connections.
+            // 1. Generate Idle events
+            // 2. Close idle channels.
+            // 3. Stream-to-message decoder
+            // 4. Hand-off decoded messages to CoAP stack
+            // 5. Close connections on errors.
+            ch.pipeline().addLast(new ChannelTracker());
+            ch.pipeline().addLast(new IdleStateHandler(0, 0, connectionIdleTimeoutSeconds));
+            ch.pipeline().addLast(new CloseOnIdleHandler());
+            ch.pipeline().addLast(new DatagramFramer());
+            ch.pipeline().addLast(new DispatchHandler(rawDataChannel));
+            ch.pipeline().addLast(new CloseOnIdleHandler());
+        }
+    }
+
+    /** Tracks active channels to send messages over them. TCPServer connector does not establish new connections. */
+    private class ChannelTracker extends ChannelInboundHandlerAdapter {
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            activeChannels.put(ctx.channel().remoteAddress(), ctx.channel());
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+            activeChannels.remove(ctx.channel().remoteAddress());
+        }
+    }
+
+    @Override
+    public boolean isSchemeSupported(String scheme) {
+        return "coap+tcp".equals(scheme);
+    }
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/Catcher.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/Catcher.java
@@ -1,0 +1,34 @@
+package org.eclipse.californium.elements.tcp;
+
+import org.eclipse.californium.elements.RawData;
+import org.eclipse.californium.elements.RawDataChannel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class Catcher implements RawDataChannel {
+    private final List<RawData> messages = new ArrayList<>();
+    private final Object lock = new Object();
+
+    @Override
+    public void receiveData(RawData raw) {
+        synchronized (lock) {
+            messages.add(raw);
+            lock.notifyAll();
+        }
+    }
+
+    void blockUntilSize(int expectedSize) throws InterruptedException {
+        synchronized (lock) {
+            while (messages.size() < expectedSize) {
+                lock.wait();
+            }
+        }
+    }
+
+    RawData getMessage(int index) {
+        synchronized (lock) {
+            return messages.get(index);
+        }
+    }
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TcpConnectorTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TcpConnectorTest.java
@@ -1,0 +1,170 @@
+package org.eclipse.californium.elements.tcp;
+
+import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.RawData;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class TcpConnectorTest {
+
+    @Rule public final Timeout timeout = new Timeout(10, TimeUnit.SECONDS);
+
+    private final int messageSize;
+    private final Random random = new Random();
+    private final List<Connector> cleanup = new ArrayList<>();
+
+    @Parameterized.Parameters
+    public static List<Object[]> parameters() {
+        // Trying different messages size to hit sharp corners in Coap-over-TCP spec
+        List<Object[]> parameters = new ArrayList<>();
+        parameters.add(new Object[]{0});
+        parameters.add(new Object[]{7});
+        parameters.add(new Object[]{13});
+        parameters.add(new Object[]{35});
+        parameters.add(new Object[]{269});
+        parameters.add(new Object[]{313});
+        parameters.add(new Object[]{65805});
+        parameters.add(new Object[]{389805});
+
+        return parameters;
+    }
+
+    public TcpConnectorTest(int messageSize) {
+        this.messageSize = messageSize;
+    }
+
+    @After
+    public void cleanup() {
+        for (Connector connector : cleanup) {
+            connector.stop();
+        }
+    }
+
+    @Test
+    public void serverClientPingPong() throws Exception {
+        int port = findEphemeralPort();
+        TcpServerConnector server = new TcpServerConnector(new InetSocketAddress(port), 100, 1);
+        TcpClientConnector client = new TcpClientConnector(1, 100, 100);
+
+        cleanup.add(server);
+        cleanup.add(client);
+
+        Catcher serverCatcher = new Catcher();
+        Catcher clientCatcher = new Catcher();
+        server.setRawDataReceiver(serverCatcher);
+        client.setRawDataReceiver(clientCatcher);
+        server.start();
+        client.start();
+
+        RawData msg = createMessage(new InetSocketAddress(port));
+
+        client.send(msg);
+        serverCatcher.blockUntilSize(1);
+        assertArrayEquals(msg.getBytes(), serverCatcher.getMessage(0).getBytes());
+
+        // Response message must go over the same connection client already opened
+        msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress());
+        server.send(msg);
+        clientCatcher.blockUntilSize(1);
+        assertArrayEquals(msg.getBytes(), clientCatcher.getMessage(0).getBytes());
+    }
+
+    @Test
+    public void singleServerManyClients() throws Exception {
+        int port = findEphemeralPort();
+        int clients = 100;
+        TcpServerConnector server = new TcpServerConnector(new InetSocketAddress(port), 100, 1);
+        cleanup.add(server);
+
+        Catcher serverCatcher = new Catcher();
+        server.setRawDataReceiver(serverCatcher);
+        server.start();
+
+        List<RawData> messages = new ArrayList<>();
+        for (int i = 0; i < clients; i++) {
+            TcpClientConnector client = new TcpClientConnector(1, 100, 100);
+            cleanup.add(client);
+            Catcher clientCatcher = new Catcher();
+            client.setRawDataReceiver(clientCatcher);
+            client.start();
+
+            RawData msg = createMessage(new InetSocketAddress(port));
+            messages.add(msg);
+            client.send(msg);
+        }
+
+        serverCatcher.blockUntilSize(clients);
+        for (int i = 0; i < clients; i++) {
+            RawData received = serverCatcher.getMessage(i);
+
+            // Make sure that we intended to send that message
+            boolean matched = false;
+            for (RawData sent : messages) {
+                if (Arrays.equals(sent.getBytes(), received.getBytes())) {
+                    matched = true;
+                    break;
+                }
+            }
+            assertTrue("Received unexpected message: " + received, matched);
+        }
+    }
+
+    private int findEphemeralPort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to bind to ephemeral port");
+        }
+    }
+
+    private RawData createMessage(InetSocketAddress address) throws Exception {
+        byte[] data = new byte[messageSize];
+        random.nextBytes(data);
+
+        try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
+            if (messageSize < 13) {
+                stream.write(messageSize << 4);
+            } else if (messageSize < (1 << 8) + 13) {
+                stream.write(13 << 4);
+                stream.write(messageSize - 13);
+            } else if (messageSize < (1 << 16) + 269) {
+                stream.write(14 << 4);
+
+                ByteBuffer buffer = ByteBuffer.allocate(2);
+                buffer.putShort((short) (messageSize - 269));
+                stream.write(buffer.array());
+            } else {
+                stream.write(15 << 4);
+
+                ByteBuffer buffer = ByteBuffer.allocate(4);
+                buffer.putInt(messageSize - 65805);
+                stream.write(buffer.array());
+            }
+
+            stream.write(1); // GET
+            stream.write(data);
+            stream.flush();
+            return new RawData(stream.toByteArray(), address);
+        }
+    }
+
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -1588,4 +1588,9 @@ public class DTLSConnector implements Connector {
 				new Object[]{record.getType(), record.getPeerAddress(), cause.getMessage()});
 		}
 	}
+
+	@Override
+	public boolean isSchemeSupported(String scheme) {
+		return "coaps".contentEquals(scheme);
+	}
 }


### PR DESCRIPTION
    Uses Netty 4.1 for non-blocking IO. Implementation splits into Server and Client TCP connector, with expectation that the client connector does not listen on a port. Still todo:

    1) Add TLS support to both client and server connector.
    2) Add call back from the TcpConnector when a connection is lost (per RFC all exchanges with that remote endpoint must be closed)
    3) Add ability for TcpServerConnector to open outbound connections. This is desireable when application is reusing the same endpoint between CoapClient and CoapServer

Signed-off-by: Joe Magerramov <joemag@amazon.com>