### PR TITLE
NullPointerException when requesting a ping

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
@@ -48,7 +48,7 @@ public abstract class DataSerializer {
 			byte[] body = serializeOptionsAndPayload(request);
 
 			MessageHeader header = new MessageHeader(CoAP.VERSION, request.getType(), request.getToken(),
-					request.getCode().value, request.getMID(), body.length);
+					request.getCode()==null?0:request.getCode().value, request.getMID(), body.length);
 			serializeHeader(writer, header);
 			writer.writeBytes(body);
 


### PR DESCRIPTION
When a CoAP Client is performing a Ping, the request sends a [**null** Code](https://github.com/eclipse/californium/blob/master/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java#L279) which eventually caught by [**DataSerializer**](https://github.com/eclipse/californium/blob/master/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java#L51) class and throws a _NullPointerException_. 

```
CoapEndpoint$5 Exception in protocol stage thread: null
java.lang.NullPointerException
	at org.eclipse.californium.core.network.serialization.DataSerializer.serializeRequest(DataSerializer.java:50)
	at org.eclipse.californium.core.network.CoapEndpoint$OutboxImpl.sendRequest(CoapEndpoint.java:577)
	at org.eclipse.californium.core.network.stack.CoapUdpStack$StackBottomAdapter.sendRequest(CoapUdpStack.java:208)
	at org.eclipse.californium.core.network.stack.AbstractLayer.sendRequest(AbstractLayer.java:65)
	at org.eclipse.californium.core.network.stack.ReliabilityLayer.sendRequest(ReliabilityLayer.java:114)
	at org.eclipse.californium.core.network.stack.AbstractLayer.sendRequest(AbstractLayer.java:65)
	at org.eclipse.californium.core.network.stack.BlockwiseLayer.sendRequest(BlockwiseLayer.java:155)
	at org.eclipse.californium.core.network.stack.AbstractLayer.sendRequest(AbstractLayer.java:65)
	at org.eclipse.californium.core.network.stack.ObserveLayer.sendRequest(ObserveLayer.java:51)
	at org.eclipse.californium.core.network.stack.AbstractLayer.sendRequest(AbstractLayer.java:65)
	at org.eclipse.californium.core.network.stack.ExchangeCleanupLayer.sendRequest(ExchangeCleanupLayer.java:14)
	at org.eclipse.californium.core.network.stack.AbstractLayer.sendRequest(AbstractLayer.java:65)
	at org.eclipse.californium.core.network.stack.CoapUdpStack$StackTopAdapter.sendRequest(CoapUdpStack.java:171)
	at org.eclipse.californium.core.network.stack.CoapUdpStack$StackTopAdapter.sendRequest(CoapUdpStack.java:166)
	at org.eclipse.californium.core.network.stack.CoapUdpStack.sendRequest(CoapUdpStack.java:120)
	at org.eclipse.californium.core.network.CoapEndpoint$3.run(CoapEndpoint.java:479)
	at org.eclipse.californium.core.network.CoapEndpoint$5.run(CoapEndpoint.java:824)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```