### PR TITLE
Fix block1 bigger block size negotiation

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -28,15 +28,15 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.californium.core.coap.BlockOption;
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
-import org.eclipse.californium.core.coap.CoAP.Code;
-import org.eclipse.californium.core.coap.CoAP.ResponseCode;
-import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfigObserverAdapter;
@@ -333,10 +333,19 @@ public class BlockwiseLayer extends AbstractLayer {
 				// TODO: the response code should be CONTINUE. Otherwise deliver random access response.
 				// Send next block
 				int currentSize = 1 << (4 + status.getCurrentSzx());
-				int nextNum = status.getCurrentNum() + currentSize / block1.getSize();
+				// Define new size of the block depending of preferred size block
+				int newSize, newSzx;
+				if (block1.getSize() < currentSize){
+					newSize = block1.getSize();
+					newSzx = block1.getSzx();
+				}else{
+					newSize = currentSize;
+					newSzx = status.getCurrentSzx();
+				}
+				int nextNum = status.getCurrentNum() + currentSize / newSize;
 				LOGGER.log(Level.FINER, "Sending next Block1 num={0}", nextNum);
 				status.setCurrentNum(nextNum);
-				status.setCurrentSzx(block1.getSzx());
+				status.setCurrentSzx(newSzx);
 				Request nextBlock = getNextRequestBlock(exchange.getRequest(), status);
 				// we use the same token to ease traceability
 				nextBlock.setToken(response.getToken());


### PR DESCRIPTION
The RFC 7959 [§2.3](https://tools.ietf.org/html/rfc7959#section-2.3)   say:
_"Finally, the SZX block size given in a control Block1 Option
         indicates the largest block size preferred by the server for
         transfers toward the resource that is **the same or smaller than
         the one used in the initial exchange**; the client SHOULD use
         this block size or a smaller one in all further requests in the
         transfer sequence, even if that means changing the block size
         (and possibly scaling the block number accordingly) from now
         on."_

Currently when a server asked for a bigger size (something not really supported by the spec) we restart transfer from first block (0).
```
CON [MID=18708, T=28d2], PUT, /test, 1:0/1/128    ----->
<-----   ACK [MID=18708, T=28d2], 2.31, 1:0/1/256    
CON [MID=18709, T=28d2], PUT, /test, 1:0/1/256    ----->
    ...  ....
```
 I'm not sure this is the best way to do, the spec also say :
_"A server MAY also return a 4.08 error code for any (final or non-final) Block1
   transfer that is not in sequence; therefore, clients that do not have
   specific mechanisms to handle this case SHOULD always start with
   block zero and send the following blocks in order."_
and 
_"Still, the client SHOULD heed the preference indicated and, for all further
   blocks, use **the block size preferred by the server or a smaller one**."_

I suppose a better solution should be to keep the original size block when it is smaller than the preferred size block.
```
CON [MID=18708, T=28d2], PUT, /test, 1:0/1/128    ----->
<-----   ACK [MID=18708, T=28d2], 2.31, 1:0/1/256    
CON [MID=18709, T=28d2], PUT, /test, 1:1/1/128    ----->
<-----   ACK [MID=18709, T=28d2], 2.31, 1:1/1/256    
CON [MID=18710, T=28d2], PUT, /test, 1:2/0/128    ----->
<-----   ACK [MID=18710, T=28d2], 2.04, 1:2/0/256    
```