### PR TITLE
Introduce TokenProvider to prevent clashes of CoAP tokens

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -25,6 +25,7 @@
  *                                      of Response(s) to Request (fix GitHub issue #1)
  *    Bosch Software Innovations GmbH - adapt message parsing error handling
  *    Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ *    Bosch Software Innovations GmbH - introduce TokenProvider
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -234,31 +235,40 @@ public class CoapEndpoint implements Endpoint {
 	 * @param config the config
 	 */
 	public CoapEndpoint(Connector connector, NetworkConfig config) {
-		this(connector, config, null);
+		this(connector, config, null, null);
 	}
 
 	/**
 	 * Instantiates a new endpoint with the specified address and configuration
 	 * and observe request store (used to persist observation).
 	 *
-	 * @param connector the connector
-	 * @param config the config
+	 * @param address the address
+	 * @param config the network configuration
+	 * @param store to store observations, if <code>null</code> default
+	 *            {@link InMemoryObservationStore} gets used
+	 * @param tokenProvider to obtain unused CoAP tokens, if <code>null</code>
+	 *            default {@link InMemoryRandomTokenProvider} gets used
 	 */
-	public CoapEndpoint(InetSocketAddress address, NetworkConfig config, ObservationStore store) {
-		this(createUDPConnector(address, config), config, store);
+	public CoapEndpoint(InetSocketAddress address, NetworkConfig config, ObservationStore store, TokenProvider tokenProvider) {
+		this(createUDPConnector(address, config), config, store, tokenProvider);
 	}
 
 	/**
-	 * Instantiates a new endpoint with the specified connector and configuration
-	 * and observe request store (used to persist observation).
+	 * Instantiates a new endpoint with the specified connector and
+	 * configuration and observe request store (used to persist observation).
 	 *
 	 * @param connector the connector
 	 * @param config the config
+	 * @param store to store observations, if <code>null</code> default
+	 *            {@link InMemoryObservationStore} gets used
+	 * @param tokenProvider to obtain unused CoAP tokens, if <code>null</code>
+	 *            default {@link InMemoryRandomTokenProvider} gets used
 	 */
-	public CoapEndpoint(Connector connector, NetworkConfig config, ObservationStore store) {
+	public CoapEndpoint(Connector connector, NetworkConfig config, ObservationStore store, TokenProvider tokenProvider) {
 		this.config = config;
 		this.connector = connector;
 		ObservationStore observationStore = store != null ? store : new InMemoryObservationStore();
+		TokenProvider actualTokenProvider = tokenProvider != null ? tokenProvider : new InMemoryRandomTokenProvider(config);
 
 		if (connector.isSchemeSupported(CoAP.COAP_TCP_URI_SCHEME) ||
 				connector.isSchemeSupported(CoAP.COAP_SECURE_TCP_URI_SCHEME)) {
@@ -267,7 +277,7 @@ public class CoapEndpoint implements Endpoint {
 			this.serializer = new TcpDataSerializer();
 			this.parser = new TcpDataParser();
 		} else {
-			this.matcher = new UdpMatcher(config, new NotificationDispatcher(), observationStore);
+			this.matcher = new UdpMatcher(config, new NotificationDispatcher(), observationStore, actualTokenProvider);
 			this.coapstack = new CoapUdpStack(config, new OutboxImpl());
 			this.serializer = new UdpDataSerializer();
 			this.parser = new UdpDataParser();

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryRandomTokenProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryRandomTokenProvider.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Daniel Maier (Bosch Software Innovations GmbH)
+ *                                - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.util.Collections;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.eclipse.californium.core.network.Exchange.KeyToken;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+
+/**
+ * {@link TokenProvider} that uses random tokens and stores them in memory. 
+ * 
+ * Note: This {@link TokenProvider} is not sufficient if persistence is in use.
+ *
+ * This implementation is thread-safe.
+ */
+public class InMemoryRandomTokenProvider implements TokenProvider {
+
+	private final Set<KeyToken> usedTokens = Collections.newSetFromMap(new ConcurrentHashMap<KeyToken, Boolean>());
+	private final int tokenSizeLimit;
+
+	/**
+	 * Creates a new {@link InMemoryRandomTokenProvider}.
+	 * 
+	 * @param networkConfig used to obtain the configured token size
+	 */
+	public InMemoryRandomTokenProvider(NetworkConfig networkConfig) {
+		this.tokenSizeLimit = networkConfig.getInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT);
+	}
+
+	@Override
+	public byte[] getUnusedToken() {
+		return createUnusedToken();
+	}
+
+	@Override
+	public void releaseToken(byte[] token) {
+		usedTokens.remove(new KeyToken(token));
+	}
+
+	@Override
+	public boolean isTokenInUse(byte[] token) {
+		return usedTokens.contains(new KeyToken(token));
+	}
+
+	private byte[] createUnusedToken() {
+		final Random random = ThreadLocalRandom.current();
+		byte[] token;
+		KeyToken result;
+		// TODO what to do when there are no more unused tokens left?
+		do {
+			token = new byte[tokenSizeLimit];
+			random.nextBytes(token);
+			result = new KeyToken(token);
+		} while (!usedTokens.add(result));
+		return result.token;
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TokenProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TokenProvider.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Daniel Maier (Bosch Software Innovations GmbH)
+ *                                - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.californium.core.network;
+
+/**
+ * A {@link TokenProvider} provides CoAP tokens that are guaranteed to be not in
+ * use. To not run out of unused tokens, used tokens MUST be released with
+ * {@link #releaseToken(byte[])} after usage.
+ *
+ * Implementations of {@link TokenProvider} MUST be thread-safe.
+ */
+public interface TokenProvider {
+
+	/**
+	 * Returns a token that is not in use. After this token is not in use
+	 * anymore it must be released with {@link #releaseToken(byte[])}.
+	 * 
+	 * @return a token that is not in use
+	 */
+	byte[] getUnusedToken();
+
+	/**
+	 * Releases the given token to be used again.
+	 * 
+	 * @param token the token to be released
+	 */
+	void releaseToken(byte[] token);
+
+	/**
+	 * Indicates if the given token is in use, i.e. was returned by
+	 * {@link #getUnusedToken()} but not yet released by
+	 * {@link #releaseToken(byte[])}.
+	 * 
+	 * @param token the token to be checked
+	 * @return <code>true</code> if the given token is still in use, <code>false</code> otherwise
+	 */
+	boolean isTokenInUse(byte[] token);
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
@@ -29,6 +29,7 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.InMemoryRandomTokenProvider;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
 import org.eclipse.californium.core.observe.InMemoryObservationStore;
@@ -57,6 +58,8 @@ public class ClusteringTest {
 	private int clientPort2;
 
 	private InMemoryObservationStore store;
+	
+	private InMemoryRandomTokenProvider tokenProvider;
 
 	private SynchronousNotificationListener notificationListener1;
 
@@ -75,9 +78,10 @@ public class ClusteringTest {
 				.setFloat(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1f).setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f);
 
 		store = new InMemoryObservationStore();
+		tokenProvider = new InMemoryRandomTokenProvider(config);
 		notificationListener1 = new SynchronousNotificationListener();
 
-		client1 = new CoapEndpoint(new InetSocketAddress(0), config, store);
+		client1 = new CoapEndpoint(new InetSocketAddress(0), config, store, tokenProvider);
 		client1.addNotificationListener(notificationListener1);
 		client1.addInterceptor(clientInterceptor);
 		client1.addInterceptor(new MessageTracer());
@@ -86,7 +90,7 @@ public class ClusteringTest {
 		System.out.println("Client 1 binds to port " + clientPort1);
 
 		notificationListener2 = new SynchronousNotificationListener();
-		client2 = new CoapEndpoint(new InetSocketAddress(0), config, store);
+		client2 = new CoapEndpoint(new InetSocketAddress(0), config, store, tokenProvider);
 		client2.addNotificationListener(notificationListener2);
 		client2.addInterceptor(clientInterceptor);
 		client2.addInterceptor(new MessageTracer());


### PR DESCRIPTION
Initial implementation to fix #83.

This PR introduces a `TokenProvider` which is responsible to provide unused token. The `TokenProvider` is plugable to give users the possibility to implement their own `TokenProvider`, e.g. a cluster ready one. The default `TokenProvider` is an in memory implementation that uses random tokens.

This PR does not modify the `TcpMatcher` because I am unsure which is the state of TCP implementation in 2.0.x branch (`TcpMatcher` does not use `ObservationStore`)

One problem is still with user provided tokens. `TokenProvider` may create same token as a user provided token, because `TokenProvider` is not aware of user provided tokens.  