### PR TITLE
Testfix for race condition at the CoapObserveRelation relation.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
@@ -364,11 +364,21 @@ public class MemoryLeakingHashMapTest {
 			this.cancelProactively = cancelProactively;
 		}
 
-		public void setObserveRelation(CoapObserveRelation relation) {
+		public synchronized void setObserveRelation(CoapObserveRelation relation) {
 			this.relation = relation;
 		}
 
 		public void onLoad(CoapResponse response) {
+			CoapObserveRelation relation;
+			synchronized (this) {
+				relation = this.relation;
+			}
+			
+			if (null == relation) {
+				LOGGER.log(Level.INFO, "Client ignore notification {0}: [{1}]", new Object[]{counter++, response.getResponseText()});
+				return;
+			}
+			
 			latch.countDown();
 			LOGGER.log(Level.FINE, "Client received notification {0}: [{1}]", new Object[]{counter++, response.getResponseText()});
 


### PR DESCRIPTION
If the CoapObserveRelation is set to late (latch.getCount() already
reached 1), the test may fail. Therefore add a check, if the relation is
already set before using the latch.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>