### PR TITLE
Testfix address cleanup

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/coap/RequestTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/coap/RequestTest.java
@@ -61,7 +61,7 @@ public class RequestTest {
 	public void testSetURISetsDestination() throws UnknownHostException {
 		InetSocketAddress dest = InetSocketAddress.createUnresolved("192.168.0.1", 12000);
 		Request req = Request.newGet().setURI("coap://192.168.0.1:12000");
-		assertThat(req.getDestination().getHostName(), is(dest.getHostName()));
+		assertThat(req.getDestination().getHostAddress(), is(dest.getHostString()));
 		assertThat(req.getDestinationPort(), is(dest.getPort()));
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -157,7 +157,7 @@ public class DTLSConnectorTest {
 	public void setUp() throws Exception {
 
 		clientConnectionStore = new InMemoryConnectionStore(CLIENT_CONNECTION_STORE_CAPACITY, 60);
-		clientEndpoint = new InetSocketAddress(InetAddress.getLocalHost(), 0);
+		clientEndpoint = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 		clientConfig = newStandardConfig(clientEndpoint);
 
 		client = new DTLSConnector(clientConfig, clientConnectionStore);
@@ -523,7 +523,7 @@ public class DTLSConnectorTest {
 		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getId());
 
 		// create a new client with different inetAddress but with the same session store.
-		clientEndpoint = new InetSocketAddress(InetAddress.getLocalHost(), 10001);
+		clientEndpoint = new InetSocketAddress(InetAddress.getLoopbackAddress(), 10001);
 		clientConfig = DTLSConnectorTest.newStandardConfig(clientEndpoint);
 		client = new DTLSConnector(clientConfig, clientConnectionStore);
 		clientRawDataChannel = new LatchDecrementingRawDataChannel();


### PR DESCRIPTION
Fixes some test for multi interface environment using consequently loopback instead of localhost.
Also remove reverse resolve of uri in other test.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>