### PR TITLE
Merge PR#85 token provider to 2.0.x

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
@@ -58,7 +58,7 @@ public abstract class BaseMatcher implements Matcher {
 	protected final void assertMessageExchangeStoreIsSet() {
 		if (exchangeStore == null) {
 			LOG.log(Level.CONFIG, "no MessageExchangeStore set, using default {0}", InMemoryMessageExchangeStore.class.getName());
-			exchangeStore = new InMemoryMessageExchangeStore(config, new InMemoryRandomTokenProvider(config));
+			exchangeStore = new InMemoryMessageExchangeStore(config);
 		}
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
@@ -58,7 +58,7 @@ public abstract class BaseMatcher implements Matcher {
 	protected final void assertMessageExchangeStoreIsSet() {
 		if (exchangeStore == null) {
 			LOG.log(Level.CONFIG, "no MessageExchangeStore set, using default {0}", InMemoryMessageExchangeStore.class.getName());
-			exchangeStore = new InMemoryMessageExchangeStore(config);
+			exchangeStore = new InMemoryMessageExchangeStore(config, new InMemoryRandomTokenProvider(config));
 		}
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -345,7 +345,7 @@ public class CoapEndpoint implements Endpoint {
 		}
 
 		if (exchangeStore == null) {
-			InMemoryMessageExchangeStore inMemoryMessageExchangeStore = new InMemoryMessageExchangeStore(config, new InMemoryRandomTokenProvider(config));			
+			InMemoryMessageExchangeStore inMemoryMessageExchangeStore = new InMemoryMessageExchangeStore(config);			
 			matcher.setMessageExchangeStore(inMemoryMessageExchangeStore);
 		} else {
 			matcher.setMessageExchangeStore(exchangeStore);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -345,7 +345,8 @@ public class CoapEndpoint implements Endpoint {
 		}
 
 		if (exchangeStore == null) {
-			matcher.setMessageExchangeStore(new InMemoryMessageExchangeStore(config));
+			InMemoryMessageExchangeStore inMemoryMessageExchangeStore = new InMemoryMessageExchangeStore(config, new InMemoryRandomTokenProvider(config));			
+			matcher.setMessageExchangeStore(inMemoryMessageExchangeStore);
 		} else {
 			matcher.setMessageExchangeStore(exchangeStore);
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
@@ -69,15 +69,8 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 	 * 
 	 */
 	public InMemoryMessageExchangeStore(final NetworkConfig config) {
-		if (config == null) {
-			throw new NullPointerException("Configuration must not be null");
-		}
-
-		this.config = config;
-		this.tokenProvider = new InMemoryRandomTokenProvider(this.config);
+		this(config, new InMemoryRandomTokenProvider(config));
 		LOGGER.log(Level.CONFIG, "using default TokenProvider {0}", InMemoryRandomTokenProvider.class.getName());
-		LOGGER.log(Level.CONFIG, "using tokens of {0} bytes in length",
-				config.getInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT));
 	}
 
 	/**
@@ -97,8 +90,6 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 		}
 		this.tokenProvider = tokenProvider;
 		this.config = config;
-		LOGGER.log(Level.CONFIG, "using tokens of {0} bytes in length",
-				config.getInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT));
 	}
 
 	private void startStatusLogging() {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryRandomTokenProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryRandomTokenProvider.java
@@ -21,6 +21,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.network.Exchange.KeyToken;
@@ -35,6 +37,8 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
  */
 public class InMemoryRandomTokenProvider implements TokenProvider {
 
+	private static final Logger LOGGER = Logger.getLogger(InMemoryRandomTokenProvider.class.getName());
+	
 	private final Set<KeyToken> usedTokens = Collections.newSetFromMap(new ConcurrentHashMap<KeyToken, Boolean>());
 	private static final int MAX_TOKEN_LENGTH = 8; // bytes
 	private final int tokenSizeLimit;
@@ -45,7 +49,12 @@ public class InMemoryRandomTokenProvider implements TokenProvider {
 	 * @param networkConfig used to obtain the configured token size
 	 */
 	public InMemoryRandomTokenProvider(NetworkConfig networkConfig) {
+		if (networkConfig == null) {
+			throw new NullPointerException("NetworkConfig must not be null");
+		}
 		this.tokenSizeLimit = networkConfig.getInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT, MAX_TOKEN_LENGTH);
+		LOGGER.log(Level.CONFIG, "using tokens of {0} bytes in length",
+				networkConfig.getInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT, MAX_TOKEN_LENGTH));
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryRandomTokenProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryRandomTokenProvider.java
@@ -36,6 +36,7 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
 public class InMemoryRandomTokenProvider implements TokenProvider {
 
 	private final Set<KeyToken> usedTokens = Collections.newSetFromMap(new ConcurrentHashMap<KeyToken, Boolean>());
+	private static final int MAX_TOKEN_LENGTH = 8; // bytes
 	private final int tokenSizeLimit;
 
 	/**
@@ -44,7 +45,7 @@ public class InMemoryRandomTokenProvider implements TokenProvider {
 	 * @param networkConfig used to obtain the configured token size
 	 */
 	public InMemoryRandomTokenProvider(NetworkConfig networkConfig) {
-		this.tokenSizeLimit = networkConfig.getInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT);
+		this.tokenSizeLimit = networkConfig.getInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT, MAX_TOKEN_LENGTH);
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryRandomTokenProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryRandomTokenProvider.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Daniel Maier (Bosch Software Innovations GmbH)
+ *                                - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.util.Collections;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.network.Exchange.KeyToken;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+
+/**
+ * {@link TokenProvider} that uses random tokens and stores them in memory. 
+ * 
+ * Note: This {@link TokenProvider} is not sufficient if persistence is in use.
+ *
+ * This implementation is thread-safe.
+ */
+public class InMemoryRandomTokenProvider implements TokenProvider {
+
+	private final Set<KeyToken> usedTokens = Collections.newSetFromMap(new ConcurrentHashMap<KeyToken, Boolean>());
+	private final int tokenSizeLimit;
+
+	/**
+	 * Creates a new {@link InMemoryRandomTokenProvider}.
+	 * 
+	 * @param networkConfig used to obtain the configured token size
+	 */
+	public InMemoryRandomTokenProvider(NetworkConfig networkConfig) {
+		this.tokenSizeLimit = networkConfig.getInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT);
+	}
+
+	@Override
+	public KeyToken getUnusedToken(Message message) {
+		return createUnusedToken(message);
+	}
+
+	@Override
+	public void releaseToken(KeyToken keyToken) {
+		usedTokens.remove(keyToken);
+	}
+
+	@Override
+	public boolean isTokenInUse(KeyToken keyToken) {
+		return usedTokens.contains(keyToken);
+	}
+
+	private KeyToken createUnusedToken(Message message) {
+		final Random random = ThreadLocalRandom.current();
+		byte[] token;
+		KeyToken result;
+		// TODO what to do when there are no more unused tokens left?
+		do {
+			token = new byte[tokenSizeLimit];
+			random.nextBytes(token);
+			result =  KeyToken.fromValues(token, message.getDestination().getAddress(), message.getDestinationPort());
+		} while (!usedTokens.add(result));
+		return result;
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
@@ -215,4 +215,11 @@ public interface MessageExchangeStore {
 	 * @return the exchanges.
 	 */
 	List<Exchange> findByToken(byte[] token);
+	
+	/**
+	 * Releases the given token to be used again.
+	 * 
+	 * @param keyToken the KeyToken to release.
+	 */
+	void releaseToken(KeyToken keyToken);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TokenProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TokenProvider.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Daniel Maier (Bosch Software Innovations GmbH)
+ *                                - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.network.Exchange.KeyToken;
+
+/**
+ * A {@link TokenProvider} provides CoAP tokens that are guaranteed to be not in
+ * use. To not run out of unused tokens, used tokens MUST be released with
+ * {@link #releaseToken(byte[])} after usage.
+ *
+ * Implementations of {@link TokenProvider} MUST be thread-safe.
+ */
+public interface TokenProvider {
+
+	/**
+	 * Returns a token that is not in use. After this token is not in use
+	 * anymore it must be released with {@link #releaseToken(byte[])}.
+	 * 
+	 * @return a token that is not in use
+	 */
+	KeyToken getUnusedToken(Message message);
+
+	/**
+	 * Releases the given token to be used again.
+	 * 
+	 * @param token the token to be released
+	 */
+	void releaseToken(KeyToken keyToken);
+
+	/**
+	 * Indicates if the given token is in use, i.e. was returned by
+	 * {@link #getUnusedToken()} but not yet released by
+	 * {@link #releaseToken(byte[])}.
+	 * 
+	 * @param token the token to be checked
+	 * @return <code>true</code> if the given token is still in use, <code>false</code> otherwise
+	 */
+	boolean isTokenInUse(KeyToken keyToken);
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
@@ -44,15 +44,13 @@ public class InMemoryMessageExchangeStoreTest {
 	 */
 	private static final int PEER_PORT = 12000;
 	InMemoryMessageExchangeStore store;
-	TokenProvider tokenProvider;
 	NetworkConfig config;
 
 	@Before
 	public void createConfig() {
 		config = NetworkConfig.createStandardWithoutFile();
 		config.setLong(NetworkConfig.Keys.EXCHANGE_LIFETIME, 200); //ms
-		tokenProvider = new InMemoryRandomTokenProvider(config);
-		store = new InMemoryMessageExchangeStore(config, tokenProvider);
+		store = new InMemoryMessageExchangeStore(config);
 		store.start();
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
@@ -15,22 +15,19 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
-
-import java.net.InetAddress;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import org.eclipse.californium.category.Small;
-import org.eclipse.californium.core.coap.CoAP.ResponseCode;
-import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.Request;
-import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange.KeyMID;
 import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -47,13 +44,15 @@ public class InMemoryMessageExchangeStoreTest {
 	 */
 	private static final int PEER_PORT = 12000;
 	InMemoryMessageExchangeStore store;
+	TokenProvider tokenProvider;
 	NetworkConfig config;
 
 	@Before
 	public void createConfig() {
 		config = NetworkConfig.createStandardWithoutFile();
 		config.setLong(NetworkConfig.Keys.EXCHANGE_LIFETIME, 200); //ms
-		store = new InMemoryMessageExchangeStore(config);
+		tokenProvider = new InMemoryRandomTokenProvider(config);
+		store = new InMemoryMessageExchangeStore(config, tokenProvider);
 		store.start();
 	}
 
@@ -109,6 +108,17 @@ public class InMemoryMessageExchangeStoreTest {
 			fail("should have thrown IllegalArgumentException");
 		} catch (IllegalArgumentException e) {
 			// THEN the store rejects the re-registration
+		}
+	}
+	
+	@Test
+	public void testShouldNotCreateInMemoryMessageExchangeStoreWithoutTokenProvider() {
+		//WHEN trying to create new InMemoryMessageExchangeStore without TokenProvider
+		try {
+			store = new InMemoryMessageExchangeStore(config, null);
+			fail("should have thrown NullPointerException");
+		} catch (NullPointerException e) {
+			//THEN NullPointerException is thrown 
 		}
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -15,7 +15,8 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.net.InetAddress;
@@ -25,12 +26,14 @@ import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange.KeyToken;
 import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.InMemoryObservationStore;
 import org.eclipse.californium.elements.CorrelationContext;
 import org.eclipse.californium.elements.DtlsCorrelationContext;
 import org.eclipse.californium.elements.MapBasedCorrelationContext;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -44,6 +47,19 @@ public class UdpMatcherTest {
 	static final String CIPHER = "TLS_PSK";
 	static final String OTHER_CIPHER = "TLS_NULL";
 	static final InetSocketAddress dest = new InetSocketAddress(InetAddress.getLoopbackAddress(), 5684);
+	
+	private InMemoryObservationStore observationStore;
+	private InMemoryRandomTokenProvider tokenProvider; 
+	private InMemoryMessageExchangeStore messageExchangeStore;
+	private NetworkConfig config;
+	
+	@Before
+	public void before(){
+		config = NetworkConfig.createStandardWithoutFile();
+		tokenProvider = new InMemoryRandomTokenProvider(config);
+		messageExchangeStore = new InMemoryMessageExchangeStore(config, tokenProvider);
+		observationStore =  new InMemoryObservationStore();
+	}
 
 	@Test
 	public void testReceiveResponseAcceptsResponseWithoutCorrelationInformation() {
@@ -186,11 +202,53 @@ public class UdpMatcherTest {
 		// THEN assert that the response is not matched
 		assertThat(matchedExchange, is(nullValue()));
 	}
+	
+	@Test
+	public void testReceiveResponseReleasesToken() {
+		// GIVEN a request without token sent
+		UdpMatcher matcher = newMatcher(false);
+		Exchange exchange = sendRequest(matcher, null);
+				// WHEN request gets completed
+		exchange.completeCurrentRequest();
+
+		// THEN assert that token got released
+		KeyToken keyToken = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
+		assertThat(tokenProvider.isTokenInUse(keyToken), is(false));
+	}
+	
+	@Test
+	public void testReceiveResponseForObserveDoesNotReleaseToken() {
+		// GIVEN a request without token sent
+		UdpMatcher matcher = newMatcher(false);
+		Exchange exchange = sendObserveRequest(matcher);
+		
+		// WHEN observe request gets completed
+		exchange.completeCurrentRequest();
+
+		// THEN assert that token got not released
+		KeyToken keyToken = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
+		assertThat(tokenProvider.isTokenInUse(keyToken), is(true));
+	}
+	
+	@Test
+	public void testCancelObserveReleasesToken() {
+		// GIVEN a request without token sent
+		UdpMatcher matcher = newMatcher(false);
+		Exchange exchange = sendRequest(matcher, null);
+		
+		// WHEN observe gets canceled
+		matcher.cancelObserve(exchange.getRequest().getToken());
+
+		// THEN assert that token got released
+		KeyToken keyToken = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
+		assertThat(tokenProvider.isTokenInUse(keyToken), is(false));
+	}
 
 	private UdpMatcher newMatcher(boolean useStrictMatching) {
-		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
 		config.setBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING, useStrictMatching);
-		UdpMatcher matcher = new UdpMatcher(config, null, new InMemoryObservationStore());
+		UdpMatcher matcher = new UdpMatcher(config, null, observationStore);
+
+		matcher.setMessageExchangeStore(messageExchangeStore);
 		matcher.start();
 		return matcher;
 	}
@@ -200,8 +258,19 @@ public class UdpMatcherTest {
 		request.setDestination(dest.getAddress());
 		request.setDestinationPort(dest.getPort());
 		Exchange exchange = new Exchange(request, Origin.LOCAL);
+		exchange.setRequest(request);
 		matcher.sendRequest(exchange, request);
 		exchange.setCorrelationContext(ctx);
+		return exchange;
+	}
+
+	private Exchange sendObserveRequest(final UdpMatcher matcher) {
+		Request request = Request.newGet();
+		request.setDestination(dest.getAddress());
+		request.setDestinationPort(dest.getPort());
+		request.setObserve();
+		Exchange exchange = new Exchange(request, Origin.LOCAL);
+		matcher.sendRequest(exchange, request);
 		return exchange;
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
@@ -75,8 +75,6 @@ public class MemoryLeakingHashMapTest {
 	private static CoapEndpoint clientEndpoint;
 	private static MessageExchangeStore clientExchangeStore;
 	private static MessageExchangeStore serverExchangeStore;
-	private static TokenProvider serverTokenProvider;
-	private static TokenProvider clientTokenProvider;
 
 	private static String currentRequestText;
 	private static String currentResponseText;
@@ -277,13 +275,11 @@ public class MemoryLeakingHashMapTest {
 			.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, TEST_BLOCK_SIZE);
 
 		// Create the endpoint for the server and create surveillant
-		serverTokenProvider = new InMemoryRandomTokenProvider(config);
-		serverExchangeStore = new InMemoryMessageExchangeStore(config, serverTokenProvider);	
+		serverExchangeStore = new InMemoryMessageExchangeStore(config);	
 		serverEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config,serverExchangeStore);
 		serverEndpoint.addInterceptor(new MessageTracer());
 		
-		clientTokenProvider = new InMemoryRandomTokenProvider(config);
-		clientExchangeStore = new InMemoryMessageExchangeStore(config, clientTokenProvider);
+		clientExchangeStore = new InMemoryMessageExchangeStore(config);
 		clientEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config,  clientExchangeStore);
 		clientEndpoint.start();
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
@@ -32,7 +32,9 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.InMemoryMessageExchangeStore;
+import org.eclipse.californium.core.network.InMemoryRandomTokenProvider;
 import org.eclipse.californium.core.network.MessageExchangeStore;
+import org.eclipse.californium.core.network.TokenProvider;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
 import org.eclipse.californium.core.server.resources.CoapExchange;
@@ -73,6 +75,8 @@ public class MemoryLeakingHashMapTest {
 	private static CoapEndpoint clientEndpoint;
 	private static MessageExchangeStore clientExchangeStore;
 	private static MessageExchangeStore serverExchangeStore;
+	private static TokenProvider serverTokenProvider;
+	private static TokenProvider clientTokenProvider;
 
 	private static String currentRequestText;
 	private static String currentResponseText;
@@ -273,12 +277,14 @@ public class MemoryLeakingHashMapTest {
 			.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, TEST_BLOCK_SIZE);
 
 		// Create the endpoint for the server and create surveillant
-		serverExchangeStore = new InMemoryMessageExchangeStore(config);
-		serverEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config, serverExchangeStore);
+		serverTokenProvider = new InMemoryRandomTokenProvider(config);
+		serverExchangeStore = new InMemoryMessageExchangeStore(config, serverTokenProvider);	
+		serverEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config,serverExchangeStore);
 		serverEndpoint.addInterceptor(new MessageTracer());
-
-		clientExchangeStore = new InMemoryMessageExchangeStore(config);
-		clientEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config, clientExchangeStore);
+		
+		clientTokenProvider = new InMemoryRandomTokenProvider(config);
+		clientExchangeStore = new InMemoryMessageExchangeStore(config, clientTokenProvider);
+		clientEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config,  clientExchangeStore);
 		clientEndpoint.start();
 
 		// Create a server with two resources: one that sends piggy-backed

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
@@ -46,6 +46,7 @@ import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.network.InMemoryMessageExchangeStore;
+import org.eclipse.californium.core.network.InMemoryRandomTokenProvider;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.MessageExchangeStore;
 import org.eclipse.californium.core.network.config.NetworkConfig;
@@ -99,7 +100,7 @@ public class BlockwiseServerSideTest {
 
 		path = "test";
 		testResource = new TestResource(path);
-		exchangeStore = new InMemoryMessageExchangeStore(CONFIG);
+		exchangeStore = new InMemoryMessageExchangeStore(CONFIG, new InMemoryRandomTokenProvider(CONFIG));
 		// bind to loopback address using an ephemeral port
 		CoapEndpoint udpEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), CONFIG, exchangeStore);
 		server = new CoapServer();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
@@ -100,7 +100,7 @@ public class BlockwiseServerSideTest {
 
 		path = "test";
 		testResource = new TestResource(path);
-		exchangeStore = new InMemoryMessageExchangeStore(CONFIG, new InMemoryRandomTokenProvider(CONFIG));
+		exchangeStore = new InMemoryMessageExchangeStore(CONFIG);
 		// bind to loopback address using an ephemeral port
 		CoapEndpoint udpEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), CONFIG, exchangeStore);
 		server = new CoapServer();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -64,7 +64,7 @@ public class ObserveClientSideTest {
 	private int mid = 8000;
 	private String respPayload;
 	private ClientBlockwiseInterceptor clientInterceptor = new ClientBlockwiseInterceptor();
-
+	
 	@BeforeClass
 	public static void init() {
 		System.out.println(System.lineSeparator() + "Start " + ObserveClientSideTest.class.getSimpleName());
@@ -78,6 +78,9 @@ public class ObserveClientSideTest {
 
 	@Before
 	public void setupEndpoints() throws Exception {
+		//exchangeStore = new InMemoryMessageExchangeStore(CONFIG, new InMemoryRandomTokenProvider(CONFIG));
+		// bind to loopback address using an ephemeral port
+	//	CoapEndpoint udpEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), CONFIG, exchangeStore);
 
 		client = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), CONFIG);
 		client.addInterceptor(clientInterceptor);


### PR DESCRIPTION
This PR merge the  #85 "Introduce TokenProvider to prevent clashes of CoAP tokens" to the actual 2.0.x branch. 
The #85 is re-factor and the TokenProvider is incorporate  into the InMemoryMessageExchangeStore
