### PR TITLE
Bugfix TCP schemes.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
@@ -951,20 +951,7 @@ public class CoapClient {
 		// custom endpoint
 		if (myEndpoint != null) return myEndpoint;
 		
-		// default endpoints
-		if (CoAP.COAP_SECURE_URI_SCHEME.equals(request.getScheme())) {
-			// this is the case when secure coap is supposed to be used
-			return EndpointManager.getEndpointManager().getDefaultSecureEndpoint();
-		} else if (CoAP.COAP_TCP_URI_SCHEME.equals(request.getScheme())) {
-			// Running over TCP.
-			return EndpointManager.getEndpointManager().getDefaultTcpEndpoint();
-		} else if (CoAP.COAP_SECURE_TCP_URI_SCHEME.equals(request.getScheme())) {
-			// Running over TLS.
-			return EndpointManager.getEndpointManager().getDefaultSecureTcpEndpoint();
-		} else {
-			// this is the normal case
-			return EndpointManager.getEndpointManager().getDefaultEndpoint();
-		}
+		return EndpointManager.getEndpointManager().getDefaultEndpoint(request.getScheme());
 	}
 
 	/*

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAP.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAP.java
@@ -102,6 +102,41 @@ public final class CoAP {
 	}
 
 	/**
+	 * Checks, if provided scheme is {@link #COAP_TCP_URI_SCHEME} or {@link #COAP_SECURE_TCP_URI_SCHEME}.
+	 * 
+	 * @param uriScheme scheme to be checked
+	 * @return true, if the provided scheme match one of the list above, false, otherwise.
+	 */
+	public static boolean isTcpScheme(final String uriScheme) {
+		return COAP_TCP_URI_SCHEME.equalsIgnoreCase(uriScheme)
+				|| COAP_SECURE_TCP_URI_SCHEME.equalsIgnoreCase(uriScheme);
+	}
+
+	/**
+	 * Checks, if provided scheme is {@link #COAP_SECURE_URI_SCHEME} or {@link #COAP_SECURE_TCP_URI_SCHEME}.
+	 * 
+	 * @param scheme scheme to be checked
+	 * @return true, if the provided scheme match one of the list above, false, otherwise.
+	 */
+	public static boolean isSecureScheme(final String uriScheme) {
+		return COAP_SECURE_URI_SCHEME.equalsIgnoreCase(uriScheme)
+				|| COAP_SECURE_TCP_URI_SCHEME.equalsIgnoreCase(uriScheme);
+	}
+
+	/**
+	 * Checks, if provided scheme is {@link #COAP_URI_SCHEME}, {@link #COAP_SECURE_URI_SCHEME}, {@link #COAP_TCP_URI_SCHEME} or {@link #COAP_SECURE_TCP_URI_SCHEME}.
+	 * 
+	 * @param uriScheme scheme to be checked
+	 * @return true, if the provided scheme match one of the list above, false, otherwise.
+	 */
+	public static boolean isSupportedScheme(final String uriScheme) {
+		return CoAP.COAP_URI_SCHEME.equalsIgnoreCase(uriScheme) ||
+				CoAP.COAP_TCP_URI_SCHEME.equalsIgnoreCase(uriScheme) ||
+				CoAP.COAP_SECURE_URI_SCHEME.equalsIgnoreCase(uriScheme) ||
+				CoAP.COAP_SECURE_TCP_URI_SCHEME.equalsIgnoreCase(uriScheme);
+	}
+
+	/**
 	 * Checks if a given CoAP code is a request code.
 	 * 
 	 * @param code the code to check.

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -230,10 +230,10 @@ public class Request extends Message {
 
 		try {
 			String coapUri = uri;
-			if (!uri.startsWith("coap://") && !uri.startsWith("coaps://") && !uri.startsWith("coap+tcp://")
-					&& !uri.startsWith("coaps+tcp://")) {
+			if (!uri.contains("://")) {
 				coapUri = "coap://" + uri;
 				LOGGER.log(Level.WARNING, "update your code to supply an RFC 7252 compliant URI including a scheme");
+				
 			}
 			return setURI(new URI(coapUri));
 		} catch (URISyntaxException e) {
@@ -263,7 +263,6 @@ public class Request extends Message {
 		final String host = uri.getHost() == null ? "localhost" : uri.getHost();
 
 		try {
-
 			InetAddress destAddress = InetAddress.getByName(host);
 			setDestination(destAddress);
 
@@ -297,7 +296,7 @@ public class Request extends Message {
 
 		if (uri == null) {
 			throw new NullPointerException("URI must not be null");
-		} else if (!isSupportedScheme(uri.getScheme())) {
+		} else if (!CoAP.isSupportedScheme(uri.getScheme())) {
 			throw new IllegalArgumentException("unsupported URI scheme: " + uri.getScheme());
 		} else if (uri.getFragment() != null) {
 			throw new IllegalArgumentException("URI must not contain a fragment");
@@ -357,16 +356,6 @@ public class Request extends Message {
 		}
 
 		return this;
-	}
-
-	private static boolean isSupportedScheme(final String uriScheme) {
-		boolean result = false;
-		if (uriScheme != null) {
-			String scheme = uriScheme.toLowerCase();
-			result = CoAP.COAP_URI_SCHEME.equalsIgnoreCase(scheme) || CoAP.COAP_SECURE_URI_SCHEME.equalsIgnoreCase(scheme) ||
-					CoAP.COAP_TCP_URI_SCHEME.equalsIgnoreCase(scheme) || CoAP.COAP_SECURE_TCP_URI_SCHEME.equalsIgnoreCase(scheme);
-		}
-		return result;
 	}
 
 	// TODO: test this method.
@@ -444,13 +433,7 @@ public class Request extends Message {
 	 */
 	public Request send() {
 		validateBeforeSending();
-		if (CoAP.COAP_SECURE_URI_SCHEME.equals(getScheme())) {
-			// This is the case when secure coap is supposed to be used
-			EndpointManager.getEndpointManager().getDefaultSecureEndpoint().sendRequest(this);
-		} else {
-			// This is the normal case
-			EndpointManager.getEndpointManager().getDefaultEndpoint().sendRequest(this);
-		}
+		EndpointManager.getEndpointManager().getDefaultEndpoint(getScheme()).sendRequest(this);
 		return this;
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -25,6 +25,7 @@
  *                                      of Response(s) to Request (fix GitHub issue #1)
  *    Bosch Software Innovations GmbH - adapt message parsing error handling
  *    Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ *    Bosch Software Innovations GmbH - adjust request scheme for TCP
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -141,6 +142,10 @@ public class CoapEndpoint implements Endpoint {
 	
 	/** The connector over which the endpoint connects to the network */
 	private final Connector connector;
+	
+	private final String scheme;
+	
+	private final String secureScheme;
 	
 	/** The configuration of this endpoint */
 	private final NetworkConfig config;
@@ -281,11 +286,15 @@ public class CoapEndpoint implements Endpoint {
 			this.coapstack = new CoapTcpStack(config, new OutboxImpl());
 			this.serializer = new TcpDataSerializer();
 			this.parser = new TcpDataParser();
+			this.scheme = CoAP.COAP_TCP_URI_SCHEME;
+			this.secureScheme = CoAP.COAP_SECURE_TCP_URI_SCHEME;
 		} else {
 			this.matcher = new UdpMatcher(config, new NotificationDispatcher(), observationStore);
 			this.coapstack = new CoapUdpStack(config, new OutboxImpl());
 			this.serializer = new UdpDataSerializer();
 			this.parser = new UdpDataParser();
+			this.scheme = CoAP.COAP_URI_SCHEME;
+			this.secureScheme = CoAP.COAP_SECURE_URI_SCHEME;
 		}
 	}
 
@@ -785,7 +794,7 @@ public class CoapEndpoint implements Endpoint {
 		private void receiveRequest(final Request request, final RawData raw) {
 
 			// set request attributes from raw data
-			request.setScheme(raw.isSecure() ? CoAP.COAP_SECURE_URI_SCHEME : CoAP.COAP_URI_SCHEME);
+			request.setScheme(raw.isSecure() ? secureScheme : scheme);
 			request.setSenderIdentity(raw.getSenderIdentity());
 
 			/* 

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/EndpointManagerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/EndpointManagerTest.java
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - initial creation (465073)
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.hamcrest.core.IsSame.sameInstance;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+
+import org.eclipse.californium.category.Small;
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.RawData;
+import org.eclipse.californium.elements.RawDataChannel;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Small.class)
+public class EndpointManagerTest {
+
+	@Before
+	public void setUp() throws Exception {
+		/* remove all endpoints, possibly changed by some other tests */
+		EndpointManager.reset();
+	}
+
+	@Test
+	public void testGetDefaultEndpoint() throws Exception {
+
+		// WHEN get the default endpoint
+		Endpoint endpoint = EndpointManager.getEndpointManager().getDefaultEndpoint();
+
+		// THEN assert that the uri scheme is "coap:" and the endpoint is
+		// started
+		assertThat(endpoint, is(notNullValue()));
+		assertThat(endpoint.getUri(), is(notNullValue()));
+		assertThat(endpoint.getUri().getScheme(), is(CoAP.COAP_URI_SCHEME));
+		assertThat(endpoint.isStarted(), is(true));
+	}
+
+	@Test
+	public void testSetDefaultEndpoint() throws Exception {
+		// GIVEN a old and a new endpoint
+		Endpoint oldEndpoint = EndpointManager.getEndpointManager().getDefaultEndpoint();
+		Endpoint endpoint = new CoapEndpoint();
+
+		// WHEN set the new default endpoint
+		EndpointManager.getEndpointManager().setDefaultEndpoint(endpoint);
+
+		// THEN get the same new default endpoint and the old is stopped
+		assertThat(EndpointManager.getEndpointManager().getDefaultEndpoint(), is(sameInstance(endpoint)));
+		assertThat(oldEndpoint.isStarted(), is(false));
+	}
+
+	@Test
+	public void testSetDefaultEndpointSchemeFailure() throws Exception {
+		// GIVEN an new endpoint with http:
+		Endpoint endpoint = new CoapEndpoint(new DummyHttpConnector(), NetworkConfig.getStandard());
+
+		// THEN set with null or unsupported scheme fails
+		try {
+			EndpointManager.getEndpointManager().setDefaultEndpoint(null);
+			assertThat("null should fail", false);
+		} catch (NullPointerException ex) {
+		}
+		try {
+			EndpointManager.getEndpointManager().setDefaultEndpoint(endpoint);
+			assertThat("http should not be supported", false);
+		} catch (IllegalArgumentException ex) {
+		}
+	}
+
+	@Test
+	public void testGetDefaultCoapEndpoint() throws Exception {
+		// WHEN get the default endpoint
+		Endpoint endpoint = EndpointManager.getEndpointManager().getDefaultEndpoint(CoAP.COAP_URI_SCHEME);
+
+		// THEN assert that the uri scheme is "coap:" and the endpoint is
+		// started
+		assertThat(endpoint, is(notNullValue()));
+		assertThat(endpoint.getUri(), is(notNullValue()));
+		assertThat(endpoint.getUri().getScheme(), is(CoAP.COAP_URI_SCHEME));
+		assertThat(endpoint.isStarted(), is(true));
+	}
+
+	@Test
+	public void testGetDefaultCoapsEndpoint() throws Exception {
+		// WHEN get the default endpoint
+		Endpoint endpoint = EndpointManager.getEndpointManager().getDefaultEndpoint(CoAP.COAP_SECURE_URI_SCHEME);
+
+		// THEN assert that the endpoint is not available
+		assertThat(endpoint, is(nullValue()));
+	}
+
+	@Test
+	public void testGetDefaultCoapOverTcpEndpoint() throws Exception {
+		// WHEN get the default endpoint
+		Endpoint endpoint = EndpointManager.getEndpointManager().getDefaultEndpoint(CoAP.COAP_TCP_URI_SCHEME);
+
+		// THEN assert that the uri scheme is "coap+tcp:" and the endpoint is
+		// started
+		assertThat(endpoint, is(notNullValue()));
+		assertThat(endpoint.getUri(), is(notNullValue()));
+		assertThat(endpoint.getUri().getScheme(), is(CoAP.COAP_TCP_URI_SCHEME));
+		assertThat(endpoint.isStarted(), is(true));
+	}
+
+	@Test
+	public void testGetDefaultCoapsOverTcpEndpoint() throws Exception {
+		// WHEN get the default endpoint
+		Endpoint endpoint = EndpointManager.getEndpointManager().getDefaultEndpoint(CoAP.COAP_SECURE_TCP_URI_SCHEME);
+
+		// THEN assert that the endpoint is not available
+		assertThat(endpoint, is(nullValue()));
+	}
+
+	private static class DummyHttpConnector implements Connector {
+
+		@Override
+		public void start() throws IOException {
+		}
+
+		@Override
+		public void stop() {
+		}
+
+		@Override
+		public void destroy() {
+		}
+
+		@Override
+		public void send(RawData msg) {
+		}
+
+		@Override
+		public void setRawDataReceiver(RawDataChannel messageHandler) {
+		}
+
+		@Override
+		public InetSocketAddress getAddress() {
+			return null;
+		}
+
+		@Override
+		public boolean isSchemeSupported(String scheme) {
+			return false;
+		}
+
+		@Override
+		public URI getUri() {
+			return URI.create("http://localhost");
+		}
+		
+	}
+}


### PR DESCRIPTION
Adjust schemes for received request according UPD or TCP usage.
Add common scheme dependent getDefaultEndpoint(String scheme) to EndpointManager. 
Adjust Request and CoapClient to use the scheme dependent default endpoint.
Fixing Request to consider TCP endpoints also (not only UDP).

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>