### PR TITLE
Store contextual information on the request

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -30,6 +30,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.security.Principal;
+import java.util.Collections;
+import java.util.Map;
 
 import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.Type;
@@ -107,8 +109,11 @@ public class Request extends Message {
 	/** The lock object used to wait for a response. */
 	private Object lock;
 
-	/** the authenticated (remote) sender's identity **/
+	/** the authenticated (remote) sender's identity */
 	private Principal senderIdentity;
+
+	/** Contextual information about this request */
+	private Map<String, String> userContext;
 
 	/**
 	 * Creates a request of type {@code CON} for a CoAP code.
@@ -549,6 +554,28 @@ public class Request extends Message {
 				lock.notifyAll();
 			}
 		}
+	}
+
+	/**
+	 * @return an unmodifiable map containing additional information about this
+	 *         request.
+	 */
+	public Map<String, String> getUserContext() {
+		if (userContext == null) {
+			return Collections.emptyMap();
+		}
+		return Collections.unmodifiableMap(userContext);
+	}
+
+	/**
+	 * Set contextual information about this request.
+	 * 
+	 * @param userContext
+	 * @return this request
+	 */
+	public Request setUserContext(Map<String, String> userContext) {
+		this.userContext = userContext;
+		return this;
 	}
 
 	/* (non-Javadoc)

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/InMemoryObservationStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/InMemoryObservationStore.java
@@ -44,6 +44,7 @@ public class InMemoryObservationStore implements ObservationStore {
 			RawData serialize = serializer.serializeRequest(obs.getRequest(), null);
 			DataParser parser = new UdpDataParser();
 			Request newRequest = (Request) parser.parseMessage(serialize);
+			newRequest.setUserContext(obs.getRequest().getUserContext());
 			return new Observation(newRequest, obs.getContext());
 		}
 		return null;


### PR DESCRIPTION
It can be needed to add some additional information to a request.
Observation is a typical use case: Californium is in charge of persisting the observation but it can be needed to persist the contextual information as well. It would not be necessary if the additional data is part of the request.