### PR TITLE
Testfix irritating failure logging.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -541,9 +541,11 @@ public class BlockwiseClientSideTest {
 		respPayload = generateRandomPayload(280);
 
 		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(62354).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 
 		server.expectRequest(CON, GET, path).storeBoth("D").noOption(OBSERVE).block2(1, false, 128).go();
+		server.goMultiExpectation();
 		server.sendResponse(ACK, CONTENT).loadBoth("D").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
 
 		server.expectRequest(CON, GET, path).storeBoth("E").noOption(OBSERVE).block2(2, false, 128).go();
@@ -557,22 +559,28 @@ public class BlockwiseClientSideTest {
 		respPayload = generateRandomPayload(290);
 
 		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(17).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 
 		// expect blockwise transfer for second notification
 		server.expectRequest(CON, GET, path).storeBoth("F").noOption(OBSERVE).block2(1, false, 128).go();
-
+		server.goMultiExpectation();
+		
 		System.out.println("Server sends third notification during transfer ");
 		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(19).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 
 		// expect blockwise transfer for third notification
 		server.expectRequest(CON, GET, path).storeBoth("G").noOption(OBSERVE).block2(1, false, 128).go();
-
+		server.goMultiExpectation();
+		
 		System.out.println("Send old notification during transfer");
 		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(18).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 		server.expectRequest(CON, GET, path).storeBoth("H").noOption(OBSERVE).block2(1, false, 128).go();
+		server.goMultiExpectation();
 
 		server.sendResponse(ACK, CONTENT).loadBoth("G").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
@@ -208,8 +208,10 @@ public class ClusteringTest {
 		server.setDestination(client2.getAddress());
 		server.sendResponse(CON, CONTENT).loadToken("T").mid(++mid).observe(obs++).block2(0, true, 16)
 				.payload(respPayload.substring(0, 16)).go();
+		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 16).go();
+		server.goMultiExpectation();
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
 		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 16).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 16).payload(respPayload.substring(32, 40)).go();
@@ -228,8 +230,10 @@ public class ClusteringTest {
 		server.setDestination(client1.getAddress());
 		server.sendResponse(CON, CONTENT).loadToken("T").mid(++mid).observe(obs++).block2(0, true, 16)
 				.payload(respPayload.substring(0, 16)).go();
+		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 16).go();
+		server.goMultiExpectation();
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
 		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 16).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 16).payload(respPayload.substring(32, 40)).go();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
@@ -185,6 +185,10 @@ public class LockstepEndpoint {
 					Assert.assertEquals("Wrong MID:", mid, message.getMID());
 					print("Correct MID: "+mid);
 				}
+
+				public String toString() {
+					return "Expected MID: " +mid;
+				}
 			});
 			return this;
 		}
@@ -196,6 +200,11 @@ public class LockstepEndpoint {
 					Assert.assertEquals("Wrong MID:", expected, message.getMID());
 					print("Correct MID: "+expected);
 				}
+
+				public String toString() {
+					int expected = (Integer) storage.get(var);
+					return "Expected MID: " + expected;
+				}
 			});
 			return this;
 		}
@@ -206,6 +215,10 @@ public class LockstepEndpoint {
 					Assert.assertEquals("Wrong type:", type, message.getType());
 					print("Correct type: "+type);
 				}
+
+				public String toString() {
+					return "Expected type: " + type;
+				}
 			});
 			return this;
 		}
@@ -215,6 +228,9 @@ public class LockstepEndpoint {
 				public void check(Message message) {
 					org.junit.Assert.assertArrayEquals("Wrong token:", token, message.getToken());
 					print("Correct token: "+Utils.toHexString(token));
+				}
+				public String toString() {
+					return "Expected token: " + Utils.toHexString(token);
 				}
 			});
 			return this;
@@ -228,6 +244,10 @@ public class LockstepEndpoint {
 					Assert.assertEquals("Wrong payload length: ", expectedLength, actualLength);
 					Assert.assertEquals("Wrong payload:", payload, message.getPayloadString());
 					print("Correct payload ("+actualLength+" bytes):\n"+message.getPayloadString());
+				}
+
+				public String toString() {
+					return "Expected payload: '"+ payload + "'";
 				}
 			});
 			return this;
@@ -248,6 +268,11 @@ public class LockstepEndpoint {
 					Assert.assertEquals("Wrong Block1 size:", size, block1.getSize());
 					print("Correct Block1 option: "+block1);
 				}
+
+				public String toString() {
+					BlockOption option = new BlockOption(BlockOption.size2Szx(size), m, num);
+					return "Expected Block1 option: "+ option;
+				}
 			});
 			return this;
 		}
@@ -262,6 +287,11 @@ public class LockstepEndpoint {
 					Assert.assertEquals("Wrong Block2 size:", size, block2.getSize());
 					print("Correct Block2 option: "+block2);
 				}
+
+				public String toString() {
+					BlockOption option = new BlockOption(BlockOption.size2Szx(size), m, num);
+					return "Expected Block2 option: "+ option;
+				}
 			});
 			return this;
 		}
@@ -273,6 +303,10 @@ public class LockstepEndpoint {
 					int actual = message.getOptions().getObserve();
 					Assert.assertEquals("Wrong observe sequence number:", observe, actual);
 					print("Correct observe sequence number: "+observe);
+				}
+
+				public String toString() {
+					return "Expected observe sequence number: "+observe;
 				}
 			});
 			return this;
@@ -290,6 +324,20 @@ public class LockstepEndpoint {
 						}
 					}
 				}
+
+				public String toString() {
+					StringBuffer result = new StringBuffer("Expected no options: [");
+					if (0 < numbers.length) {
+						final int end = numbers.length -1;
+						int index = 0;
+						for (; index < end; ++index) {
+							result.append(numbers[index]).append(",");
+						}
+						result.append(numbers[index]);
+					}
+					result.append(']');
+					return result.toString();
+				}
 			});
 			return this;
 		}
@@ -298,6 +346,10 @@ public class LockstepEndpoint {
 			expectations.add(new Expectation<Message>() {
 				public void check(Message message) {
 					storage.put(var, message.getMID());
+				}
+
+				public String toString() {
+					return "";
 				}
 			});
 			return this;
@@ -308,6 +360,10 @@ public class LockstepEndpoint {
 				public void check(Message message) {
 					storage.put(var, message.getToken());
 				}
+
+				public String toString() {
+					return "";
+				}
 			});
 			return this;
 		}
@@ -315,6 +371,22 @@ public class LockstepEndpoint {
 		public void check(Message message) {
 			for (Expectation<Message> expectation:expectations)
 				expectation.check(message);
+		}
+		
+		public String toString() {
+			StringBuffer result = new StringBuffer("{");
+			for (Expectation<Message> expectation:expectations) {
+				String info = expectation.toString();
+				if (!info.isEmpty()) {
+					result.append(info).append(",");
+				}
+			}
+			int end = result.length() - 1;
+			if (0 <= end && ',' == result.charAt(end)) {
+				result.setLength(end);
+			}
+			result.append("}");
+			return result.toString();
 		}
 	}
 	
@@ -417,7 +489,7 @@ public class LockstepEndpoint {
 				check(request);
 
 			} else {
-				Assert.fail("Expected request but received " + msg);
+				Assert.fail("Expected request for " + this + ", but received " + msg);
 			}
 		}
 	}
@@ -558,7 +630,7 @@ public class LockstepEndpoint {
 				check(response);
 
 			} else {
-				Assert.fail("Expected response but received " + msg);
+				Assert.fail("Expected response for " + this + ", but received " + msg);
 			}
 		}
 		
@@ -582,7 +654,7 @@ public class LockstepEndpoint {
 				msg.setSourcePort(raw.getPort());
 				check(msg);
 			} else {
-				Assert.fail("Expected empty message but received " + msg);
+				Assert.fail("Expected empty message for " + this + ", but received " + msg);
 			}
 		}
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
@@ -417,7 +417,7 @@ public class LockstepEndpoint {
 				check(request);
 
 			} else {
-				Assert.fail("Expected request but received " + parser);
+				Assert.fail("Expected request but received " + msg);
 			}
 		}
 	}
@@ -558,7 +558,7 @@ public class LockstepEndpoint {
 				check(response);
 
 			} else {
-				Assert.fail("Expected response but received " + parser);
+				Assert.fail("Expected response but received " + msg);
 			}
 		}
 		
@@ -582,7 +582,7 @@ public class LockstepEndpoint {
 				msg.setSourcePort(raw.getPort());
 				check(msg);
 			} else {
-				Assert.fail("Expected empty message but received " + parser);
+				Assert.fail("Expected empty message but received " + msg);
 			}
 		}
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -181,8 +181,10 @@ public class ObserveClientSideTest {
 		// normal notification
 		server.sendResponse(CON, CONTENT).loadToken("T").mid(++mid).observe(1).block2(0, true, 16).payload(respPayload.substring(0, 16)).go();
 		// TODO: allow for messages to be received in arbitrary order
+		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 16).go();
+		server.goMultiExpectation();
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
 		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 16).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 16).payload(respPayload.substring(32, 40)).go();
@@ -197,8 +199,10 @@ public class ObserveClientSideTest {
 		// override transfer with new notification
 		server.sendResponse(CON, CONTENT).loadToken("T").mid(++mid).observe(2).block2(0, true, 16).payload(respPayload.substring(0, 16)).go();
 		// TODO: allow for messages to be received in arbitrary order
+		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 16).go();
+		server.goMultiExpectation();
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
 		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 16).go();
 
@@ -226,16 +230,20 @@ public class ObserveClientSideTest {
 		// override transfer with new notification and conflicting block number
 		server.sendResponse(CON, CONTENT).loadToken("T").mid(++mid).observe(4).block2(0, true, 16).payload(respPayload.substring(0, 16)).go();
 		// TODO: allow for messages to be received in arbitrary order
+		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 		server.expectRequest(CON, GET, path).storeBoth("F").block2(1, false, 16).go();
+		server.goMultiExpectation();
 
 		clientInterceptor.log("\n\n//////// Overriding notification 2 ////////");
 		String respPayload4 = "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMN";
 
 		// start new block
 		server.sendResponse(CON, CONTENT).loadToken("T").mid(++mid).observe(5).block2(0, true, 16).payload(respPayload4.substring(0, 16)).go();
+		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 		server.expectRequest(CON, GET, path).storeBoth("G").block2(1, false, 16).go();
+		server.goMultiExpectation();
 
 		// old block
 		clientInterceptor.log("\n\n//////// Conflicting notification block ////////");
@@ -265,8 +273,11 @@ public class ObserveClientSideTest {
 		clientInterceptor.log("\n\n//////// Notification after cancellation ////////");
 		server.sendResponse(CON, CONTENT).loadToken("T").mid(++mid).observe(6).block2(0, true, 16).payload(respPayload.substring(0, 16)).go();
 		// TODO: allow for messages to be received in arbitrary order
+		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 16).go();
+		server.goMultiExpectation();
+		
 		// canceling in the middle of blockwise transfer
 		client.cancelObservation(request.getToken());
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();


### PR DESCRIPTION
I got that failure logging from the unit tests (once, not frequently):

Failed tests: 
  ObserveClientSideTest.testBlockwiseObserve:200 Expected empty message
but received
org.eclipse.californium.core.network.serialization.UdpDataParser@3a5ed7a6

That's irritating, because, sure, the parser isn't received.
Therefore replace the parser with the received message in the failure
logging. So maybe, next time we see what sporadically went wrong.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>