### PR TITLE
Changed the visibility of observeAndWait() and observe() to public

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
@@ -840,39 +840,55 @@ public class CoapClient {
 		return request;
 	}
 	
-	/*
+	/**
 	 * Sends the specified observe request and waits for the response whereupon
 	 * the specified handler is invoked when a notification arrives.
 	 *
 	 * @param request the request
+	 * 
 	 * @param handler the Response handler
+	 * 
 	 * @return the CoAP observe relation
+	 * @throws IllegalArgumentException if the observe option is not set in the
+	 *             request
 	 */
-	private CoapObserveRelation observeAndWait(Request request, CoapHandler handler) {
-		Endpoint outEndpoint = getEffectiveEndpoint(request);
-		CoapObserveRelation relation = new CoapObserveRelation(request, outEndpoint);
-		request.addMessageObserver(new ObserveMessageObserverImpl(handler, relation));
-		CoapResponse response = synchronous(request, outEndpoint);
-		if (response == null || !response.advanced().getOptions().hasObserve())
-			relation.setCanceled(true);
-		relation.setCurrent(response);
-		return relation;
+	public CoapObserveRelation observeAndWait(Request request, CoapHandler handler) {
+		if (request.getOptions().hasObserve()) {
+			Endpoint outEndpoint = getEffectiveEndpoint(request);
+			CoapObserveRelation relation = new CoapObserveRelation(request, outEndpoint);
+			request.addMessageObserver(new ObserveMessageObserverImpl(handler, relation));
+			CoapResponse response = synchronous(request, outEndpoint);
+			if (response == null || !response.advanced().getOptions().hasObserve())
+				relation.setCanceled(true);
+			relation.setCurrent(response);
+			return relation;
+		} else {
+			throw new IllegalArgumentException("please make sure that the request has observe option set.");
+		}
 	}
 	
-	/*
+	/**
 	 * Sends the specified observe request and invokes the specified handler
 	 * each time a notification arrives.
 	 *
 	 * @param request the request
+	 * 
 	 * @param handler the Response handler
+	 * 
 	 * @return the CoAP observe relation
+	 * @throws IllegalArgumentException if the observe option is not set in the
+	 *             request
 	 */
-	private CoapObserveRelation observe(Request request, CoapHandler handler) {
-		Endpoint outEndpoint = getEffectiveEndpoint(request);
-		CoapObserveRelation relation = new CoapObserveRelation(request, outEndpoint);
-		request.addMessageObserver(new ObserveMessageObserverImpl(handler, relation));
-		send(request, outEndpoint);
-		return relation;
+	public CoapObserveRelation observe(Request request, CoapHandler handler) {
+		if (request.getOptions().hasObserve()) {
+			Endpoint outEndpoint = getEffectiveEndpoint(request);
+			CoapObserveRelation relation = new CoapObserveRelation(request, outEndpoint);
+			request.addMessageObserver(new ObserveMessageObserverImpl(handler, relation));
+			send(request, outEndpoint);
+			return relation;
+		} else {
+			throw new IllegalArgumentException("please make sure that the request has observe option set.");
+		}
 	}
 	
 	/**

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ObserveTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ObserveTest.java
@@ -205,6 +205,63 @@ public class ObserveTest {
 		
 	}
 	
+	/**
+	 * Test case for CoapClient.observeAndWait(Request request, CoapHandler
+	 * handler) exception handling.
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testObserveAndWaitExceptionHandling() throws Exception {
+		CoapClient client = new CoapClient(uriX);
+		Request request = Request.newGet().setURI(uriX);
+
+		@SuppressWarnings("unused")
+		CoapObserveRelation rel =null;
+		try {
+			rel = client.observeAndWait(request, new CoapHandler() {
+
+				@Override
+				public void onLoad(CoapResponse response) {
+				}
+
+				@Override
+				public void onError() {
+				}
+			});
+		} catch (Exception e) {
+			assertTrue(e instanceof IllegalArgumentException);
+		}
+	}
+	
+	/**
+	 * Test case for CoapClient.observe(Request request, CoapHandler
+	 * handler) exception handling.
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testObserveExceptionHandling() throws Exception {
+		CoapClient client = new CoapClient(uriX);
+		Request request = Request.newGet().setURI(uriX);
+
+		@SuppressWarnings("unused")
+		CoapObserveRelation rel =null;
+		try {
+			rel = client.observe(request, new CoapHandler() {
+				@Override
+				public void onLoad(CoapResponse response) {
+				}
+
+				@Override
+				public void onError() {
+				}
+			});
+		} catch (Exception e) {
+			assertTrue(e instanceof IllegalArgumentException);
+		}
+	}
+	
 	private void createServer() {
 		// retransmit constantly all 2 seconds
 		NetworkConfig config = new NetworkConfig()


### PR DESCRIPTION
Changed the visibility of observeAndWait(request,handler) and
observe(request,handler) to public as per discussion on the issue
https://github.com/eclipse/californium/issues/92 ..

Both the methods now checks that passed request has observer set on it,
if the observer is not set it raises IllegalArgumentException.

Test case also has been added for both methods.

Signed-off-by: Praful Bhatnagar <prafulbhatnagar@gmail.com>