### PR TITLE
Introduce conditional message sending for TCP based connections.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/MessageNotSentCallback.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/MessageNotSentCallback.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial version
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+public interface MessageNotSentCallback extends MessageCallback {
+
+	/**
+	 * Called when an outbound message could not be sent.
+	 * If this is used as MessageCallback, a tcp based connector 
+	 * should not reopen a connection and instead should call this method.
+	 */
+	void onNotSent();
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpClientConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpClientConnector.java
@@ -28,6 +28,8 @@ import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.MessageCallback;
+import org.eclipse.californium.elements.MessageNotSentCallback;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
 
@@ -98,6 +100,11 @@ public class TcpClientConnector implements Connector {
 	}
 
 	@Override public void send(final RawData msg) {
+		MessageCallback callback = msg.getMessageCallback();
+		if (callback instanceof MessageNotSentCallback && !poolMap.contains(msg.getInetSocketAddress())) {
+			((MessageNotSentCallback) callback).onNotSent();
+			return;
+		}
 		final ChannelPool channelPool = poolMap.get(new InetSocketAddress(msg.getAddress(), msg.getPort()));
 		Future<Channel> acquire = channelPool.acquire();
 		acquire.addListener(new GenericFutureListener<Future<Channel>>() {

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpServerConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpServerConnector.java
@@ -23,6 +23,8 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.timeout.IdleStateHandler;
 import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.MessageCallback;
+import org.eclipse.californium.elements.MessageNotSentCallback;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
 
@@ -111,8 +113,13 @@ public class TcpServerConnector implements Connector {
 		Channel channel = activeChannels.get(msg.getInetSocketAddress());
 		if (channel == null) {
 			// TODO: Is it worth allowing opening a new connection when in server mode?
-			LOGGER.log(Level.WARNING, "Attempting to send message to an address without an active connection {0}",
-					msg.getAddress());
+			MessageCallback callback = msg.getMessageCallback();
+			if (callback instanceof MessageNotSentCallback) {
+				((MessageNotSentCallback) callback).onNotSent();
+			} else {
+				LOGGER.log(Level.WARNING, "Attempting to send message to an address without an active connection {0}",
+						msg.getAddress());
+			}
 			return;
 		}
 
@@ -181,7 +188,7 @@ public class TcpServerConnector implements Connector {
 	}
 
 	protected String getSupportedScheme() {
-		return "coap+tcp";
+		return SUPPORTED_SCHEME;
 	}
 
 	private URI getListenUri(final InetSocketAddress listenAddress) {


### PR DESCRIPTION
Some messages must only be sent, if no new connection must be
established. Use CON/NON to determine, if conditional sending is used.
(Required e.g. for "cancel observe" or "response".)
(Cleanup  on losing the connection is right now not implemented.)

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>