### PR TITLE
Introduce message flavor to distinguish serialized message bytes.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
@@ -18,6 +18,7 @@
  *    Kai Hudalla - logging
  *    Achim Kraus (Bosch Software Innovations GmbH) - add getPayloadTracingString 
  *                                                    (for message tracing)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - introduce Flavor for UPD/TCP support
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
@@ -61,6 +62,10 @@ public abstract class Message {
 
 	protected final static Logger LOGGER = Logger.getLogger(Message.class.getCanonicalName());
 
+	public enum Flavor {
+		UDP, TCP
+	}
+	
 	/** The Constant NONE in case no MID has been set. */
 	public static final int NONE = -1;
 	/**
@@ -118,6 +123,9 @@ public abstract class Message {
 
 	/** Indicates if the message is a duplicate. */
 	private boolean duplicate;
+
+	/** The flavor of the serialized message as byte array. TCP or UDP */
+	private Flavor bytesFlavor;
 
 	/** The serialized message as byte array. */
 	private byte[] bytes;
@@ -610,12 +618,23 @@ a	 */
 	}
 
 	/**
+	 * Gets the flavor of the serialized message or null if not serialized yet.
+	 *
+	 * @return the flavor of the serialized message or null
+	 */
+	public Flavor getBytesFlavor() {
+		return bytesFlavor;
+	}
+	
+	/**
 	 * Sets the bytes of the serialized message.
 	 * Not part of the fluent API.
 	 *
+	 * @param bytesFlavor the flavor of the serialized bytes
 	 * @param bytes the serialized bytes
 	 */
-	public void setBytes(byte[] bytes) {
+	public void setBytes(byte[] bytes, Flavor flavor) {
+		this.bytesFlavor = flavor;
 		this.bytes = bytes;
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataSerializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataSerializer.java
@@ -18,11 +18,13 @@
  * Kai Hudalla - logging
  * Bosch Software Innovations GmbH - turn into utility class with static methods only
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ * Achim Kraus (Bosch Software Innovations GmbH) - add Flavor for UPD/TCP support
  ******************************************************************************/
 package org.eclipse.californium.core.network.serialization;
 
 import static org.eclipse.californium.core.coap.CoAP.MessageFormat.*;
 
+import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.elements.util.DatagramWriter;
 
 /**
@@ -31,6 +33,10 @@ import org.eclipse.californium.elements.util.DatagramWriter;
  */
 public final class TcpDataSerializer extends DataSerializer {
 
+	public TcpDataSerializer() {
+		super(Message.Flavor.TCP);
+	}
+	
 	@Override protected void serializeHeader(final DatagramWriter writer, final MessageHeader header) {
 		// Variable length encoding per: https://tools.ietf.org/html/draft-ietf-core-coap-tcp-tls-02
 		if (header.getBodyLength() < 13) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/UdpDataSerializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/UdpDataSerializer.java
@@ -18,17 +18,23 @@
  * Kai Hudalla - logging
  * Bosch Software Innovations GmbH - turn into utility class with static methods only
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ * Achim Kraus (Bosch Software Innovations GmbH) - add Flavor for UPD/TCP support
  ******************************************************************************/
 package org.eclipse.californium.core.network.serialization;
 
 import static org.eclipse.californium.core.coap.CoAP.MessageFormat.*;
 
+import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.elements.util.DatagramWriter;
 
 /**
  * The DataSerialized serializes outgoing messages to byte arrays.
  */
 public final class UdpDataSerializer extends DataSerializer {
+
+	public UdpDataSerializer() {
+		super(Message.Flavor.UDP);
+	}
 
 	@Override protected void serializeHeader(final DatagramWriter writer, final MessageHeader header) {
 		writer.write(VERSION, VERSION_BITS);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/TcpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/TcpMatcherTest.java
@@ -17,6 +17,7 @@ package org.eclipse.californium.core.network;
 
 import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange.Origin;
@@ -67,7 +68,7 @@ public class TcpMatcherTest {
 		Response response = new Response(ResponseCode.CONTENT);
 		response.setMID(request.getMID());
 		response.setToken(request.getToken());
-		response.setBytes(new byte[]{});
+		response.setBytes(new byte[]{}, Message.Flavor.TCP);
 		response.setSource(request.getDestination());
 		response.setSourcePort(request.getDestinationPort());
 		response.setDestination(request.getSource());

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -24,6 +24,7 @@ import java.net.InetSocketAddress;
 
 import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange.KeyToken;
@@ -278,7 +279,7 @@ public class UdpMatcherTest {
 		Response response = new Response(ResponseCode.CONTENT);
 		response.setMID(request.getMID());
 		response.setToken(request.getToken());
-		response.setBytes(new byte[]{});
+		response.setBytes(new byte[]{}, Message.Flavor.UDP);
 		response.setSource(request.getDestination());
 		response.setSourcePort(request.getDestinationPort());
 		response.setDestination(request.getSource());


### PR DESCRIPTION
Message caches already serialized bytes. But, though the serialization
is depending on TCP or UDP flavor, this caching may fail. Introducing a
message flavor and check the flavor prior using the cached bytes fixes
possible resulting issues.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>