### PR TITLE
Corrected NullPointerException for CoapClient#ping()

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -146,7 +146,7 @@ public class Request extends Message {
 
 	@Override
 	public int getRawCode() {
-		return code.value;
+		return code == null ? 0 : code.value;
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
@@ -93,7 +93,7 @@ public abstract class DataSerializer {
 		byte[] body = serializeOptionsAndPayload(request);
 
 		MessageHeader header = new MessageHeader(CoAP.VERSION, request.getType(), request.getToken(),
-				request.getCode().value, request.getMID(), body.length);
+				request.getRawCode(), request.getMID(), body.length);
 		serializeHeader(writer, header);
 		writer.writeBytes(body);
 


### PR DESCRIPTION
* DataSerializer used request.getCode().value which lead to a NullPointerException using CoapClient.ping()
* QuickFix: Request#getRawCode returns 0 instead of a NullPointerException if Request#code is null

Fixes: eclipse/californium#146
Closes: eclipse/californium#116

Signed-off-by: Marc Mettke <marc@itmettke.de>