### PR TITLE
Server Name Indication Extension doesn't include server_name_list length field

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Response.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Response.java
@@ -133,4 +133,14 @@ public class Response extends Message {
 	public boolean isNotification() {
 		return getOptions().hasObserve();
 	}
+
+	/**
+	 * Checks whether this response has either a <em>block1</em> or
+	 * <em>block2</em> option.
+	 * 
+	 * @return {@code true} if this response has a block option.
+	 */
+	public boolean hasBlockOption() {
+		return getOptions().hasBlock1() || getOptions().hasBlock2();
+	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -392,30 +392,26 @@ public class Exchange {
 		this.currentTimeout = currentTimeout;
 	}
 
-	public ScheduledFuture<?> getRetransmissionHandle() {
+	public synchronized ScheduledFuture<?> getRetransmissionHandle() {
 		return retransmissionHandle;
 	}
 
-	public void setRetransmissionHandle(ScheduledFuture<?> retransmissionHandle) {
+	public synchronized void setRetransmissionHandle(ScheduledFuture<?> retransmissionHandle) {
 		// avoid race condition of multiple responses (e.g., notifications)
-		synchronized (this) {
-			if (this.retransmissionHandle!=null) {
-				this.retransmissionHandle.cancel(false);
-			}
+		if (this.retransmissionHandle!=null) {
+			this.retransmissionHandle.cancel(false);
 		}
 		this.retransmissionHandle = retransmissionHandle;
 	}
 
-	public ScheduledFuture<?> getBlockCleanupHandle() {
+	public synchronized ScheduledFuture<?> getBlockCleanupHandle() {
 		return blockCleanupHandle;
 	}
 
-	public void setBlockCleanupHandle(ScheduledFuture<?> blockCleanupHandle) {
+	public synchronized void setBlockCleanupHandle(final ScheduledFuture<?> blockCleanupHandle) {
 		// avoid race condition of multiple block requests
-		synchronized (this) {
-			if (this.blockCleanupHandle!=null) {
-				this.blockCleanupHandle.cancel(false);
-			}
+		if (this.blockCleanupHandle != null) {
+			this.blockCleanupHandle.cancel(false);
 		}
 		this.blockCleanupHandle = blockCleanupHandle;
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -96,8 +96,36 @@ public final class NetworkConfig {
 		public static final String USE_RANDOM_MID_START = "USE_RANDOM_MID_START";
 		public static final String TOKEN_SIZE_LIMIT = "TOKEN_SIZE_LIMIT";
 
+		/**
+		 * The block size (number of bytes) to use when doing a blockwise transfer.
+		 * This value serves as the upper limit for block size in blockwise transfers.
+		 */
 		public static final String PREFERRED_BLOCK_SIZE = "PREFERRED_BLOCK_SIZE";
+		/**
+		 * The maximum payload size (in bytes) that can be transferred in a single message,
+		 * i.e. without requiring a blockwise transfer.
+		 * 
+		 * NB: this value MUST be adapted to the maximum message size supported by the
+		 * transport layer. In particular, this value cannot exceed the network's MTU if
+		 * UDP is used as the transport protocol.
+		 */
 		public static final String MAX_MESSAGE_SIZE = "MAX_MESSAGE_SIZE";
+		/**
+		 * The maximum size of a resource body (in bytes) that will be accepted as the payload of a
+		 * POST/PUT or the response to a GET request in a <em>transparent</em> blockwise transfer.
+		 * <p>
+		 * This option serves as a safeguard against excessive memory consumption when many resources
+		 * contain large bodies that cannot be transferred in a single CoAP message. This option
+		 * has no impact on *manually* managed blockwise transfers in which the blocks are handled
+		 * individually.
+		 * <p>Note that this option does not prevent local clients or resource implementations from
+		 * sending large bodies as part of a request or response to a peer.
+		 * <p>
+		 * The default value of this property is {@link NetworkConfigDefaults#DEFAULT_MAX_RESOURCE_BODY_SIZE}.
+		 * <p>
+		 * A value of {@code 0} turns off transparent handling of blockwise transfers altogether.
+		 */
+		public static final String MAX_RESOURCE_BODY_SIZE = "MAX_RESOURCE_BODY_SIZE";
 		public static final String BLOCKWISE_STATUS_LIFETIME = "BLOCKWISE_STATUS_LIFETIME";
 
 		public static final String NOTIFICATION_CHECK_INTERVAL_TIME = "NOTIFICATION_CHECK_INTERVAL";

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
@@ -25,6 +25,12 @@ import org.eclipse.californium.elements.UDPConnector;
 
 public class NetworkConfigDefaults {
 
+	/**
+	 * The default maximum resource body size that can be transparently transferred
+	 * in a blockwise tranfer.
+	 */
+	public static final int DEFAULT_MAX_RESOURCE_BODY_SIZE = 2048; // bytes
+
 	/*
 	 * Accept other message versions than 1
 	 * Refuse unknown options
@@ -59,6 +65,7 @@ public class NetworkConfigDefaults {
 
 		config.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 512);
 		config.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 1024);
+		config.setInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE, DEFAULT_MAX_RESOURCE_BODY_SIZE);
 		config.setInt(NetworkConfig.Keys.BLOCKWISE_STATUS_LIFETIME, 10 * 60 * 1000); // ms
 
 		config.setLong(NetworkConfig.Keys.NOTIFICATION_CHECK_INTERVAL_TIME, 24 * 60 * 60 * 1000); // ms

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -41,16 +41,23 @@ import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfigObserverAdapter;
 
+/**
+ * Provides transparent handling of blockwise transfer of a large <em>resource body</em>.
+ * <p>
+ * Outbound requests containing a large resource body that is too large to be sent in the payload
+ * of a single message are transparently replaced by a sequence of message exchanges doing a
+ * blockwise transfer of the body to the server.
+ * <p>
+ * If a response received from a server contains a payload that represents a single block of
+ * a resource body then a blockwise transfer for retrieving the individual blocks of the resource
+ * body is started. Once all blocks are retrieved, they are assembled into a single {@code Response}
+ * object containing the full body which is then delivered to the application layer.
+ * 
+ */
 public class BlockwiseLayer extends AbstractLayer {
 
-	/** The logger. */
-	protected final static Logger LOGGER = Logger.getLogger(BlockwiseLayer.class.getCanonicalName());
-
-	// TODO: Size Option. Include only in first block.
-	// TODO: DoS: server should have max allowed blocks/bytes/time to allocate.
 	// TODO: Random access for Cf servers: The draft still needs to specify a reaction to "overshoot"
 	// TODO: Blockwise with separate response or NONs. Not yet mentioned in draft.
-	// TODO: How should our client deal with a server that handles blocks non-atomic?
 	// TODO: Forward cancellation and timeouts of a request to its blocks.
 
 	/*
@@ -86,26 +93,31 @@ public class BlockwiseLayer extends AbstractLayer {
 	 * matches the example in the draft.
 	 */
 
+	private static final Logger LOGGER = Logger.getLogger(BlockwiseLayer.class.getName());
 	private int max_message_size;
 	private int preferred_block_size;
 	private int block_timeout;
+	private int maxResourceBodySize;
 	private final NetworkConfigObserverAdapter observer;
 	final private NetworkConfig config;
 
 	/**
-	 * Constructs a new blockwise layer.
+	 * Creates a new blockwise layer for a configuration.
+	 * <p>
 	 * Changes to the configuration are observed and automatically applied.
-	 * @param config the configuration
+
+	 * @param config The configuration values to use.
 	 */
 	public BlockwiseLayer(final NetworkConfig config) {
 		this.config = config;
-		max_message_size = config.getInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE);
-		preferred_block_size = config.getInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE);
+		max_message_size = config.getInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 1024);
+		preferred_block_size = config.getInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 512);
 		block_timeout = config.getInt(NetworkConfig.Keys.BLOCKWISE_STATUS_LIFETIME);
+		maxResourceBodySize = config.getInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE, 2048);
 
 		LOGGER.log(Level.CONFIG,
-			"BlockwiseLayer uses MAX_MESSAGE_SIZE={0}, DEFAULT_BLOCK_SIZE={1} and BLOCKWISE_STATUS_LIFETIME={2}",
-			new Object[]{max_message_size, preferred_block_size, block_timeout});
+			"BlockwiseLayer uses MAX_MESSAGE_SIZE={0}, DEFAULT_BLOCK_SIZE={1}, BLOCKWISE_STATUS_LIFETIME={2} and MAX_RESOURCE_BODY_SIZE={3}",
+			new Object[]{max_message_size, preferred_block_size, block_timeout, maxResourceBodySize});
 
 		observer = new NetworkConfigObserverAdapter() {
 			@Override
@@ -124,15 +136,16 @@ public class BlockwiseLayer extends AbstractLayer {
 
 	@Override
 	public void sendRequest(final Exchange exchange, final Request request) {
-		if (request.getOptions().hasBlock2() && request.getOptions().getBlock2().getNum() > 0) {
+
+		BlockOption block2 = request.getOptions().getBlock2();
+		if (block2 != null && block2.getNum() > 0) {
 			// This is the case if the user has explicitly added a block option
 			// for random access.
 			// Note: We do not regard it as random access when the block num is
 			// 0. This is because the user might just want to do early block
 			// size negotiation but actually wants to receive all blocks.
-			LOGGER.fine("Request carries explicit defined block2 option: create random access blockwise status");
-			BlockwiseStatus status = new BlockwiseStatus(request.getOptions().getContentFormat());
-			BlockOption block2 = request.getOptions().getBlock2();
+			LOGGER.fine("request contains block2 option, creating random-access blockwise status");
+			BlockwiseStatus status = new BlockwiseStatus(getSizeForSzx(block2.getSzx()), request.getOptions().getContentFormat());
 			status.setCurrentSzx(block2.getSzx());
 			status.setCurrentNum(block2.getNum());
 			status.setRandomAccess(true);
@@ -141,28 +154,90 @@ public class BlockwiseLayer extends AbstractLayer {
 
 		} else if (requiresBlockwise(request)) {
 			// This must be a large POST or PUT request
-			LOGGER.log(Level.FINE, "Request payload {0}/{1} requires Blockwise", new Object[]{request.getPayloadSize(), max_message_size});
-			BlockwiseStatus status = findRequestBlockStatus(exchange, request);
-
-			Request block = getNextRequestBlock(request, status);
-
-			exchange.setRequestBlockStatus(status);
-			exchange.setCurrentRequest(block);
-			super.sendRequest(exchange, block);
+			startBlockwiseUpload(exchange, request);
 
 		} else {
+			// no blockwise transfer required
 			exchange.setCurrentRequest(request);
 			super.sendRequest(exchange, request);
 		}
 	}
 
+	private void startBlockwiseUpload(final Exchange exchange, final Request request) {
+
+		BlockwiseStatus status = findRequestBlockStatus(exchange, request);
+
+		final Request block = getNextRequestBlock(request, status);
+		// indicate overall body size to peer
+		block.getOptions().setSize1(request.getPayloadSize());
+
+		exchange.setRequestBlockStatus(status);
+		exchange.setCurrentRequest(block);
+		super.sendRequest(exchange, block);
+	}
+
 	@Override
 	public void receiveRequest(final Exchange exchange, final Request request) {
-		if (request.getOptions().hasBlock1()) {
-			// This must be a large POST or PUT request
 
-			BlockOption block1 = request.getOptions().getBlock1();
-			LOGGER.log(Level.FINE, "Request contains block1 option {0}", block1);
+		BlockOption block1 = request.getOptions().getBlock1();
+		if (block1 != null) {
+
+			// This is a large POST or PUT request
+			LOGGER.log(Level.FINE, "inbound request contains block1 option {0}", block1);
+
+			if (isTransparentBlockwiseHandlingEnabled()) {
+
+				handleInboundBlockwiseUpload(block1, exchange, request);
+
+			} else {
+
+				LOGGER.fine("transparent blockwise handling is disabled, delivering request to application layer");
+				super.receiveRequest(exchange, request);
+
+			}
+
+		} else if (exchange.getResponse() != null && request.getOptions().hasBlock2()) {
+			// The response has already been generated and the client just wants its next block
+
+			BlockOption block2 = request.getOptions().getBlock2();
+			Response response = exchange.getResponse();
+			BlockwiseStatus status = findResponseBlockStatus(exchange, response);
+			status.setCurrentNum(block2.getNum());
+			status.setCurrentSzx(block2.getSzx());
+
+			Response block = getNextResponseBlock(response, status);
+			// indicate overall body size to peer
+			block.getOptions().setSize2(response.getPayloadSize());
+			if (status.isComplete()) {
+				// clean up blockwise status
+				LOGGER.log(Level.FINE, "peer has requested last block of blockwise transfer: {0}", status);
+				exchange.setResponseBlockStatus(null);
+				exchange.setBlockCleanupHandle(null);
+			} else {
+				LOGGER.log(Level.FINE, "peer has requested intermediary block of blockwise transfer: {0}", status);
+			}
+
+			exchange.setCurrentResponse(block);
+			super.sendResponse(exchange, block);
+
+		} else {
+			earlyBlock2Negotiation(exchange, request);
+
+			exchange.setRequest(request);
+			super.receiveRequest(exchange, request);
+		}
+	}
+
+	private void handleInboundBlockwiseUpload(final BlockOption block1, final Exchange exchange, final Request request) {
+
+		if (requestExceedsMaxBodySize(request)) {
+
+			Response error = Response.createResponse(request, ResponseCode.REQUEST_ENTITY_TOO_LARGE);
+			error.setPayload(String.format("body too large, can process %d bytes max", maxResourceBodySize));
+			error.getOptions().setSize1(maxResourceBodySize);
+			super.sendResponse(exchange, error);
+
+		} else {
 
 			BlockwiseStatus status = findRequestBlockStatus(exchange, request);
 
@@ -176,48 +251,49 @@ public class BlockwiseLayer extends AbstractLayer {
 			}
 
 			if (block1.getNum() == status.getCurrentNum()) {
-				
-				if (request.getOptions().getContentFormat()==status.getContentFormat()) {
+
+				if (status.hasContentFormat(request.getOptions().getContentFormat())) {
+
 					status.addBlock(request.getPayload());
+					status.setCurrentNum(status.getCurrentNum() + 1);
+					if ( block1.isM() ) {
+						LOGGER.finest("There are more blocks to come. Acknowledge this block.");
+						
+						Response piggybacked = Response.createResponse(request, ResponseCode.CONTINUE);
+						piggybacked.getOptions().setBlock1(block1.getSzx(), true, block1.getNum());
+						piggybacked.setLast(false);
+
+						exchange.setCurrentResponse(piggybacked);
+						super.sendResponse(exchange, piggybacked);
+
+						// do not assemble and deliver the request yet
+
+					} else {
+						LOGGER.finer("This was the last block. Deliver request");
+
+						// Remember block to acknowledge. TODO: We might make this a boolean flag in status.
+						exchange.setBlock1ToAck(block1); 
+
+						// Block2 early negotiation
+						earlyBlock2Negotiation(exchange, request);
+
+						// Assemble and deliver
+						Request assembled = new Request(request.getCode());
+						assembled.setSenderIdentity(request.getSenderIdentity());
+						assembleMessage(status, assembled);
+
+						exchange.setRequest(assembled);
+						super.receiveRequest(exchange, assembled);
+					}
+
 				} else {
 					Response error = Response.createResponse(request, ResponseCode.REQUEST_ENTITY_INCOMPLETE);
 					error.getOptions().setBlock1(block1.getSzx(), block1.isM(), block1.getNum());
-					error.setPayload("Changed Content-Format");
-					
+					error.setPayload("unexpected Content-Format");
+
 					exchange.setCurrentResponse(error);
 					super.sendResponse(exchange, error);
 					return;
-				}
-
-				status.setCurrentNum(status.getCurrentNum() + 1);
-				if ( block1.isM() ) {
-					LOGGER.finest("There are more blocks to come. Acknowledge this block.");
-					
-					Response piggybacked = Response.createResponse(request, ResponseCode.CONTINUE);
-					piggybacked.getOptions().setBlock1(block1.getSzx(), true, block1.getNum());
-					piggybacked.setLast(false);
-
-					exchange.setCurrentResponse(piggybacked);
-					super.sendResponse(exchange, piggybacked);
-
-					// do not assemble and deliver the request yet
-
-				} else {
-					LOGGER.finer("This was the last block. Deliver request");
-
-					// Remember block to acknowledge. TODO: We might make this a boolean flag in status.
-					exchange.setBlock1ToAck(block1); 
-
-					// Block2 early negotiation
-					earlyBlock2Negotiation(exchange, request);
-
-					// Assemble and deliver
-					Request assembled = new Request(request.getCode());
-					assembled.setSenderIdentity(request.getSenderIdentity());
-					assembleMessage(status, assembled);
-
-					exchange.setRequest(assembled);
-					super.receiveRequest(exchange, assembled);
 				}
 
 			} else {
@@ -232,50 +308,25 @@ public class BlockwiseLayer extends AbstractLayer {
 
 				super.sendResponse(exchange, error);
 			}
-
-		} else if (exchange.getResponse()!=null && request.getOptions().hasBlock2()) {
-			// The response has already been generated and the client just wants its next block
-
-			BlockOption block2 = request.getOptions().getBlock2();
-			Response response = exchange.getResponse();
-			BlockwiseStatus status = findResponseBlockStatus(exchange, response);
-			status.setCurrentNum(block2.getNum());
-			status.setCurrentSzx(block2.getSzx());
-
-			Response block = getNextResponseBlock(response, status);
-
-			if (status.isComplete()) {
-				// clean up blockwise status
-				LOGGER.log(Level.FINE, "Ongoing is complete {0}", status);
-				exchange.setResponseBlockStatus(null);
-				exchange.setBlockCleanupHandle(null);
-			} else {
-				LOGGER.log(Level.FINE, "Ongoing is continuing {0}", status);
-			}
-
-			exchange.setCurrentResponse(block);
-			super.sendResponse(exchange, block);
-
-		} else {
-			earlyBlock2Negotiation(exchange, request);
-
-			exchange.setRequest(request);
-			super.receiveRequest(exchange, request);
 		}
 	}
 
 	@Override
 	public void sendResponse(final Exchange exchange, final Response response) {
+
 		BlockOption block1 = exchange.getBlock1ToAck();
+
 		if (block1 != null) {
 			exchange.setBlock1ToAck(null);
 		}
-		if (requireBlockwise(exchange, response)) {
-			LOGGER.log(Level.FINE, "Response payload {0}/{1} requires Blockwise", new Object[]{response.getPayloadSize(), max_message_size});
+
+		if (requiresBlockwise(exchange, response)) {
 
 			BlockwiseStatus status = findResponseBlockStatus(exchange, response);
-
+			int bodySize = response.getPayloadSize();
 			Response block = getNextResponseBlock(response, status);
+			// indicate overall body size to peer
+			block.getOptions().setSize2(bodySize);
 
 			if (block1 != null) { // in case we still have to ack the last block1
 				block.getOptions().setBlock1(block1);
@@ -293,7 +344,9 @@ public class BlockwiseLayer extends AbstractLayer {
 			super.sendResponse(exchange, block);
 
 		} else {
-			if (block1 != null) response.getOptions().setBlock1(block1);
+			if (block1 != null) {
+				response.getOptions().setBlock1(block1);
+			}
 			exchange.setCurrentResponse(response);
 			// Block1 transfer completed
 			exchange.setBlockCleanupHandle(null);
@@ -301,201 +354,285 @@ public class BlockwiseLayer extends AbstractLayer {
 		}
 	}
 
+	/**
+	 * Invoked when a response has been received from a peer.
+	 * <p>
+	 * Checks whether the response either contains a block of an already ongoing
+	 * blockwise transfer or contains the first block of a large body and
+	 * requires the start of a blockwise transfer to retrieve the remaining blocks
+	 * of the body.
+	 * 
+	 * @param exchange The message exchange that the response is part of.
+	 * @param response The response received from the peer.
+	 */
 	@Override
 	public void receiveResponse(final Exchange exchange, final Response response) {
 
-		// do not continue fetching blocks if canceled
 		if (exchange.getRequest().isCanceled()) {
+			// do not continue fetching blocks if canceled
 			// reject (in particular for Block+Observe)
 			if (response.getType()!=Type.ACK) {
-				LOGGER.finer("Rejecting blockwise transfer for canceled Exchange");
+				LOGGER.finer("rejecting blockwise transfer for canceled Exchange");
 				EmptyMessage rst = EmptyMessage.newRST(response);
 				sendEmptyMessage(exchange, rst);
 				// Matcher sets exchange as complete when RST is sent
 			}
-			return;
-		}
 
-		if (!response.getOptions().hasBlock1() && !response.getOptions().hasBlock2()) {
-			// There is no block1 or block2 option, therefore it is a normal response
+		} else if (!response.hasBlockOption()) {
+
+			// This is a normal response, no special treatment necessary
 			exchange.setResponse(response);
 			super.receiveResponse(exchange, response);
+
+		} else {
+
+			BlockOption block = response.getOptions().getBlock1();
+			if (block != null) {
+				handleBlock1Response(exchange, response, block);
+			}
+
+			block = response.getOptions().getBlock2();
+			if (block != null) {
+				handleBlock2Response(exchange, response, block);
+			}
+		}
+
+	}
+
+	/**
+	 * Checks if a response acknowledges a block sent in a POST/PUT request and
+	 * sends the next block if applicable.
+	 * 
+	 * @param exchange The message exchange that the response is part of.
+	 * @param response The response received from the peer.
+	 * @param block1 The block1 option from the response.
+	 */
+	private void handleBlock1Response(final Exchange exchange, final Response response, final BlockOption block1) {
+
+		LOGGER.log(Level.FINER, "received response acknowledging block {0}", block1);
+
+		BlockwiseStatus status = exchange.getRequestBlockStatus();
+		if (status == null) {
+
+			// request has not been sent blockwise
+			LOGGER.log(Level.FINE, "discarding response containing unexpected block1 option: {0}", response);
+
+		} else if (!status.isComplete()) {
+
+			if (block1.isM()) {
+				// server wants us to send the remaining blocks before returning
+				// its response
+				sendNextBlock(exchange, response, block1, status);
+
+			} else {
+				// this means that the response already contains the server's final
+				// response to the request. However, the server is still expecting us
+				// to continue to send the remaining blocks as specified in
+				// https://tools.ietf.org/html/rfc7959#section-2.3
+
+				// the current implementation does not allow us to forward the response
+				// to the application layer, though, because it would "complete"
+				// the exchange and thus remove the blockwise status necessary
+				// to keep track of this POST/PUT request
+				// we therefore go on sending all pending blocks and then return the
+				// response received for the last block
+				sendNextBlock(exchange, response, block1, status);
+			}
+
+		} else if (!response.getOptions().hasBlock2()) {
+
+			// All request block have been acknowledged and we receive a piggy-backed
+			// response that needs no blockwise transfer. Thus, deliver it.
+			super.receiveResponse(exchange, response);
+
+		} else {
+
+			LOGGER.finer("Block1 followed by Block2 transfer");
+
+		}
+	}
+
+	private void sendNextBlock(final Exchange exchange, final Response response, final BlockOption block1, final BlockwiseStatus requestStatus) {
+
+		// Send next block
+		int currentSize = 1 << (4 + requestStatus.getCurrentSzx());
+		// Define new size of the block depending of preferred size block
+		int newSize, newSzx;
+		if (block1.getSize() < currentSize) {
+			newSize = block1.getSize();
+			newSzx = block1.getSzx();
+		} else {
+			newSize = currentSize;
+			newSzx = requestStatus.getCurrentSzx();
+		}
+		int nextNum = requestStatus.getCurrentNum() + currentSize / newSize;
+		LOGGER.log(Level.FINER, "Sending next Block1 num={0}", nextNum);
+		requestStatus.setCurrentNum(nextNum);
+		requestStatus.setCurrentSzx(newSzx);
+		Request nextBlock = getNextRequestBlock(exchange.getRequest(), requestStatus);
+
+		// indicate overall body size to peer
+		nextBlock.getOptions().setSize1(exchange.getRequest().getPayloadSize());
+
+		// we use the same token to ease traceability
+		nextBlock.setToken(response.getToken());
+
+		exchange.setCurrentRequest(nextBlock);
+		super.sendRequest(exchange, nextBlock);
+		// do not deliver response
+	}
+
+	/**
+	 * Checks if a response contains a single block of a large payload only and
+	 * retrieves the remaining blocks if applicable.
+	 * 
+	 * @param exchange The message exchange that the response is part of.
+	 * @param response The response received from the peer.
+	 * @param block2 The block2 option from the reponse.
+	 */
+	private void handleBlock2Response(final Exchange exchange, final Response response, final BlockOption block2) {
+
+		if (responseExceedsMaxBodySize(response)) {
+			LOGGER.log(Level.FINE, "requested resource body exceeds max buffer size [{0}], aborting request", maxResourceBodySize);
+			exchange.getRequest().cancel();
 			return;
 		}
 
-		if (response.getOptions().hasBlock1()) {
-			// TODO: What if request has not been sent blockwise (server error)
-			BlockOption block1 = response.getOptions().getBlock1();
-			LOGGER.log(Level.FINER, "Response acknowledges block {0}", block1);
+		BlockwiseStatus responseStatus = findResponseBlockStatus(exchange, response);
 
-			BlockwiseStatus status = exchange.getRequestBlockStatus();
-			if (!status.isComplete()) {
-				// TODO: the response code should be CONTINUE. Otherwise deliver random access response.
-				// Send next block
-				int currentSize = 1 << (4 + status.getCurrentSzx());
-				// Define new size of the block depending of preferred size block
-				int newSize, newSzx;
-				if (block1.getSize() < currentSize){
-					newSize = block1.getSize();
-					newSzx = block1.getSzx();
-				}else{
-					newSize = currentSize;
-					newSzx = status.getCurrentSzx();
-				}
-				int nextNum = status.getCurrentNum() + currentSize / newSize;
-				LOGGER.log(Level.FINER, "Sending next Block1 num={0}", nextNum);
-				status.setCurrentNum(nextNum);
-				status.setCurrentSzx(newSzx);
-				Request nextBlock = getNextRequestBlock(exchange.getRequest(), status);
-				// we use the same token to ease traceability
-				nextBlock.setToken(response.getToken());
+		// a new notification might arrive during a blockwise transfer
+		if (response.isNotification() && block2.getNum() == 0 && responseStatus.getCurrentNum() != 0) {
 
-				exchange.setCurrentRequest(nextBlock);
-				super.sendRequest(exchange, nextBlock);
-				// do not deliver response
-
-			} else if (!response.getOptions().hasBlock2()) {
-				// All request block have been acknowledged and we receive a piggy-backed
-				// response that needs no blockwise transfer. Thus, deliver it.
-				super.receiveResponse(exchange, response);
+			if (response.getOptions().getObserve() > responseStatus.getObserve()) {
+				// log a warning, since this might cause a loop where no notification is ever assembled (when the server sends notifications faster than the blocks can be transmitted)
+				LOGGER.log(Level.WARNING, "ongoing blockwise transfer reset at num = {0} by new notification: {1}", new Object[]{responseStatus.getCurrentNum(), response});
+				// reset current status
+				exchange.setResponseBlockStatus(null);
+				// and create new status for fresher notification
+				responseStatus = findResponseBlockStatus(exchange, response);
 			} else {
-				LOGGER.finer("Block1 followed by Block2 transfer");
+				LOGGER.log(Level.FINE, "discarding old notification received during ongoing blockwise transfer: {0}", response);
+				return;
 			}
 		}
 
-		if (response.getOptions().hasBlock2()) {
+		// check token to avoid mixed blockwise transfers (possible with observe) 
+		if (block2.getNum() == responseStatus.getCurrentNum() && (block2.getNum() == 0 || Arrays.equals(response.getToken(), exchange.getCurrentRequest().getToken()))) {
 
-			BlockOption block2 = response.getOptions().getBlock2();
-			BlockwiseStatus status = findResponseBlockStatus(exchange, response);
+			// We got the block we expected :-)
 
-			// a new notification might arrive during a blockwise transfer
-			if (response.getOptions().hasObserve() && block2.getNum()==0 && status.getCurrentNum()!=0) {
-
-				if (response.getOptions().getObserve()>status.getObserve()) {
-					// log a warning, since this might cause a loop where no notification is ever assembled (when the server sends notifications faster than the blocks can be transmitted)
-					LOGGER.log(Level.WARNING, "Ongoing blockwise transfer reseted at num={0} by new notification: {1}", new Object[]{status.getCurrentNum(), response});
-					// reset current status
-					exchange.setResponseBlockStatus(null);
-					// and create new status for fresher notification
-					status = findResponseBlockStatus(exchange, response);
-				} else {
-					LOGGER.log(Level.INFO, "Ignoring old notification during ongoing blockwise transfer: {0}", response);
-					return;
-				}
+			if (!responseStatus.addBlock(response.getPayload())) {
+				LOGGER.log(Level.FINE, "requested resource body exceeds max buffer size [{0}], aborting request", maxResourceBodySize);
+				exchange.getRequest().cancel();
+				return;
 			}
 
-			// check token to avoid mixed blockwise transfers (possible with observe) 
-			if (block2.getNum() == status.getCurrentNum() && (block2.getNum()==0 || Arrays.equals(response.getToken(), exchange.getCurrentRequest().getToken()))) {
+			// store the observe sequence number to set it in the assembled response
+			if (response.getOptions().hasObserve()) {
+				responseStatus.setObserve(response.getOptions().getObserve());
+			}
 
-				// We got the block we expected :-)
-				status.addBlock(response.getPayload());
+			if (responseStatus.isRandomAccess()) {
+				// The client has requested this specific block and we deliver it
+				exchange.setResponse(response);
+				super.receiveResponse(exchange, response);
+			
+			} else if (block2.isM()) {
 
-				// store the observe sequence number to set it in the assembled response
-				if (response.getOptions().hasObserve()) {
-					status.setObserve(response.getOptions().getObserve());
-				}
+				Request request = exchange.getRequest();
+				int num = block2.getNum() + 1;
+				int szx = block2.getSzx();
+				boolean m = false;
 
-				if (status.isRandomAccess()) {
-					// The client has requested this specifc block and we deliver it
-					exchange.setResponse(response);
-					super.receiveResponse(exchange, response);
-				
-				} else if (block2.isM()) {
+				LOGGER.log(Level.FINER, "Requesting next Block2 num={0}", num);
 
-					Request request = exchange.getRequest();
-					int num = block2.getNum() + 1;
-					int szx = block2.getSzx();
-					boolean m = false;
+				Request block = new Request(request.getCode());
+				// do not enforce CON, since NON could make sense over SMS or similar transports
+				block.setType(request.getType());
+				block.setDestination(request.getDestination());
+				block.setDestinationPort(request.getDestinationPort());
 
-					LOGGER.log(Level.FINER, "Requesting next Block2 num={0}", num);
+				/*
+				 * WARNING:
+				 * 
+				 * For Observe, the Matcher then will store the same
+				 * exchange under a different KeyToken in exchangesByToken,
+				 * which is cleaned up in the else case below.
+				 */
+				if (!response.getOptions().hasObserve()) block.setToken(response.getToken());
 
-					Request block = new Request(request.getCode());
-					// do not enforce CON, since NON could make sense over SMS or similar transports
-					block.setType(request.getType());
-					block.setDestination(request.getDestination());
-					block.setDestinationPort(request.getDestinationPort());
+				// copy options
+				block.setOptions(new OptionSet(request.getOptions()));
+				// make sure NOT to use Observe for block retrieval
+				block.getOptions().removeObserve();
 
-					/*
-					 * WARNING:
-					 * 
-					 * For Observe, the Matcher then will store the same
-					 * exchange under a different KeyToken in exchangesByToken,
-					 * which is cleaned up in the else case below.
-					 */
-					if (!response.getOptions().hasObserve()) block.setToken(response.getToken());
+				block.getOptions().setBlock2(szx, m, num);
 
-					// copy options
-					block.setOptions(new OptionSet(request.getOptions()));
-					// make sure NOT to use Observe for block retrieval
-					block.getOptions().removeObserve();
+				// copy message observers from original request so that they will be notified
+				// if something goes wrong with this blockwise request, e.g. if it times out
+				block.addMessageObservers(request.getMessageObservers());
 
-					block.getOptions().setBlock2(szx, m, num);
+				responseStatus.setCurrentNum(num);
 
-					// copy message observers from original request so that they will be notified
-					// if something goes wrong with this blockwise request, e.g. if it times out
-					block.addMessageObservers(request.getMessageObservers());
-
-					status.setCurrentNum(num);
-
-					exchange.setCurrentRequest(block);
-					super.sendRequest(exchange, block);
-
-				} else {
-					LOGGER.log(Level.FINER, "We have received all {0} blocks of the response. Assemble and deliver", status.getBlockCount());
-					Response assembled = new Response(response.getCode());
-
-					assembleMessage(status, assembled);
-
-					// set overall transfer RTT
-					assembled.setRTT(System.currentTimeMillis() - exchange.getTimestamp());
-
-					// Check if this response is a notification
-					int observe = status.getObserve();
-					if (observe != BlockwiseStatus.NO_OBSERVE) {
-
-						/*
-						 * When retrieving the rest of a blockwise notification
-						 * with a different token, the additional Matcher state
-						 * must be cleaned up through the call below.
-						 */
-						if (!response.getOptions().hasObserve()) {
-							// call the clean-up mechanism for the additional Matcher entry in exchangesByToken
-							exchange.completeCurrentRequest();
-						}
-
-						assembled.getOptions().setObserve(observe);
-						// This is necessary for notifications that are sent blockwise:
-						// Reset block number AND container with all blocks
-						exchange.setResponseBlockStatus(null);
-					}
-
-					LOGGER.log(Level.FINE, "Assembled response: {0}", assembled);
-					exchange.setResponse(assembled);
-					super.receiveResponse(exchange, assembled);
-				}
+				exchange.setCurrentRequest(block);
+				super.sendRequest(exchange, block);
 
 			} else {
-				// ERROR, wrong block number (server error)
-				// TODO: This scenario is not specified in the draft.
-				// Canceling the request would interfere with Observe, so just ignore it
-				LOGGER.log(Level.WARNING,
-						"Wrong block number. Expected {0} but received {1}: {2}",
-						new Object[]{status.getCurrentNum(), block2.getNum(), response});
-				if (response.getType()==Type.CON) {
-					EmptyMessage rst = EmptyMessage.newRST(response);
-					super.sendEmptyMessage(exchange, rst);
+				LOGGER.log(Level.FINER, "We have received all {0} blocks of the response. Assemble and deliver", responseStatus.getBlockCount());
+				Response assembled = new Response(response.getCode());
+
+				assembleMessage(responseStatus, assembled);
+
+				// set overall transfer RTT
+				assembled.setRTT(System.currentTimeMillis() - exchange.getTimestamp());
+
+				// Check if this response is a notification
+				int observe = responseStatus.getObserve();
+				if (observe != BlockwiseStatus.NO_OBSERVE) {
+
+					/*
+					 * When retrieving the rest of a blockwise notification
+					 * with a different token, the additional Matcher state
+					 * must be cleaned up through the call below.
+					 */
+					if (!response.getOptions().hasObserve()) {
+						// call the clean-up mechanism for the additional Matcher entry in exchangesByToken
+						exchange.completeCurrentRequest();
+					}
+
+					assembled.getOptions().setObserve(observe);
+					// This is necessary for notifications that are sent blockwise:
+					// Reset block number AND container with all blocks
+					exchange.setResponseBlockStatus(null);
 				}
+
+				LOGGER.log(Level.FINE, "Assembled response: {0}", assembled);
+				// Set the assembled response as current response
+				exchange.setResponse(assembled);
+				super.receiveResponse(exchange, assembled);
+			}
+
+		} else {
+			// ERROR, wrong block number (server error)
+			// TODO: This scenario is not specified in the draft.
+			// Canceling the request would interfere with Observe, so just ignore it
+			LOGGER.log(Level.WARNING,
+					"Wrong block number. Expected {0} but received {1}: {2}",
+					new Object[]{responseStatus.getCurrentNum(), block2.getNum(), response});
+			if (response.getType()==Type.CON) {
+				EmptyMessage rst = EmptyMessage.newRST(response);
+				super.sendEmptyMessage(exchange, rst);
 			}
 		}
 	}
 
 	/////////// HELPER METHODS //////////
 
-	private void earlyBlock2Negotiation(final Exchange exchange, final Request request) {
+	private static void earlyBlock2Negotiation(final Exchange exchange, final Request request) {
 		// Call this method when a request has completely arrived (might have
 		// been sent in one piece without blockwise).
-		if (request.getOptions().hasBlock2()) {
-			BlockOption block2 = request.getOptions().getBlock2();
+		BlockOption block2 = request.getOptions().getBlock2();
+		if (block2 != null) {
 			BlockwiseStatus status2 = new BlockwiseStatus(request.getOptions().getContentFormat(), block2.getNum(), block2.getSzx());
 			LOGGER.log(Level.FINE, "Request with early block negotiation {0}. Create and set new Block2 status: {1}", new Object[]{block2, status2});
 			exchange.setResponseBlockStatus(status2);
@@ -510,9 +647,22 @@ public class BlockwiseLayer extends AbstractLayer {
 	private BlockwiseStatus findRequestBlockStatus(final Exchange exchange, final Request request) {
 		BlockwiseStatus status = exchange.getRequestBlockStatus();
 		if (status == null) {
-			status = new BlockwiseStatus(request.getOptions().getContentFormat());
+			if (exchange.isOfLocalOrigin()) {
+				// we are sending a large body out in a POST/GET to a peer
+				// we only need to buffer one block each
+				status = new BlockwiseStatus(preferred_block_size, request.getOptions().getContentFormat());
+			} else {
+				// we are receiving a large body in a POST/GET from a peer
+				// we need to be prepared to buffer up to MAX_RESOURCE_BODY_SIZE bytes
+				int bufferSize = maxResourceBodySize;
+				if (request.getOptions().hasBlock1() && request.getOptions().hasSize1()) {
+					// use size indication for allocating buffer
+					bufferSize = request.getOptions().getSize1();
+				}
+				status = new BlockwiseStatus(bufferSize, request.getOptions().getContentFormat());
+			}
 			status.setFirst(request);
-			status.setCurrentSzx( computeSZX(preferred_block_size) );
+			status.setCurrentSzx(computeSZX(preferred_block_size));
 			exchange.setRequestBlockStatus(status);
 			LOGGER.log(Level.FINER, "There is no assembler status yet. Create and set new Block1 status: {0}", status);
 		} else {
@@ -531,8 +681,21 @@ public class BlockwiseLayer extends AbstractLayer {
 	private BlockwiseStatus findResponseBlockStatus(final Exchange exchange, final Response response) {
 		BlockwiseStatus status = exchange.getResponseBlockStatus();
 		if (status == null) {
-			status = new BlockwiseStatus(response.getOptions().getContentFormat());
-			status.setCurrentSzx( computeSZX(preferred_block_size) );
+			if (exchange.isOfLocalOrigin()) {
+				// we are receiving a large body in response to a request originating locally
+				// we need to be prepared to buffer up to MAX_RESOURCE_BODY_SIZE bytes
+				int bufferSize = maxResourceBodySize;
+				if (response.getOptions().hasBlock2() && response.getOptions().hasSize2()) {
+					// use size indication for allocating buffer
+					bufferSize = response.getOptions().getSize2();
+				}
+				status = new BlockwiseStatus(bufferSize, response.getOptions().getContentFormat());
+			} else {
+				// we are sending out a large body in response to a request from a peer
+				// we do not need to buffer and assemble anything
+				status = new BlockwiseStatus(0, response.getOptions().getContentFormat());
+			}
+			status.setCurrentSzx(computeSZX(preferred_block_size));
 			status.setFirst(response);
 			exchange.setResponseBlockStatus(status);
 			LOGGER.log(Level.FINER, "There is no blockwise status yet. Create and set new Block2 status: {0}", status);
@@ -574,6 +737,7 @@ public class BlockwiseLayer extends AbstractLayer {
 	}
 
 	private static Response getNextResponseBlock(final Response response, final BlockwiseStatus status) {
+
 		Response block;
 		int szx = status.getCurrentSzx();
 		int num = status.getCurrentNum();
@@ -625,31 +789,40 @@ public class BlockwiseLayer extends AbstractLayer {
 		message.setMID(status.getFirst().getMID());
 		message.setToken(status.getFirst().getToken());
 		message.setOptions(new OptionSet(status.getFirst().getOptions()));
-
-		int length = 0;
-		for (byte[] block:status.getBlocks()) {
-			length += block.length;
-		}
-		byte[] payload = new byte[length];
-		int offset = 0;
-		for (byte[] block:status.getBlocks()) {
-			System.arraycopy(block, 0, payload, offset, block.length);
-			offset += block.length;
-		}
-
-		message.setPayload(payload);
+		message.setPayload(status.getBody());
 	}
-	
+
 	private boolean requiresBlockwise(final Request request) {
+		boolean blockwiseRequired = false;
 		if (request.getCode() == Code.PUT || request.getCode() == Code.POST) {
-			return request.getPayloadSize() > max_message_size;
-		} else {
-			return false;
+			blockwiseRequired = request.getPayloadSize() > max_message_size;
 		}
+		if (blockwiseRequired) {
+			LOGGER.log(Level.FINE, "request body [{0}/{1}] requires blockwise trasnfer",
+					new Object[]{request.getPayloadSize(), max_message_size});
+		}
+		return blockwiseRequired;
 	}
 
-	private boolean requireBlockwise(final Exchange exchange, final Response response) {
-		return response.getPayloadSize() > max_message_size || exchange.getResponseBlockStatus() != null;
+	private boolean requiresBlockwise(final Exchange exchange, final Response response) {
+		boolean blockwiseRequired = response.getPayloadSize() > max_message_size || exchange.getResponseBlockStatus() != null;
+		if (blockwiseRequired) {
+			LOGGER.log(Level.FINE, "response body [{0}/{1}] requires blockwise transfer",
+					new Object[]{response.getPayloadSize(), max_message_size});
+		}
+		return blockwiseRequired;
+	}
+
+	private boolean isTransparentBlockwiseHandlingEnabled() {
+		return maxResourceBodySize > 0;
+	}
+
+	private boolean responseExceedsMaxBodySize(final Response response) {
+		return response.getOptions().hasSize2() && response.getOptions().getSize2() > maxResourceBodySize;
+	}
+
+	private boolean requestExceedsMaxBodySize(final Request request) {
+		return request.getOptions().hasSize1() && request.getOptions().getSize1() > maxResourceBodySize;
 	}
 
 	/*
@@ -660,8 +833,25 @@ public class BlockwiseLayer extends AbstractLayer {
 	 * ... 
 	 * 1024 bytes = 2^10 -> 6
 	 */
-	private static int computeSZX(final int blockSize) {
-		return (int)(Math.log(blockSize)/Math.log(2)) - 4;
+	static int computeSZX(final int blockSize) {
+		if (blockSize > 1024) {
+			return 6;
+		} else if (blockSize <= 16) {
+			return 0;
+		} else {
+			int maxOneBit = Integer.highestOneBit(blockSize);
+			return Integer.numberOfTrailingZeros(maxOneBit) - 4;
+		}
+	}
+
+	static int getSizeForSzx(final int szx) {
+		if (szx <= 0) {
+			return 16;
+		} else if (szx >= 6) {
+			return 1024;
+		} else {
+			return 1 << (szx + 4);
+		}
 	}
 
 	/**

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/BlockwiseLayerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/BlockwiseLayerTest.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network.stack;
+
+import static org.eclipse.californium.TestTools.generateRandomPayload;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.eclipse.californium.category.Small;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MessageObserver;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.Exchange.Origin;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+
+/**
+ * Verifies behavior of the {@code BlockwiseLayer}.
+ *
+ */
+@Category(Small.class)
+public class BlockwiseLayerTest {
+
+	/**
+	 * Verifies that conversion from block size to szx code works.
+	 */
+	@Test
+	public void testComputeSzxReturnsNextSmallerSize() {
+		assertThat(BlockwiseLayer.computeSZX(1600), is(6));
+		assertThat(BlockwiseLayer.computeSZX(1024), is(6));
+		assertThat(BlockwiseLayer.computeSZX(540), is(5));
+		assertThat(BlockwiseLayer.computeSZX(512), is(5));
+		assertThat(BlockwiseLayer.computeSZX(400), is(4));
+		assertThat(BlockwiseLayer.computeSZX(256), is(4));
+		assertThat(BlockwiseLayer.computeSZX(170), is(3));
+		assertThat(BlockwiseLayer.computeSZX(128), is(3));
+		assertThat(BlockwiseLayer.computeSZX(90), is(2));
+		assertThat(BlockwiseLayer.computeSZX(64), is(2));
+		assertThat(BlockwiseLayer.computeSZX(33), is(1));
+		assertThat(BlockwiseLayer.computeSZX(32), is(1));
+		assertThat(BlockwiseLayer.computeSZX(25), is(0));
+		assertThat(BlockwiseLayer.computeSZX(16), is(0));
+	}
+
+	/**
+	 * Verifies that block size < 16 is mapped to szx 0.
+	 */
+	@Test
+	public void testComputeSzxReturnsMinSize() {
+		assertThat(BlockwiseLayer.computeSZX(8), is(0));
+	}
+
+	/**
+	 * Verifies that conversion from szx codes to block size works.
+	 */
+	@Test
+	public void testGetSizeForSzx() {
+		assertThat(BlockwiseLayer.getSizeForSzx(-1), is(16));
+		assertThat(BlockwiseLayer.getSizeForSzx(0), is(16));
+		assertThat(BlockwiseLayer.getSizeForSzx(1), is(32));
+		assertThat(BlockwiseLayer.getSizeForSzx(2), is(64));
+		assertThat(BlockwiseLayer.getSizeForSzx(3), is(128));
+		assertThat(BlockwiseLayer.getSizeForSzx(4), is(256));
+		assertThat(BlockwiseLayer.getSizeForSzx(5), is(512));
+		assertThat(BlockwiseLayer.getSizeForSzx(6), is(1024));
+		assertThat(BlockwiseLayer.getSizeForSzx(8), is(1024));
+	}
+
+	/**
+	 * Verifies that an inbound blockwise request is forwarded to application layer
+	 * if overall transparent blockwise handling is disabled.
+	 */
+	@Test
+	public void testReceiveRequestDelegatesToApplicationLayer() {
+
+		NetworkConfig config = NetworkConfig.createStandardWithoutFile()
+				.setInt(Keys.MAX_MESSAGE_SIZE, 128)
+				.setInt(Keys.MAX_RESOURCE_BODY_SIZE, 0);
+		Layer appLayer = mock(Layer.class);
+
+		BlockwiseLayer blockwiseLayer = new BlockwiseLayer(config);
+		blockwiseLayer.setUpperLayer(appLayer);
+
+		Request request = newBlockwiseRequest(256, 64);
+		Exchange exchange = new Exchange(request, Origin.REMOTE);
+
+		blockwiseLayer.receiveRequest(exchange, request);
+
+		verify(appLayer).receiveRequest(exchange, request);
+	}
+
+	/**
+	 * Verifies that an inbound blockwise request is rejected with a 4.13 error response.
+	 */
+	@Test
+	public void testReceiveRequestRejectsExcessiveRequestBody() {
+
+		NetworkConfig config = NetworkConfig.createStandardWithoutFile()
+				.setInt(Keys.MAX_MESSAGE_SIZE, 128)
+				.setInt(Keys.MAX_RESOURCE_BODY_SIZE, 200);
+		Layer outbox = mock(Layer.class);
+		ArgumentCaptor<Response> errorResponse = ArgumentCaptor.forClass(Response.class);
+
+		BlockwiseLayer blockwiseLayer = new BlockwiseLayer(config);
+		blockwiseLayer.setLowerLayer(outbox);
+
+		Request request = newBlockwiseRequest(256, 64);
+		Exchange exchange = new Exchange(request, Origin.REMOTE);
+
+		blockwiseLayer.receiveRequest(exchange, request);
+
+		verify(outbox).sendResponse(Mockito.any(Exchange.class), errorResponse.capture());
+		assertThat(errorResponse.getValue().getCode(), is(ResponseCode.REQUEST_ENTITY_TOO_LARGE));
+	}
+
+	/**
+	 * Verifies that a request for a resource with a body exceeding the max buffer size is
+	 * cancelled when the first response block is received.
+	 */
+	@Test
+	public void testReceiveResponseCancelsRequestForExcessiveResponseBody() {
+
+		NetworkConfig config = NetworkConfig.createStandardWithoutFile()
+				.setInt(Keys.MAX_MESSAGE_SIZE, 128)
+				.setInt(Keys.MAX_RESOURCE_BODY_SIZE, 200);
+		MessageObserver requestObserver = mock(MessageObserver.class);
+		BlockwiseLayer blockwiseLayer = new BlockwiseLayer(config);
+
+		Request req = Request.newGet();
+		req.setURI("coap://127.0.0.1/bigResource");
+		req.addMessageObserver(requestObserver);
+
+		Response response = Response.createResponse(req, ResponseCode.CONTENT);
+		response.getOptions().setSize2(256).setBlock2(BlockwiseLayer.computeSZX(64), true, 0);
+
+		Exchange exchange = new Exchange(null, Origin.LOCAL);
+		exchange.setRequest(req);
+
+		blockwiseLayer.receiveResponse(exchange, response);
+
+		verify(requestObserver).onCancel();
+	}
+
+	private static Request newBlockwiseRequest(final int bodySize, final int blockSize) {
+		Request request = Request.newPut();
+		request.getOptions().setBlock1(BlockwiseLayer.computeSZX(blockSize), true, 0).setSize1(bodySize);
+		request.setPayload(generateRandomPayload(blockSize));
+		return request;
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/BlockOptionTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/BlockOptionTest.java
@@ -25,8 +25,8 @@ import static org.junit.Assert.assertEquals;
 import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.core.coap.BlockOption;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -39,14 +39,14 @@ import org.junit.experimental.categories.Category;
 @Category(Small.class)
 public class BlockOptionTest {
 
-	@Before
-	public void setupServer() {
-		System.out.println("\nStart "+getClass().getSimpleName());
+	@BeforeClass
+	public static void start() {
+		System.out.println(System.lineSeparator() + "Start " + BlockOptionTest.class.getSimpleName());
 	}
-	
-	@After
-	public void shutdownServer() {
-		System.out.println("End "+getClass().getSimpleName());
+
+	@AfterClass
+	public static void end() {
+		System.out.println(System.lineSeparator() + "End " + BlockOptionTest.class.getSimpleName());
 	}
 	
 	/**
@@ -92,7 +92,7 @@ public class BlockOptionTest {
 	 * Converts a BlockOption with the specified parameters to a byte array and
 	 * back and checks that the result is the same as the original.
 	 */
-	private void testCombined(int szx, boolean m, int num) {
+	private static void testCombined(int szx, boolean m, int num) {
 		BlockOption block = new BlockOption(szx, m, num);
 		BlockOption copy = new BlockOption(block.getValue());
 		assertEquals(block.getSzx(), copy.getSzx());
@@ -106,7 +106,7 @@ public class BlockOptionTest {
 	 * Helper function that creates a BlockOption with the specified parameters
 	 * and serializes them to a byte array.
 	 */
-	private byte[] toBytes(int szx, boolean m, int num) {
+	private static byte[] toBytes(int szx, boolean m, int num) {
 		byte[] bytes = new BlockOption(szx, m, num).getValue();
 		 System.out.println("(szx="+szx+", m="+m+", num="+num+") => "
 				 + Utils.toHexString(bytes));
@@ -116,7 +116,7 @@ public class BlockOptionTest {
 	/**
 	 * Helper function that converts an int array to a byte array.
 	 */
-	private byte[] b(int... a) {
+	private static byte[] b(int... a) {
 		byte[] ret = new byte[a.length];
 		for (int i = 0; i < a.length; i++)
 			ret[i] = (byte) a[i];

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/BlockwiseTransferTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/BlockwiseTransferTest.java
@@ -20,30 +20,32 @@
  ******************************************************************************/
 package org.eclipse.californium.core.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.eclipse.californium.TestTools.*;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.californium.category.Medium;
+import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.BlockOption;
-import org.eclipse.californium.core.coap.CoAP.Code;
-import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
-import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
-import org.eclipse.californium.core.server.MessageDeliverer;
+import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -61,141 +63,156 @@ import org.junit.experimental.categories.Category;
 @Category(Medium.class)
 public class BlockwiseTransferTest {
 
+	private static final String PARAM_SHORT_RESP = "srr";
+	private static final String PARAM_SHORT_REQ = "sr";
+	private static final String RESOURCE_TEST = "test";
+	private static final String RESOURCE_BIG = "big";
+
 	private static final String SHORT_POST_REQUEST  = "<Short request>";
 	private static final String LONG_POST_REQUEST   = "<Long request 1x2x3x4x5x>".replace("x", "ABCDEFGHIJKLMNOPQRSTUVWXYZ ");
 	private static final String SHORT_POST_RESPONSE = "<Short response>";
 	private static final String LONG_POST_RESPONSE  = "<Long response 1x2x3x4x5x>".replace("x", "ABCDEFGHIJKLMNOPQRSTUVWXYZ ");
 	private static final String SHORT_GET_RESPONSE = SHORT_POST_RESPONSE.toLowerCase();
 	private static final String LONG_GET_RESPONSE  = LONG_POST_RESPONSE.toLowerCase();
-
+	private static final String OVERSIZE_BODY = generateRandomPayload(510);
+	private static CoapServer server;
 	private static NetworkConfig config;
+	private static Endpoint serverEndpoint;
+	private static ServerBlockwiseInterceptor interceptor = new ServerBlockwiseInterceptor();
 
-	private boolean request_short = true;
-	private boolean respond_short = true;
-	private boolean cancel_request = false;
-	
-	private CoapServer server;
-	private ServerBlockwiseInterceptor interceptor = new ServerBlockwiseInterceptor();
-	private int serverPort;
-	
 	private Endpoint clientEndpoint;
 
 	@BeforeClass
 	public static void prepare() {
-		config = new NetworkConfig()
+		System.out.println(System.lineSeparator() + "Start " + BlockwiseTransferTest.class.getSimpleName());
+		config = NetworkConfig.createStandardWithoutFile()
 			.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 32)
-			.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 32);
+			.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 32)
+			.setInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE, 500);
+		server = createSimpleServer();
 	}
 
 	@Before
-	public void setupServer() throws IOException {
-		System.out.println(System.lineSeparator() + "Start " + getClass().getSimpleName());
+	public void createClient() throws IOException {
 
-		server = createSimpleServer();
 		clientEndpoint = new CoapEndpoint(config);
 		clientEndpoint.start();
 	}
 
 	@After
-	public void shutdownServer() throws Exception {
+	public void destroyClient() throws Exception {
 		clientEndpoint.destroy();
+	}
+
+	@AfterClass
+	public static void shutdownServer() throws Exception {
 		server.destroy();
-		System.out.println("End " + getClass().getSimpleName());
+		System.out.println("End " + BlockwiseTransferTest.class.getSimpleName());
 	}
 
 	@Test
-	public void test_all() throws Exception {
-		test_POST_short_short();
-		test_POST_long_short();
-		test_POST_short_long();
-		test_POST_long_long();
-		// repeat test to check ongoing clean-up
-		test_POST_long_long();
-		test_GET_short();
-		test_GET_long();
-		// repeat test to check ongoing clean-up
-		test_GET_long();
-		test_GET_long_cancel();
-	}
-	
 	public void test_POST_short_short() throws Exception {
 		System.out.println("-- POST short short --");
-		request_short = true;
-		respond_short = true;
-		executePOSTRequest();
-	}
-	
-	public void test_POST_long_short() throws Exception {
-		System.out.println("-- POST long short --");
-		request_short = false;
-		respond_short = true;
-		executePOSTRequest();
-	}
-	
-	public void test_POST_short_long() throws Exception {
-		System.out.println("-- POST short long --");
-		request_short = true;
-		respond_short = false;
-		executePOSTRequest();
-	}
-	
-	public void test_POST_long_long() throws Exception {
-		System.out.println("-- POST long long --");
-		request_short = false;
-		respond_short = false;
-		executePOSTRequest();
-	}
-	
-	public void test_GET_short() throws Exception {
-		System.out.println("-- GET short --");
-		respond_short = true;
-		executeGETRequest();
-	}
-	
-	public void test_GET_long() throws Exception {
-		System.out.println("-- GET long --");
-		respond_short = false;
-		executeGETRequest();
+		executePOSTRequest(true, true);
 	}
 
+	@Test
+	public void test_POST_long_short() throws Exception {
+		System.out.println("-- POST long short --");
+		executePOSTRequest(false, true);
+	}
+
+	@Test
+	public void test_POST_short_long() throws Exception {
+		System.out.println("-- POST short long --");
+		executePOSTRequest(true, false);
+	}
+
+	@Test
+	public void test_POST_long_long() throws Exception {
+		System.out.println("-- POST long long --");
+		executePOSTRequest(false, false);
+		// repeat test to check ongoing clean-up
+		executePOSTRequest(false, false);
+	}
+
+	@Test
+	public void test_GET_short() throws Exception {
+		System.out.println("-- GET short --");
+		executeGETRequest(true);
+	}
+
+	@Test
+	public void test_GET_long() throws Exception {
+		System.out.println("-- GET long --");
+		executeGETRequest(false);
+		// repeat test to check ongoing clean-up
+		executeGETRequest(false);
+	}
+
+	@Test
 	public void test_GET_long_cancel() throws Exception {
 		System.out.println("-- GET long, cancel --");
-		respond_short = false;
-		cancel_request = true;
-		executeGETRequest();
+		executeGETRequest(false, true);
 	}
-	
-	private void executeGETRequest() throws Exception {
+
+	@Test
+	public void testRequestForOversizedBodyGetsCanceled() throws InterruptedException {
+
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		Request req = Request.newGet().setURI(getUri(serverEndpoint, RESOURCE_BIG));
+		req.addMessageObserver(new MessageObserverAdapter() {
+
+			@Override
+			public void onCancel() {
+				latch.countDown();
+			}
+		});
+		clientEndpoint.sendRequest(req);
+		assertTrue(latch.await(1000, TimeUnit.MILLISECONDS));
+	}
+
+	private void executeGETRequest(final boolean respondShort) throws Exception {
+		executeGETRequest(respondShort, false);
+	}
+
+	private void executeGETRequest(final boolean respondShort, final boolean cancelRequest) throws Exception {
 		String payload = "nothing";
 		try {
 			interceptor.clear();
 			final AtomicInteger counter = new AtomicInteger(0);
 			final Request request = Request.newGet();
-			request.setDestination(InetAddress.getLoopbackAddress());
-			request.setDestinationPort(serverPort);
+			request.setURI(getUri(serverEndpoint, RESOURCE_TEST));
+			if (respondShort) {
+				request.getOptions().addUriQuery(PARAM_SHORT_RESP);
+			}
 			interceptor.handler = new ReceiveRequestHandler() {
 				@Override
 				public void receiveRequest(Request received) {
 					counter.getAndIncrement();
-					if (cancel_request) {
+					if (cancelRequest) {
 						request.cancel();
 					}
 				}
 			};
-			
+
 			clientEndpoint.sendRequest(request);
-			
+
 			// receive response and check
 			Response response = request.waitForResponse(2000);
 
-			if (cancel_request) {
+			if (cancelRequest) {
 				Thread.sleep(1000); // Quickly wait for more blocks (should not happen)
 				assertEquals(1, counter.get());
 			} else {
 				assertNotNull("Client received no response", response);
 				payload = response.getPayloadString();
-				if (respond_short) assertEquals(SHORT_GET_RESPONSE, payload);
-				else assertEquals(LONG_GET_RESPONSE, payload);
+				if (respondShort) {
+					assertEquals(SHORT_GET_RESPONSE, payload);
+				} else {
+					assertEquals(LONG_GET_RESPONSE, payload);
+				}
 			}
 		} finally {
 			Thread.sleep(100); // Quickly wait until last ACKs arrive
@@ -203,81 +220,94 @@ public class BlockwiseTransferTest {
 				+ "\n" + interceptor.toString() + "\n");
 		}
 	}
-	
-	private void executePOSTRequest() throws Exception {
+
+	private void executePOSTRequest(final boolean shortRequest, final boolean respondShort) throws Exception {
 		String payload = "--no payload--";
 		try {
 			interceptor.clear();
-			String uri = String.format(
-					"coap://%s:%d/%s%s",
-					InetAddress.getLoopbackAddress().getHostAddress(),
-					serverPort,
-					request_short,
-					respond_short);
-			Request request = Request.newPost().setURI(uri);
-			if (request_short) request.setPayload(SHORT_POST_REQUEST);
-			else request.setPayload(LONG_POST_REQUEST);
+			Request request = Request.newPost().setURI(getUri(serverEndpoint, RESOURCE_TEST));
+			if (shortRequest) {
+				request.setPayload(SHORT_POST_REQUEST);
+				request.getOptions().addUriQuery(PARAM_SHORT_REQ);
+			} else {
+				request.setPayload(LONG_POST_REQUEST);
+			}
+			if (respondShort) {
+				request.getOptions().addUriQuery(PARAM_SHORT_RESP);
+			}
 			clientEndpoint.sendRequest(request);
-			
+
 			// receive response and check
 			Response response = request.waitForResponse(2000);
-			
+
 			assertNotNull("Client received no response", response);
 			payload = response.getPayloadString();
-			
-			if (respond_short)assertEquals(SHORT_POST_RESPONSE, payload);
-			else assertEquals(LONG_POST_RESPONSE, payload);
+
+			if (respondShort) {
+				assertEquals(SHORT_POST_RESPONSE, payload);
+			} else {
+				assertEquals(LONG_POST_RESPONSE, payload);
+			}
 		} finally {
 			Thread.sleep(100); // Quickly wait until last ACKs arrive
-			System.out.println("Client received "+payload
-				+ "\n" + interceptor.toString() + "\n");
+			System.out.println("Client received " + payload + "\n" + interceptor.toString() + "\n");
 		}
 	}
 
-	private CoapServer createSimpleServer() {
+	private static CoapServer createSimpleServer() {
 
 		CoapServer result = new CoapServer();
 
-		CoapEndpoint endpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
-		endpoint.addInterceptor(interceptor);
-		result.addEndpoint(endpoint);
-		result.setMessageDeliverer(new MessageDeliverer() {
+		serverEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
+		serverEndpoint.addInterceptor(interceptor);
+		result.addEndpoint(serverEndpoint);
+		result.add(new CoapResource(RESOURCE_TEST) {
+
+			private boolean isShortRequest(final CoapExchange exchange) {
+				return exchange.getQueryParameter(PARAM_SHORT_REQ) != null;
+			}
+
+			private boolean isShortResponseRequested(final CoapExchange exchange) {
+				return exchange.getQueryParameter(PARAM_SHORT_RESP) != null;
+			}
+
 			@Override
-			public void deliverRequest(Exchange exchange) {
-				if (exchange.getRequest().getCode() == Code.GET)
-					processGET(exchange);
-				else
-					processPOST(exchange);
-			}
-
-			private void processPOST(Exchange exchange) {
-				String payload = exchange.getRequest().getPayloadString();
-				if (request_short)assertEquals(payload, SHORT_POST_REQUEST);
-				else assertEquals(payload, LONG_POST_REQUEST);
-				System.out.println("Server received "+payload);
-					
-				Response response = new Response(ResponseCode.CHANGED);
-				if (respond_short)
-					response.setPayload(SHORT_POST_RESPONSE);
-				else response.setPayload(LONG_POST_RESPONSE);
-				exchange.sendResponse(response);
-			}
-
-			private void processGET(Exchange exchange) {
+			public void handleGET(final CoapExchange exchange) {
 				System.out.println("Server received GET request");
-				Response response = new Response(ResponseCode.CONTENT);
-				if (respond_short)
-					response.setPayload(SHORT_GET_RESPONSE);
-				else response.setPayload(LONG_GET_RESPONSE);
-				exchange.sendResponse(response);
+				if (isShortResponseRequested(exchange)) {
+					exchange.respond(SHORT_GET_RESPONSE);
+				} else {
+					exchange.respond(LONG_GET_RESPONSE);
+				}
 			}
 
 			@Override
-			public void deliverResponse(Exchange exchange, Response response) { }
+			public void handlePOST(final CoapExchange exchange) {
+				String payload = exchange.getRequestText();
+				System.out.println("Server received " + payload);
+				if (isShortRequest(exchange)) {
+					assertEquals(payload, SHORT_POST_REQUEST);
+				} else {
+					assertEquals(payload, LONG_POST_REQUEST);
+				}
+
+				if (isShortResponseRequested(exchange)) {
+					exchange.respond(SHORT_POST_RESPONSE);
+				} else {
+					exchange.respond(LONG_POST_RESPONSE);
+				}
+			}
 		});
+		result.add(new CoapResource(RESOURCE_BIG) {
+
+			@Override
+			public void handleGET(final CoapExchange exchange) {
+				exchange.respond(OVERSIZE_BODY);
+			}
+		});
+
 		result.start();
-		serverPort = endpoint.getAddress().getPort();
-		System.out.println("serverPort: " + serverPort);
+		System.out.println("serverPort: " + serverEndpoint.getAddress().getPort());
 		return result;
 	}
 
@@ -337,13 +367,13 @@ public class BlockwiseTransferTest {
 			buffer.append(str);
 		}
 		
-		private String blockOptionString(int nbr, BlockOption option) {
+		private static String blockOptionString(int nbr, BlockOption option) {
 			if (option == null) return "";
 			return String.format(", %d:%d/%d/%d", nbr, option.getNum(),
 					option.isM()?1:0, option.getSize());
 		}
 		
-		private String observeOptionString(OptionSet options) {
+		private static String observeOptionString(OptionSet options) {
 			if (options == null) return "";
 			if (!options.hasObserve()) return "";
 			return ", observe("+options.getObserve()+")";

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/RandomAccessBlockTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/RandomAccessBlockTest.java
@@ -1,5 +1,7 @@
 package org.eclipse.californium.core.test;
 
+import static org.eclipse.californium.TestTools.*;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
@@ -21,7 +23,7 @@ import org.junit.experimental.categories.Category;
 public class RandomAccessBlockTest {
 
 	public static String TARGET = "test";
-	public static String RESPONSE_PAYLOAD = "123456789_123456789_123456789_1234567890";
+	public static String RESPONSE_PAYLOAD = generateRandomPayload(40);
 
 	private InetSocketAddress serverAddress;
 	private CoapServer server;
@@ -32,7 +34,12 @@ public class RandomAccessBlockTest {
 		CoapEndpoint endpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		server = new CoapServer();
 		server.addEndpoint(endpoint);
-		server.add(new TestResource(TARGET));
+		server.add(new CoapResource(TARGET) {
+			@Override
+			public void handleGET(CoapExchange exchange) {
+				exchange.respond(RESPONSE_PAYLOAD);
+			}
+		});
 		server.start();
 		serverAddress = endpoint.getAddress();
 	}
@@ -49,7 +56,7 @@ public class RandomAccessBlockTest {
 		// know if the user attempts to just retrieve block 0 or if he wants to
 		// do early block negotiation with a specific size but actually wants to
 		// retrieve all blocks.
-		
+
 		int[] blockOrder = {2,1,3};
 		String[] expectations = {
 				RESPONSE_PAYLOAD.substring(32 /* until the end */),
@@ -57,7 +64,7 @@ public class RandomAccessBlockTest {
 				"" // block is out of bounds
 		};
 
-		String uri = String.format("coap://%s:%d/%s", serverAddress.getAddress().getHostAddress(), serverAddress.getPort(), TARGET);
+		String uri = getUri(serverAddress, TARGET);
 		for (int i = 0; i < blockOrder.length; i++) {
 			int num = blockOrder[i];
 			System.out.println("Request block number " + num);
@@ -73,18 +80,6 @@ public class RandomAccessBlockTest {
 			Assert.assertTrue(response.getOptions().hasBlock2());
 			Assert.assertEquals(num, response.getOptions().getBlock2().getNum());
 			Assert.assertEquals(szx, response.getOptions().getBlock2().getSzx());
-		}
-	}
-
-	private class TestResource extends CoapResource {
-
-		public TestResource(String name) {
-			super(name);
-		}
-
-		@Override
-		public void handleGET(CoapExchange exchange) {
-			exchange.respond(RESPONSE_PAYLOAD);
 		}
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -142,31 +142,6 @@ public class BlockwiseClientSideTest {
 		printServerLog(clientInterceptor);
 	}
 
-	// TODO: what is the purpose of this test?
-	@Test
-	public void testGET2() throws Exception {
-		System.out.println("Simple blockwise GET:");
-		respPayload = generateRandomPayload(10);
-		String path = "test";
-
-		Request request = createRequest(GET, path, server);
-		client.sendRequest(request);
-
-		server.expectRequest(CON, GET, path).storeMID("A").storeToken("B").go();
-		server.sendEmpty(ACK).loadMID("A").go();
-		Thread.sleep(50);
-		server.sendResponse(CON, CONTENT).loadToken("B").payload(respPayload).mid(++mid).go();
-		server.expectEmpty(ACK, mid).mid(mid).go(); // lost
-		clientInterceptor.log(" // lost");
-		server.sendResponse(CON, CONTENT).loadToken("B").payload(respPayload).mid(mid).go();
-		server.expectEmpty(ACK, mid).mid(mid).go(); // lost
-
-		Response response = request.waitForResponse(1000);
-		assertResponseContainsExpectedPayload(response, respPayload);
-
-		printServerLog(clientInterceptor);
-	}
-
 	/**
 	 * In the second example, the client anticipates the blockwise transfer
 	 * (e.g., because of a size indication in the link- format description
@@ -315,7 +290,7 @@ public class BlockwiseClientSideTest {
 		request.setPayload(reqtPayload);
 		client.sendRequest(request);
 
-		server.expectRequest(CON, PUT, path).storeBoth("A").block1(0, true, 128).payload(reqtPayload.substring(0, 128)).go();
+		server.expectRequest(CON, PUT, path).storeBoth("A").block1(0, true, 128).size1(reqtPayload.length()).payload(reqtPayload.substring(0, 128)).go();
 		server.sendResponse(ACK, CONTINUE).loadBoth("A").block1(0, true, 128).go();
 
 		server.expectRequest(CON, PUT, path).storeBoth("B").block1(1, true, 128).payload(reqtPayload.substring(128, 256)).go();
@@ -367,7 +342,8 @@ public class BlockwiseClientSideTest {
 		request.setPayload(reqtPayload);
 		client.sendRequest(request);
 
-		server.expectRequest(CON, PUT, path).storeBoth("A").block1(0, true, 128).payload(reqtPayload.substring(0, 128)).go();
+		server.expectRequest(CON, PUT, path).storeBoth("A").block1(0, true, 128).size1(reqtPayload.length())
+				.payload(reqtPayload.substring(0, 128)).go();
 		server.sendResponse(ACK, CONTINUE).loadBoth("A").block1(0, true, 32).go();
 
 		server.expectRequest(CON, PUT, path).storeBoth("B").block1(4, true, 32).payload(reqtPayload.substring(128, 160)).go();
@@ -418,8 +394,8 @@ public class BlockwiseClientSideTest {
 		request.setPayload(reqtPayload);
 		client.sendRequest(request);
 
-		server.expectRequest(CON, PUT, path).storeBoth("A").block1(0, true, 128).payload(reqtPayload.substring(0, 128))
-				.go();
+		server.expectRequest(CON, PUT, path).storeBoth("A").block1(0, true, 128).size1(reqtPayload.length())
+				.payload(reqtPayload.substring(0, 128)).go();
 		server.sendResponse(ACK, CONTINUE).loadBoth("A").block1(0, true, 256).go();
 
 		server.expectRequest(CON, PUT, path).storeBoth("B").block1(1, true, 128)
@@ -479,14 +455,16 @@ public class BlockwiseClientSideTest {
 		request.setPayload(reqtPayload);
 		client.sendRequest(request);
 
-		server.expectRequest(CON, POST, path).storeBoth("A").block1(0, true, 128).payload(reqtPayload.substring(0, 128)).go();
+		server.expectRequest(CON, POST, path).storeBoth("A").block1(0, true, 128).size1(reqtPayload.length())
+				.payload(reqtPayload.substring(0, 128)).go();
 		server.sendResponse(ACK, CONTINUE).loadBoth("A").block1(0, true, 128).go();
 
 		server.expectRequest(CON, POST, path).storeBoth("B").block1(1, true, 128).payload(reqtPayload.substring(128, 256)).go();
 		server.sendResponse(ACK, CONTINUE).loadBoth("B").block1(1, true, 128).go();
 
 		server.expectRequest(CON, POST, path).storeBoth("C").block1(2, false, 128).payload(reqtPayload.substring(256, 300)).go();
-		server.sendResponse(ACK, CHANGED).loadBoth("C").block1(2, false, 128).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		server.sendResponse(ACK, CHANGED).loadBoth("C").block1(2, false, 128).block2(0, true, 128).size2(respPayload.length())
+				.payload(respPayload.substring(0, 128)).go();
 
 		server.expectRequest(CON, POST, path).storeBoth("D").block2(1, false, 128).go();
 		server.sendResponse(ACK, CHANGED).loadBoth("D").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
@@ -522,7 +500,8 @@ public class BlockwiseClientSideTest {
 		System.out.println("Establish observe relation to " + path);
 
 		server.expectRequest(CON, GET, path).storeToken("At").storeMID("Am").observe(0).go();
-		server.sendResponse(ACK, CONTENT).loadToken("At").loadMID("Am").observe(62350).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		server.sendResponse(ACK, CONTENT).loadToken("At").loadMID("Am").observe(62350).block2(0, true, 128).size2(respPayload.length())
+			.payload(respPayload.substring(0, 128)).go();
 
 		server.expectRequest(CON, GET, path).storeBoth("B").noOption(OBSERVE).block2(1, false, 128).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
@@ -538,7 +517,8 @@ public class BlockwiseClientSideTest {
 		clientInterceptor.log(System.lineSeparator() + "... time passes ...");
 		respPayload = generateRandomPayload(280);
 
-		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(62354).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(62354).block2(0, true, 128).size2(respPayload.length())
+			.payload(respPayload.substring(0, 128)).go();
 		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 
@@ -556,7 +536,8 @@ public class BlockwiseClientSideTest {
 		clientInterceptor.log(System.lineSeparator() + "... time passes ...");
 		respPayload = generateRandomPayload(290);
 
-		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(17).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(17).block2(0, true, 128).size2(respPayload.length())
+			.payload(respPayload.substring(0, 128)).go();
 		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 
@@ -565,7 +546,8 @@ public class BlockwiseClientSideTest {
 		server.goMultiExpectation();
 		
 		System.out.println("Server sends third notification during transfer ");
-		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(19).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(19).block2(0, true, 128).size2(respPayload.length())
+			.payload(respPayload.substring(0, 128)).go();
 		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 
@@ -574,7 +556,8 @@ public class BlockwiseClientSideTest {
 		server.goMultiExpectation();
 		
 		System.out.println("Send old notification during transfer");
-		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(18).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(18).block2(0, true, 128).size2(respPayload.length())
+			.payload(respPayload.substring(0, 128)).go();
 		server.expectEmpty(ACK, mid).go();
 
 		server.sendResponse(ACK, CONTENT).loadBoth("G").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -57,7 +57,7 @@ import org.junit.experimental.categories.Category;
 @Category(Medium.class)
 public class BlockwiseClientSideTest {
 
-	private static NetworkConfig CONFIG;
+	private static NetworkConfig config;
 
 	private LockstepEndpoint server;
 	private Endpoint client;
@@ -70,7 +70,7 @@ public class BlockwiseClientSideTest {
 	public static void init() {
 		System.out.println(System.lineSeparator() + "Start " + BlockwiseClientSideTest.class.getSimpleName());
 
-		CONFIG = NetworkConfig.createStandardWithoutFile()
+		config = NetworkConfig.createStandardWithoutFile()
 				.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 128)
 				.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 128)
 				.setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200) // client retransmits after 200 ms
@@ -81,7 +81,7 @@ public class BlockwiseClientSideTest {
 	@Before
 	public void setupEndpoints() throws Exception {
 
-		client = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), CONFIG);
+		client = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
 		client.addInterceptor(clientInterceptor);
 		client.start();
 		System.out.println("Client binds to port " + client.getAddress().getPort());
@@ -196,7 +196,7 @@ public class BlockwiseClientSideTest {
 	 * </pre>
 	 */
 	@Test
-	public void testGETEarlyNegotion() throws Exception {
+	public void testGETEarlyNegotiation() throws Exception {
 		System.out.println("Blockwise GET with early negotiation: (low priority for Cf client)");
 		respPayload = generateRandomPayload(350);
 		String path = "test";
@@ -250,7 +250,7 @@ public class BlockwiseClientSideTest {
      * </pre>
 	 */
 	@Test
-	public void testGETLateNegotionAndLostACK() throws Exception {
+	public void testGETLateNegotiationAndLostACK() throws Exception {
 		System.out.println("Blockwise GET with late negotiation and lost ACK:");
 		respPayload = generateRandomPayload(300);
 		String path = "test";
@@ -357,8 +357,8 @@ public class BlockwiseClientSideTest {
 	 * </pre>
 	 */
 	@Test
-	public void testSimpleAtomicBlockwisePUTWithSmallerNegociation() throws Exception {
-		System.out.println("Simple atomic blockwise PUT with smaller size negociation");
+	public void testSimpleAtomicBlockwisePUTWithSmallerNegotiation() throws Exception {
+		System.out.println("Simple atomic blockwise PUT with smaller size negotiation");
 		reqtPayload = generateRandomPayload(200);
 		respPayload = generateRandomPayload(50);
 		String path = "test";
@@ -374,7 +374,7 @@ public class BlockwiseClientSideTest {
 		server.sendResponse(ACK, CONTINUE).loadBoth("B").block1(4, true, 32).go();
 
 		server.expectRequest(CON, PUT, path).storeBoth("C").block1(5, true, 32).payload(reqtPayload.substring(160, 192)).go();
-		server.sendResponse(ACK, CHANGED).loadBoth("C").block1(5, true, 32).go();
+		server.sendResponse(ACK, CONTINUE).loadBoth("C").block1(5, true, 32).go();
 
 		server.expectRequest(CON, PUT, path).storeBoth("D").block1(6, false, 32)
 				.payload(reqtPayload.substring(192, 200)).go();
@@ -408,8 +408,8 @@ public class BlockwiseClientSideTest {
 	 * </pre>
 	 */
 	@Test
-	public void testSimpleAtomicBlockwisePUTWithBiggerNegociation() throws Exception {
-		System.out.println("Simple atomic blockwise PUT with bigger size negociation");
+	public void testSimpleAtomicBlockwisePUTWithBiggerNegotiation() throws Exception {
+		System.out.println("Simple atomic blockwise PUT with bigger size negotiation");
 		reqtPayload = generateRandomPayload(300);
 		respPayload = generateRandomPayload(50);
 		String path = "test";

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
@@ -150,7 +150,7 @@ public class BlockwiseServerSideTest {
 		String path = "test";
 
 		client.sendRequest(CON, GET, tok, ++mid).path(path).go();
-		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 128).size2(300).payload(respPayload.substring(0, 128)).go();
 		client.sendRequest(CON, GET, tok, ++mid).path(path).block2(1, false, 128).go();
 		client.expectResponse(ACK, CONTENT, tok, mid).block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
 		client.sendRequest(CON, GET, tok, ++mid).path(path).block2(2, false, 128).go();
@@ -168,7 +168,7 @@ public class BlockwiseServerSideTest {
 		String path = "test";
 
 		client.sendRequest(CON, GET, tok, ++mid).path(path).go();
-		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 128).size2(300).payload(respPayload.substring(0, 128)).go();
 		client.sendRequest(CON, GET, tok, ++mid).path(path).block2(1, false, 128).go();
 		client.expectResponse(ACK, CONTENT, tok, mid).block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
 		serverInterceptor.log(System.lineSeparator() + "//////// Missing last GET ////////");
@@ -208,14 +208,14 @@ public class BlockwiseServerSideTest {
 	 * </pre>
 	 */
 	@Test
-	public void testGETEarlyNegotion() throws Exception {
+	public void testGETEarlyNegotiation() throws Exception {
 		System.out.println("Blockwise GET with early negotiation");
 		respPayload = generateRandomPayload(350);
 		byte[] tok = generateNextToken();
 		String path = "test";
 
 		client.sendRequest(CON, GET, tok, ++mid).path(path).block2(0, false, 64).go();
-		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 64).size2(350).payload(respPayload.substring(0, 64)).go();
 
 		client.sendRequest(CON, GET, tok, ++mid).path(path).block2(1, false, 64).go();
 		client.expectResponse(ACK, CONTENT, tok, mid).block2(1, true, 64).payload(respPayload.substring(64, 128)).go();
@@ -267,14 +267,15 @@ public class BlockwiseServerSideTest {
      * </pre>
 	 */
 	@Test
-	public void testGETLateNegotion() throws Exception {
+	public void testGETLateNegotiation() throws Exception {
 		System.out.println("Blockwise GET with late negotiation:");
 		respPayload = generateRandomPayload(350);
 		byte[] tok = generateNextToken();
 		String path = "test";
 
 		client.sendRequest(CON, GET, tok, ++mid).path(path).go();
-		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 128).size2(respPayload.length())
+			.payload(respPayload.substring(0, 128)).go();
 
 		client.sendRequest(CON, GET, tok, ++mid).path(path).block2(2, false, 64).go(); // late negotiation
 		client.expectResponse(ACK, CONTENT, tok, mid).block2(2, true, 64).payload(respPayload.substring(128, 192)).go();
@@ -315,14 +316,15 @@ public class BlockwiseServerSideTest {
      * </pre>
 	 */
 	@Test
-	public void testGETLateNegotionalLostACK() throws Exception {
+	public void testGETLateNegotiationLostACK() throws Exception {
 		System.out.println("Blockwise GET with late negotiation and lost ACK:");
 		respPayload = generateRandomPayload(220);
 		byte[] tok = generateNextToken();
 		String path = "test";
 
 		client.sendRequest(CON, GET, tok, ++mid).path(path).go();
-		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 128).size2(respPayload.length())
+			.payload(respPayload.substring(0, 128)).go();
 
 		client.sendRequest(CON, GET, tok, ++mid).path(path).block2(2, false, 64).go();
 		client.expectResponse(ACK, CONTENT, tok, mid).block2(2, true, 64).payload(respPayload.substring(128, 192)).go();
@@ -473,7 +475,7 @@ public class BlockwiseServerSideTest {
 
 		client.sendRequest(CON, POST, tok, ++mid).path(path).block1(2, false, 128).payload(reqtPayload.substring(256, 300)).go();
 		client.expectResponse(ACK, CHANGED, tok, mid).payload(respPayload.substring(0, 128))
-				.block1(2, false, 128).block2(0, true, 128).go();
+				.block1(2, false, 128).block2(0, true, 128).size2(500).go();
 
 		client.sendRequest(CON, POST, tok, ++mid).path(path).block2(1, false, 128).go();
 		client.expectResponse(ACK, CHANGED, tok, mid).block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
@@ -504,7 +506,7 @@ public class BlockwiseServerSideTest {
 
 		client.sendRequest(CON, POST, tok, ++mid).path(path).block1(2, false, 128).payload(reqtPayload.substring(256, 300)).go();
 		client.expectResponse(ACK, CHANGED, tok, mid).payload(respPayload.substring(0, 128))
-				.block1(2, false, 128).block2(0, true, 128).go();
+				.block1(2, false, 128).block2(0, true, 128).size2(300).go();
 
 		client.sendRequest(CON, POST, tok, ++mid).path(path).block2(2, false, 64).go();
 		client.expectResponse(ACK, CHANGED, tok, mid).block2(2, true, 64).payload(respPayload.substring(128, 192)).go();
@@ -566,7 +568,7 @@ public class BlockwiseServerSideTest {
 		client.sendRequest(CON, POST, tok, ++mid).path(path).payload(reqtPayload.substring(256, 300))
 				.block1(2, false, 128).block2(0, false, 64).go();
 		client.expectResponse(ACK, CHANGED, tok, mid).payload(respPayload.substring(0, 64))
-				.block1(2, false, 128).block2(0, true, 64).go();
+				.block1(2, false, 128).block2(0, true, 64).size2(250).go();
 		serverInterceptor.log("// early negotiation");
 
 		client.sendRequest(CON, POST, tok, ++mid).path(path).block2(1, false, 64).go();
@@ -630,7 +632,7 @@ public class BlockwiseServerSideTest {
 		System.out.println("Establish observe relation to " + path);
 
 		client.sendRequest(CON, GET, tok, ++mid).path(path).observe(0).go();
-		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 128).observe(0).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 128).size2(respPayload.length()).observe(0).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
 
 		byte[] tok1 = generateNextToken();
 		client.sendRequest(CON, GET, tok1, ++mid).path(path).block2(1, false, 128).go();
@@ -644,7 +646,7 @@ public class BlockwiseServerSideTest {
 		respPayload = generateRandomPayload(280);
 		test1.changed();
 
-		client.expectResponse().responseType("T", CON, NON).code(CONTENT).token(tok).storeMID("A").observe(1).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		client.expectResponse().responseType("T", CON, NON).code(CONTENT).token(tok).storeMID("A").size2(respPayload.length()).observe(1).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
 		if (client.get("T") == CON)
 			client.sendEmpty(ACK).loadMID("A").go();
 
@@ -660,7 +662,7 @@ public class BlockwiseServerSideTest {
 		respPayload = generateRandomPayload(290);
 		test1.changed();
 
-		client.expectResponse().responseType("T", CON, NON).code(CONTENT).token(tok).storeMID("A").observe(2).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		client.expectResponse().responseType("T", CON, NON).code(CONTENT).token(tok).storeMID("A").size2(respPayload.length()).observe(2).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
 		if (client.get("T") == CON)
 			client.sendEmpty(ACK).loadMID("A").go();
 
@@ -684,7 +686,7 @@ public class BlockwiseServerSideTest {
 		System.out.println("Establish observe relation to "+path);
 
 		client.sendRequest(CON, GET, tok, ++mid).path(path).observe(0).block2(0, false, 64).go();
-		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 64).observe(0).block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 64).observe(0).size2(respPayload.length()).block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
 
 		client.sendRequest(CON, GET, tok, ++mid).path(path).block2(1, false, 64).go();
 		client.expectResponse(ACK, CONTENT, tok, mid).block2(1, true, 64).noOption(OBSERVE).payload(respPayload.substring(64, 128)).go();
@@ -697,7 +699,7 @@ public class BlockwiseServerSideTest {
 		respPayload = generateRandomPayload(140);
 		test2.changed(); // First notification
 
-		client.expectResponse().responseType("T", CON, NON).code(CONTENT).token(tok).storeMID("A").observe(1).block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
+		client.expectResponse().responseType("T", CON, NON).code(CONTENT).token(tok).storeMID("A").observe(1).size2(respPayload.length()).block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
 		if (client.get("T") == CON)
 			client.sendEmpty(ACK).loadMID("A").go();
 
@@ -713,7 +715,7 @@ public class BlockwiseServerSideTest {
 		respPayload = generateRandomPayload(145);
 		test2.changed(); // Second notification
 
-		client.expectResponse().responseType("T", CON, NON).code(CONTENT).token(tok).storeMID("A").observe(2).block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
+		client.expectResponse().responseType("T", CON, NON).code(CONTENT).token(tok).storeMID("A").observe(2).size2(respPayload.length()).block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
 		if (client.get("T") == CON)
 			client.sendEmpty(ACK).loadMID("A").go();
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
@@ -20,6 +20,8 @@
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
+import static org.hamcrest.CoreMatchers.*;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
@@ -307,7 +309,37 @@ public class LockstepEndpoint {
 			});
 			return this;
 		}
-		
+
+		public MessageExpectation size1(final int expectedSize) {
+			expectations.add(new Expectation<Message>() {
+				@Override
+				public void check(final Message message) {
+					Assert.assertThat("Wrong size1", message.getOptions().getSize1(), is(expectedSize)); 
+				}
+
+				@Override
+				public String toString() {
+					return "Expected Size1 option: " + expectedSize;
+				}
+			});
+			return this;
+		}
+
+		public MessageExpectation size2(final int expectedSize) {
+			expectations.add(new Expectation<Message>() {
+				@Override
+				public void check(final Message message) {
+					Assert.assertThat("Wrong size2", message.getOptions().getSize2(), is(expectedSize)); 
+				}
+
+				@Override
+				public String toString() {
+					return "Expected Size2 option: " + expectedSize;
+				}
+			});
+			return this;
+		}
+
 		public MessageExpectation observe(final int observe) {
 			expectations.add(new Expectation<Message>() {
 				public void check(Message message) {
@@ -823,6 +855,26 @@ public class LockstepEndpoint {
 			return this;
 		}
 		
+		public MessageProperty size1(final int size) {
+			properties.add(new Property<Message>() {
+				@Override
+				public void set(final Message message) {
+					message.getOptions().setSize1(size);
+				}
+			});
+			return this;
+		}
+
+		public MessageProperty size2(final int size) {
+			properties.add(new Property<Message>() {
+				@Override
+				public void set(final Message message) {
+					message.getOptions().setSize2(size);
+				}
+			});
+			return this;
+		}
+
 		public MessageProperty observe(final int observe) {
 			properties.add(new Property<Message>() {
 				public void set(Message message) {
@@ -896,6 +948,16 @@ public class LockstepEndpoint {
 			super.block2(num, m, size); return this;
 		}
 		
+		@Override
+		public RequestProperty size1(int size) {
+			super.size1(size); return this;
+		}
+		
+		@Override
+		public RequestProperty size2(int size) {
+			super.size2(size); return this;
+		}
+		
 		@Override public RequestProperty observe(final int observe) {
 			super.observe(observe); return this;
 		}
@@ -967,6 +1029,16 @@ public class LockstepEndpoint {
 
 		@Override public ResponseProperty block2(final int num, final boolean m, final int size) {
 			super.block2(num, m, size); return this;
+		}
+		
+		@Override
+		public ResponseProperty size1(int size) {
+			super.size1(size); return this;
+		}
+		
+		@Override
+		public ResponseProperty size2(int size) {
+			super.size2(size); return this;
 		}
 		
 		@Override public ResponseProperty observe(final int observe) {

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/Catcher.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/Catcher.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Amazon Web Services.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.html.
+ * <p>
+ * Contributors:
+ * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
 import org.eclipse.californium.elements.RawData;
@@ -7,28 +22,29 @@ import java.util.ArrayList;
 import java.util.List;
 
 class Catcher implements RawDataChannel {
-    private final List<RawData> messages = new ArrayList<>();
-    private final Object lock = new Object();
 
-    @Override
-    public void receiveData(RawData raw) {
-        synchronized (lock) {
-            messages.add(raw);
-            lock.notifyAll();
-        }
-    }
+	private final List<RawData> messages = new ArrayList<>();
+	private final Object lock = new Object();
 
-    void blockUntilSize(int expectedSize) throws InterruptedException {
-        synchronized (lock) {
-            while (messages.size() < expectedSize) {
-                lock.wait();
-            }
-        }
-    }
+	@Override
+	public void receiveData(RawData raw) {
+		synchronized (lock) {
+			messages.add(raw);
+			lock.notifyAll();
+		}
+	}
 
-    RawData getMessage(int index) {
-        synchronized (lock) {
-            return messages.get(index);
-        }
-    }
+	void blockUntilSize(int expectedSize) throws InterruptedException {
+		synchronized (lock) {
+			while (messages.size() < expectedSize) {
+				lock.wait();
+			}
+		}
+	}
+
+	RawData getMessage(int index) {
+		synchronized (lock) {
+			return messages.get(index);
+		}
+	}
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TcpConnectorTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TcpConnectorTest.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Amazon Web Services.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.html.
+ * <p>
+ * Contributors:
+ * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
 import org.eclipse.californium.elements.Connector;
@@ -26,147 +41,151 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class TcpConnectorTest {
 
-    private static final int NUMBER_OF_THREADS = 1;
-    private static final int IDLE_TIMEOUT = 100;
+	private static final int NUMBER_OF_THREADS = 1;
+	private static final int IDLE_TIMEOUT = 100;
 
-    @Rule public final Timeout timeout = new Timeout(20, TimeUnit.SECONDS);
+	@Rule
+	public final Timeout timeout = new Timeout(20, TimeUnit.SECONDS);
 
-    private final int messageSize;
-    private final Random random = new Random();
-    private final List<Connector> cleanup = new ArrayList<>();
+	private final int messageSize;
+	private final Random random = new Random();
+	private final List<Connector> cleanup = new ArrayList<>();
 
-    @Parameterized.Parameters
-    public static List<Object[]> parameters() {
-        // Trying different messages size to hit sharp corners in Coap-over-TCP spec
-        List<Object[]> parameters = new ArrayList<>();
-        parameters.add(new Object[]{0});
-        parameters.add(new Object[]{7});
-        parameters.add(new Object[]{13});
-        parameters.add(new Object[]{35});
-        parameters.add(new Object[]{269});
-        parameters.add(new Object[]{313});
-        parameters.add(new Object[]{65805});
-        parameters.add(new Object[]{389805});
+	@Parameterized.Parameters
+	public static List<Object[]> parameters() {
+		// Trying different messages size to hit sharp corners in Coap-over-TCP
+		// spec
+		List<Object[]> parameters = new ArrayList<>();
+		parameters.add(new Object[] { 0 });
+		parameters.add(new Object[] { 7 });
+		parameters.add(new Object[] { 13 });
+		parameters.add(new Object[] { 35 });
+		parameters.add(new Object[] { 269 });
+		parameters.add(new Object[] { 313 });
+		parameters.add(new Object[] { 65805 });
+		parameters.add(new Object[] { 389805 });
 
-        return parameters;
-    }
+		return parameters;
+	}
 
-    public TcpConnectorTest(int messageSize) {
-        this.messageSize = messageSize;
-    }
+	public TcpConnectorTest(int messageSize) {
+		this.messageSize = messageSize;
+	}
 
-    @After
-    public void cleanup() {
-        for (Connector connector : cleanup) {
-            connector.stop();
-        }
-    }
+	@After
+	public void cleanup() {
+		for (Connector connector : cleanup) {
+			connector.stop();
+		}
+	}
 
-    @Test
-    public void serverClientPingPong() throws Exception {
-        int port = findEphemeralPort();
-        TcpServerConnector server = new TcpServerConnector(new InetSocketAddress(port), NUMBER_OF_THREADS, IDLE_TIMEOUT);
-        TcpClientConnector client = new TcpClientConnector(NUMBER_OF_THREADS, 100, IDLE_TIMEOUT);
+	@Test
+	public void serverClientPingPong() throws Exception {
+		int port = findEphemeralPort();
+		TcpServerConnector server = new TcpServerConnector(new InetSocketAddress(port), NUMBER_OF_THREADS,
+				IDLE_TIMEOUT);
+		TcpClientConnector client = new TcpClientConnector(NUMBER_OF_THREADS, 100, IDLE_TIMEOUT);
 
-        cleanup.add(server);
-        cleanup.add(client);
+		cleanup.add(server);
+		cleanup.add(client);
 
-        Catcher serverCatcher = new Catcher();
-        Catcher clientCatcher = new Catcher();
-        server.setRawDataReceiver(serverCatcher);
-        client.setRawDataReceiver(clientCatcher);
-        server.start();
-        client.start();
+		Catcher serverCatcher = new Catcher();
+		Catcher clientCatcher = new Catcher();
+		server.setRawDataReceiver(serverCatcher);
+		client.setRawDataReceiver(clientCatcher);
+		server.start();
+		client.start();
 
-        RawData msg = createMessage(new InetSocketAddress(port));
+		RawData msg = createMessage(new InetSocketAddress(port));
 
-        client.send(msg);
-        serverCatcher.blockUntilSize(1);
-        assertArrayEquals(msg.getBytes(), serverCatcher.getMessage(0).getBytes());
+		client.send(msg);
+		serverCatcher.blockUntilSize(1);
+		assertArrayEquals(msg.getBytes(), serverCatcher.getMessage(0).getBytes());
 
-        // Response message must go over the same connection client already opened
-        msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress());
-        server.send(msg);
-        clientCatcher.blockUntilSize(1);
-        assertArrayEquals(msg.getBytes(), clientCatcher.getMessage(0).getBytes());
-    }
+		// Response message must go over the same connection client already
+		// opened
+		msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress());
+		server.send(msg);
+		clientCatcher.blockUntilSize(1);
+		assertArrayEquals(msg.getBytes(), clientCatcher.getMessage(0).getBytes());
+	}
 
-    @Test
-    public void singleServerManyClients() throws Exception {
-        int port = findEphemeralPort();
-        int clients = 100;
-        TcpServerConnector server = new TcpServerConnector(new InetSocketAddress(port), NUMBER_OF_THREADS, IDLE_TIMEOUT);
-        cleanup.add(server);
+	@Test
+	public void singleServerManyClients() throws Exception {
+		int port = findEphemeralPort();
+		int clients = 100;
+		TcpServerConnector server = new TcpServerConnector(new InetSocketAddress(port), NUMBER_OF_THREADS, IDLE_TIMEOUT);
+		cleanup.add(server);
 
-        Catcher serverCatcher = new Catcher();
-        server.setRawDataReceiver(serverCatcher);
-        server.start();
+		Catcher serverCatcher = new Catcher();
+		server.setRawDataReceiver(serverCatcher);
+		server.start();
 
-        List<RawData> messages = new ArrayList<>();
-        for (int i = 0; i < clients; i++) {
-            TcpClientConnector client = new TcpClientConnector(NUMBER_OF_THREADS, 100, IDLE_TIMEOUT);
-            cleanup.add(client);
-            Catcher clientCatcher = new Catcher();
-            client.setRawDataReceiver(clientCatcher);
-            client.start();
+		List<RawData> messages = new ArrayList<>();
+		for (int i = 0; i < clients; i++) {
+			TcpClientConnector client = new TcpClientConnector(NUMBER_OF_THREADS, 100, IDLE_TIMEOUT);
+			cleanup.add(client);
+			Catcher clientCatcher = new Catcher();
+			client.setRawDataReceiver(clientCatcher);
+			client.start();
 
-            RawData msg = createMessage(new InetSocketAddress(port));
-            messages.add(msg);
-            client.send(msg);
-        }
+			RawData msg = createMessage(new InetSocketAddress(port));
+			messages.add(msg);
+			client.send(msg);
+		}
 
-        serverCatcher.blockUntilSize(clients);
-        for (int i = 0; i < clients; i++) {
-            RawData received = serverCatcher.getMessage(i);
+		serverCatcher.blockUntilSize(clients);
+		for (int i = 0; i < clients; i++) {
+			RawData received = serverCatcher.getMessage(i);
 
-            // Make sure that we intended to send that message
-            boolean matched = false;
-            for (RawData sent : messages) {
-                if (Arrays.equals(sent.getBytes(), received.getBytes())) {
-                    matched = true;
-                    break;
-                }
-            }
-            assertTrue("Received unexpected message: " + received, matched);
-        }
-    }
+			// Make sure that we intended to send that message
+			boolean matched = false;
+			for (RawData sent : messages) {
+				if (Arrays.equals(sent.getBytes(), received.getBytes())) {
+					matched = true;
+					break;
+				}
+			}
+			assertTrue("Received unexpected message: " + received, matched);
+		}
+	}
 
-    private static int findEphemeralPort() {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
-        } catch (IOException e) {
-            throw new IllegalStateException("Unable to bind to ephemeral port");
-        }
-    }
+	private static int findEphemeralPort() {
+		try (ServerSocket socket = new ServerSocket(0)) {
+			return socket.getLocalPort();
+		} catch (IOException e) {
+			throw new IllegalStateException("Unable to bind to ephemeral port");
+		}
+	}
 
-    private RawData createMessage(InetSocketAddress address) throws Exception {
-        byte[] data = new byte[messageSize];
-        random.nextBytes(data);
+	private RawData createMessage(InetSocketAddress address) throws Exception {
+		byte[] data = new byte[messageSize];
+		random.nextBytes(data);
 
-        try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
-            if (messageSize < 13) {
-                stream.write(messageSize << 4);
-            } else if (messageSize < (1 << 8) + 13) {
-                stream.write(13 << 4);
-                stream.write(messageSize - 13);
-            } else if (messageSize < (1 << 16) + 269) {
-                stream.write(14 << 4);
+		try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
+			if (messageSize < 13) {
+				stream.write(messageSize << 4);
+			} else if (messageSize < (1 << 8) + 13) {
+				stream.write(13 << 4);
+				stream.write(messageSize - 13);
+			} else if (messageSize < (1 << 16) + 269) {
+				stream.write(14 << 4);
 
-                ByteBuffer buffer = ByteBuffer.allocate(2);
-                buffer.putShort((short) (messageSize - 269));
-                stream.write(buffer.array());
-            } else {
-                stream.write(15 << 4);
+				ByteBuffer buffer = ByteBuffer.allocate(2);
+				buffer.putShort((short) (messageSize - 269));
+				stream.write(buffer.array());
+			} else {
+				stream.write(15 << 4);
 
-                ByteBuffer buffer = ByteBuffer.allocate(4);
-                buffer.putInt(messageSize - 65805);
-                stream.write(buffer.array());
-            }
+				ByteBuffer buffer = ByteBuffer.allocate(4);
+				buffer.putInt(messageSize - 65805);
+				stream.write(buffer.array());
+			}
 
-            stream.write(1); // GET
-            stream.write(data);
-            stream.flush();
-            return new RawData(stream.toByteArray(), address);
-        }
-    }
+			stream.write(1); // GET
+			stream.write(data);
+			stream.flush();
+			return new RawData(stream.toByteArray(), address);
+		}
+	}
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TlsConnectorTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TlsConnectorTest.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Amazon Web Services.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.html.
+ * <p>
+ * Contributors:
+ * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
 
@@ -36,203 +51,207 @@ import org.junit.rules.Timeout;
 
 public class TlsConnectorTest {
 
-    private static final int NUMBER_OF_THREADS = 1;
-    private static final int IDLE_TIMEOUT = 100;
-    private static SSLContext serverContext;
-    private static SSLContext clientContext;
-    private final Random random = new Random(0);
+	private static final int NUMBER_OF_THREADS = 1;
+	private static final int IDLE_TIMEOUT = 100;
+	private static SSLContext serverContext;
+	private static SSLContext clientContext;
+	private final Random random = new Random(0);
 
-    @Rule
-    public final Timeout timeout = new Timeout(10, TimeUnit.SECONDS);
-    private final List<Connector> cleanup = new ArrayList<>();
+	@Rule
+	public final Timeout timeout = new Timeout(10, TimeUnit.SECONDS);
+	private final List<Connector> cleanup = new ArrayList<>();
 
-    @BeforeClass
-    public static void initializeSsl() throws Exception {
-        String algorithm = Security.getProperty("ssl.KeyManagerFactory.algorithm");
+	@BeforeClass
+	public static void initializeSsl() throws Exception {
+		String algorithm = Security.getProperty("ssl.KeyManagerFactory.algorithm");
 
-        KeyStore ks = KeyStore.getInstance("JKS");
-        ks.load(TlsConnectorTest.class.getResourceAsStream("/cert.jks"), "secret".toCharArray());
+		KeyStore ks = KeyStore.getInstance("JKS");
+		ks.load(TlsConnectorTest.class.getResourceAsStream("/cert.jks"), "secret".toCharArray());
 
-        // Set up key manager factory to use our key store
-        KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
-        kmf.init(ks, "secret".toCharArray());
+		// Set up key manager factory to use our key store
+		KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
+		kmf.init(ks, "secret".toCharArray());
 
-        // Initialize the SSLContext to work with our key managers.
-        serverContext = SSLContext.getInstance("TLS");
-        serverContext.init(kmf.getKeyManagers(), null, null);
+		// Initialize the SSLContext to work with our key managers.
+		serverContext = SSLContext.getInstance("TLS");
+		serverContext.init(kmf.getKeyManagers(), null, null);
 
-        clientContext = SSLContext.getInstance("TLS");
-        clientContext.init(null, new TrustManager[]{new TrustEveryoneTrustManager()}, null);
-    }
+		clientContext = SSLContext.getInstance("TLS");
+		clientContext.init(null, new TrustManager[] { new TrustEveryoneTrustManager() }, null);
+	}
 
+	@After
+	public void cleanup() {
+		for (Connector connector : cleanup) {
+			connector.stop();
+		}
+	}
 
-    @After
-    public void cleanup() {
-        for (Connector connector : cleanup) {
-            connector.stop();
-        }
-    }
+	@Test
+	public void pingPongMessage() throws Exception {
+		int port = findEphemeralPort();
+		TlsServerConnector server = new TlsServerConnector(serverContext, new InetSocketAddress(port),
+				NUMBER_OF_THREADS, IDLE_TIMEOUT);
+		TlsClientConnector client = new TlsClientConnector(clientContext, NUMBER_OF_THREADS, 100, 10);
 
-    @Test
-    public void pingPongMessage() throws Exception {
-        int port = findEphemeralPort();
-        TlsServerConnector server = new TlsServerConnector(serverContext, new InetSocketAddress(port), NUMBER_OF_THREADS, IDLE_TIMEOUT);
-        TlsClientConnector client = new TlsClientConnector(clientContext, NUMBER_OF_THREADS, 100, 10);
+		Catcher serverCatcher = new Catcher();
+		Catcher clientCatcher = new Catcher();
+		server.setRawDataReceiver(serverCatcher);
+		client.setRawDataReceiver(clientCatcher);
+		cleanup.add(server);
+		cleanup.add(client);
+		server.start();
+		client.start();
 
-        Catcher serverCatcher = new Catcher();
-        Catcher clientCatcher = new Catcher();
-        server.setRawDataReceiver(serverCatcher);
-        client.setRawDataReceiver(clientCatcher);
-        cleanup.add(server);
-        cleanup.add(client);
-        server.start();
-        client.start();
+		RawData msg = createMessage(new InetSocketAddress(port), 100);
 
-        RawData msg = createMessage(new InetSocketAddress(port), 100);
+		client.send(msg);
+		serverCatcher.blockUntilSize(1);
+		assertArrayEquals(msg.getBytes(), serverCatcher.getMessage(0).getBytes());
 
-        client.send(msg);
-        serverCatcher.blockUntilSize(1);
-        assertArrayEquals(msg.getBytes(), serverCatcher.getMessage(0).getBytes());
+		// Response message must go over the same connection client already
+		// opened
+		msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress(), 10000);
+		server.send(msg);
+		clientCatcher.blockUntilSize(1);
+		assertArrayEquals(msg.getBytes(), clientCatcher.getMessage(0).getBytes());
+	}
 
-        // Response message must go over the same connection client already opened
-        msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress(), 10000);
-        server.send(msg);
-        clientCatcher.blockUntilSize(1);
-        assertArrayEquals(msg.getBytes(), clientCatcher.getMessage(0).getBytes());
-    }
+	@Test
+	public void singleServerManyClients() throws Exception {
+		int port = findEphemeralPort();
+		int clients = 100;
+		TlsServerConnector server = new TlsServerConnector(serverContext, new InetSocketAddress(port),
+				NUMBER_OF_THREADS, IDLE_TIMEOUT);
+		cleanup.add(server);
 
-    @Test
-    public void singleServerManyClients() throws Exception {
-        int port = findEphemeralPort();
-        int clients = 100;
-        TlsServerConnector server = new TlsServerConnector(serverContext, new InetSocketAddress(port), NUMBER_OF_THREADS, IDLE_TIMEOUT);
-        cleanup.add(server);
+		Catcher serverCatcher = new Catcher();
+		server.setRawDataReceiver(serverCatcher);
+		server.start();
 
-        Catcher serverCatcher = new Catcher();
-        server.setRawDataReceiver(serverCatcher);
-        server.start();
+		List<RawData> messages = new ArrayList<>();
+		for (int i = 0; i < clients; i++) {
+			TlsClientConnector client = new TlsClientConnector(clientContext, NUMBER_OF_THREADS, 100, IDLE_TIMEOUT);
+			cleanup.add(client);
+			Catcher clientCatcher = new Catcher();
+			client.setRawDataReceiver(clientCatcher);
+			client.start();
 
-        List<RawData> messages = new ArrayList<>();
-        for (int i = 0; i < clients; i++) {
-            TlsClientConnector client = new TlsClientConnector(clientContext, NUMBER_OF_THREADS, 100, IDLE_TIMEOUT);
-            cleanup.add(client);
-            Catcher clientCatcher = new Catcher();
-            client.setRawDataReceiver(clientCatcher);
-            client.start();
+			RawData msg = createMessage(new InetSocketAddress(port), 100);
+			messages.add(msg);
+			client.send(msg);
+		}
 
-            RawData msg = createMessage(new InetSocketAddress(port), 100);
-            messages.add(msg);
-            client.send(msg);
-        }
+		serverCatcher.blockUntilSize(clients);
+		for (int i = 0; i < clients; i++) {
+			RawData received = serverCatcher.getMessage(i);
 
-        serverCatcher.blockUntilSize(clients);
-        for (int i = 0; i < clients; i++) {
-            RawData received = serverCatcher.getMessage(i);
+			// Make sure that we intended to send that message
+			boolean matched = false;
+			for (RawData sent : messages) {
+				if (Arrays.equals(sent.getBytes(), received.getBytes())) {
+					matched = true;
+					break;
+				}
+			}
+			assertTrue("Received unexpected message: " + received, matched);
+		}
+	}
 
-            // Make sure that we intended to send that message
-            boolean matched = false;
-            for (RawData sent : messages) {
-                if (Arrays.equals(sent.getBytes(), received.getBytes())) {
-                    matched = true;
-                    break;
-                }
-            }
-            assertTrue("Received unexpected message: " + received, matched);
-        }
-    }
+	@Test
+	public void singleClientManyServers() throws Exception {
+		int serverCount = 3;
+		Map<InetSocketAddress, Catcher> servers = new IdentityHashMap<>();
+		for (int i = 0; i < serverCount; i++) {
+			int port = findEphemeralPort();
+			TlsServerConnector server = new TlsServerConnector(serverContext, new InetSocketAddress(port),
+					NUMBER_OF_THREADS, IDLE_TIMEOUT);
+			cleanup.add(server);
+			Catcher serverCatcher = new Catcher();
+			server.setRawDataReceiver(serverCatcher);
+			server.start();
 
-    @Test
-    public void singleClientManyServers() throws Exception {
-        int serverCount = 3;
-        Map<InetSocketAddress, Catcher> servers = new IdentityHashMap<>();
-        for (int i = 0; i < serverCount; i++) {
-            int port = findEphemeralPort();
-            TlsServerConnector server = new TlsServerConnector(serverContext, new InetSocketAddress(port), NUMBER_OF_THREADS, IDLE_TIMEOUT);
-            cleanup.add(server);
-            Catcher serverCatcher = new Catcher();
-            server.setRawDataReceiver(serverCatcher);
-            server.start();
+			servers.put(server.getAddress(), serverCatcher);
+		}
 
-            servers.put(server.getAddress(), serverCatcher);
-        }
+		TlsClientConnector client = new TlsClientConnector(clientContext, NUMBER_OF_THREADS, 100, IDLE_TIMEOUT);
+		cleanup.add(client);
+		Catcher clientCatcher = new Catcher();
+		client.setRawDataReceiver(clientCatcher);
+		client.start();
 
-        TlsClientConnector client = new TlsClientConnector(clientContext, NUMBER_OF_THREADS, 100, IDLE_TIMEOUT);
-        cleanup.add(client);
-        Catcher clientCatcher = new Catcher();
-        client.setRawDataReceiver(clientCatcher);
-        client.start();
+		List<RawData> messages = new ArrayList<>();
+		for (InetSocketAddress address : servers.keySet()) {
+			RawData message = createMessage(address, 100);
+			messages.add(message);
+			client.send(message);
+		}
 
-        List<RawData> messages = new ArrayList<>();
-        for (InetSocketAddress address : servers.keySet()) {
-            RawData message = createMessage(address, 100);
-            messages.add(message);
-            client.send(message);
-        }
+		for (RawData message : messages) {
+			Catcher catcher = servers.get(message.getInetSocketAddress());
+			catcher.blockUntilSize(1);
+			assertArrayEquals(message.getBytes(), catcher.getMessage(0).getBytes());
+		}
+	}
 
-        for (RawData message : messages) {
-            Catcher catcher = servers.get(message.getInetSocketAddress());
-            catcher.blockUntilSize(1);
-            assertArrayEquals(message.getBytes(), catcher.getMessage(0).getBytes());
-        }
-    }
+	private int findEphemeralPort() {
+		try (ServerSocket socket = new ServerSocket(0)) {
+			return socket.getLocalPort();
+		} catch (IOException e) {
+			throw new IllegalStateException("Unable to bind to ephemeral port");
+		}
+	}
 
-    private int findEphemeralPort() {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
-        } catch (IOException e) {
-            throw new IllegalStateException("Unable to bind to ephemeral port");
-        }
-    }
+	private RawData createMessage(InetSocketAddress address, int messageSize) throws Exception {
+		byte[] data = new byte[messageSize];
+		random.nextBytes(data);
 
-    private RawData createMessage(InetSocketAddress address, int messageSize) throws Exception {
-        byte[] data = new byte[messageSize];
-        random.nextBytes(data);
+		try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
+			if (messageSize < 13) {
+				stream.write(messageSize << 4);
+			} else if (messageSize < (1 << 8) + 13) {
+				stream.write(13 << 4);
+				stream.write(messageSize - 13);
+			} else if (messageSize < (1 << 16) + 269) {
+				stream.write(14 << 4);
 
-        try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
-            if (messageSize < 13) {
-                stream.write(messageSize << 4);
-            } else if (messageSize < (1 << 8) + 13) {
-                stream.write(13 << 4);
-                stream.write(messageSize - 13);
-            } else if (messageSize < (1 << 16) + 269) {
-                stream.write(14 << 4);
+				ByteBuffer buffer = ByteBuffer.allocate(2);
+				buffer.putShort((short) (messageSize - 269));
+				stream.write(buffer.array());
+			} else {
+				stream.write(15 << 4);
 
-                ByteBuffer buffer = ByteBuffer.allocate(2);
-                buffer.putShort((short) (messageSize - 269));
-                stream.write(buffer.array());
-            } else {
-                stream.write(15 << 4);
+				ByteBuffer buffer = ByteBuffer.allocate(4);
+				buffer.putInt(messageSize - 65805);
+				stream.write(buffer.array());
+			}
 
-                ByteBuffer buffer = ByteBuffer.allocate(4);
-                buffer.putInt(messageSize - 65805);
-                stream.write(buffer.array());
-            }
+			stream.write(1); // GET
+			stream.write(data);
+			stream.flush();
+			return new RawData(stream.toByteArray(), address);
+		}
+	}
 
-            stream.write(1); // GET
-            stream.write(data);
-            stream.flush();
-            return new RawData(stream.toByteArray(), address);
-        }
-    }
+	private static class TrustEveryoneTrustManager implements X509TrustManager {
 
-    private static class TrustEveryoneTrustManager implements X509TrustManager {
-        @Override
-        public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
-        }
+		@Override
+		public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+		}
 
-        @Override
-        public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
-            for (X509Certificate cert : x509Certificates) {
-                cert.checkValidity();
-                if (!cert.getSubjectDN().getName().equals("CN=californium")) {
-                    throw new CertificateException("Unexpected domain name: " + cert.getSubjectDN());
-                }
-            }
-        }
+		@Override
+		public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+			for (X509Certificate cert : x509Certificates) {
+				cert.checkValidity();
+				if (!cert.getSubjectDN().getName().equals("CN=californium")) {
+					throw new CertificateException("Unexpected domain name: " + cert.getSubjectDN());
+				}
+			}
+		}
 
-        @Override
-        public X509Certificate[] getAcceptedIssuers() {
-            return new X509Certificate[0];
-        }
-    }
+		@Override
+		public X509Certificate[] getAcceptedIssuers() {
+			return new X509Certificate[0];
+		}
+	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerNameExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerNameExtension.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
- * 
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
- * 
+ *
  * The Eclipse Public License is available at
  *    http://www.eclipse.org/legal/epl-v10.html
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
- * 
+ *
  * Contributors:
  *    Bosch Software Innovations - initial creation
  ******************************************************************************/
@@ -34,6 +34,8 @@ import org.eclipse.californium.scandium.util.ServerNames;
  */
 public final class ServerNameExtension extends HelloExtension {
 
+    private static final int LIST_LENGTH_BITS = 16;
+
 	private ServerNames serverNames;
 
 	private ServerNameExtension() {
@@ -45,7 +47,7 @@ public final class ServerNameExtension extends HelloExtension {
 	 * <p>
 	 * This constructor should be used by a client who wants to include the <em>Server Name Indication</em>
 	 * extension in its <em>CLIENT_HELLO</em> handshake message.
-	 * 
+	 *
 	 * @param serverNames The server names.
 	 * @throws NullPointerException if the server name list is {@code null}.
 	 */
@@ -62,7 +64,7 @@ public final class ServerNameExtension extends HelloExtension {
 	 * <p>
 	 * This method should be used by a server that wants to include an empty <em>Server Name Indication</em>
 	 * extension in its <em>SERVER_HELLO</em> handshake message.
-	 * 
+	 *
 	 * @return The new instance.
 	 */
 	public static ServerNameExtension emptyServerNameIndication() {
@@ -74,7 +76,7 @@ public final class ServerNameExtension extends HelloExtension {
 	 * <p>
 	 * This method should be used by a client that wants to include the <em>Server Name Indication</em>
 	 * extension in its <em>CLIENT_HELLO</em> handshake message.
-	 * 
+	 *
 	 * @param hostName The host name of the server. NB: The host name MUST only contain ASCII characters,
 	 *                 non-ASCII characters will be replaced by {@code StandardCharsets.US_ASCII}'s default
 	 *                 replacement byte.
@@ -90,7 +92,7 @@ public final class ServerNameExtension extends HelloExtension {
 	 * <p>
 	 * This constructor should be used by a client who wants to include the <em>Server Name Indication</em>
 	 * extension in its <em>CLIENT_HELLO</em> handshake message.
-	 * 
+	 *
 	 * @param serverNames The server names.
 	 * @return The new instance.
 	 * @throws NullPointerException if the server name list is {@code null}.
@@ -117,7 +119,7 @@ public final class ServerNameExtension extends HelloExtension {
 
 	/**
 	 * Creates a new instance from its byte representation.
-	 * 
+	 *
 	 * @param extensionData The byte representation.
 	 * @param peerAddress The IP address and port that the extension has been received from.
 	 * @return The instance.
@@ -138,13 +140,16 @@ public final class ServerNameExtension extends HelloExtension {
 			final InetSocketAddress peerAddress) throws HandshakeException {
 
 		ServerNames serverNames = ServerNames.newInstance();
-		while (reader.bytesAvailable()) {
+        int listLengthBytes = reader.read(LIST_LENGTH_BITS);
+        while (listLengthBytes > 0) {
 			if (reader.bitsLeft() >= 8) {
 				NameType nameType = NameType.fromCode(reader.readNextByte());
 				switch (nameType) {
 				case HOST_NAME:
-					serverNames.add(ServerName.from(nameType, readHostName(reader, peerAddress)));
-					break;
+                    byte[] hostname = readHostName(reader, peerAddress);
+                    serverNames.add(ServerName.from(nameType, hostname));
+                    listLengthBytes -= (hostname.length + 3);
+                    break;
 				default:
 					throw new HandshakeException(
 							"Server Name Indication extension contains unknown name_type",
@@ -177,7 +182,7 @@ public final class ServerNameExtension extends HelloExtension {
 
 	/**
 	 * Gets the server name list conveyed in this extension.
-	 * 
+	 *
 	 * @return The server names.
 	 */
 	public ServerNames getServerNames() {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerNameExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerNameExtension.java
@@ -107,7 +107,8 @@ public final class ServerNameExtension extends HelloExtension {
 		if (serverNames == null) {
 			writer.write(0, LENGTH_BITS);
 		} else {
-			writer.write(serverNames.getEncodedLength(), LENGTH_BITS);
+		    writer.write(serverNames.getEncodedLength() + 2, LENGTH_BITS); //extension_length
+			writer.write(serverNames.getEncodedLength(), LIST_LENGTH_BITS); //server_names_list_length
 
 			for (ServerName serverName : serverNames) {
 				writer.writeByte(serverName.getType().getCode()); // name type
@@ -193,8 +194,9 @@ public final class ServerNameExtension extends HelloExtension {
 	public int getLength() {
 		int length = 2; // 2 bytes indicating extension type
 		length += 2; // overall extension length
-		if (serverNames != null) {
-			length += serverNames.getEncodedLength();
+        if (serverNames != null) {
+            length += 2; // server_name_list_length
+            length += serverNames.getEncodedLength();
 		}
 		return length;
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DtlsTestTools.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DtlsTestTools.java
@@ -140,6 +140,7 @@ public final class DtlsTestTools {
 
 		byte[] name = hostName.getBytes(StandardCharsets.US_ASCII);
 		DatagramWriter writer = new DatagramWriter();
+		writer.write(name.length + 3, 16); //server_name_list_length
 		writer.writeByte((byte) 0x00);
 		writer.write(name.length, 16);
 		writer.writeBytes(name);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerNameExtensionTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerNameExtensionTest.java
@@ -87,7 +87,7 @@ public class ServerNameExtensionTest {
 		// GIVEN a serialized server name extension object
 		ServerNameExtension ext = ServerNameExtension.forHostName("iot.eclipse.org");
 		ByteBuffer b = ByteBuffer.allocate(1024);
-		writeLength(ext.getLength(), b);
+		writeLength(ext.getLength(), b); //extension length
 		b.put(ext.toByteArray());
 		b.flip();
 		serverNameStructure = new byte[b.limit()];
@@ -157,6 +157,7 @@ public class ServerNameExtensionTest {
 
 		ByteBuffer ext = ByteBuffer.allocate(1024);
 		ext.put((byte) 0x00).put((byte) 0x00); // type code 0x0000 = server_name
+		writeLength(nameEntry.limit() + 2, ext); //extension_data length
 		writeLength(nameEntry.limit(), ext); // server name list length
 		ext.put(nameEntry);
 		ext.flip();


### PR DESCRIPTION
Testing with mbedTLS reveals that mbed's client_hello sni extension cannot be decoded. 
This is due to missing server_name_list length field (encoding and decoding) in extension (as required for vectors).
