### PR TITLE
Use NONE as mid for TCP messages.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataParser.java
@@ -18,10 +18,12 @@
  * Kai Hudalla - logging
  * Bosch Software Innovations GmbH - introduce dedicated MessageFormatException
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ * Achim Kraus (Bosch Software Innovations GmbH) - use Message.NONE as mid
  ******************************************************************************/
 package org.eclipse.californium.core.network.serialization;
 
 import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.elements.tcp.DatagramFramer;
 import org.eclipse.californium.elements.util.DatagramReader;
 
@@ -44,6 +46,6 @@ public final class TcpDataParser extends DataParser {
 		byte token[] = reader.readBytes(tokenLength);
 
 		// No MID/Type/VERSION in TCP message. Use defaults.
-		return new MessageHeader(CoAP.VERSION, CoAP.Type.CON, token, code, 0, 0);
+		return new MessageHeader(CoAP.VERSION, CoAP.Type.CON, token, code, Message.NONE, 0);
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataParserTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataParserTest.java
@@ -32,6 +32,7 @@ import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.MessageFormatException;
 import org.eclipse.californium.core.coap.Option;
 import org.eclipse.californium.core.coap.Request;
@@ -61,7 +62,7 @@ import org.junit.runners.Parameterized;
 	@Parameterized.Parameters public static List<Object[]> parameters() {
 		List<Object[]> parameters = new ArrayList<>();
 		parameters.add(new Object[] { new UdpDataSerializer(), new UdpDataParser(), 7 });
-		parameters.add(new Object[] { new TcpDataSerializer(), new TcpDataParser(), 0 });
+		parameters.add(new Object[] { new TcpDataSerializer(), new TcpDataParser(), Message.NONE });
 		return parameters;
 	}
 
@@ -161,7 +162,7 @@ import org.junit.runners.Parameterized;
 	@Test public void testUTF8Encoding() {
 		Response response = new Response(ResponseCode.CONTENT);
 		response.setType(Type.NON);
-		response.setMID(9);
+		response.setMID(expectedMid);
 		response.setToken(new byte[] {});
 		response.getOptions().addLocationPath("ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ").addLocationPath("γλώσσα")
 				.addLocationPath("пустынных").addLocationQuery("ვეპხის=யாமறிந்த").addLocationQuery("⠊⠀⠉⠁⠝=⠑⠁⠞⠀⠛⠇⠁⠎⠎");
@@ -173,5 +174,6 @@ import org.junit.runners.Parameterized;
 		assertEquals("ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ/γλώσσα/пустынных", response.getOptions().getLocationPathString());
 		assertEquals("ვეპხის=யாமறிந்த&⠊⠀⠉⠁⠝=⠑⠁⠞⠀⠛⠇⠁⠎⠎", response.getOptions().getLocationQueryString());
 		assertEquals("⠊⠀⠉⠁⠝⠀⠑⠁⠞⠀⠛⠇⠁⠎⠎⠀⠁⠝⠙⠀⠊⠞⠀⠙⠕⠑⠎⠝⠞⠀⠓⠥⠗⠞⠀⠍⠑", result.getPayloadString());
+		assertEquals(response.getMID(), result.getMID());
 	}
 }


### PR DESCRIPTION
Prevents accidently usage of MID.
(Alternatively introducing a TCP_MID -2 would distinguish even between empty and TCP.)
This is also very helpfull in analysing logs in mixed endpoints.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>