### PR TITLE
fix stale observations in CoAPClient when CoAPServer cannot add an observation

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -322,12 +322,17 @@ public final class UdpMatcher extends BaseMatcher {
 
 					@Override
 					public void onResponse(Response response) {
+						// check whether the client has established the observe
+						// requested
 						if (!response.getOptions().hasObserve()) {
+							// Observe response received with no observe option
+							// set. It could be that the Client was not able to
+							// establish the observe. So remove the observe
+							// relation from observation store, which was stored
+							// earlier when the request was sent.
 							LOGGER.log(Level.FINE,
-									"Removed entry from observation store as observe response with token {0} didn't have observe option: ",
+									"Response to observe request with token {0} does not contain observe option, removing request from observation store",
 									idByToken);
-							// no observe option set. Client was not able to
-							// establish observe
 							observationStore.remove(request.getToken());
 						} else {
 							notificationListener.onNotification(request, response);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -289,7 +289,7 @@ public final class UdpMatcher extends BaseMatcher {
 		 */
 
 		KeyMID idByMID = KeyMID.fromInboundMessage(response);
-		KeyToken idByToken = KeyToken.fromInboundMessage(response);
+		final KeyToken idByToken = KeyToken.fromInboundMessage(response);
 		LOGGER.log(Level.FINER, "received response {0}", response);
 		Exchange exchange = exchangeStore.get(idByToken);
 
@@ -321,8 +321,17 @@ public final class UdpMatcher extends BaseMatcher {
 					}
 
 					@Override
-					public void onResponse(final Response resp) {
-						notificationListener.onNotification(request, resp);
+					public void onResponse(Response response) {
+						if (!response.getOptions().hasObserve()) {
+							LOGGER.log(Level.FINE,
+									"Removed entry from observation store as observe response with token {0} didn't have observe option: ",
+									idByToken);
+							// no observe option set. Client was not able to
+							// establish observe
+							observationStore.remove(request.getToken());
+						} else {
+							notificationListener.onNotification(request, response);
+						}
 					}
 
 					@Override


### PR DESCRIPTION
As per CoAP Spec RFC 7641 Section [§2](https://tools.ietf.org/html/rfc7641#section-2) 

> If the server is unwilling or unable to add a new entry to the list of
   observers, then the request falls back to a normal GET request and
   the response does not include the Observe Option.

If the server sends a normal ACK for the observe request without the observe option, the [observation that was added to observation store in UdpMatcher#L204](https://github.com/eclipse/californium/blob/2.0.x/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java#L204) will never be removed leading to stale entries.

This PR aims to fix this problem.

Signed-off-by: Bala Azhagappan balasubramanian.azhagappan@bosch-si.com