### PR TITLE
Fix Exchange leak if response is never received

### DIFF
--- a/californium-core/pom.xml
+++ b/californium-core/pom.xml
@@ -23,6 +23,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.9.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>element-connector</artifactId>
 			<type>jar</type>

--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
@@ -764,8 +764,13 @@ public class CoapClient {
 	private CoapResponse synchronous(Request request, Endpoint outEndpoint) {
 		try {
 			Response response = send(request, outEndpoint).waitForResponse(getTimeout());
-			if (response == null) return null;
-			else return new CoapResponse(response);
+			if (response == null) {
+				// Cancel request so appropriate clean up can happen.
+				request.cancel();
+				return null;
+			} else {
+				return new CoapResponse(response);
+			}
 		} catch (InterruptedException e) {
 			throw new RuntimeException(e);
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -246,7 +246,7 @@ public class UdpMatcher implements Matcher {
 		 * This request could be
 		 *  - Complete origin request => deliver with new exchange
 		 *  - One origin block        => deliver with ongoing exchange
-		 *  - Complete duplicate request or one duplicate block (because client got no ACK) 
+		 *  - Complete duplicate request or one duplicate block (because client got no ACK)
 		 *      =>
 		 * 		if ACK got lost => resend ACK
 		 * 		if ACK+response got lost => resend ACK+response
@@ -301,7 +301,7 @@ public class UdpMatcher implements Matcher {
 				return ongoing;
 
 			} else {
-				// We have no ongoing exchange for that request block. 
+				// We have no ongoing exchange for that request block.
 				/*
 				 * Note the difficulty of the following code: The first message
 				 * of a blockwise transfer might arrive twice due to a
@@ -495,7 +495,7 @@ public class UdpMatcher implements Matcher {
 
 		@Override public void completed(final Exchange exchange) {
 
-			/* 
+			/*
 			 * Logging in this method leads to significant performance loss.
 			 * Uncomment logging code only for debugging purposes.
 			 */

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapTcpStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapTcpStack.java
@@ -57,6 +57,8 @@ import java.util.logging.Logger;
  * | +---------v-+-------+ |
  * | | Stack Top         | |
  * | +-------------------+ |
+ * | | {@link ExchangeCleanupLayer}      | |
+ * * | +-------------------+ |
  * | | {@link ObserveLayer}      | |
  * | +-------------------+ |
  * | | {@link BlockwiseLayer}    | |
@@ -91,8 +93,13 @@ public class CoapTcpStack implements CoapStack {
 		this.top = new StackTopAdapter();
 		this.outbox = outbox;
 
-		this.layers = new Layer.TopDownBuilder().add(top).add(new ObserveLayer(config)).add(new BlockwiseLayer(config))
-				.add(bottom = new StackBottomAdapter()).create();
+		this.layers = new Layer.TopDownBuilder()
+				.add(top)
+				.add(new ExchangeCleanupLayer())
+				.add(new ObserveLayer(config))
+				.add(new BlockwiseLayer(config))
+				.add(bottom = new StackBottomAdapter())
+				.create();
 
 		// make sure the endpoint sets a MessageDeliverer
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapUdpStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapUdpStack.java
@@ -56,6 +56,8 @@ import java.util.logging.Logger;
  * | +---------v-+-------+ |
  * | | Stack Top         | |
  * | +-------------------+ |
+ * | | {@link ExchangeCleanupLayer} | |
+ * * | +-------------------+ |
  * | | {@link ObserveLayer}      | |
  * | +-------------------+ |
  * | | {@link BlockwiseLayer}    | |
@@ -100,8 +102,15 @@ public class CoapUdpStack implements CoapStack {
 			reliabilityLayer = new ReliabilityLayer(config);
 		}
 
-		this.layers = new Layer.TopDownBuilder().add(top).add(new ObserveLayer(config)).add(new BlockwiseLayer(config))
-				.add(reliabilityLayer).add(bottom = new StackBottomAdapter()).create();
+
+		this.layers = new Layer.TopDownBuilder()
+				.add(top)
+				.add(new ExchangeCleanupLayer())
+				.add(new ObserveLayer(config))
+				.add(new BlockwiseLayer(config))
+				.add(reliabilityLayer)
+				.add(bottom = new StackBottomAdapter())
+				.create();
 
 		// make sure the endpoint sets a MessageDeliverer
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ExchangeCleanupLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ExchangeCleanupLayer.java
@@ -1,0 +1,31 @@
+package org.eclipse.californium.core.network.stack;
+
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.Exchange;
+
+/**
+ * A layer that reacts to user cancelled outgoing requests, and completes exchange, which causes state clean up.
+ */
+public class ExchangeCleanupLayer extends AbstractLayer {
+
+	@Override public void sendRequest(Exchange exchange, Request request) {
+		request.addMessageObserver(new CancelledMessageObserver(exchange));
+		super.sendRequest(exchange, request);
+	}
+
+	private static class CancelledMessageObserver extends MessageObserverAdapter {
+
+		private final Exchange exchange;
+
+		CancelledMessageObserver(Exchange exchange) {
+			this.exchange = exchange;
+		}
+
+		@Override public void onCancel() {
+			if (!exchange.isComplete()) {
+				exchange.setComplete();
+			}
+		}
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/TcpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/TcpMatcherTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import org.eclipse.californium.category.Small;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange.Origin;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.CorrelationContext;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+import static org.junit.Assert.assertSame;
+
+@Category(Small.class)
+public class TcpMatcherTest {
+
+	private static final InetSocketAddress dest = new InetSocketAddress(InetAddress.getLoopbackAddress(), 5684);
+	private static final InetSocketAddress source = new InetSocketAddress(InetAddress.getLoopbackAddress(), 12000);
+
+	@Test
+	public void testRequestMatchesResponse() {
+		TcpMatcher matcher = newMatcher(false);
+		Exchange exchange = sendRequest(matcher, null);
+
+		Exchange matched = matcher.receiveResponse(responseFor(exchange.getCurrentRequest()), null);
+		assertSame(exchange, matched);
+	}
+
+	private TcpMatcher newMatcher(boolean useStrictMatching) {
+		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
+		config.setBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING, useStrictMatching);
+		return new TcpMatcher(config);
+	}
+
+	private Exchange sendRequest(final TcpMatcher matcher, final CorrelationContext ctx) {
+		Request request = Request.newGet();
+		request.setDestination(dest.getAddress());
+		request.setDestinationPort(dest.getPort());
+		Exchange exchange = new Exchange(request, Origin.LOCAL);
+		exchange.setRequest(request);
+		matcher.sendRequest(exchange, request);
+		exchange.setCorrelationContext(ctx);
+		return exchange;
+	}
+
+	private Response responseFor(final Request request) {
+		Response response = new Response(ResponseCode.CONTENT);
+		response.setMID(request.getMID());
+		response.setToken(request.getToken());
+		response.setBytes(new byte[]{});
+		response.setSource(source.getAddress());
+		response.setSourcePort(source.getPort());
+		return response;
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -81,7 +81,7 @@ public class UdpMatcherTest {
 
 	@Test
 	public void testReceiveResponseAcceptsResponseFromDifferentEpochUsingLaxMatching() {
-		// GIVEN a request sent via a DTLS transport using a matcher set to lax matching 
+		// GIVEN a request sent via a DTLS transport using a matcher set to lax matching
 		UdpMatcher matcher = newMatcher(false);
 		Exchange exchange = sendRequest(matcher, new DtlsCorrelationContext(SESSION_ID, EPOCH, CIPHER));
 
@@ -129,7 +129,7 @@ public class UdpMatcherTest {
 
 	@Test
 	public void testReceiveResponseAcceptsResponseFromSameSessionEpochAndCipherUsingStrictMatching() {
-		// GIVEN a request sent via a DTLS transport 
+		// GIVEN a request sent via a DTLS transport
 		UdpMatcher matcher = newMatcher(true);
 		Exchange exchange = sendRequest(matcher, new DtlsCorrelationContext(SESSION_ID, EPOCH, CIPHER));
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapStackTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapStackTest.java
@@ -1,0 +1,64 @@
+package org.eclipse.californium.core.network.stack;
+
+import org.eclipse.californium.category.Small;
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.Outbox;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+
+@Category(Small.class) @RunWith(Parameterized.class)
+public class CoapStackTest {
+
+	private static final NetworkConfig CONFIG = NetworkConfig.createStandardWithoutFile();
+
+	private final CoapStack stack;
+	private final Outbox outbox;
+
+	public CoapStackTest(CoapStack stack, Outbox outbox) {
+		this.stack = stack;
+		this.stack.setExecutor(Executors.newSingleThreadScheduledExecutor());
+		this.outbox = outbox;
+	}
+
+	@Parameterized.Parameters public static List<Object[]> parameters() {
+		Outbox udpOutbox = mock(Outbox.class);
+		Outbox tcpOutbox = mock(Outbox.class);
+
+		List<Object[]> parameters = new ArrayList<>();
+		parameters.add(new Object[]{new CoapTcpStack(CONFIG, tcpOutbox), tcpOutbox});
+		parameters.add(new Object[]{new CoapUdpStack(CONFIG, udpOutbox), udpOutbox});
+		return parameters;
+	}
+
+	@Test public void cancelledMessageExpectExchangeComplete() {
+		Request request = new Request(CoAP.Code.GET);
+
+		ArgumentCaptor<Exchange> exchangeCaptor = ArgumentCaptor.forClass(Exchange.class);
+		doNothing().when(outbox).sendRequest(exchangeCaptor.capture(), eq(request));
+
+		stack.sendRequest(request);
+
+		// Capture exchange
+		Exchange exchange = exchangeCaptor.getValue();
+		assertFalse(exchange.isComplete());
+
+		request.setCanceled(true);
+		assertTrue(exchange.isComplete());
+	}
+}


### PR DESCRIPTION
Fixes issues: https://github.com/eclipse/californium/issues/73 and https://github.com/eclipse/californium/issues/72

Prior to this fix, if a response to the request (or in UDP stack response for an acknowledged request) never arrived we'd leak Exchange in the Matcher maps. We'd also never call back client's CoapHandler.onError() callback.

This change adds an explicit expiration to CoAP exchanges based on MAX_EXCHANGE_LIFECYCLE parameter.

Signed-off-by: Joe Magerramov <joemag@amazon.com>