### PR TITLE
Change the visibilityof  observeAndWait() and observe() to public

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
@@ -848,7 +848,7 @@ public class CoapClient {
 	 * @param handler the Response handler
 	 * @return the CoAP observe relation
 	 */
-	private CoapObserveRelation observeAndWait(Request request, CoapHandler handler) {
+	public CoapObserveRelation observeAndWait(Request request, CoapHandler handler) {
 		Endpoint outEndpoint = getEffectiveEndpoint(request);
 		CoapObserveRelation relation = new CoapObserveRelation(request, outEndpoint);
 		request.addMessageObserver(new ObserveMessageObserverImpl(handler, relation));
@@ -867,7 +867,7 @@ public class CoapClient {
 	 * @param handler the Response handler
 	 * @return the CoAP observe relation
 	 */
-	private CoapObserveRelation observe(Request request, CoapHandler handler) {
+	public CoapObserveRelation observe(Request request, CoapHandler handler) {
 		Endpoint outEndpoint = getEffectiveEndpoint(request);
 		CoapObserveRelation relation = new CoapObserveRelation(request, outEndpoint);
 		request.addMessageObserver(new ObserveMessageObserverImpl(handler, relation));


### PR DESCRIPTION
Change the visibility of  observeAndWait() and observe() to public as per
disucssion on the issue https://github.com/eclipse/californium/issues/92