### PR TITLE
Fix #63 

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
@@ -238,7 +238,7 @@ public class CoapServer implements ServerInterface {
 			running = false;
 		}
 	}
-	
+
 	/**
 	 * Destroys the server, i.e., unbinds from all ports and frees all system resources.
 	 */
@@ -248,6 +248,9 @@ public class CoapServer implements ServerInterface {
 		LOGGER.info("Destroying server");
 		// prevent new tasks from being submitted
 		executor.shutdown(); // cannot be started again
+		for (Endpoint ep : endpoints) {
+			ep.destroy();
+		}
 		try {
 			// wait for currently executing tasks to complete
 			if (!executor.awaitTermination(1, TimeUnit.SECONDS)) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
@@ -63,6 +63,12 @@ public abstract class Message {
 
 	/** The Constant NONE in case no MID has been set. */
 	public static final int NONE = -1;
+	/**
+	 * The largest message ID allowed by CoAP.
+	 * <p>
+	 * The value of this constant is 2^16 - 1.
+	 */
+	public static final int MAX_MID = (1 << 16) - 1;
 
 	/** The type. One of {CON, NON, ACK or RST}. */
 	private CoAP.Type type;
@@ -70,8 +76,15 @@ public abstract class Message {
 	/** The 16-bit Message Identification. */
 	private int mid = NONE; // Message ID
 
-	/** The token, a 0-8 byte array. */
-	private byte[] token;
+	/**
+	 * The token, a 0-8 byte array.
+	 * <p>
+	 * This field is initialized to {@code null} so that client code can
+	 * determine whether the message already has a token assigned or not.
+	 * An empty array would not work here because it is already a valid token
+	 * according to the CoAP spec.
+	 */
+	private byte[] token = null;
 
 	/** The set of options of this message. */
 	private OptionSet options;
@@ -202,6 +215,15 @@ public abstract class Message {
 	}
 
 	/**
+	 * Checks whether this message has a valid ID.
+	 * 
+	 * @return {@code true} if this message's ID is a 16 bit unsigned integer.
+a	 */
+	public boolean hasMID() {
+		return mid != NONE;
+	}
+
+	/**
 	 * Sets the 16-bit message identification.
 	 * Provides a fluent API to chain setters.
 	 *
@@ -209,8 +231,9 @@ public abstract class Message {
 	 * @return this Message
 	 */
 	public Message setMID(int mid) {
-		if (mid >= 1<<16 || mid < NONE)
-			throw new IllegalArgumentException("The MID must be a 16-bit number between 0 and "+((1<<16)-1)+" inclusive but was "+mid);
+		if (mid > MAX_MID || mid < NONE) { // NONE is allowed as a temporary placeholder
+			throw new IllegalArgumentException("The MID must be an unsigned 16-bit number but was " + mid);
+		}
 		this.mid = mid;
 		return this;
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -529,7 +529,7 @@ public class Request extends Message {
 		synchronized (lock) {
 			while (this.response == null && !isCanceled() && !isTimedOut() && !isRejected()) {
 				lock.wait(timeout);
-				long now = System.currentTimeMillis();				
+				long now = System.currentTimeMillis();
 				// timeout expired?
 				if (timeout > 0 && expired <= now) {
 					// break loop since response is still null

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.californium.core.network.config.NetworkConfig;
+
+/**
+ * A base class for implementing Matchers that provides support for
+ * using a {@code MessageExchangeStore}.
+ */
+public abstract class BaseMatcher implements Matcher {
+
+	private static final Logger LOG = Logger.getLogger(BaseMatcher.class.getName());
+	protected final NetworkConfig config;
+	protected boolean running = false;
+	protected MessageExchangeStore exchangeStore;
+
+	/**
+	 * Creates a new matcher based on configuration values.
+	 * 
+	 * @param config the configuration to use.
+	 */
+	public BaseMatcher(final NetworkConfig config) {
+		if (config == null) {
+			throw new NullPointerException("Config must not be null");
+		} else {
+			this.config = config;
+		}
+	}
+
+	@Override
+	public synchronized final void setMessageExchangeStore(final MessageExchangeStore store) {
+		if (running) {
+			throw new IllegalStateException("MessageExchangeStore can only be set on stopped Matcher");
+		} else if (store == null) {
+			throw new NullPointerException("Message exchange store must not be null");
+		} else {
+			this.exchangeStore = store;
+		}
+	}
+
+	protected final void assertMessageExchangeStoreIsSet() {
+		if (exchangeStore == null) {
+			LOG.log(Level.CONFIG, "no MessageExchangeStore set, using default {0}", InMemoryMessageExchangeStore.class.getName());
+			exchangeStore = new InMemoryMessageExchangeStore(config);
+		}
+	}
+
+	@Override
+	public synchronized void start() {
+		if (!running) {
+			assertMessageExchangeStoreIsSet();
+			exchangeStore.start();
+			running = true;
+		}
+	}
+
+	@Override
+	public synchronized void stop() {
+		if (running) {
+			exchangeStore.stop();
+			clear();
+			running = false;
+		}
+	}
+
+	/**
+	 * This method does nothing.
+	 * <p>
+	 * Subclasses should override this method in order to clear any internal state.
+	 */
+	@Override
+	public void clear() {
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
@@ -1,0 +1,397 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.californium.core.Utils;
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.Exchange.KeyMID;
+import org.eclipse.californium.core.network.Exchange.KeyToken;
+import org.eclipse.californium.core.network.Exchange.KeyUri;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.deduplication.Deduplicator;
+import org.eclipse.californium.core.network.deduplication.DeduplicatorFactory;
+import org.eclipse.californium.elements.CorrelationContext;
+
+
+/**
+ * A {@code MessageExchangeStore} that manages all exchanges in local memory.
+ *
+ */
+public class InMemoryMessageExchangeStore implements MessageExchangeStore {
+
+	private static final Logger LOGGER = Logger.getLogger(InMemoryMessageExchangeStore.class.getName());
+	private static final int MAX_TOKEN_LENGTH = 8; // bytes
+	private final ConcurrentMap<KeyMID, Exchange> exchangesByMID = new ConcurrentHashMap<>(); // for all
+	private final ConcurrentMap<KeyToken, Exchange> exchangesByToken = new ConcurrentHashMap<>(); // for outgoing
+	private final ConcurrentMap<KeyUri, Exchange> ongoingExchanges = new ConcurrentHashMap<>();
+
+	private final NetworkConfig config;
+	private final int tokenLength;
+	private boolean running = false;
+	private Deduplicator deduplicator;
+	private ScheduledFuture<?> statusLogger;
+	private ScheduledExecutorService scheduler;
+	private MessageIdProvider messageIdProvider;
+
+	/**
+	 * Creates a new store for configuration values.
+	 * 
+	 * @param config the configuration to use.
+	 */
+	public InMemoryMessageExchangeStore(final NetworkConfig config) {
+		if (config == null) {
+			throw new NullPointerException("Configuration must not be null");
+		}else {
+			this.config = config;
+			this.tokenLength = config.getInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT, MAX_TOKEN_LENGTH);
+			LOGGER.log(Level.CONFIG, "using tokens of {0} bytes in length", tokenLength);
+		}
+	}
+
+	private void startStatusLogging() {
+
+		final Level healthStatusLevel = Level.parse(config.getString(NetworkConfig.Keys.HEALTH_STATUS_PRINT_LEVEL, Level.FINEST.getName()));
+		final int healthStatusInterval = config.getInt(NetworkConfig.Keys.HEALTH_STATUS_INTERVAL, 60); // seconds
+		// this is a useful health metric that could later be exported to some kind of monitoring interface
+		if (LOGGER.isLoggable(healthStatusLevel)) {
+			this.scheduler = Executors.newSingleThreadScheduledExecutor(new Utils.DaemonThreadFactory("MessageExchangeStore"));
+			statusLogger = scheduler.scheduleAtFixedRate(new Runnable() {
+				@Override
+				public void run() {
+					LOGGER.log(healthStatusLevel, dumpCurrentLoadLevels());
+				}
+			}, healthStatusInterval, healthStatusInterval, TimeUnit.SECONDS);
+		}
+	}
+
+	private String dumpCurrentLoadLevels() {
+		StringBuilder b = new StringBuilder("MessageExchangeStore contents: ");
+		b.append(exchangesByMID.size()).append(" exchanges by MID, ");
+		b.append(exchangesByToken.size()).append(" exchanges by token, ");
+		b.append(ongoingExchanges.size()).append(" ongoing blockwise exchanges");
+		return b.toString();
+	}
+
+	/**
+	 * Sets the object to use for detecting duplicate incoming messages.
+	 * 
+	 * @param deduplicator the deduplicator.
+	 * @throws NullPointerException if deduplicator is {@code null}.
+	 * @throws IllegalStateException if this store is already running.
+	 */
+	public synchronized void setDeduplicator(final Deduplicator deduplicator) {
+		if (running) {
+			throw new IllegalStateException("Cannot set Deduplicator when store is already started");
+		} else if (deduplicator == null) {
+			throw new NullPointerException("Deduplicator must not be null");
+		} else {
+			this.deduplicator = deduplicator;
+		}
+	}
+
+	/**
+	 * Sets the provider to use for creating message IDs for outbound messages.
+	 * 
+	 * @param provider the provider.
+	 * @throws NullPointerException if provider is {@code null}.
+	 * @throws IllegalStateException if this store is already running.
+	 */
+	public synchronized void setMessageIdProvider(final MessageIdProvider provider) {
+		if (running) {
+			throw new IllegalStateException("Cannot set messageIdProvider when store is already started");
+		} else if (provider == null) {
+			throw new NullPointerException("Message ID Provider must not be null");
+		} else {
+			this.messageIdProvider = provider;
+		}
+	}
+
+	@Override
+	public boolean isEmpty() {
+		LOGGER.finer(dumpCurrentLoadLevels());
+		return exchangesByMID.isEmpty() && exchangesByToken.isEmpty() && ongoingExchanges.isEmpty() &&
+				deduplicator.isEmpty();
+	}
+
+	@Override
+	public void assignMessageId(final Message message) {
+		if (message.getMID() == Message.NONE) {
+			InetSocketAddress dest = new InetSocketAddress(message.getDestination(), message.getDestinationPort());
+			int mid = messageIdProvider.getNextMessageId(dest);
+			if (mid < 0) {
+				LOGGER.log(Level.WARNING, "Cannot send message to {0}, all MIDs are in use", dest);
+			} else {
+				message.setMID(mid);
+			}
+		}
+	}
+
+	private void registerWithMessageId(final Exchange exchange, final Message message) {
+		synchronized (messageIdProvider) {
+			if (message.getMID() == Message.NONE) {
+				InetSocketAddress dest = new InetSocketAddress(message.getDestination(), message.getDestinationPort());
+				int mid = messageIdProvider.getNextMessageId(dest);
+				if (mid < 0) {
+					LOGGER.log(Level.WARNING, "Cannot send message to {0}, all MIDs are in use", dest);
+				} else {
+					message.setMID(mid);
+					if (exchangesByMID.putIfAbsent(KeyMID.fromOutboundMessage(message), exchange) != null) {
+						LOGGER.log(Level.WARNING, "newly generated MID [{0}] already in use, overwriting already registered exchange",
+								message.getMID());
+					}
+				}
+			} else {
+				Exchange existingExchange = exchangesByMID.putIfAbsent(KeyMID.fromOutboundMessage(message), exchange);
+				if (existingExchange != null) {
+					if (existingExchange != exchange) {
+						throw new IllegalArgumentException(String.format("message ID [%d] already in use, cannot register exchange", message.getMID()));
+					} else if (exchange.getFailedTransmissionCount() == 0) {
+						throw new IllegalArgumentException(String.format("message with already registered ID [%d] is not a re-transmission, cannot register exchange",
+								message.getMID()));
+					}
+				}
+			}
+		}
+	}
+
+	private void registerWithToken(final Exchange exchange) {
+		Request request = exchange.getCurrentRequest();
+		KeyToken idByToken;
+		synchronized (exchangesByToken) {
+			if (request.getToken() == null) {
+				idByToken = createUnusedToken(tokenLength, request);
+				request.setToken(idByToken.getToken());
+			} else {
+				idByToken = KeyToken.fromOutboundMessage(request);
+				// ongoing requests may reuse token
+				if (!(exchange.getFailedTransmissionCount() > 0 || request.getOptions().hasBlock1() || request.getOptions()
+						.hasBlock2() || request.getOptions().hasObserve()) && exchangesByToken.get(idByToken) != null) {
+					LOGGER.log(Level.WARNING, "Manual token overrides existing open request: {0}", idByToken);
+				}
+			}
+			exchangesByToken.put(idByToken, exchange);
+		}
+	}
+
+	/**
+	 * Creates a new token.
+	 * 
+	 * @param length the length of the token in bytes.
+	 * @return the newly created token.
+	 */
+	private KeyToken createUnusedToken(final int maxLength, final Message msg) {
+		Random random = ThreadLocalRandom.current();
+		byte[] token;
+		KeyToken result;
+		do {
+			token = new byte[maxLength];
+			// random value
+			random.nextBytes(token);
+			result = KeyToken.fromValues(token, msg.getDestination().getAddress(), msg.getDestinationPort());
+		} while (exchangesByToken.get(result) != null);
+
+		return result;
+	}
+
+	@Override
+	public void registerOutboundRequest(final Exchange exchange) {
+
+		if (exchange == null) {
+			throw new NullPointerException("exchange must not be null");
+		} else if (exchange.getCurrentRequest() == null) {
+			throw new IllegalArgumentException("exchange does not contain a request");
+		} else {
+			registerWithMessageId(exchange, exchange.getCurrentRequest());
+			registerWithToken(exchange);
+		}
+	}
+
+	@Override
+	public void registerOutboundRequestWithTokenOnly(final Exchange exchange) {
+		if (exchange == null) {
+			throw new NullPointerException("exchange must not be null");
+		} else if (exchange.getCurrentRequest() == null) {
+			throw new IllegalArgumentException("exchange does not contain a request");
+		} else {
+			registerWithToken(exchange);
+		}
+	}
+
+	@Override
+	public void remove(final KeyToken token) {
+		synchronized (exchangesByToken) {
+			exchangesByToken.remove(token);
+		}
+	}
+
+	@Override
+	public Exchange remove(final KeyMID messageId) {
+		synchronized (messageIdProvider) {
+			return exchangesByMID.remove(messageId);
+		}
+	}
+
+	@Override
+	public Exchange get(final KeyToken token) {
+		if (token == null) {
+			return null;
+		} else {
+			synchronized (exchangesByToken) {
+				return exchangesByToken.get(token);
+			}
+		}
+	}
+
+	@Override
+	public Exchange get(final KeyMID messageId) {
+		if (messageId == null) {
+			return null;
+		} else {
+			synchronized (messageIdProvider) {
+				return exchangesByMID.get(messageId);
+			}
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * This method does nothing because all exchanges are kept in memory and thus
+	 * the correlation context will already be set on the corresponding exchange object.
+	 */
+	@Override
+	public void setContext(final KeyToken token, final CorrelationContext correlationContext) {
+		// nothing to do
+	}
+
+	@Override
+	public void registerOutboundResponse(final Exchange exchange) {
+		if (exchange == null) {
+			throw new NullPointerException("exchange must not be null");
+		} else if (exchange.getCurrentResponse() == null) {
+			throw new IllegalArgumentException("exchange does not contain a response");
+		} else {
+			registerWithMessageId(exchange, exchange.getCurrentResponse());
+		}
+	}
+
+	@Override
+	public Exchange get(final KeyUri requestUri) {
+		if (requestUri == null) {
+			return null;
+		} else {
+			return ongoingExchanges.get(requestUri);
+		}
+	}
+
+	/**
+	 * Purges all registered exchanges from this store.
+	 */
+	public void clear() {
+		synchronized (messageIdProvider) {
+			synchronized (exchangesByToken) {
+				exchangesByMID.clear();
+				exchangesByToken.clear();
+				ongoingExchanges.clear();
+			}
+		}
+	}
+
+	@Override
+	public Exchange registerBlockwiseExchange(final KeyUri requestUri, final Exchange exchange) {
+		return ongoingExchanges.put(requestUri, exchange);
+	}
+
+	@Override
+	public void remove(final KeyUri requestUri) {
+		ongoingExchanges.remove(requestUri);
+	}
+
+	@Override
+	public synchronized void start() {
+		if (!running) {
+			startStatusLogging();
+			if (deduplicator == null) {
+				DeduplicatorFactory factory = DeduplicatorFactory.getDeduplicatorFactory();
+				this.deduplicator = factory.createDeduplicator(config);
+			}
+			deduplicator.start();
+			if (messageIdProvider == null) {
+				LOGGER.log(Level.CONFIG, "no MessageIdProvider set, using default {0}", InMemoryMessageIdProvider.class.getName());
+				messageIdProvider = new InMemoryMessageIdProvider(config);
+			}
+			running = true;
+		}
+	}
+
+	/**
+	 * Stops this store and purges all registered exchanges.
+	 */
+	@Override
+	public synchronized void stop() {
+		if (running) {
+			if (statusLogger != null) {
+				statusLogger.cancel(false);
+			}
+			deduplicator.stop();
+			clear();
+			running = false;
+		}
+	}
+
+	@Override
+	public Exchange findPrevious(final KeyMID messageId, final Exchange exchange) {
+		return deduplicator.findPrevious(messageId, exchange);
+	}
+
+	@Override
+	public Exchange find(final KeyMID messageId) {
+		return deduplicator.find(messageId);
+	}
+
+	@Override
+	public List<Exchange> findByToken(byte[] token) {
+		List<Exchange> result = new ArrayList<>();
+		if (token != null) {
+			for (Entry<KeyToken, Exchange> entry : exchangesByToken.entrySet()) {
+				if (entry.getValue().isOfLocalOrigin()) {
+					Request request = entry.getValue().getRequest();
+					if (request != null && Arrays.equals(token, request.getToken())) {
+						result.add(entry.getValue());
+					}
+				}
+			}
+		}
+		return result;
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageIdProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageIdProvider.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.californium.core.network.config.NetworkConfig;
+
+
+/**
+ * A provider for message IDs thats keeps track of all message IDs in memory.
+ * <p>
+ * This provider maintains an instance of {@link MessageIdTracker} for each
+ * endpoint identified by IP address and port.
+ */
+public class InMemoryMessageIdProvider implements MessageIdProvider {
+
+	private final Map<InetSocketAddress, MessageIdTracker> trackers;
+	private final NetworkConfig config;
+
+	/**
+	 * Creates an new provider for configuration values.
+	 * 
+	 * @param config the configuration to use. In particular, the <em>EXCHANGE_LIFETIME</em>
+	 *         configuration parameter is used as the period of time a message ID is marked as
+	 *         <em>in use</em> when it is allocated for a message exchange.
+	 */
+	public InMemoryMessageIdProvider(final NetworkConfig config) {
+		this.config = config;
+		trackers = new ConcurrentHashMap<>(32000);
+	}
+
+	@Override
+	public int getNextMessageId(final InetSocketAddress destination) {
+		MessageIdTracker tracker = trackers.get(destination);
+		if (tracker == null) {
+			// create new tracker for destination lazily
+			tracker = new MessageIdTracker(config);
+			MessageIdTracker existingTracker = trackers.putIfAbsent(destination, tracker);
+			if (existingTracker != null) {
+				tracker = existingTracker;
+			}
+		}
+		return tracker.getNextMessageId();
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
@@ -5,8 +5,6 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.elements.CorrelationContext;
 
-import java.util.concurrent.ScheduledExecutorService;
-
 /**
  * The Matcher is the component at the bottom of the CoAP stack.
  * <p>
@@ -36,9 +34,13 @@ public interface Matcher {
 	void stop();
 
 	/**
-	 * Sets executor over which this matcher will perform match and clean up tasks.
+	 * Sets the exchange store to use for keeping track of message exchanges with endpoints.
+	 * 
+	 * @param store the store to use.
+	 * @throws NullPointerException if store is {@code null}.
+	 * @throws IllegalStateException if this Matcher is already started.
 	 */
-	void setExecutor(ScheduledExecutorService executor);
+	void setMessageExchangeStore(MessageExchangeStore store);
 
 	/**
 	 * Notifies this matcher about a request message being sent to a peer.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.util.List;
+
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.network.Exchange.KeyMID;
+import org.eclipse.californium.core.network.Exchange.KeyToken;
+import org.eclipse.californium.core.network.Exchange.KeyUri;
+import org.eclipse.californium.elements.CorrelationContext;
+
+/**
+ * A registry for keeping track of message exchanges with peers.
+ * <p>
+ * The information kept in this registry is particularly intended to be shared
+ * with other Californium instances (running on other nodes) to support failing over
+ * the processing of notifications received by another node after the original node
+ * (which initiated the observation of the resource) has crashed.
+ * </p>
+ */
+public interface MessageExchangeStore {
+
+	/**
+	 * Starts this store.
+	 */
+	void start();
+
+	/**
+	 * Stops this store.
+	 */
+	void stop();
+
+	/**
+	 * Assigns an unused message ID to a message.
+	 * 
+	 * @param message the message. The message will have its <em>mid</em> property set
+	 *        to {@code -1} if all message IDs are currently in use for the message's destination endpoint.
+	 */
+	void assignMessageId(Message message);
+
+	/**
+	 * Registers an exchange for an outbound request.
+	 * <p>
+	 * This method assigns an unused message ID to the request contained in the exchange
+	 * and marks it as being <em>in-use</em>.
+	 * If the request does not already contain a token, this method also generates a valid
+	 * token and sets it on the request.
+	 * <p>
+	 * The exchange can later be retrieved from this store using the corresponding <em>get</em>
+	 * method.
+	 * 
+	 * @param exchange the exchange to register.
+	 * @throws NullPointerException if any of the given params is {@code null}.
+	 * @throws IllegalArgumentException if the exchange does not contain a (current) request.
+	 */
+	void registerOutboundRequest(Exchange exchange);
+
+	/**
+	 * Registers an exchange for an outbound request.
+	 * <p>
+	 * If the request does not already contain a token, this method generates a valid
+	 * and (currently) unused token and sets it on the request. The exchange is then
+	 * registered under the request's token.
+	 * <p>
+	 * The exchange can later be retrieved from this store using the corresponding <em>get</em>
+	 * method.
+	 * 
+	 * @param exchange the exchange to register.
+	 * @throws NullPointerException if any of the given params is {@code null}.
+	 * @throws IllegalArgumentException if the exchange does not contain a (current) request.
+	 */
+	void registerOutboundRequestWithTokenOnly(Exchange exchange);
+
+	/**
+	 * Registers an exchange for an outbound response.
+	 * <p>
+	 * If the response contained in the exchange does not already contain a message ID, this method
+	 * assigns an unused message ID to the request and marks the message ID as being <em>in-use</em>.
+	 * <p>
+	 * The exchange can later be retrieved from this store using the corresponding <em>get</em>
+	 * method.
+	 * 
+	 * @param exchange the exchange to register.
+	 * @throws NullPointerException if any of the given params is {@code null}.
+	 * @throws IllegalArgumentException if the exchange does not contain a (current) response.
+	 */
+	void registerOutboundResponse(Exchange exchange);
+
+	/**
+	 * Registers an exchange used for doing a blockwise transfer with a given URI.
+	 * 
+	 * @param requestUri the URI to register the exchange for.
+	 * @param exchange the exchange to register.
+	 * @throws NullPointerException if any of the given params is {@code null}.
+	 * @return the exchange previously registered with the given URI or {@code null}.
+	 */
+	Exchange registerBlockwiseExchange(KeyUri requestUri, Exchange exchange);
+
+	/**
+	 * Removes the exchange registered under a given token.
+	 * 
+	 * @param token the token of the exchange to remove.
+	 */
+	void remove(KeyToken token);
+
+	/**
+	 * Removes the exchange registered under a given message ID.
+	 * 
+	 * @param messageId the message ID to remove the exchange for.
+	 * @return the exchange that was registered under the given message ID or {@code null}
+	 * if no exchange was registered under the ID.
+	 */
+	Exchange remove(KeyMID messageId);
+
+	/**
+	 * Removes the exchange used for a blockwise transfer of a resource.
+	 * 
+	 * @param requestUri the URI under which the exchange has been registered.
+	 */
+	void remove(KeyUri requestUri);
+
+	/**
+	 * Gets the exchange registered under a given token.
+	 * 
+	 * @param token the token under which the exchange has been registered.
+	 * @return the exchange or {@code null} if no exchange exists for the given token.
+	 */
+	Exchange get(KeyToken token);
+
+	/**
+	 * Gets the exchange registered under a given message ID.
+	 * 
+	 * @param messageId the MID under which the exchange has been registered.
+	 * @return the exchange or {@code null} if no exchange exists for the given message ID.
+	 */
+	Exchange get(KeyMID messageId);
+
+	/**
+	 * Gets the blockwise transfer exchange registered under a given URI.
+	 * 
+	 * @param requestUri the URI under which the exchange has been registered.
+	 * @return the exchange or {@code null} if no exchange is registered for the given URI.
+	 */
+	Exchange get(KeyUri requestUri);
+
+	/**
+	 * Sets the correlation context on the exchange initiated by a request
+	 * with a given token.
+	 * <p>
+	 * This method is necessary because the correlation context may not be known
+	 * when the exchange is originally registered. This is due to the fact
+	 * that the information contained in the correlation context is gathered by
+	 * the transport layer when the request establishing the observation is sent
+	 * to the peer.
+	 * 
+	 * @param token the token of the request.
+	 * @param correlationContext the context.
+	 */
+	void setContext(KeyToken token, CorrelationContext correlationContext);
+
+	/**
+	 * Checks if the specified message ID is already associated with a previous
+	 * exchange and otherwise associates the key with the exchange specified. 
+	 * This method can also be thought of as <em>put if absent</em>.
+	 * This is equivalent to
+     * <pre>
+     *   if (!duplicator.containsKey(key))
+     *       return duplicator.put(key, value);
+     *   else
+     *       return duplicator.get(key);
+     * </pre>
+     * except that the action is performed atomically.
+	 * 
+	 * @param messageId the message ID of the request
+	 * @param exchange the exchange
+	 * @return the previous exchange associated with the specified key, or
+     *         <tt>null</tt> if there was no mapping for the key.
+	 */
+	Exchange findPrevious(KeyMID messageId, Exchange exchange);
+
+	/**
+	 * Checks if a message with a given ID has been processed already.
+	 * 
+	 * @param messageId the message ID.
+	 * @return the exchange that the message has been a part of or {@code null}
+	 *         if no message with the given ID has been received for at least
+	 *         {@code EXCHANGE_LIFETIME}.
+	 */
+	Exchange find(KeyMID messageId);
+
+	/**
+	 * Checks if there are any exchanges currently being registered in this store.
+	 * 
+	 * @return {@code true} if there no exchanges registered.
+	 */
+	boolean isEmpty();
+
+	/**
+	 * Gets all message exchanges of local origin that contain a request
+	 * with a given token.
+	 * 
+	 * @param token the token to look for.
+	 * @return the exchanges.
+	 */
+	List<Exchange> findByToken(byte[] token);
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessageIdProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessageIdProvider.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.net.InetSocketAddress;
+
+/**
+ * A provider of CoAP message IDs.
+ */
+public interface MessageIdProvider {
+
+	/**
+	 * Gets a message ID for a destination endpoint.
+	 * <p>
+	 * Message IDs are guaranteed to not being issued twice within EXCHANGE_LIFETIME
+	 * as defined by the <a href="https://tools.ietf.org/html/rfc7252#section-4.4">CoAP spec</a>.
+	 * 
+	 * @param destination the destination that the message ID must be <em>free to use</em> for.
+	 *        This means that the message ID returned must not have been used in a message
+	 *        to this destination for at least EXCHANGE_LIFETIME.
+	 * @return a message ID or {@code -1} if there is no message ID available for the given destination
+	 *         at the moment.
+	 */
+	int getNextMessageId(InetSocketAddress destination);
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessageIdTracker.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessageIdTracker.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.californium.core.network.config.NetworkConfig;
+
+/**
+ * A helper for keeping track of message IDs.
+ * <p>
+ * According to the <a href="https://tools.ietf.org/html/rfc7252#section-4.4">CoAP spec</a>
+ * <pre>
+ * The same Message ID MUST NOT be reused (in communicating with the
+   same endpoint) within the EXCHANGE_LIFETIME (Section 4.8.2).
+   </pre>
+ */
+public class MessageIdTracker {
+
+	private static final int TOTAL_NO_OF_MIDS = 1 << 16;
+	private final long exchangeLifetime; // milliseconds
+	private Map<Integer, Long> messageIds;
+	private AtomicInteger counter;
+
+	/**
+	 * Creates a new tracker based on configuration values.
+	 * <p>
+	 * The following configuration values are used:
+	 * <ul>
+	 * <li>{@link org.eclipse.californium.core.network.config.NetworkConfig.Keys#EXCHANGE_LIFETIME} - each
+	 * message ID returned by <em>getNextMessageId</em> is marked as <em>in use</em> for this amount of
+	 * time (ms).</li>
+	 * <li>{@link org.eclipse.californium.core.network.config.NetworkConfig.Keys#USE_RANDOM_MID_START} - if
+	 * this value is {@code true} then the message IDs returned by <em>getNextMessageId</em> will start at a
+	 * random index. Otherwise the first message ID returned will be {@code 0}.</li>
+	 * </ul>
+	 * 
+	 * @param config the configuration to use.
+	 */
+	public MessageIdTracker(final NetworkConfig config) {
+		exchangeLifetime = config.getLong(NetworkConfig.Keys.EXCHANGE_LIFETIME);
+		boolean useRandomFirstMID = config.getBoolean(NetworkConfig.Keys.USE_RANDOM_MID_START);
+		if (useRandomFirstMID) {
+			counter = new AtomicInteger(new Random().nextInt(1 << 10));
+		} else {
+			counter = new AtomicInteger(0);
+		}
+		messageIds = new HashMap<>(TOTAL_NO_OF_MIDS);
+	}
+
+	/**
+	 * Gets the next usable message ID.
+	 * 
+	 * @return a message ID or {@code -1} if all message IDs are in use currently.
+	 */
+	public int getNextMessageId() {
+		int result = -1;
+		boolean wrapped = false;
+		synchronized (messageIds) {
+			int startIdx = counter.get() % TOTAL_NO_OF_MIDS;
+			while (result < 0 && !wrapped) {
+				int idx = counter.getAndIncrement() % TOTAL_NO_OF_MIDS;
+				Long earliestUsage = messageIds.get(idx);
+				if (earliestUsage != null) {
+					// MID has been used before
+					if (System.currentTimeMillis() >= earliestUsage) {
+						// message Id can be safely re-used
+						result = idx;
+						messageIds.put(idx, computeMidRetirementPeriod());
+					}
+				} else {
+					// MID has not been used before
+					result = idx;
+					messageIds.put(idx, computeMidRetirementPeriod());
+				}
+				wrapped = counter.get() % TOTAL_NO_OF_MIDS == startIdx;
+			}
+		}
+		return result;
+	}
+
+	private long computeMidRetirementPeriod() {
+		return System.currentTimeMillis() + exchangeLifetime;
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -26,18 +26,11 @@ package org.eclipse.californium.core.network;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map.Entry;
-import java.util.Random;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.EmptyMessage;
-import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
@@ -46,9 +39,6 @@ import org.eclipse.californium.core.network.Exchange.KeyToken;
 import org.eclipse.californium.core.network.Exchange.KeyUri;
 import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
-import org.eclipse.californium.core.network.deduplication.Deduplicator;
-import org.eclipse.californium.core.network.deduplication.DeduplicatorFactory;
-import org.eclipse.californium.core.observe.InMemoryObservationStore;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.observe.Observation;
 import org.eclipse.californium.core.observe.ObservationStore;
@@ -56,149 +46,51 @@ import org.eclipse.californium.core.observe.ObserveRelation;
 import org.eclipse.californium.elements.CorrelationContext;
 import org.eclipse.californium.elements.DtlsCorrelationContext;
 
-public class UdpMatcher implements Matcher {
+/**
+ * A Matcher for CoAP messages transmitted over UDP.
+ */
+public final class UdpMatcher extends BaseMatcher {
 
-	private static final Logger LOGGER = Logger.getLogger(Matcher.class.getCanonicalName());
+	private static final Logger LOGGER = Logger.getLogger(UdpMatcher.class.getName());
 
-	private final ConcurrentHashMap<KeyMID, Exchange> exchangesByMID; // for all
-	private final ConcurrentHashMap<KeyToken, Exchange> exchangesByToken; // for outgoing
-	private final ConcurrentHashMap<KeyUri, Exchange> ongoingExchanges; // for blockwise
 	private final ExchangeObserver exchangeObserver = new ExchangeObserverImpl();
-	/* managing the MID per endpoint requires remote endpoint management */
-	private final AtomicInteger currendMID;
 	// TODO: Multicast Exchanges: should not be removed from deduplicator
-	private final Deduplicator deduplicator;
-	// Idea: Only store acks/rsts and not the whole exchange. Responses should be sent CON.
-
 	private final boolean useStrictResponseMatching;
-	/* limit the token size to save bytes in closed environments */
-	private final int tokenSizeLimit;
-	/* Health status output */
-	private final Level healthStatusLevel;
-	private final int healthStatusInterval; // seconds
-
-	private boolean started;
-
-	/* the executor, by default the one of the protocol stage */
-	private ScheduledExecutorService executor;
-
 	private NotificationListener notificationListener;
-	private final ObservationStore observationStore;
+	private ObservationStore observationStore;
 
-	public UdpMatcher(final NetworkConfig config){
-		this(config, null, new InMemoryObservationStore());
-	}	
-
+	/**
+	 * Creates a new matcher for running CoAP over UDP.
+	 * 
+	 * @param config the configuration to use.
+	 * @throws NullPointerException if the configuration is {@code null}.
+	 */
 	public UdpMatcher(final NetworkConfig config, final NotificationListener notificationListener,
 			final ObservationStore observationStore) {
-
-		this.started = false;
+		super(config);
 		this.notificationListener = notificationListener;
 		this.observationStore = observationStore;
-		this.exchangesByMID = new ConcurrentHashMap<>();
-		this.exchangesByToken = new ConcurrentHashMap<>();
-		this.ongoingExchanges = new ConcurrentHashMap<>();
-
-		DeduplicatorFactory factory = DeduplicatorFactory.getDeduplicatorFactory();
-		this.deduplicator = factory.createDeduplicator(config);
-
-		tokenSizeLimit = config.getInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT);
 		useStrictResponseMatching = config.getBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING);
-		boolean randomMID = config.getBoolean(NetworkConfig.Keys.USE_RANDOM_MID_START);
-		if (randomMID) {
-			currendMID = new AtomicInteger(new Random().nextInt(1<<16));
-		} else {
-			currendMID = new AtomicInteger(0);
-		}
 
 		if (LOGGER.isLoggable(Level.CONFIG)) {
-			String msg = new StringBuilder("Matcher uses ")
-					.append(NetworkConfig.Keys.USE_RANDOM_MID_START).append("=").append(randomMID).append(", ")
-					.append(NetworkConfig.Keys.TOKEN_SIZE_LIMIT).append("=").append(tokenSizeLimit).append(" and ")
-					.append(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING).append("=").append(useStrictResponseMatching)
-					.toString();
+			String msg = new StringBuilder("UdpMatcher uses ").append(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING)
+					.append("=").append(useStrictResponseMatching).toString();
 			LOGGER.config(msg);
 		}
-
-		healthStatusLevel = Level.parse(config.getString(NetworkConfig.Keys.HEALTH_STATUS_PRINT_LEVEL));
-		healthStatusInterval = config.getInt(NetworkConfig.Keys.HEALTH_STATUS_INTERVAL);
-	}
-
-	@Override
-	public synchronized void start() {
-		if (started) {
-			return;
-		} else if (executor == null) {
-			throw new IllegalStateException("Matcher has no executor to schedule exchange removal");
-		} else {
-			started = true;
-			deduplicator.start();
-	
-			// this is a useful health metric that could later be exported to some kind of monitoring interface
-			if (LOGGER.isLoggable(healthStatusLevel)) {
-				executor.scheduleAtFixedRate(new Runnable() {
-					@Override
-					public void run() {
-						LOGGER.log(
-							healthStatusLevel,
-							"Matcher state: {0} exchangesByMID, {1} exchangesByToken, {2} ongoingExchanges",
-							new Object[]{exchangesByMID.size(), exchangesByToken.size(), ongoingExchanges.size()});
-					}
-				}, healthStatusInterval, healthStatusInterval, TimeUnit.SECONDS);
-			}
-		}
-	}
-
-	@Override
-	public synchronized void stop() {
-		if (!started) {
-			return;
-		} else {
-			started = false;
-			deduplicator.stop();
-			clear();
-		}
-	}
-
-	@Override
-	public synchronized void setExecutor(final ScheduledExecutorService executor) {
-		deduplicator.setExecutor(executor);
-		this.executor = executor;
-		// health status runnable is not migrated at the moment
 	}
 
 	@Override
 	public void sendRequest(final Exchange exchange, final Request request) {
 
-		// ensure MID is set
-		if (request.getMID() == Message.NONE) {
-			request.setMID(currendMID.getAndIncrement()%(1<<16)); // wrap at 2^16
-		}
-		// request MID is from the local namespace -- use blank address
-		KeyMID idByMID = new KeyMID(request.getMID());
-
-		// ensure Token is set
-		KeyToken idByToken;
-		if (request.getToken() == null) {
-			idByToken = createUnusedToken();
-			request.setToken(idByToken.token);
-			// if original request has no token set it too.
-			// this is the case where request and currentRequest is not the same
-			if (exchange.getRequest() != null && exchange.getRequest().getToken() == null)
-				exchange.getRequest().setToken(idByToken.token);
-		} else {
-			idByToken = new KeyToken(request.getToken());
-			// ongoing requests may reuse token
-			if (!(exchange.getFailedTransmissionCount()>0 || request.getOptions().hasBlock1() || request.getOptions().hasBlock2() || request.getOptions().hasObserve()) && exchangesByToken.get(idByToken) != null) {
-				LOGGER.log(Level.WARNING, "Manual token overrides existing open request: {0}", idByToken);
-			}
-		}
+		exchange.setObserver(exchangeObserver);
+		exchangeStore.registerOutboundRequest(exchange);
 
 		// for observe request.
 		// We ignore blockwise request, except when this is an early negociation (num and M is set to 0)  
 		if (request.getOptions().hasObserve() && request.getOptions().getObserve() == 0 && (!request.getOptions().hasBlock2()
 				|| request.getOptions().getBlock2().getNum() == 0 && !request.getOptions().getBlock2().isM())) {
 			// add request to the store
+			LOGGER.log(Level.FINER, "registering observe request {0}", request);
 			observationStore.add(new Observation(request, null));
 			// remove it if the request is cancelled, rejected or timedout
 			request.addMessageObserver(new MessageObserverAdapter() {
@@ -217,20 +109,16 @@ public class UdpMatcher implements Matcher {
 			});
 		}
 
-		exchange.setObserver(exchangeObserver);
-		LOGGER.log(Level.FINE, "Tracking open request using {0}, {1}", new Object[]{idByMID, idByToken});
-
-		exchangesByMID.put(idByMID, exchange);
-		exchangesByToken.put(idByToken, exchange);
+		if (LOGGER.isLoggable(Level.FINER)) {
+			LOGGER.log(
+					Level.FINER,
+					"Tracking open request [MID: {0}, Token: {1}]",
+					new Object[] { request.getMID(), request.getTokenString() });
+		}
 	}
 
 	@Override
 	public void sendResponse(final Exchange exchange, final Response response) {
-
-		// ensure MID is set
-		if (response.getMID() == Message.NONE) {
-			response.setMID(currendMID.getAndIncrement()%(1<<16));
-		}
 
 		// ensure Token is set
 		response.setToken(exchange.getCurrentRequest().getToken());
@@ -250,7 +138,7 @@ public class UdpMatcher implements Matcher {
 			// Observe notifications only send the first block, hence do not store them as ongoing
 			if (exchange.getResponseBlockStatus() != null && !response.getOptions().hasObserve()) {
 				// Remember ongoing blockwise GET requests
-				if (ongoingExchanges.put(idByUri, exchange) == null) {
+				if (exchangeStore.registerBlockwiseExchange(idByUri, exchange) == null) {
 					LOGGER.log(Level.FINE, "Ongoing Block2 started late, storing {0} for {1}",
 							new Object[]{idByUri, request});
 				} else {
@@ -259,16 +147,29 @@ public class UdpMatcher implements Matcher {
 				}
 			} else {
 				LOGGER.log(Level.FINE, "Ongoing Block2 completed, cleaning up {0} for {1}",
-						new Object[]{idByUri, request});
-				ongoingExchanges.remove(idByUri);
+						new Object[] { idByUri, request });
+				exchangeStore.remove(idByUri);
 			}
 		}
 
-		// Insert CON and NON to match ACKs and RSTs to the exchange.
+		// Insert CON to match ACKs and RSTs to the exchange.
 		// Do not insert ACKs and RSTs.
-		if (response.getType() == Type.CON || response.getType() == Type.NON) {
-			KeyMID idByMID = new KeyMID(response.getMID());
-			exchangesByMID.put(idByMID, exchange);
+		if (response.getType() == Type.CON) {
+			exchangeStore.registerOutboundResponse(exchange);
+		} else if (response.getType() == Type.NON) {
+			if (response.getOptions().hasObserve()) {
+				// this is a NON notification
+				// we need to register it so that we can match an RST sent by a peer
+				// that wants to cancel the observation
+				// these NON notifications will later be removed from the exchange store
+				// when ExchangeObserverImpl.completed() is called 
+				exchangeStore.registerOutboundResponse(exchange);
+			} else {
+				// we only need to assign an unused MID but we do not need to register
+				//the exchange under the MID since we do not expect/want a reply
+				// that we would need to match it against
+				exchangeStore.assignMessageId(response);
+			}
 		}
 
 		// Only CONs and Observe keep the exchange active
@@ -314,7 +215,7 @@ public class UdpMatcher implements Matcher {
 		if (!request.getOptions().hasBlock1() && !request.getOptions().hasBlock2()) {
 
 			Exchange exchange = new Exchange(request, Origin.REMOTE);
-			Exchange previous = deduplicator.findPrevious(idByMID, exchange);
+			Exchange previous = exchangeStore.findPrevious(idByMID, exchange);
 			if (previous == null) {
 				exchange.setObserver(exchangeObserver);
 				return exchange;
@@ -330,20 +231,21 @@ public class UdpMatcher implements Matcher {
 			KeyUri idByUri = new KeyUri(request.getURI(), request.getSource().getAddress(), request.getSourcePort());
 			LOGGER.log(Level.FINE, "Looking up ongoing exchange for {0}", idByUri);
 
-			Exchange ongoing = ongoingExchanges.get(idByUri);
+			Exchange ongoing = exchangeStore.get(idByUri);
 			if (ongoing != null) {
 
-				Exchange prev = deduplicator.findPrevious(idByMID, ongoing);
+				Exchange prev = exchangeStore.findPrevious(idByMID, ongoing);
 				if (prev != null) {
 					LOGGER.log(Level.FINER, "Duplicate ongoing request: {0}", request);
 					request.setDuplicate(true);
 				} else {
 					// the exchange is continuing, we can (i.e., must) clean up the previous response
 					// check for null, in case no response was created (e.g., because the resource handler crashed...)
-					if (ongoing.getCurrentResponse() != null && ongoing.getCurrentResponse().getType() != Type.ACK && !ongoing.getCurrentResponse().getOptions().hasObserve()) {
-						idByMID = new KeyMID(ongoing.getCurrentResponse().getMID());
+					if (ongoing.getCurrentResponse() != null && ongoing.getCurrentResponse().getType() != Type.ACK
+							&& !ongoing.getCurrentResponse().getOptions().hasObserve()) {
+						idByMID = KeyMID.fromOutboundMessage(ongoing.getCurrentResponse());
 						LOGGER.log(Level.FINE, "Ongoing exchange got new request, cleaning up {0}", idByMID);
-						exchangesByMID.remove(idByMID);
+						exchangeStore.remove(idByMID);
 					}
 				}
 				return ongoing;
@@ -359,11 +261,11 @@ public class UdpMatcher implements Matcher {
 				 */
 				
 				Exchange exchange = new Exchange(request, Origin.REMOTE);
-				Exchange previous = deduplicator.findPrevious(idByMID, exchange);
+				Exchange previous = exchangeStore.findPrevious(idByMID, exchange);
 				if (previous == null) {
 					LOGGER.log(Level.FINER, "New ongoing request, storing {0} for {1}", new Object[]{idByUri, request});
 					exchange.setObserver(exchangeObserver);
-					ongoingExchanges.put(idByUri, exchange);
+					exchangeStore.registerBlockwiseExchange(idByUri, exchange);
 					return exchange;
 				} else {
 					LOGGER.log(Level.FINER, "Duplicate initial request: {0}", request);
@@ -384,27 +286,27 @@ public class UdpMatcher implements Matcher {
 		 * 		=> resend ACK
 		 */
 
-		KeyMID idByMID;
-		if (response.getType() == Type.ACK) {
-			// own namespace
-			idByMID = new KeyMID(response.getMID());
-		} else {
-			// remote namespace
-			idByMID = KeyMID.fromInboundMessage(response);
-		}
+		KeyMID idByMID = KeyMID.fromInboundMessage(response);
+		KeyToken idByToken = KeyToken.fromInboundMessage(response);
+		LOGGER.log(Level.FINER, "received response {0}", response);
+		Exchange exchange = exchangeStore.get(idByToken);
 
-		KeyToken idByToken = new KeyToken(response.getToken());
-
-		Exchange exchange = exchangesByToken.get(idByToken);
 		if (exchange == null && observationStore != null ) {
+			// we didn't find a message exchange for the token frmo the response
+			// that is scoped to the response's source endpoint address
+			// let's try to find an existing observation for the token
 			final Observation obs = observationStore.get(response.getToken());
 			if (obs != null) {
+				// there is an observation for the token from the response
+				// re-create a corresponding Exchange object for it so
+				// that the "upper" layers can correctly process the response
 				final Request request = obs.getRequest();
 				request.setDestination(response.getSource());
 				request.setDestinationPort(response.getSourcePort());
 				exchange = new Exchange(request, Origin.LOCAL, obs.getContext());
 				exchange.setRequest(request);
 				exchange.setObserver(exchangeObserver);
+				LOGGER.log(Level.FINER, "re-created exchange from observation for {0}", request);
 				request.addMessageObserver(new MessageObserverAdapter() {
 
 					@Override
@@ -431,10 +333,12 @@ public class UdpMatcher implements Matcher {
 		}
 
 		if (exchange == null) {
-			// There is no exchange with the given token.
+			// There is no exchange with the given token, nor is there
+			// an active observation for that token
+			// finally check if the response is a duplicate
 			if (response.getType() != Type.ACK) {
-				// only act upon separate (non piggy-backed) responses
-				Exchange prev = deduplicator.find(idByMID);
+				// deduplication is only relevant for CON/NON messages
+				Exchange prev = exchangeStore.find(idByMID);
 				if (prev != null) {
 					LOGGER.log(Level.FINER, "Received response for already completed exchange: {0}", response);
 					response.setDuplicate(true);
@@ -447,15 +351,19 @@ public class UdpMatcher implements Matcher {
 			// ignore response
 			return null;
 		} else if (isResponseRelatedToRequest(exchange, responseContext)) {
-			// we have received a Response matching the Request of an ongoing Exchange
-			Exchange prev = deduplicator.findPrevious(idByMID, exchange);
-			if (prev != null) { // (and thus it holds: prev == exchange)
+
+			// we have received a Response matching the token of an ongoing Exchange's Request
+			// according to the CoAP spec (https://tools.ietf.org/html/rfc7252#section-4.5),
+			// message deduplication is relevant for CON and NON messages only
+
+			if ((response.getType() == Type.CON || response.getType() == Type.NON) &&
+					exchangeStore.findPrevious(idByMID, exchange) != null) {
 				LOGGER.log(Level.FINER, "Received duplicate response for open exchange: {0}", response);
 				response.setDuplicate(true);
 			} else {
 				// we have received the expected response for the original request
-				idByMID = new KeyMID(exchange.getCurrentRequest().getMID());
-				exchangesByMID.remove(idByMID);
+				idByMID = KeyMID.fromOutboundMessage(exchange.getCurrentRequest());
+				exchangeStore.remove(idByMID);
 				LOGGER.log(Level.FINE, "Closed open request [{0}]", idByMID);
 			}
 
@@ -520,14 +428,14 @@ public class UdpMatcher implements Matcher {
 	@Override
 	public Exchange receiveEmptyMessage(final EmptyMessage message) {
 
-		// local namespace
-		KeyMID idByMID = new KeyMID(message.getMID());
-
-		Exchange exchange = exchangesByMID.get(idByMID);
+		// an empty ACK or RST always is received as a reply to a message
+		// exchange originating locally, i.e. the message will echo an MID
+		// that has been created here
+		KeyMID idByMID = KeyMID.fromInboundMessage(message);
+		Exchange exchange = exchangeStore.remove(idByMID);
 
 		if (exchange != null) {
-			LOGGER.log(Level.FINE, "Exchange got reply: Cleaning up {0}", idByMID);
-			exchangesByMID.remove(idByMID);
+			LOGGER.log(Level.FINE, "Received expected reply for message exchange {0}", idByMID);
 		} else {
 			LOGGER.log(Level.FINE,
 					"Ignoring unmatchable empty message from {0}:{1}: {2}",
@@ -536,44 +444,16 @@ public class UdpMatcher implements Matcher {
 		return exchange;
 	}
 
-	@Override
-	public void clear() {
-		this.exchangesByMID.clear();
-		this.exchangesByToken.clear();
-		this.ongoingExchanges.clear();
-		deduplicator.clear();
-	}
-
 	private void removeNotificationsOf(final ObserveRelation relation) {
-		LOGGER.fine("Remove all remaining NON-notifications of observe relation");
-		for (Iterator<Response> iterator = relation.getNotificationIterator(); iterator.hasNext();) {
+		LOGGER.log(Level.FINE, "Removing all remaining NON-notifications of observe relation with {0}",
+				relation.getSource());
+		for (Iterator<Response> iterator = relation.getNotificationIterator(); iterator.hasNext(); ) {
 			Response previous = iterator.next();
 			// notifications are local MID namespace
-			KeyMID idByMID = new KeyMID(previous.getMID(), null, 0);
-			exchangesByMID.remove(idByMID);
+			KeyMID idByMID = KeyMID.fromOutboundMessage(previous);
+			exchangeStore.remove(idByMID);
 			iterator.remove();
 		}
-	}
-
-	/**
-	 * Creates a new token that is never the empty token (i.e., always 1-8 bytes).
-	 * @return the new token
-	 */
-	private KeyToken createUnusedToken() {
-
-		Random random = ThreadLocalRandom.current();
-		byte[] token;
-		KeyToken result;
-		do {
-			// random length between 1 and tokenSizeLimit
-			// TODO: why would we want to have a random length token?
-			token = new byte[random.nextInt(tokenSizeLimit)+1];
-			// random value
-			random.nextBytes(token);
-			result = new KeyToken(token);
-		} while (exchangesByToken.get(result) != null && observationStore.get(token) != null);
-
-		return result;
 	}
 
 	private class ExchangeObserverImpl implements ExchangeObserver {
@@ -589,31 +469,37 @@ public class UdpMatcher implements Matcher {
 			if (exchange.getOrigin() == Origin.LOCAL) {
 				// this endpoint created the Exchange by issuing a request
 
-				KeyMID idByMID = new KeyMID(exchange.getCurrentRequest().getMID());
-				KeyToken idByToken = new KeyToken(exchange.getCurrentRequest().getToken());
-
-//				LOGGER.log(Level.FINE, "Exchange completed: Cleaning up {0}", idByToken);
-				exchangesByToken.remove(idByToken);
+				KeyToken idByToken = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
+				exchangeStore.remove(idByToken);
 
 				// in case an empty ACK was lost
-				exchangesByMID.remove(idByMID);
+				KeyMID idByMID = KeyMID.fromOutboundMessage(exchange.getCurrentRequest());
+				exchangeStore.remove(idByMID);
+				LOGGER.log(Level.FINER, "Exchange [{0}, {1}] completed", new Object[]{idByToken, exchange.getOrigin()});
 
 			} else { // Origin.REMOTE
 				// this endpoint created the Exchange to respond to a request
 
 				Response response = exchange.getCurrentResponse();
+				Request request = exchange.getCurrentRequest();
+
 				if (response != null && response.getType() != Type.ACK) {
-					// only response MIDs are stored for ACK and RST, no reponse Tokens
-					KeyMID midKey = new KeyMID(response.getMID(), null, 0);
-//					LOGGER.log(Level.FINE, "Remote ongoing completed, cleaning up {0}", midKey);
-					exchangesByMID.remove(midKey);
+					// this means that we have sent the response in a separate CON/NON message
+					// (not piggy-backed in ACK). The response therefore has a different MID
+					// than the original request
+
+					// first remove the entry for the (separate) response's MID
+					KeyMID midKey = KeyMID.fromOutboundMessage(response);
+					exchangeStore.remove(midKey);
+
+					LOGGER.log(Level.FINER, "Exchange [{0}, {1}] completed", new Object[]{midKey, exchange.getOrigin()});
 				}
 
-				Request request = exchange.getCurrentRequest();
-				if (request != null && (request.getOptions().hasBlock1() || response.getOptions().hasBlock2()) ) {
-					KeyUri uriKey = new KeyUri(request.getURI(), request.getSource().getAddress(), request.getSourcePort());
-					LOGGER.log(Level.FINE, "Remote ongoing completed, cleaning up ", uriKey);
-					ongoingExchanges.remove(uriKey);
+				if (request != null && (request.getOptions().hasBlock1() || response.getOptions().hasBlock2())) {
+					KeyUri uriKey = new KeyUri(request.getURI(), request.getSource().getAddress(),
+							request.getSourcePort());
+					LOGGER.log(Level.FINE, "Blockwise exchange with remote peer {0} completed, cleaning up ", uriKey);
+					exchangeStore.remove(uriKey);
 				}
 
 				// Remove all remaining NON-notifications if this exchange is an observe relation
@@ -628,17 +514,23 @@ public class UdpMatcher implements Matcher {
 		public void contextEstablished(Exchange exchange) {
 			if (exchange.getRequest() != null)
 				observationStore.setContext(exchange.getRequest().getToken(), exchange.getCorrelationContext());
+			KeyToken token = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
+			exchangeStore.setContext(token, exchange.getCorrelationContext());
 		}
 	}
 
+	/**
+	 * Cancels all pending blockwise requests that have been induced by a notification
+	 * we have received indicating a blockwise transfer of the resource.
+	 * 
+	 * @param token the token of the observation.
+	 */
 	@Override
 	public void cancelObserve(final byte[] token) {
-		// search for pending blockwise exchange for this observe request
-		for (Entry<KeyToken, Exchange> key : exchangesByToken.entrySet()) {
-			Request cachedRequest = key.getValue().getRequest();
-			if (cachedRequest != null && Arrays.equals(token, cachedRequest.getToken())) {
-				cachedRequest.cancel();
-			}
+		// we do not know the destination endpoint the requests have been sent to
+		// therefore we need to find them by token only
+		for (Exchange exchange : exchangeStore.findByToken(token)) {
+			exchange.getRequest().cancel();
 		}
 		observationStore.remove(token);
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -60,6 +60,23 @@ public class NetworkConfig {
 	 * Network configuration key names
 	 */
 	public class Keys {
+
+		/**
+		 * The maximum number of active peers supported.
+		 * <p>
+		 * An active peer is a node with which we exchange CoAP messages.
+		 * For each active peer we need to maintain some state, e.g. we need
+		 * to keep track of MIDs and tokens in use with the peer. It
+		 * therefore is reasonable to limit the number of peers so that
+		 * memory consumption can be better predicted.
+		 */
+		public static final String MAX_ACTIVE_PEERS = "MAX_ACTIVE_PEERS";
+		/**
+		 * The maximum number of seconds a peer may be inactive for before it is
+		 * considered stale and all state associated with it can be discarded.
+		 */
+		public static final String MAX_PEER_INACTIVITY_PERIOD = "MAX_PEER_INACTIVITY_PERIOD";
+
 		public static final String COAP_PORT = "COAP_PORT";
 		public static final String COAP_SECURE_PORT = "COAP_SECURE_PORT";
 		public static final String ACK_TIMEOUT = "ACK_TIMEOUT";

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -66,27 +66,30 @@ public class NetworkConfig {
 		public static final String ACK_RANDOM_FACTOR = "ACK_RANDOM_FACTOR";
 		public static final String ACK_TIMEOUT_SCALE = "ACK_TIMEOUT_SCALE";
 		public static final String MAX_RETRANSMIT = "MAX_RETRANSMIT";
+		/**
+		 * The EXCHANGE_LIFETIME as defined by the CoAP spec in MILLISECONDS.
+		 */
 		public static final String EXCHANGE_LIFETIME = "EXCHANGE_LIFETIME";
 		public static final String NON_LIFETIME = "NON_LIFETIME";
 		public static final String MAX_TRANSMIT_WAIT = "MAX_TRANSMIT_WAIT";
 		public static final String NSTART = "NSTART";
 		public static final String LEISURE = "LEISURE";
 		public static final String PROBING_RATE = "PROBING_RATE";
-		
+
 		public static final String USE_RANDOM_MID_START = "USE_RANDOM_MID_START";
 		public static final String TOKEN_SIZE_LIMIT = "TOKEN_SIZE_LIMIT";
-		
+
 		public static final String PREFERRED_BLOCK_SIZE = "PREFERRED_BLOCK_SIZE";
 		public static final String MAX_MESSAGE_SIZE = "MAX_MESSAGE_SIZE";
 		public static final String BLOCKWISE_STATUS_LIFETIME = "BLOCKWISE_STATUS_LIFETIME";
-		
+
 		public static final String NOTIFICATION_CHECK_INTERVAL_TIME = "NOTIFICATION_CHECK_INTERVAL";
 		public static final String NOTIFICATION_CHECK_INTERVAL_COUNT = "NOTIFICATION_CHECK_INTERVAL_COUNT";
 		public static final String NOTIFICATION_REREGISTRATION_BACKOFF = "NOTIFICATION_REREGISTRATION_BACKOFF";
-	
+
 		public static final String USE_CONGESTION_CONTROL = "USE_CONGESTION_CONTROL";
 		public static final String CONGESTION_CONTROL_ALGORITHM = "CONGESTION_CONTROL_ALGORITHM";
-		
+
 		public static final String PROTOCOL_STAGE_THREAD_COUNT = "PROTOCOL_STAGE_THREAD_COUNT";
 		public static final String NETWORK_STAGE_RECEIVER_THREAD_COUNT = "NETWORK_STAGE_RECEIVER_THREAD_COUNT";
 		public static final String NETWORK_STAGE_SENDER_THREAD_COUNT = "NETWORK_STAGE_SENDER_THREAD_COUNT";
@@ -98,6 +101,9 @@ public class NetworkConfig {
 
 		public static final String DEDUPLICATOR = "DEDUPLICATOR";
 		public static final String DEDUPLICATOR_MARK_AND_SWEEP = "DEDUPLICATOR_MARK_AND_SWEEP";
+		/**
+		 * The interval after which the next sweep run should occur (in MILLISECONDS).
+		 */
 		public static final String MARK_AND_SWEEP_INTERVAL = "MARK_AND_SWEEP_INTERVAL";
 		public static final String DEDUPLICATOR_CROP_ROTATION = "DEDUPLICATOR_CROP_ROTATION";
 		public static final String CROP_ROTATION_PERIOD = "CROP_ROTATION_PERIOD";

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
@@ -76,7 +76,7 @@ public class NetworkConfigDefaults {
 		config.setInt(NetworkConfig.Keys.UDP_CONNECTOR_OUT_CAPACITY, Integer.MAX_VALUE); // unbounded
 
 		config.setString(NetworkConfig.Keys.DEDUPLICATOR, NetworkConfig.Keys.DEDUPLICATOR_MARK_AND_SWEEP);
-		config.setLong(NetworkConfig.Keys.MARK_AND_SWEEP_INTERVAL, 10 * 1000);
+		config.setLong(NetworkConfig.Keys.MARK_AND_SWEEP_INTERVAL, 10 * 1000); // 10 secs
 		config.setInt(NetworkConfig.Keys.CROP_ROTATION_PERIOD, 2000);
 		config.setBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING, false);
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
@@ -30,17 +30,19 @@ public class NetworkConfigDefaults {
 	 * Refuse unknown options
 	 * Disable dedupl for GET/..
 	 */
-	
-	
-	public static void setDefaults(NetworkConfig config) {
+
+	public static void setDefaults(final NetworkConfig config) {
 
 		final int CORES = Runtime.getRuntime().availableProcessors();
 		final String OS = System.getProperty("os.name");
 		final boolean WINDOWS = OS.startsWith("Windows");
-		
+
+		config.setInt(NetworkConfig.Keys.MAX_ACTIVE_PEERS, 500000);
+		config.setLong(NetworkConfig.Keys.MAX_PEER_INACTIVITY_PERIOD, 36 * 60 * 60); // 36h
+
 		config.setInt(NetworkConfig.Keys.COAP_PORT, CoAP.DEFAULT_COAP_PORT);
 		config.setInt(NetworkConfig.Keys.COAP_SECURE_PORT, CoAP.DEFAULT_COAP_SECURE_PORT);
-		
+
 		config.setInt(NetworkConfig.Keys.ACK_TIMEOUT, 2000);
 		config.setFloat(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1.5f);
 		config.setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 2f);
@@ -62,14 +64,14 @@ public class NetworkConfigDefaults {
 		config.setLong(NetworkConfig.Keys.NOTIFICATION_CHECK_INTERVAL_TIME, 24 * 60 * 60 * 1000); // ms
 		config.setInt(NetworkConfig.Keys.NOTIFICATION_CHECK_INTERVAL_COUNT, 100);
 		config.setLong(NetworkConfig.Keys.NOTIFICATION_REREGISTRATION_BACKOFF, 2000); // ms
-		
+
 		config.setBoolean(NetworkConfig.Keys.USE_CONGESTION_CONTROL, false);
 		config.setString(NetworkConfig.Keys.CONGESTION_CONTROL_ALGORITHM, "Cocoa"); // see org.eclipse.californium.core.network.stack.congestioncontrol
-		
+
 		config.setInt(NetworkConfig.Keys.PROTOCOL_STAGE_THREAD_COUNT, CORES);
 		config.setInt(NetworkConfig.Keys.NETWORK_STAGE_RECEIVER_THREAD_COUNT, WINDOWS ? CORES : 1);
 		config.setInt(NetworkConfig.Keys.NETWORK_STAGE_SENDER_THREAD_COUNT, WINDOWS ? CORES : 1);
-		
+
 		config.setInt(NetworkConfig.Keys.UDP_CONNECTOR_DATAGRAM_SIZE, 2048);
 		config.setInt(NetworkConfig.Keys.UDP_CONNECTOR_RECEIVE_BUFFER, UDPConnector.UNDEFINED);
 		config.setInt(NetworkConfig.Keys.UDP_CONNECTOR_SEND_BUFFER, UDPConnector.UNDEFINED);
@@ -85,7 +87,7 @@ public class NetworkConfigDefaults {
 		config.setInt(NetworkConfig.Keys.HTTP_SERVER_SOCKET_BUFFER_SIZE, 8192);
 		config.setInt(NetworkConfig.Keys.HTTP_CACHE_RESPONSE_MAX_AGE, 86400);
 		config.setInt(NetworkConfig.Keys.HTTP_CACHE_SIZE, 32);
-		
+
 		config.setString(NetworkConfig.Keys.HEALTH_STATUS_PRINT_LEVEL, "FINEST");
 		config.setInt(NetworkConfig.Keys.HEALTH_STATUS_INTERVAL, 60); // s
 
@@ -93,7 +95,7 @@ public class NetworkConfigDefaults {
 		config.setInt(NetworkConfig.Keys.TCP_WORKER_THREADS, 1);
 		config.setInt(NetworkConfig.Keys.TCP_CONNECT_TIMEOUT, 10000); // ms
 	}
-	
+
 	// prevent instantiation
 	private NetworkConfigDefaults() { }
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/Deduplicator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/Deduplicator.java
@@ -19,8 +19,6 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network.deduplication;
 
-import java.util.concurrent.ScheduledExecutorService;
-
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.Exchange.KeyMID;
 
@@ -34,20 +32,13 @@ public interface Deduplicator {
 	/**
 	 * Starts the deduplicator
 	 */
-	public void start();
-	
+	void start();
+
 	/**
 	 * Stops the deduplicator. The deduplicator should NOT clear its state.
 	 */
-	public void stop();
-	
-	/**
-	 * Set the specified executor. This method might call stop(), replace the
-	 * executor and then start() again.
-	 * @param executor the executor
-	 */
-	public void setExecutor(ScheduledExecutorService executor);
-	
+	void stop();
+
 	/**
 	 * Checks if the specified key is already associated with a previous
 	 * exchange and otherwise associates the key with the exchange specified. 
@@ -66,12 +57,14 @@ public interface Deduplicator {
 	 * @return the previous exchange associated with the specified key, or
      *         <tt>null</tt> if there was no mapping for the key.
 	 */
-	public Exchange findPrevious(KeyMID key, Exchange exchange);
-	
-	public Exchange find(KeyMID key);
-	
+	Exchange findPrevious(KeyMID key, Exchange exchange);
+
+	Exchange find(KeyMID key);
+
+	boolean isEmpty();
+
 	/**
 	 * Clears the state of this deduplicator.
 	 */
-	public void clear();
+	void clear();
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/DeduplicatorFactory.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/DeduplicatorFactory.java
@@ -62,13 +62,16 @@ public class DeduplicatorFactory {
 	 * @param config the configuration
 	 * @return the deduplicator
 	 */
-	public Deduplicator createDeduplicator(NetworkConfig config) {
+	public Deduplicator createDeduplicator(final NetworkConfig config) {
 		String type = config.getString(NetworkConfig.Keys.DEDUPLICATOR);
-		if (NetworkConfig.Keys.DEDUPLICATOR_MARK_AND_SWEEP.equals(type)) return new SweepDeduplicator(config);
-		else if (NetworkConfig.Keys.DEDUPLICATOR_CROP_ROTATION.equals(type)) return new CropRotation(config);
-		else if (NetworkConfig.Keys.NO_DEDUPLICATOR.equals(type)) return new NoDeduplicator();
-		else {
-			LOGGER.log(Level.WARNING, "Unknown deduplicator type: {0}", type);
+		if (NetworkConfig.Keys.DEDUPLICATOR_MARK_AND_SWEEP.equals(type)) {
+			return new SweepDeduplicator(config);
+		} else if (NetworkConfig.Keys.DEDUPLICATOR_CROP_ROTATION.equals(type)) {
+			return new CropRotation(config);
+		} else if (NetworkConfig.Keys.NO_DEDUPLICATOR.equals(type)) {
+			return new NoDeduplicator();
+		} else {
+			LOGGER.log(Level.WARNING, "Unsupported deduplicator type: {0}", type);
 			return new NoDeduplicator();
 		}
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/NoDeduplicator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/NoDeduplicator.java
@@ -19,8 +19,6 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network.deduplication;
 
-import java.util.concurrent.ScheduledExecutorService;
-
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.Exchange.KeyMID;
 
@@ -39,9 +37,6 @@ public class NoDeduplicator implements Deduplicator {
 	public void stop() { }
 
 	@Override
-	public void setExecutor(ScheduledExecutorService executor) { }
-
-	@Override
 	public Exchange findPrevious(KeyMID key, Exchange exchange) {
 		return null;
 	}
@@ -54,4 +49,8 @@ public class NoDeduplicator implements Deduplicator {
 	@Override
 	public void clear() { }
 
+	@Override
+	public boolean isEmpty() {
+		return true;
+	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -698,10 +698,10 @@ public class BlockwiseLayer extends AbstractLayer {
 
 		@Override
 		public void run() {
-			if (exchange.getRequest()==null) {
+			if (exchange.getRequest() == null) {
 				LOGGER.log(Level.INFO, "Block1 transfer timed out: {0}", exchange.getCurrentRequest());
 			} else {
-				LOGGER.log(Level.INFO, "Block2 transfer timed out: {1}", exchange.getRequest());
+				LOGGER.log(Level.INFO, "Block2 transfer timed out: {0}", exchange.getRequest());
 			}
 			exchange.setComplete();
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapUdpStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapUdpStack.java
@@ -201,8 +201,9 @@ public class CoapUdpStack implements CoapStack {
 
 		@Override
 		public void receiveResponse(Exchange exchange, Response response) {
+			// we always complete the message exchange when we have received a response
 			exchange.setComplete();
-			if (deliverer != null) {
+			if (hasDeliverer()) {
 				deliverer.deliverResponse(exchange, response); // notify request that response has arrived
 			} else {
 				LOGGER.severe("Top of CoAP stack has no deliverer to deliver response");

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/InMemoryObservationStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/InMemoryObservationStore.java
@@ -13,11 +13,14 @@
  ******************************************************************************/
 package org.eclipse.californium.core.observe;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.core.coap.Request;
-import org.eclipse.californium.core.network.Exchange.KeyToken;
 import org.eclipse.californium.core.network.serialization.DataParser;
 import org.eclipse.californium.core.network.serialization.DataSerializer;
 import org.eclipse.californium.core.network.serialization.UdpDataParser;
@@ -27,20 +30,27 @@ import org.eclipse.californium.elements.RawData;
 
 public class InMemoryObservationStore implements ObservationStore {
 
+	private static final Logger LOG = Logger.getLogger(InMemoryObservationStore.class.getName());
 	private static final DataSerializer serializer = new UdpDataSerializer();
-	private Map<KeyToken, Observation> map = new ConcurrentHashMap<>();
+	private Map<Key, Observation> map = new ConcurrentHashMap<>();
 
 	@Override
 	public void add(Observation obs) {
 		if (obs != null) {
-			map.put(new KeyToken(obs.getRequest().getToken()), obs);
+			Key key = Key.fromToken(obs.getRequest().getToken());
+			LOG.log(Level.FINER, "adding observation for token {0}", key);
+			map.put(key, obs);
 		}
 	}
 
 	@Override
 	public Observation get(byte[] token) {
-		Observation obs = map.get(new KeyToken(token));
+		Key key = Key.fromToken(token);
+		LOG.log(Level.FINER, "looking up observation for token {0}", key);
+		Observation obs = map.get(key);
 		if (obs != null) {
+			LOG.log(Level.FINER, "found observation for token {0}", key);
+			// clone registered Observation
 			RawData serialize = serializer.serializeRequest(obs.getRequest(), null);
 			DataParser parser = new UdpDataParser();
 			Request newRequest = (Request) parser.parseMessage(serialize);
@@ -52,7 +62,9 @@ public class InMemoryObservationStore implements ObservationStore {
 
 	@Override
 	public void remove(byte[] token) {
-		map.remove(new KeyToken(token));
+		Key key = Key.fromToken(token);
+		map.remove(key);
+		LOG.log(Level.FINER, "removed observation for token {0}", key);
 	}
 
 	public boolean isEmpty(){
@@ -69,9 +81,49 @@ public class InMemoryObservationStore implements ObservationStore {
 
 	@Override
 	public void setContext(byte[] token, CorrelationContext ctx) {
-		Observation obs = map.get(new KeyToken(token));
+		Key key = Key.fromToken(token);
+		Observation obs = map.get(key);
 		if (obs != null) {
-			map.put(new KeyToken(token), new Observation(obs.getRequest(), ctx));
+			map.put(key, new Observation(obs.getRequest(), ctx));
+		}
+	}
+
+	private static class Key {
+		private final byte[] token;
+
+		private Key(final byte[] token) {
+			this.token = token;
+		}
+
+		private static Key fromToken(byte[] token) {
+			return new Key(token);
+		}
+
+		@Override
+		public String toString() {
+			return Utils.toHexString(token);
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + Arrays.hashCode(token);
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			Key other = (Key) obj;
+			if (!Arrays.equals(token, other.token))
+				return false;
+			return true;
 		}
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.net.InetAddress;
+
+import org.eclipse.californium.category.Small;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange.KeyMID;
+import org.eclipse.californium.core.network.Exchange.Origin;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+/**
+ * Verifies behavior of the {@link InMemoryMessageExchangeStore} class.
+ *
+ */
+@Category(Small.class)
+public class InMemoryMessageExchangeStoreTest {
+
+	/**
+	 * 
+	 */
+	private static final int PEER_PORT = 12000;
+	InMemoryMessageExchangeStore store;
+	NetworkConfig config;
+
+	@Before
+	public void createConfig() {
+		config = NetworkConfig.createStandardWithoutFile();
+		config.setLong(NetworkConfig.Keys.EXCHANGE_LIFETIME, 200); //ms
+		store = new InMemoryMessageExchangeStore(config);
+		store.start();
+	}
+
+	@After
+	public void stop() {
+		store.stop();
+	}
+
+	@Test
+	public void testRegisterOutboundRequestAssignsMid() {
+
+		Exchange exchange = newOutboundRequest();
+
+		// WHEN registering the outbound request
+		store.registerOutboundRequest(exchange);
+
+		// THEN the request gets assigned an MID and is put to the store
+		assertNotNull(exchange.getCurrentRequest().getMID());
+		KeyMID key = KeyMID.fromOutboundMessage(exchange.getCurrentRequest());
+		assertThat(store.get(key), is(exchange));
+	}
+
+	@Test
+	public void testRegisterOutboundRequestRejectsOtherRequestWithAlreadyUsedMid() {
+
+		Exchange exchange = newOutboundRequest();
+		store.registerOutboundRequest(exchange);
+
+		// WHEN registering another request with the same MID
+		Exchange newExchange = newOutboundRequest();
+		newExchange.getCurrentRequest().setMID(exchange.getCurrentRequest().getMID());
+		try {
+			store.registerOutboundRequest(newExchange);
+			fail("should have thrown IllegalArgumentException");
+		} catch (IllegalArgumentException e) {
+			// THEN the newExchange is not put to the store
+			KeyMID key = KeyMID.fromOutboundMessage(exchange.getCurrentRequest());
+			Exchange exchangeFromStore = store.get(key);
+			assertThat(exchangeFromStore, is(exchange));
+			assertThat(exchangeFromStore, is(not(newExchange)));
+		}
+	}
+
+	@Test
+	public void testRegisterOutboundRequestRejectsMultipleRegistrationOfSameRequest() {
+
+		Exchange exchange = newOutboundRequest();
+		store.registerOutboundRequest(exchange);
+
+		// WHEN registering the same request again
+		try {
+			store.registerOutboundRequest(exchange);
+			fail("should have thrown IllegalArgumentException");
+		} catch (IllegalArgumentException e) {
+			// THEN the store rejects the re-registration
+		}
+	}
+
+	public void testRegisterOutboundRequestAcceptsRetransmittedRequest() {
+
+		Exchange exchange = newOutboundRequest();
+		store.registerOutboundRequest(exchange);
+
+		// WHEN registering the same request as a re-transmission
+		exchange.setFailedTransmissionCount(1);
+		store.registerOutboundRequest(exchange);
+
+		// THEN the store contains the re-transmitted request
+		KeyMID key = KeyMID.fromOutboundMessage(exchange.getCurrentRequest());
+		Exchange exchangeFromStore = store.get(key);
+		assertThat(exchangeFromStore, is(exchange));
+		assertThat(exchangeFromStore.getFailedTransmissionCount(), is(1));
+	}
+
+	private Exchange newOutboundRequest() {
+		Request request = Request.newGet();
+		request.setURI("coap://127.0.0.1:12000/test");
+		Exchange exchange = new Exchange(request, Origin.LOCAL);
+		return exchange;
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageIdProviderTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageIdProviderTest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import org.eclipse.californium.category.Small;
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Verifies behavior of {@code InMemoryMessageIdProvider}.
+ *
+ */
+@Category(Small.class)
+public class InMemoryMessageIdProviderTest {
+
+	NetworkConfig config;
+
+	@Before
+	public void setup() {
+		config = NetworkConfig.createStandardWithoutFile();
+	}
+
+	@Test
+	public void testGetNextMessageIdReturnsMid() {
+
+		InMemoryMessageIdProvider provider = new InMemoryMessageIdProvider(config);
+		InetSocketAddress peerAddress = getPeerAddress(1);
+		int mid1 = provider.getNextMessageId(peerAddress);
+		int mid2 = provider.getNextMessageId(peerAddress);
+		assertThat(mid1, is(not(-1)));
+		assertThat(mid2, is(not(-1)));
+		assertThat(mid1, is(not(mid2)));
+	}
+
+	@Test
+	public void testGetNextMessageIdFailsIfMaxPeersIsReached() {
+
+		int MAX_PEERS = 2;
+		config.setLong(NetworkConfig.Keys.MAX_ACTIVE_PEERS, MAX_PEERS);
+		InMemoryMessageIdProvider provider = new InMemoryMessageIdProvider(config);
+		addPeers(provider, MAX_PEERS);
+
+		assertThat(
+				"Should not have been able to add more peers",
+				provider.getNextMessageId(getPeerAddress(MAX_PEERS + 1)),
+				is(-1));
+	}
+
+	private static void addPeers(final MessageIdProvider provider, final int peerCount) {
+		for (int i = 0; i < peerCount; i++) {
+			provider.getNextMessageId(getPeerAddress(i));
+		}
+	}
+
+	private static InetSocketAddress getPeerAddress(final int i) {
+
+		try {
+			InetAddress addr = InetAddress.getByAddress(new byte[]{(byte) 192, (byte) 168, 0, (byte) i});
+			return new InetSocketAddress(addr, CoAP.DEFAULT_COAP_PORT);
+		} catch (UnknownHostException e) {
+			// should not happen
+			return null;
+		}
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/MessageIdTrackerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/MessageIdTrackerTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ * Verifies that MessageIdTracker correctly marks MIDs as <em>in use</em>.
+ *
+ */
+public class MessageIdTrackerTest {
+
+	private static final int TOTAL_NO_OF_MIDS = 1 << 16;
+	private NetworkConfig config;
+
+	@Before
+	public void setUp() {
+		config = NetworkConfig.createStandardWithoutFile();
+	}
+
+	@Test
+	public void testGetNextMessageIdFailsIfAllMidsAreInUse() throws Exception {
+		// GIVEN a tracker whose MIDs are all in use
+		MessageIdTracker tracker = new MessageIdTracker(config);
+		for (int i = 0; i < TOTAL_NO_OF_MIDS; i++) {
+			tracker.getNextMessageId();
+		}
+
+		// WHEN retrieving the next message IDs from the tracker
+		int mid = tracker.getNextMessageId();
+
+		// THEN the returned MID is -1
+		assertThat(mid, is(-1));
+	}
+
+	@Test
+	public void testGetNextMessageIdReusesIdAfterExchangeLifetime() throws Exception {
+		// GIVEN a tracker with an EXCHANGE_LIFETIME of 100ms
+		int exchangeLifetime = 100; // ms
+		config.setInt(NetworkConfig.Keys.EXCHANGE_LIFETIME, exchangeLifetime);
+		MessageIdTracker tracker = new MessageIdTracker(config);
+
+		// WHEN retrieving all message IDs from the tracker
+		int firstMid = tracker.getNextMessageId();
+		long start = System.currentTimeMillis();
+		for (int i = 1; i < TOTAL_NO_OF_MIDS; i++) {
+			tracker.getNextMessageId();
+		}
+
+		// THEN the first message ID is re-used after EXCHANGE_LIFETIME has expired
+		long timeElapsed = System.currentTimeMillis() - start;
+		if (timeElapsed < exchangeLifetime) {
+			Thread.sleep(exchangeLifetime - timeElapsed);
+		}
+		int mid = tracker.getNextMessageId();
+		assertThat(mid, is(firstMid));
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/TcpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/TcpMatcherTest.java
@@ -34,7 +34,6 @@ import static org.junit.Assert.assertSame;
 public class TcpMatcherTest {
 
 	private static final InetSocketAddress dest = new InetSocketAddress(InetAddress.getLoopbackAddress(), 5684);
-	private static final InetSocketAddress source = new InetSocketAddress(InetAddress.getLoopbackAddress(), 12000);
 
 	@Test
 	public void testRequestMatchesResponse() {
@@ -48,7 +47,9 @@ public class TcpMatcherTest {
 	private TcpMatcher newMatcher(boolean useStrictMatching) {
 		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
 		config.setBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING, useStrictMatching);
-		return new TcpMatcher(config);
+		TcpMatcher matcher = new TcpMatcher(config);
+		matcher.start();
+		return matcher;
 	}
 
 	private Exchange sendRequest(final TcpMatcher matcher, final CorrelationContext ctx) {
@@ -67,8 +68,10 @@ public class TcpMatcherTest {
 		response.setMID(request.getMID());
 		response.setToken(request.getToken());
 		response.setBytes(new byte[]{});
-		response.setSource(source.getAddress());
-		response.setSourcePort(source.getPort());
+		response.setSource(request.getDestination());
+		response.setSourcePort(request.getDestinationPort());
+		response.setDestination(request.getSource());
+		response.setDestinationPort(request.getSourcePort());
 		return response;
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -27,6 +27,7 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.observe.InMemoryObservationStore;
 import org.eclipse.californium.elements.CorrelationContext;
 import org.eclipse.californium.elements.DtlsCorrelationContext;
 import org.eclipse.californium.elements.MapBasedCorrelationContext;
@@ -43,7 +44,6 @@ public class UdpMatcherTest {
 	static final String CIPHER = "TLS_PSK";
 	static final String OTHER_CIPHER = "TLS_NULL";
 	static final InetSocketAddress dest = new InetSocketAddress(InetAddress.getLoopbackAddress(), 5684);
-	static final InetSocketAddress source = new InetSocketAddress(InetAddress.getLoopbackAddress(), 12000);
 
 	@Test
 	public void testReceiveResponseAcceptsResponseWithoutCorrelationInformation() {
@@ -190,7 +190,9 @@ public class UdpMatcherTest {
 	private UdpMatcher newMatcher(boolean useStrictMatching) {
 		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
 		config.setBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING, useStrictMatching);
-		return new UdpMatcher(config);
+		UdpMatcher matcher = new UdpMatcher(config, null, new InMemoryObservationStore());
+		matcher.start();
+		return matcher;
 	}
 
 	private Exchange sendRequest(final UdpMatcher matcher, final CorrelationContext ctx) {
@@ -208,8 +210,10 @@ public class UdpMatcherTest {
 		response.setMID(request.getMID());
 		response.setToken(request.getToken());
 		response.setBytes(new byte[]{});
-		response.setSource(source.getAddress());
-		response.setSourcePort(source.getPort());
+		response.setSource(request.getDestination());
+		response.setSourcePort(request.getDestinationPort());
+		response.setDestination(request.getSource());
+		response.setDestinationPort(request.getSourcePort());
 		return response;
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
@@ -1,13 +1,18 @@
 package org.eclipse.californium.core.test;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
@@ -25,12 +30,15 @@ import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.InMemoryMessageExchangeStore;
 import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.MessageExchangeStore;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -40,21 +48,21 @@ import org.junit.experimental.categories.Category;
 public class MemoryLeakingHashMapTest {
 
 	// Configuration for this test
-	public static final int TEST_EXCHANGE_LIFETIME = 247; // milliseconds
-	public static final int TEST_SWEEP_DEDUPLICATOR_INTERVAL = 100; // milliseconds
-	public static final int TEST_BLOCK_SIZE = 16; // 16 bytes
+	private static final int TEST_EXCHANGE_LIFETIME = 247; // milliseconds
+	private static final int TEST_SWEEP_DEDUPLICATOR_INTERVAL = 100; // milliseconds
+	private static final int TEST_BLOCK_SIZE = 16; // 16 bytes
 
-	public static final String LONG_REQUEST = "123456789.123456789.";
-	public static final String LONG_RESPONSE = LONG_REQUEST + LONG_REQUEST;
+	private static final String LONG_REQUEST = "123456789.123456789.";
+	private static final String LONG_RESPONSE = LONG_REQUEST + LONG_REQUEST;
 
-	public static final int OBS_NOTIFICATION_INTERVAL = 50; // send one notification per 50 ms
-	public static final int HOW_MANY_NOTIFICATION_WE_WAIT_FOR = 3;
-	public static final int ACK_TIMEOUT = 500; // ms
+	private static final int OBS_NOTIFICATION_INTERVAL = 50; // send a notification every 50 ms
+	private static final int HOW_MANY_NOTIFICATION_WE_WAIT_FOR = 3;
+	private static final int ACK_TIMEOUT = 500; // ms
 
 	// The names of the two resources of the server
-	public static final String PIGGY = "piggy";
-	public static final String SEPARATE = "separate";
-	
+	private static final String PIGGY = "piggy";
+	private static final String SEPARATE = "separate";
+
 	private static final Logger LOGGER = Logger.getLogger(MemoryLeakingHashMapTest.class.getName());
 	private static ScheduledExecutorService timer;
 	private static CoapServer server;
@@ -63,8 +71,8 @@ public class MemoryLeakingHashMapTest {
 	// The server endpoint that we test
 	private static CoapEndpoint serverEndpoint;
 	private static CoapEndpoint clientEndpoint;
-	private static EndpointSurveillant serverSurveillant;
-	private static EndpointSurveillant clientSurveillant;
+	private static MessageExchangeStore clientExchangeStore;
+	private static MessageExchangeStore serverExchangeStore;
 
 	private static String currentRequestText;
 	private static String currentResponseText;
@@ -72,22 +80,34 @@ public class MemoryLeakingHashMapTest {
 	@BeforeClass
 	public static void startupServer() throws Exception {
 		LOGGER.log(Level.FINE, "Start {0}", MemoryLeakingHashMapTest.class.getSimpleName());
-		timer = new ScheduledThreadPoolExecutor(1);
+		timer = Executors.newSingleThreadScheduledExecutor();
 		createServerAndClientEndpoints();
 	}
 
 	@AfterClass
 	public static void shutdownServer() {
-		server.destroy();
 		timer.shutdown();
+		clientEndpoint.stop();
+		server.destroy();
 		LOGGER.log(Level.FINE, "End {0}", MemoryLeakingHashMapTest.class.getSimpleName());
 	}
 
+	@Before
+	public void startExchangeStores() {
+		clientExchangeStore.start();
+		serverExchangeStore.start();
+	}
+
 	@After
-	public void assertHashMapsEmpty() {
-		serverSurveillant.waitUntilDeduplicatorShouldBeEmpty();
-		serverSurveillant.assertHashMapsEmpty();
-		clientSurveillant.assertHashMapsEmpty();
+	public void assertAllExchangesAreCompleted() {
+		try {
+			waitUntilDeduplicatorShouldBeEmpty(TEST_EXCHANGE_LIFETIME, TEST_SWEEP_DEDUPLICATOR_INTERVAL);
+			assertTrue("Client side message exchange store still contains exchanges", clientExchangeStore.isEmpty());
+			assertTrue("Server side message exchange store still contains exchanges", serverExchangeStore.isEmpty());
+		} finally {
+			clientExchangeStore.stop();
+			serverExchangeStore.stop();
+		}
 	}
 
 	@Test
@@ -252,13 +272,13 @@ public class MemoryLeakingHashMapTest {
 			.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, TEST_BLOCK_SIZE);
 
 		// Create the endpoint for the server and create surveillant
-		serverEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
+		serverExchangeStore = new InMemoryMessageExchangeStore(config);
+		serverEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config, serverExchangeStore);
 		serverEndpoint.addInterceptor(new MessageTracer());
-		serverSurveillant = new EndpointSurveillant("server", serverEndpoint);
 
-		clientEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
+		clientExchangeStore = new InMemoryMessageExchangeStore(config);
+		clientEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config, clientExchangeStore);
 		clientEndpoint.start();
-		clientSurveillant = new EndpointSurveillant("client", clientEndpoint);
 
 		// Create a server with two resources: one that sends piggy-backed
 		// responses and one that sends separate responses
@@ -274,7 +294,7 @@ public class MemoryLeakingHashMapTest {
 	private String uriOf(String resourcePath) {
 		return "coap://localhost:" + serverPort + "/" + resourcePath;
 	}
-	
+
 	public enum Mode { PIGGY_BACKED_RESPONSE, SEPARATE_RESPONE; }
 	
 	public static class TestResource extends CoapResource {

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/RandomAccessBlockTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/RandomAccessBlockTest.java
@@ -12,6 +12,7 @@ import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.junit.After;
 import org.junit.Before;

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -498,9 +498,9 @@ public class BlockwiseClientSideTest {
 		server.sendResponse(ACK, CHANGED).loadBoth("F").block2(3, false, 128).payload(respPayload.substring(384, 500)).go();
 
 		Response response = request.waitForResponse(1000);
+		printServerLog(clientInterceptor);
 		assertResponseContainsExpectedPayload(response, CHANGED, respPayload);
 
-		printServerLog(clientInterceptor);
 	}
 
 	@Test

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/DeduplicationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/DeduplicationTest.java
@@ -24,14 +24,12 @@ import static org.eclipse.californium.core.coap.CoAP.ResponseCode.CONTENT;
 import static org.eclipse.californium.core.coap.CoAP.Type.ACK;
 import static org.eclipse.californium.core.coap.CoAP.Type.CON;
 import static org.eclipse.californium.core.coap.CoAP.Type.RST;
+import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.*;
+import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
-import org.junit.Assert;
-
-import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.category.Medium;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
@@ -50,60 +48,50 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Medium.class)
 public class DeduplicationTest {
-	
+
 	private LockstepEndpoint server;
-	
+
 	private Endpoint client;
 	private int clientPort;
-	
+
 	@Before
-	public void setupServer() throws IOException {
-		System.out.println("\nStart "+getClass().getSimpleName());
-		
+	public void setupServer() throws Exception {
+		System.out.println(System.lineSeparator() + "Start " + getClass().getSimpleName());
+
 		NetworkConfig config = new NetworkConfig()
 			.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 128)
 			.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 128)
 			.setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200) // client retransmits after 200 ms
 			.setInt(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1);
-		client = new CoapEndpoint(new InetSocketAddress(0), config);
+		client = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
 		client.addInterceptor(new MessageTracer());
 		client.start();
 		clientPort = client.getAddress().getPort();
-		System.out.println("Client binds to port "+clientPort);
+		server = createLockstepEndpoint(client.getAddress());
+		System.out.println("Client binds to port " + clientPort);
 	}
-	
+
 	@After
 	public void shutdownServer() {
-		System.out.println();
-		client.destroy();
-		System.out.println("End "+getClass().getSimpleName());
-	}
-	
-	@Test
-	public void test() throws Throwable {
-		try {
-			testGET();
-			
-		} catch (Exception e) {
-			e.printStackTrace();
-			System.err.println("Make sure you did not forget a .go() at the end of a line.");
-			throw e;
-		} catch (Throwable t) {
-			System.err.println(t);
-			throw t;
+		if (server != null) {
+			server.destroy();
 		}
+		if (client != null) {
+			client.destroy();
+		}
+		System.out.println(System.lineSeparator() + "End " + getClass().getSimpleName());
 	}
-	
-	private void testGET() throws Exception {
-		System.out.println("Simple blockwise GET:");
+
+	@Test
+	public void testGET() throws Exception {
+		System.out.println("Simple GET:");
 		String path = "test";
 		String payload = "possible conflict";
-		server = createLockstepEndpoint();
-		
-		Request request = createRequest(GET, path);
+
+		Request request = createRequest(GET, path, server);
 		request.setMID(1234);
 		client.sendRequest(request);
-		
+
 		server.expectRequest(CON, GET, path).storeToken("A").go();
 		server.sendEmpty(ACK).mid(1234).go();
 		server.sendEmpty(ACK).mid(1234).go();
@@ -113,38 +101,19 @@ public class DeduplicationTest {
 		server.expectEmpty(ACK, 4711).go();
 		server.sendResponse(CON, CONTENT).loadToken("A").mid(42).payload("separate").go();
 		server.expectEmpty(RST, 42).go();
-		
-		request = createRequest(GET, path);
+
+		request = createRequest(GET, path, server);
 		request.setMID(4711);
 		client.sendRequest(request);
-		
+
 		server.expectRequest(CON, GET, path).storeBoth("B").storeToken("C").go();
 		server.sendResponse(ACK, CONTENT).loadBoth("B").payload("possible conflict").go();
 		server.sendResponse(ACK, CONTENT).loadBoth("B").payload("possible conflict").go();
-		
-		Response response = request.waitForResponse(1000);
-		Assert.assertNotNull("Client received no response", response);
-		Assert.assertEquals("Client received wrong response code:", CONTENT, response.getCode());
-		Assert.assertEquals("Client received wrong payload:", payload, response.getPayloadString());
-		
-		response = request.waitForResponse(1000);
-		Assert.assertNull("Client received duplicate", response);
-	}
-		
-	private LockstepEndpoint createLockstepEndpoint() {
-		try {
-			LockstepEndpoint endpoint = new LockstepEndpoint();
-			endpoint.setDestination(new InetSocketAddress(InetAddress.getByName("localhost"), clientPort));
-			return endpoint;
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-	
-	private Request createRequest(Code code, String path) throws Exception {
-		Request request = new Request(code);
-		String uri = "coap://localhost:"+(server.getPort())+"/"+path;
-		request.setURI(uri);
-		return request; 
+
+		Response response = request.waitForResponse(500);
+		assertResponseContainsExpectedPayload(response, CONTENT, payload);
+
+		response = request.waitForResponse(500);
+		assertNull("Client received duplicate", response);
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/IntegrationTestTools.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/IntegrationTestTools.java
@@ -99,8 +99,20 @@ public final class IntegrationTestTools {
 
 	private static byte[] b(int... is) {
 		byte[] bytes = new byte[is.length];
-		for (int i=0;i<bytes.length;i++)
+		for (int i=0; i < bytes.length; i++) {
 			bytes[i] = (byte) is[i];
+		}
 		return bytes;
 	}
+
+	public static void waitUntilDeduplicatorShouldBeEmpty(final int exchangeLifetime, final int sweepInterval) {
+		try {
+			int timeToWait = exchangeLifetime + sweepInterval + 100; // milliseconds
+			System.out.println("Wait until deduplicator should be empty (" + timeToWait/1000f + " seconds)");
+			Thread.sleep(timeToWait);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/SynchronousNotificationListener.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/SynchronousNotificationListener.java
@@ -24,7 +24,7 @@ import org.eclipse.californium.core.observe.NotificationListener;
 public class SynchronousNotificationListener implements NotificationListener {
 
 	private Request request; // request to listen
-	private Response currentResponse;
+	private Response response;
 	private Object lock = new Object();
 
 	public SynchronousNotificationListener() {
@@ -43,13 +43,13 @@ public class SynchronousNotificationListener implements NotificationListener {
 	public Response waitForResponse(long timeoutInMs) throws InterruptedException {
 		Response r;
 		synchronized (lock) {
-			if (currentResponse != null)
-				r = currentResponse;
+			if (response != null)
+				r = response;
 			else {
 				lock.wait(timeoutInMs);
-				r = currentResponse;
+				r = response;
 			}
-			currentResponse = null;
+			response = null;
 		}
 		return r;
 	}
@@ -58,7 +58,7 @@ public class SynchronousNotificationListener implements NotificationListener {
 	public void onNotification(Request req, Response resp) {
 		if (request == null || Arrays.equals(request.getToken(), req.getToken())) {
 			synchronized (lock) {
-				currentResponse = resp;
+				response = resp;
 				lock.notifyAll();
 			}
 		}


### PR DESCRIPTION
This is supposed to fix the problem with re-using MIDs in exchanges with the same peer before EXCHANGE_LIFETIME has expired.
The PR introduces a `MessageExchangeStore` that encapsulates generation & tracking of MIDs per peer and the registration & management of `Exchange` objects in order to eliminate race conditions.

In a next step we should integrate the `TokenProvider` proposed in PR #85 to make sure that we always use a unique token as well. 