### PR TITLE
fixed and handled the request Code null pointer exception

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
@@ -48,7 +48,7 @@ public abstract class DataSerializer {
 			byte[] body = serializeOptionsAndPayload(request);
 
 			MessageHeader header = new MessageHeader(CoAP.VERSION, request.getType(), request.getToken(),
-					request.getCode()==null?0:request.getCode().value, request.getMID(), body.length);
+					request.getCode().value, request.getMID(), body.length);
 			serializeHeader(writer, header);
 			writer.writeBytes(body);
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
@@ -48,7 +48,7 @@ public abstract class DataSerializer {
 			byte[] body = serializeOptionsAndPayload(request);
 
 			MessageHeader header = new MessageHeader(CoAP.VERSION, request.getType(), request.getToken(),
-					request.getCode().value, request.getMID(), body.length);
+					request.getCode()==null?0:request.getCode().value, request.getMID(), body.length);
 			serializeHeader(writer, header);
 			writer.writeBytes(body);
 


### PR DESCRIPTION
When a CoAP Client is performing a Ping, the request sends a [**null** Code](https://github.com/eclipse/californium/blob/master/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java#L279) which eventually caught by [**DataSerializer**](https://github.com/eclipse/californium/blob/master/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java#L51) class and throws a _NullPointerException_. 