### PR TITLE
Fixes to persist observation

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -478,14 +478,13 @@ public class UdpMatcher implements Matcher {
 			// no correlation information available for request, thus any
 			// additional correlation information available in the response is ignored
 			return true;
-		} else if (exchange.getCorrelationContext() instanceof DtlsCorrelationContext) {
+		} else if (exchange.getCorrelationContext().get(DtlsCorrelationContext.KEY_SESSION_ID) != null) {
 			// original request has been sent via a DTLS protected transport
-			DtlsCorrelationContext exchangeDtlsContext = (DtlsCorrelationContext) exchange.getCorrelationContext();
 			// check if the response has been received in the same DTLS session
 			if (useStrictResponseMatching) {
-				return isResponseStrictlyRelatedToDtlsRequest(exchangeDtlsContext, responseContext);
+				return isResponseStrictlyRelatedToDtlsRequest(exchange.getCorrelationContext(), responseContext);
 			} else {
-				return isResponseRelatedToDtlsRequest(exchangeDtlsContext, responseContext);
+				return isResponseRelatedToDtlsRequest(exchange.getCorrelationContext(), responseContext);
 			}
 		} else {
 			// compare message context used for sending original request to context
@@ -494,22 +493,27 @@ public class UdpMatcher implements Matcher {
 		}
 	}
 
-	private boolean isResponseRelatedToDtlsRequest(final DtlsCorrelationContext requestContext, final CorrelationContext responseContext) {
+	private boolean isResponseRelatedToDtlsRequest(final CorrelationContext requestContext, final CorrelationContext responseContext) {
 		if (responseContext == null) {
 			return false;
 		} else {
-			return requestContext.getSessionId().equals(responseContext.get(DtlsCorrelationContext.KEY_SESSION_ID))
-					&& requestContext.getCipher().equals(responseContext.get(DtlsCorrelationContext.KEY_CIPHER));
+			return requestContext.get(DtlsCorrelationContext.KEY_SESSION_ID)
+					.equals(responseContext.get(DtlsCorrelationContext.KEY_SESSION_ID))
+					&& requestContext.get(DtlsCorrelationContext.KEY_CIPHER)
+							.equals(responseContext.get(DtlsCorrelationContext.KEY_CIPHER));
 		}
 	}
 
-	private boolean isResponseStrictlyRelatedToDtlsRequest(final DtlsCorrelationContext requestContext, final CorrelationContext responseContext) {
+	private boolean isResponseStrictlyRelatedToDtlsRequest(final CorrelationContext requestContext, final CorrelationContext responseContext) {
 		if (responseContext == null) {
 			return false;
 		} else {
-			return requestContext.getSessionId().equals(responseContext.get(DtlsCorrelationContext.KEY_SESSION_ID))
-					&& requestContext.getEpoch().equals(responseContext.get(DtlsCorrelationContext.KEY_EPOCH))
-					&& requestContext.getCipher().equals(responseContext.get(DtlsCorrelationContext.KEY_CIPHER));
+			return requestContext.get(DtlsCorrelationContext.KEY_SESSION_ID)
+					.equals(responseContext.get(DtlsCorrelationContext.KEY_SESSION_ID))
+					&& requestContext.get(DtlsCorrelationContext.KEY_EPOCH)
+							.equals(responseContext.get(DtlsCorrelationContext.KEY_EPOCH))
+					&& requestContext.get(DtlsCorrelationContext.KEY_CIPHER)
+							.equals(responseContext.get(DtlsCorrelationContext.KEY_CIPHER));
 		}
 	}
 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/CorrelationContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/CorrelationContext.java
@@ -17,6 +17,7 @@
  ******************************************************************************/
 package org.eclipse.californium.elements;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -35,9 +36,9 @@ public interface CorrelationContext {
 	String get(String key);
 
 	/**
-	 * Sends the list of keys available in the context.
+	 * Gets a Set of a Map.Entry which contains the key-value pair of the CorrelationContext.
 	 *
-	 * @return list of keys set in the context.
+	 * @return A set of a map entry containing the key value pair.
 	 */
-	Set<String> getKeys();
+	Set<Map.Entry<String, String>> entrySet();
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/CorrelationContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/CorrelationContext.java
@@ -17,9 +17,11 @@
  ******************************************************************************/
 package org.eclipse.californium.elements;
 
+import java.util.Set;
+
 /**
- * A container for storing transport specific information about the context
- * in which a message has been sent or received.
+ * A container for storing transport specific information about the context in
+ * which a message has been sent or received.
  */
 public interface CorrelationContext {
 
@@ -27,8 +29,15 @@ public interface CorrelationContext {
 	 * Gets a value from this context.
 	 * 
 	 * @param key the key to retrieve the value for.
-	 * @return the value or <code>null</code> if this context does not contain
-	 *         a value for the given key.
+	 * @return the value or <code>null</code> if this context does not contain a
+	 *         value for the given key.
 	 */
 	String get(String key);
+
+	/**
+	 * Sends the list of keys available in the context.
+	 *
+	 * @return list of keys set in the context.
+	 */
+	Set<String> getKeys();
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedCorrelationContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedCorrelationContext.java
@@ -19,6 +19,7 @@ package org.eclipse.californium.elements;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A map based correlation context.
@@ -45,6 +46,14 @@ public class MapBasedCorrelationContext implements CorrelationContext {
 	@Override
 	public String get(String key) {
 		return entries.get(key);
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Set<String> getKeys() {
+		return entries.keySet();
 	}
 
 	/**

--- a/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedCorrelationContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedCorrelationContext.java
@@ -52,8 +52,8 @@ public class MapBasedCorrelationContext implements CorrelationContext {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public Set<String> getKeys() {
-		return entries.keySet();
+	public Set<Map.Entry<String, String>> entrySet() {
+		return entries.entrySet();
 	}
 
 	/**


### PR DESCRIPTION
Added some fixes to persist Observation in ObservationStore to a permanent store like Redis or MongoDB.

- In CorrelationContex added getKeys(), this allows to store the associated context.
- In UdpMatcher replaced the instantOf check of DtlsCorrelationContext. Check if in the given exchange the correlationContext with key "KEY_SESSION_ID" is available.
Otherwise we would have to persist something like the information about the instance of the correlationContext.
- Removed the cast to the DtlsCorrelationContext, because all information can be retrieved over the CorrelationContext, which is used in the isResponseRelatedToDtlsRequest and isResponseStrictlyRelatedToDtlsRequest method.
All operation can be done through the Interface.