### PR TITLE
Reduce code duplications in CoapStack.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -96,7 +96,7 @@ public final class TcpMatcher extends BaseMatcher {
 			}
 		}
 
-		// Only Observes keep the exchange active
+		// Only Observes keep the exchange active (CoAP server side)
 		if (response.isLast()) {
 			exchange.setComplete();
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -175,7 +175,7 @@ public final class UdpMatcher extends BaseMatcher {
 			}
 		}
 
-		// Only CONs and Observe keep the exchange active
+		// Only CONs and Observe keep the exchange active (CoAP server side)
 		if (response.getType() != Type.CON && response.isLast()) {
 			exchange.setComplete();
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2016 Institute for Pervasive Computing, ETH Zurich and others.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.html.
+ * <p>
+ * Contributors:
+ * Matthias Kovatsch - creator and main architect
+ * Martin Lanter - architect and re-implementation
+ * Dominique Im Obersteg - parsers and initial implementation
+ * Daniel Pauli - parsers and initial implementation
+ * Kai Hudalla - logging
+ * Kai Hudalla (Bosch Software Innovations GmbH) - use Logger's message formatting instead of
+ *                                                 explicit String concatenation
+ * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ * Achim Kraus (Bosch Software Innovations GmbH) - derived from UDP and TCP CoAP stack
+ ******************************************************************************/
+package org.eclipse.californium.core.network.stack;
+
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.logging.Logger;
+
+import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.Exchange.Origin;
+import org.eclipse.californium.core.network.Outbox;
+import org.eclipse.californium.core.network.stack.Layer.TopDownBuilder;
+import org.eclipse.californium.core.server.MessageDeliverer;
+
+/**
+ * The BaseCoapStack passes the messages through the layers configured in the
+ * stacks implementations.
+ */
+public abstract class BaseCoapStack implements CoapStack {
+
+	/** The LOGGER. */
+	private static final Logger LOGGER = Logger.getLogger(BaseCoapStack.class.getCanonicalName());
+
+	private List<Layer> layers;
+	private final Outbox outbox;
+	private final StackTopAdapter top;
+	private final StackBottomAdapter bottom;
+	private MessageDeliverer deliverer;
+
+	protected BaseCoapStack(Outbox outbox) {
+		this.top = new StackTopAdapter();
+		this.bottom = new StackBottomAdapter();
+		this.outbox = outbox;
+	}
+
+	/**
+	 * Set layers to passes message through.
+	 * 
+	 * @param specificLayers stack specific layers.
+	 */
+	protected void setLayers(Layer specificLayers[]) {
+		TopDownBuilder builder = new Layer.TopDownBuilder().add(top);
+		for (Layer layer : specificLayers) {
+			builder.add(layer);
+		}
+		builder.add(bottom);
+		layers = builder.create();
+	}
+
+	@Override
+	public void sendRequest(Request request) {
+		// delegate to top
+		top.sendRequest(request);
+	}
+
+	@Override
+	public void sendResponse(Exchange exchange, Response response) {
+		// delegate to top
+		top.sendResponse(exchange, response);
+	}
+
+	@Override
+	public void sendEmptyMessage(Exchange exchange, EmptyMessage message) {
+		// delegate to top
+		top.sendEmptyMessage(exchange, message);
+	}
+
+	@Override
+	public void receiveRequest(Exchange exchange, Request request) {
+		// delegate to bottom
+		bottom.receiveRequest(exchange, request);
+	}
+
+	@Override
+	public void receiveResponse(Exchange exchange, Response response) {
+		// delegate to bottom
+		bottom.receiveResponse(exchange, response);
+	}
+
+	@Override
+	public void receiveEmptyMessage(Exchange exchange, EmptyMessage message) {
+		// delegate to bottom
+		bottom.receiveEmptyMessage(exchange, message);
+	}
+
+	@Override
+	public void setExecutor(ScheduledExecutorService executor) {
+		for (Layer layer : layers) {
+			layer.setExecutor(executor);
+		}
+	}
+
+	@Override
+	public void setDeliverer(MessageDeliverer deliverer) {
+		this.deliverer = deliverer;
+	}
+
+	@Override
+	public void destroy() {
+		for (Layer layer : layers) {
+			layer.destroy();
+		}
+	}
+
+	private class StackTopAdapter extends AbstractLayer {
+
+		public void sendRequest(Request request) {
+			Exchange exchange = new Exchange(request, Origin.LOCAL);
+			sendRequest(exchange, request); // layer method
+		}
+
+		@Override
+		public void sendRequest(Exchange exchange, Request request) {
+			exchange.setRequest(request);
+			super.sendRequest(exchange, request);
+		}
+
+		@Override
+		public void sendResponse(Exchange exchange, Response response) {
+			exchange.setResponse(response);
+			super.sendResponse(exchange, response);
+		}
+
+		@Override
+		public void receiveRequest(Exchange exchange, Request request) {
+			// if there is no BlockwiseLayer we still have to set it
+			if (exchange.getRequest() == null) {
+				exchange.setRequest(request);
+			}
+			if (hasDeliverer()) {
+				deliverer.deliverRequest(exchange);
+			} else {
+				LOGGER.severe("Top of CoAP stack has no deliverer to deliver request");
+			}
+		}
+
+		@Override
+		public void receiveResponse(Exchange exchange, Response response) {
+			exchange.setComplete();
+			if (hasDeliverer()) {
+				deliverer.deliverResponse(exchange, response); // notify request
+																// that response
+																// has arrived
+			} else {
+				LOGGER.severe("Top of CoAP stack has no deliverer to deliver response");
+			}
+		}
+
+		@Override
+		public void receiveEmptyMessage(Exchange exchange, EmptyMessage message) {
+			// When empty messages reach the top of the CoAP stack we can ignore
+			// them.
+		}
+	}
+
+	private class StackBottomAdapter extends AbstractLayer {
+
+		@Override
+		public void sendRequest(Exchange exchange, Request request) {
+			outbox.sendRequest(exchange, request);
+		}
+
+		@Override
+		public void sendResponse(Exchange exchange, Response response) {
+			outbox.sendResponse(exchange, response);
+		}
+
+		@Override
+		public void sendEmptyMessage(Exchange exchange, EmptyMessage message) {
+			outbox.sendEmptyMessage(exchange, message);
+		}
+
+	}
+
+	@Override
+	public boolean hasDeliverer() {
+		return deliverer != null;
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapTcpStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapTcpStack.java
@@ -19,24 +19,14 @@
  * Kai Hudalla (Bosch Software Innovations GmbH) - use Logger's message formatting instead of
  * explicit String concatenation
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ * Achim Kraus (Bosch Software Innovations GmbH) - move common function to BaseCoapStack
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
-import org.eclipse.californium.core.coap.EmptyMessage;
-import org.eclipse.californium.core.coap.Request;
-import org.eclipse.californium.core.coap.Response;
-import org.eclipse.californium.core.coap.CoAP.Type;
-import org.eclipse.californium.core.network.Exchange;
-import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.Outbox;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.MessageDeliverer;
 import org.eclipse.californium.elements.Connector;
-
-import java.util.List;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * The CoapTcpStack builds up the stack of CoAP layers that process the CoAP
@@ -46,187 +36,51 @@ import java.util.logging.Logger;
  * The class <code>CoapStack</code> builds up the part between the Stack Top and
  * Bottom.
  * <hr><blockquote><pre>
- * +-----------------------+
- * | {@link MessageDeliverer}      |
- * +-------------A---------+
- *               A
- *             * A
- * +-----------+-A---------+
- * |       CoAPEndpoint    |
- * |           v A         |
- * |           v A         |
- * | +---------v-+-------+ |
- * | | Stack Top         | |
- * | +-------------------+ |
- * | | {@link ExchangeCleanupLayer}      | |
- * * | +-------------------+ |
- * | | {@link ObserveLayer}      | |
- * | +-------------------+ |
- * | | {@link BlockwiseLayer}    | |
- * | +-------------------+ |
- * | | Stack Bottom      | |
- * | +---------+-A-------+ |
- * |           v A         |
- * |         Matcher       |
- * |           v A         |
- * |       Interceptor     |
- * |           v A         |
- * +-----------v-A---------+
- *             v A 
- *             v A 
- * +-----------v-+---------+
- * | {@link Connector}             |
- * +-----------------------+
+ * +--------------------------+
+ * | {@link MessageDeliverer}         |
+ * +--------------A-----------+
+ *                A
+ *              * A
+ * +------------+-A-----------+
+ * |        CoAPEndpoint      |
+ * |            v A           |
+ * |            v A           |
+ * | +----------v-+---------+ |
+ * | | Stack Top            | |
+ * | +----------------------+ |
+ * | | {@link ExchangeCleanupLayer} | |
+ * | +----------------------+ |
+ * | | {@link TcpObserveLayer}      | |
+ * | +----------------------+ |
+ * | | {@link BlockwiseLayer}       | |
+ * | +----------------------+ |
+ * | | {@link TcpAdaptionLayer}     | |
+ * | +----------------------+ |
+ * | | Stack Bottom         | |
+ * | +----------+-A---------+ |
+ * |            v A           |
+ * |          Matcher         |
+ * |            v A           |
+ * |        Interceptor       |
+ * |            v A           |
+ * +------------v-A-----------+
+ *              v A 
+ *              v A 
+ * +------------v-+-----------+
+ * | {@link Connector}                |
+ * +--------------------------+
  * </pre></blockquote><hr>
  */
-public class CoapTcpStack implements CoapStack {
-
-	/** The LOGGER. */
-	private final static Logger LOGGER = Logger.getLogger(CoapTcpStack.class.getCanonicalName());
-
-	private List<Layer> layers;
-	private Outbox outbox;
-	private StackTopAdapter top;
-	private StackBottomAdapter bottom;
-	private MessageDeliverer deliverer;
+public class CoapTcpStack extends BaseCoapStack {
 
 	public CoapTcpStack(NetworkConfig config, Outbox outbox) {
-		this.top = new StackTopAdapter();
-		this.outbox = outbox;
+		super(outbox);
 
-		this.layers = new Layer.TopDownBuilder()
-				.add(top)
-				.add(new ExchangeCleanupLayer())
-				.add(new ObserveLayer(config))
-				.add(new BlockwiseLayer(config))
-				.add(bottom = new StackBottomAdapter())
-				.create();
+		Layer layers[] = new Layer[] { new ExchangeCleanupLayer(), new TcpObserveLayer(config),
+				new BlockwiseLayer(config), new TcpAdaptionLayer() };
+
+		setLayers(layers);
 
 		// make sure the endpoint sets a MessageDeliverer
-	}
-
-	// delegate to top
-	@Override public void sendRequest(Request request) {
-		if (null == request.getType()) {
-			request.setType(Type.CON);
-		}
-		top.sendRequest(request);
-		// CoAP over TCP does not have acknowledgements. Everything is automatically acknowledged.
-		request.setAcknowledged(true);
-	}
-
-	// delegate to top
-	@Override public void sendResponse(Exchange exchange, Response response) {
-		if (null == response.getType()) {
-			response.setType(Type.CON);
-		}
-		top.sendResponse(exchange, response);
-		// CoAP over TCP does not have acknowledgements. Everything is automatically acknowledged.
-		response.setAcknowledged(true);
-	}
-
-	// delegate to top
-	@Override public void sendEmptyMessage(Exchange exchange, EmptyMessage message) {
-		// Empty messages don't make sense when running over TCP connector.
-		LOGGER.log(Level.WARNING, "Attempting to send empty message in TCP mode {0}", message);
-	}
-
-	// delegate to bottom
-	@Override public void receiveRequest(Exchange exchange, Request request) {
-		request.setAcknowledged(true);
-		bottom.receiveRequest(exchange, request);
-	}
-
-	// delegate to bottom
-	@Override public void receiveResponse(Exchange exchange, Response response) {
-		response.setAcknowledged(true);
-		bottom.receiveResponse(exchange, response);
-	}
-
-	// delegate to bottom
-	@Override public void receiveEmptyMessage(Exchange exchange, EmptyMessage message) {
-		// Empty messages don't make sense when running over TCP connector.
-		LOGGER.log(Level.WARNING, "Received empty message in TCP mode {0}", message);
-	}
-
-	@Override public void setExecutor(ScheduledExecutorService executor) {
-		for (Layer layer : layers) {
-			layer.setExecutor(executor);
-		}
-	}
-
-	@Override public void setDeliverer(MessageDeliverer deliverer) {
-		this.deliverer = deliverer;
-	}
-
-	@Override public void destroy() {
-		for (Layer layer : layers) {
-			layer.destroy();
-		}
-	}
-
-	private class StackTopAdapter extends AbstractLayer {
-
-		public void sendRequest(Request request) {
-			Exchange exchange = new Exchange(request, Origin.LOCAL);
-			sendRequest(exchange, request); // layer method
-		}
-
-		@Override public void sendRequest(Exchange exchange, Request request) {
-			exchange.setRequest(request);
-			super.sendRequest(exchange, request);
-		}
-
-		@Override public void sendResponse(Exchange exchange, Response response) {
-			exchange.setResponse(response);
-			super.sendResponse(exchange, response);
-		}
-
-		@Override public void receiveRequest(Exchange exchange, Request request) {
-			// if there is no BlockwiseLayer we still have to set it
-			if (exchange.getRequest() == null) {
-				exchange.setRequest(request);
-			}
-			if (hasDeliverer()) {
-				deliverer.deliverRequest(exchange);
-			} else {
-				LOGGER.severe("Top of CoAP stack has no deliverer to deliver request");
-			}
-		}
-
-		@Override public void receiveResponse(Exchange exchange, Response response) {
-			if (!response.getOptions().hasObserve()) {
-				exchange.setComplete();
-			}
-			if (hasDeliverer()) {
-				deliverer.deliverResponse(exchange, response); // notify request that response has arrived
-			} else {
-				LOGGER.severe("Top of CoAP stack has no deliverer to deliver response");
-			}
-		}
-
-		@Override public void receiveEmptyMessage(Exchange exchange, EmptyMessage message) {
-			// When empty messages reach the top of the CoAP stack we can ignore them. 
-		}
-	}
-
-	private class StackBottomAdapter extends AbstractLayer {
-
-		@Override public void sendRequest(Exchange exchange, Request request) {
-			outbox.sendRequest(exchange, request);
-		}
-
-		@Override public void sendResponse(Exchange exchange, Response response) {
-			outbox.sendResponse(exchange, response);
-		}
-
-		@Override public void sendEmptyMessage(Exchange exchange, EmptyMessage message) {
-			outbox.sendEmptyMessage(exchange, message);
-		}
-
-	}
-
-	@Override public boolean hasDeliverer() {
-		return deliverer != null;
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapUdpStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapUdpStack.java
@@ -18,24 +18,17 @@
  *    Kai Hudalla - logging
  *    Kai Hudalla (Bosch Software Innovations GmbH) - use Logger's message formatting instead of
  *                                                    explicit String concatenation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - move common function to BaseCoapStack
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
-import java.util.List;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.eclipse.californium.core.coap.EmptyMessage;
-import org.eclipse.californium.core.coap.Request;
-import org.eclipse.californium.core.coap.Response;
-import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.Outbox;
-import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.MessageDeliverer;
 import org.eclipse.californium.elements.Connector;
-
 
 /**
  * The CoAPStack builds up the stack of CoAP layers that process the CoAP
@@ -45,55 +38,48 @@ import org.eclipse.californium.elements.Connector;
  * The class <code>CoapStack</code> builds up the part between the Stack Top and
  * Bottom.
  * <hr><blockquote><pre>
- * +-----------------------+
- * | {@link MessageDeliverer}      |
- * +-------------A---------+
- *               A
- *             * A
- * +-----------+-A---------+
- * |       CoAPEndpoint    |
- * |           v A         |
- * |           v A         |
- * | +---------v-+-------+ |
- * | | Stack Top         | |
- * | +-------------------+ |
+ * +--------------------------+
+ * | {@link MessageDeliverer}         |
+ * +--------------A-----------+
+ *                A
+ *              * A
+ * +------------+-A-----------+
+ * |       CoAPEndpoint       |
+ * |            v A           |
+ * |            v A           |
+ * | +----------v-+---------+ |
+ * | | Stack Top            | |
+ * | +----------------------+ |
  * | | {@link ExchangeCleanupLayer} | |
- * * | +-------------------+ |
- * | | {@link ObserveLayer}      | |
- * | +-------------------+ |
- * | | {@link BlockwiseLayer}    | |
- * | +-------------------+ |
- * | | {@link ReliabilityLayer}  | |
- * | +-------------------+ |
- * | | Stack Bottom      | |
- * | +---------+-A-------+ |
- * |           v A         |
- * |         Matcher       |
- * |           v A         |
- * |       Interceptor     |
- * |           v A         |
- * +-----------v-A---------+
- *             v A 
- *             v A 
- * +-----------v-+---------+
- * | {@link Connector}             |
- * +-----------------------+
+ * | +----------------------+ |
+ * | | {@link ObserveLayer}         | |
+ * | +----------------------+ |
+ * | | {@link BlockwiseLayer}       | |
+ * | +----------------------+ |
+ * | | {@link ReliabilityLayer}     | |
+ * | +----------------------+ |
+ * | | Stack Bottom         | |
+ * | +----------+-A---------+ |
+ * |            v A           |
+ * |          Matcher         |
+ * |            v A           |
+ * |        Interceptor       |
+ * |            v A           |
+ * +------------v-A-----------+
+ *              v A 
+ *              v A 
+ * +------------v-+-----------+
+ * | {@link Connector}                |
+ * +--------------------------+
  * </pre></blockquote><hr>
  */
-public class CoapUdpStack implements CoapStack {
+public class CoapUdpStack extends BaseCoapStack {
 
 	/** The LOGGER. */
 	private final static Logger LOGGER = Logger.getLogger(CoapStack.class.getCanonicalName());
 
-	private List<Layer> layers;
-	private Outbox outbox;
-	private StackTopAdapter top;
-	private StackBottomAdapter bottom;
-	private MessageDeliverer deliverer;
-
 	public CoapUdpStack(NetworkConfig config, Outbox outbox) {
-		this.top = new StackTopAdapter();
-		this.outbox = outbox;
+		super(outbox);
 
 		ReliabilityLayer reliabilityLayer;
 		if (config.getBoolean(NetworkConfig.Keys.USE_CONGESTION_CONTROL) == true) {
@@ -103,140 +89,11 @@ public class CoapUdpStack implements CoapStack {
 			reliabilityLayer = new ReliabilityLayer(config);
 		}
 
-		this.layers = new Layer.TopDownBuilder()
-				.add(top)
-				.add(new ExchangeCleanupLayer())
-				.add(new ObserveLayer(config))
-				.add(new BlockwiseLayer(config))
-				.add(reliabilityLayer)
-				.add(bottom = new StackBottomAdapter())
-				.create();
+		Layer layers[] = new Layer[] { new ExchangeCleanupLayer(), new ObserveLayer(config),
+				new BlockwiseLayer(config), reliabilityLayer };
+
+		setLayers(layers);
 
 		// make sure the endpoint sets a MessageDeliverer
-	}
-
-	@Override
-	public void sendRequest(Request request) {
-		// delegate to top
-		top.sendRequest(request);
-	}
-
-	@Override
-	public void sendResponse(Exchange exchange, Response response) {
-		// delegate to top
-		top.sendResponse(exchange, response);
-	}
-
-	@Override
-	public void sendEmptyMessage(Exchange exchange, EmptyMessage message) {
-		// delegate to top
-		top.sendEmptyMessage(exchange, message);
-	}
-
-	@Override
-	public void receiveRequest(Exchange exchange, Request request) {
-		// delegate to bottom
-		bottom.receiveRequest(exchange, request);
-	}
-
-	@Override
-	public void receiveResponse(Exchange exchange, Response response) {
-		// delegate to bottom
-		bottom.receiveResponse(exchange, response);
-	}
-
-	@Override
-	public void receiveEmptyMessage(Exchange exchange, EmptyMessage message) {
-		// delegate to bottom
-		bottom.receiveEmptyMessage(exchange, message);
-	}
-
-	@Override
-	public void setExecutor(ScheduledExecutorService executor) {
-		for (Layer layer:layers)
-			layer.setExecutor(executor);
-	}
-
-	@Override
-	public void setDeliverer(MessageDeliverer deliverer) {
-		this.deliverer = deliverer;
-	}
-
-	@Override
-	public void destroy() {
-		for (Layer layer:layers)
-			layer.destroy();
-	}
-
-	private class StackTopAdapter extends AbstractLayer {
-
-		public void sendRequest(Request request) {
-			Exchange exchange = new Exchange(request, Origin.LOCAL);
-			sendRequest(exchange, request); // layer method
-		}
-
-		@Override
-		public void sendRequest(Exchange exchange, Request request) {
-			exchange.setRequest(request);
-			super.sendRequest(exchange, request);
-		}
-
-		@Override
-		public void sendResponse(Exchange exchange, Response response) {
-			exchange.setResponse(response);
-			super.sendResponse(exchange, response);
-		}
-
-		@Override
-		public void receiveRequest(Exchange exchange, Request request) {
-			// if there is no BlockwiseLayer we still have to set it
-			if (exchange.getRequest() == null)
-				exchange.setRequest(request);
-			if (deliverer != null) {
-				deliverer.deliverRequest(exchange);
-			} else {
-				LOGGER.severe("Top of CoAP stack has no deliverer to deliver request");
-			}
-		}
-
-		@Override
-		public void receiveResponse(Exchange exchange, Response response) {
-			// we always complete the message exchange when we have received a response
-			exchange.setComplete();
-			if (hasDeliverer()) {
-				deliverer.deliverResponse(exchange, response); // notify request that response has arrived
-			} else {
-				LOGGER.severe("Top of CoAP stack has no deliverer to deliver response");
-			}
-		}
-
-		@Override
-		public void receiveEmptyMessage(Exchange exchange, EmptyMessage message) {
-			// When empty messages reach the top of the CoAP stack we can ignore them. 
-		}
-	}
-
-	private class StackBottomAdapter extends AbstractLayer {
-
-		@Override
-		public void sendRequest(Exchange exchange, Request request) {
-			outbox.sendRequest(exchange, request);
-		}
-
-		@Override
-		public void sendResponse(Exchange exchange, Response response) {
-			outbox.sendResponse(exchange, response);
-		}
-
-		@Override
-		public void sendEmptyMessage(Exchange exchange, EmptyMessage message) {
-			outbox.sendEmptyMessage(exchange, message);
-		}
-
-	}
-
-	@Override
-	public boolean hasDeliverer() {
-		return deliverer != null;
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
@@ -37,7 +37,9 @@ import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.ObserveRelation;
 
-
+/**
+ * UDP observe layer.
+ */
 public class ObserveLayer extends AbstractLayer {
 
 	private static final Logger LOGGER = Logger.getLogger(ObserveLayer.class.getName());
@@ -45,18 +47,18 @@ public class ObserveLayer extends AbstractLayer {
 	public ObserveLayer(NetworkConfig config) {
 		// so far no configuration values for this layer
 	}
-	
+
 	@Override
 	public void sendRequest(Exchange exchange, Request request) {
 		super.sendRequest(exchange, request);
 	}
-	
+
 	@Override
 	public void sendResponse(final Exchange exchange, Response response) {
 		final ObserveRelation relation = exchange.getRelation();
 		if (relation != null && relation.isEstablished()) {
-			
-			if (exchange.getRequest().isAcknowledged() || exchange.getRequest().getType()==Type.NON) {
+
+			if (exchange.getRequest().isAcknowledged() || exchange.getRequest().getType() == Type.NON) {
 				// Transmit errors as CON
 				if (!ResponseCode.isSuccess(response.getCode())) {
 					LOGGER.log(Level.FINE, "Response has error code {0} and must be sent as CON", response.getCode());
@@ -68,15 +70,18 @@ public class ObserveLayer extends AbstractLayer {
 						LOGGER.fine("The observe relation check requires the notification to be sent as CON");
 						response.setType(Type.CON);
 					} else {
-						// By default use NON, but do not override resource decision
-						if (response.getType()==null) response.setType(Type.NON);
+						// By default use NON, but do not override resource
+						// decision
+						if (response.getType() == null) {
+							response.setType(Type.NON);
+						}
 					}
 				}
 			}
-			
+
 			// This is a notification
 			response.setLast(false);
-			
+
 			/*
 			 * The matcher must be able to find the NON notifications to remove
 			 * them from the exchangesByMID hashmap
@@ -84,7 +89,7 @@ public class ObserveLayer extends AbstractLayer {
 			if (response.getType() == Type.NON) {
 				relation.addNotification(response);
 			}
-			
+
 			/*
 			 * Only one Confirmable message is allowed to be in transit. A CON
 			 * is in transit as long as it has not been acknowledged, rejected,
@@ -97,7 +102,7 @@ public class ObserveLayer extends AbstractLayer {
 			if (response.getType() == Type.CON) {
 				prepareSelfReplacement(exchange, response);
 			}
-			
+
 			// The decision whether to postpone this notification or not and the
 			// decision which notification is the freshest to send next must be
 			// synchronized
@@ -119,11 +124,11 @@ public class ObserveLayer extends AbstractLayer {
 		} // else no observe was requested or the resource does not allow it
 		super.sendResponse(exchange, response);
 	}
-	
+
 	/**
 	 * Returns true if the specified response is still in transit. A response is
 	 * in transit if it has not yet been acknowledged, rejected or its current
-	 * transmission has not yet timed out. 
+	 * transmission has not yet timed out.
 	 */
 	private boolean isInTransit(Response response) {
 		Type type = response.getType();
@@ -146,7 +151,7 @@ public class ObserveLayer extends AbstractLayer {
 			super.receiveResponse(exchange, response);
 		}
 	}
-	
+
 	@Override
 	public void receiveEmptyMessage(Exchange exchange, EmptyMessage message) {
 		// NOTE: We could also move this into the MessageObserverAdapter from
@@ -156,41 +161,45 @@ public class ObserveLayer extends AbstractLayer {
 			ObserveRelation relation = exchange.getRelation();
 			if (relation != null) {
 				relation.cancel();
-			} // else there was no observe relation ship and this layer ignores the rst
+			} // else there was no observe relation ship and this layer ignores
+				// the rst
 		}
 		super.receiveEmptyMessage(exchange, message);
 	}
-	
+
 	private void prepareSelfReplacement(Exchange exchange, Response response) {
 		response.addMessageObserver(new NotificationController(exchange, response));
 	}
-	
+
 	/**
 	 * Sends the next CON as soon as the former CON is no longer in transit.
 	 */
 	private class NotificationController extends MessageObserverAdapter {
-		
+
 		private Exchange exchange;
 		private Response response;
-		
+
 		public NotificationController(Exchange exchange, Response response) {
 			this.exchange = exchange;
 			this.response = response;
 		}
-		
+
 		@Override
 		public void onAcknowledgement() {
 			synchronized (exchange) {
 				ObserveRelation relation = exchange.getRelation();
 				final Response next = relation.getNextControlNotification();
-				relation.setCurrentControlNotification(next); // next may be null
+				relation.setCurrentControlNotification(next);
+				 // next may be null
 				relation.setNextControlNotification(null);
 				if (next != null) {
 					LOGGER.fine("Notification has been acknowledged, send the next one");
 					// this is not a self replacement, hence a new MID
 					next.setMID(Message.NONE);
-					// Create a new task for sending next response so that we can leave the sync-block
+					// Create a new task for sending next response so that we
+					// can leave the sync-block
 					executor.execute(new Runnable() {
+
 						public void run() {
 							ObserveLayer.super.sendResponse(exchange, next);
 						}
@@ -198,7 +207,7 @@ public class ObserveLayer extends AbstractLayer {
 				}
 			}
 		}
-		
+
 		@Override
 		public void onRetransmission() {
 			synchronized (exchange) {
@@ -206,7 +215,8 @@ public class ObserveLayer extends AbstractLayer {
 				final Response next = relation.getNextControlNotification();
 				if (next != null) {
 					LOGGER.fine("The notification has timed out and there is a fresher notification for the retransmission");
-					// Cancel the original retransmission and send the fresh notification here
+					// Cancel the original retransmission and send the fresh
+					// notification here
 					response.cancel();
 					// use the same MID
 					next.setMID(response.getMID());
@@ -217,8 +227,10 @@ public class ObserveLayer extends AbstractLayer {
 					}
 					relation.setCurrentControlNotification(next);
 					relation.setNextControlNotification(null);
-					// Create a new task for sending next response so that we can leave the sync-block
+					// Create a new task for sending next response so that we
+					// can leave the sync-block
 					executor.execute(new Runnable() {
+
 						public void run() {
 							ObserveLayer.super.sendResponse(exchange, next);
 						}
@@ -230,12 +242,11 @@ public class ObserveLayer extends AbstractLayer {
 		@Override
 		public void onTimeout() {
 			ObserveRelation relation = exchange.getRelation();
-			LOGGER.log(Level.INFO,
-					"Notification {0} timed out. Cancel all relations with source {1}",
-					new Object[]{relation.getExchange().getRequest().getTokenString(), relation.getSource()});
+			LOGGER.log(Level.INFO, "Notification {0} timed out. Cancel all relations with source {1}", new Object[] {
+					relation.getExchange().getRequest().getTokenString(), relation.getSource() });
 			relation.cancelAll();
 		}
-		
+
 		// Cancellation on RST is done in receiveEmptyMessage()
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpAdaptionLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpAdaptionLayer.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.core.network.stack;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+
+/**
+ * TCP adaption layer. Set acknowledged on response receiving.
+ */
+public class TcpAdaptionLayer extends AbstractLayer {
+
+	private static final Logger LOGGER = Logger.getLogger(TcpAdaptionLayer.class.getName());
+
+	public TcpAdaptionLayer() {
+	}
+
+	@Override
+	public void sendEmptyMessage(final Exchange exchange, final EmptyMessage message) {
+		if (message.isConfirmable()) {
+			// CoAP over TCP uses empty messages as pings for keep alive.
+			super.sendEmptyMessage(exchange, message);
+		} else {
+			// Empty messages don't make sense when running over TCP connector.
+			LOGGER.log(Level.WARNING, "Attempting to send empty message (ACK/RST) in TCP mode {0}", message);
+		}
+	}
+
+	@Override
+	public void receiveRequest(final Exchange exchange, final Request request) {
+		request.setAcknowledged(true);
+		super.receiveRequest(exchange, request);
+	}
+
+	@Override
+	public void receiveResponse(Exchange exchange, Response response) {
+		response.setAcknowledged(true);
+		super.receiveResponse(exchange, response);
+	}
+
+	@Override
+	public void receiveEmptyMessage(Exchange exchange, EmptyMessage message) {
+		// Empty messages are ignored when running over TCP connector.
+		LOGGER.log(Level.INFO, "Received empty message in TCP mode {0}", message);
+	}
+
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpObserveLayer.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+/*******************************************************************************
+ * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial implementation,
+ *                                                    Derived from ObserveLayer
+ ******************************************************************************/
+package org.eclipse.californium.core.network.stack;
+
+import java.util.logging.Logger;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.observe.ObserveRelation;
+
+/**
+ * TCP related observe/notify handling.
+ * No CON/NON logic possible nor required.
+ */
+public class TcpObserveLayer extends AbstractLayer {
+
+	private static final Logger LOGGER = Logger.getLogger(TcpObserveLayer.class.getName());
+
+	private static final Integer CANCEL = 1;
+
+	public TcpObserveLayer(NetworkConfig config) {
+		// so far no configuration values for this layer
+	}
+
+	@Override
+	public void sendRequest(Exchange exchange, Request request) {
+		if (CANCEL.equals(request.getOptions().getObserve())) {
+			/* TODO: don't send, if connection is not available */
+		}
+		super.sendRequest(exchange, request);
+	}
+
+	@Override
+	public void sendResponse(final Exchange exchange, Response response) {
+		final ObserveRelation relation = exchange.getRelation();
+		if (relation != null && relation.isEstablished()) {
+			if (!response.getOptions().hasObserve()) {
+				/* response for cancel request */
+				relation.cancel();
+				response.setLast(true);
+			} else {
+				response.setLast(false);
+			}
+		} // else no observe was requested or the resource does not allow it
+		super.sendResponse(exchange, response);
+	}
+
+	@Override
+	public void receiveResponse(Exchange exchange, Response response) {
+		if (response.getOptions().hasObserve() && exchange.getRequest().isCanceled()) {
+			// The request was canceled and we no longer want notifications
+			LOGGER.finer("Ignore notification for canceled TCP Exchange");
+		} else {
+			// No observe option in response => always deliver
+			super.receiveResponse(exchange, response);
+		}
+	}
+}


### PR DESCRIPTION
Introduce BaseCoapStack with common functionality.
Add TcpAdaptionLayer and TcpObserverLayer.
Uses CON/NON for conditional sending over TCP. 
(based on PR#132)

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>