### PR TITLE
Observationstore improvement

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/InMemoryObservationStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/InMemoryObservationStore.java
@@ -13,6 +13,8 @@
  ******************************************************************************/
 package org.eclipse.californium.core.observe;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -31,10 +33,11 @@ public class InMemoryObservationStore implements ObservationStore {
 	private Map<KeyToken, Observation> map = new ConcurrentHashMap<>();
 
 	@Override
-	public void add(Observation obs) {
+	public List<Observation> add(Observation obs) {
 		if (obs != null) {
 			map.put(new KeyToken(obs.getRequest().getToken()), obs);
 		}
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationStore.java
@@ -13,6 +13,8 @@
  ******************************************************************************/
 package org.eclipse.californium.core.observe;
 
+import java.util.List;
+
 import org.eclipse.californium.elements.CorrelationContext;
 
 /**
@@ -28,8 +30,12 @@ public interface ObservationStore {
 
 	/**
 	 * Adds an observation to the store.
+	 * 
+	 * @return observations removed from the store pending this addition. (Could
+	 *         be used to ensure there is only one observation for a target
+	 *         resource)
 	 */
-	void add(Observation obs);
+	List<Observation> add(Observation obs);
 
 	/**
 	 * Removes the observation initiated by the request with the given token.


### PR DESCRIPTION
Add the possibility to return observations removed from the store pending an addition.

This could be useful to limit the number of observations for a given target resource.
(There is a discussion about that [here](https://github.com/eclipse/leshan/pull/169#issuecomment-243166705))
