### PR TITLE
Test epoch after session resumption.

### DIFF
--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -654,6 +654,11 @@ public class DTLSConnectorTest {
 		// Do a first handshake
 		givenAnEstablishedSession();
 		byte[] sessionId = establishedServerSession.getSessionIdentifier().getId();
+		// save the current epoch
+		int readEpoch = establishedServerSession.getReadEpoch();
+		int writeEpoch = establishedServerSession.getWriteEpoch();
+		assertEquals(readEpoch, 1);
+		assertEquals(writeEpoch, 1);
 
 		// Force a resume session the next time we send data
 		client.forceResumeSessionFor(serverEndpoint);
@@ -674,6 +679,9 @@ public class DTLSConnectorTest {
 		connection = clientConnectionStore.get(serverEndpoint);
 		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getId());
 		assertClientIdentity(RawPublicKeyIdentity.class);
+		// check epochs after resume
+		assertEquals(readEpoch, connection.getEstablishedSession().getReadEpoch());
+		assertEquals(writeEpoch, connection.getEstablishedSession().getWriteEpoch());
 	}
 
 	@Test


### PR DESCRIPTION
NOT INTENDED TO BE REALLY MERGED!!!

The test shows, the epoch is still 1 after resumption. So, is this a bug? 
If not, I'm wondering, why we need the two variants of
isResponse???RelatedToDtlsRequest (UdpMatcher). 
Do we want/require to support a reshandshake? 

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>