### PR TITLE
Adding list length field to the Server Name Indication extension (clean&new)

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerNameExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerNameExtension.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
- *
+ * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
- *
+ * 
  * The Eclipse Public License is available at
  *    http://www.eclipse.org/legal/epl-v10.html
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
- *
+ * 
  * Contributors:
  *    Bosch Software Innovations - initial creation
  ******************************************************************************/
@@ -47,7 +47,7 @@ public final class ServerNameExtension extends HelloExtension {
 	 * <p>
 	 * This constructor should be used by a client who wants to include the <em>Server Name Indication</em>
 	 * extension in its <em>CLIENT_HELLO</em> handshake message.
-	 *
+	 * 
 	 * @param serverNames The server names.
 	 * @throws NullPointerException if the server name list is {@code null}.
 	 */
@@ -64,7 +64,7 @@ public final class ServerNameExtension extends HelloExtension {
 	 * <p>
 	 * This method should be used by a server that wants to include an empty <em>Server Name Indication</em>
 	 * extension in its <em>SERVER_HELLO</em> handshake message.
-	 *
+	 * 
 	 * @return The new instance.
 	 */
 	public static ServerNameExtension emptyServerNameIndication() {
@@ -76,7 +76,7 @@ public final class ServerNameExtension extends HelloExtension {
 	 * <p>
 	 * This method should be used by a client that wants to include the <em>Server Name Indication</em>
 	 * extension in its <em>CLIENT_HELLO</em> handshake message.
-	 *
+	 * 
 	 * @param hostName The host name of the server. NB: The host name MUST only contain ASCII characters,
 	 *                 non-ASCII characters will be replaced by {@code StandardCharsets.US_ASCII}'s default
 	 *                 replacement byte.
@@ -92,7 +92,7 @@ public final class ServerNameExtension extends HelloExtension {
 	 * <p>
 	 * This constructor should be used by a client who wants to include the <em>Server Name Indication</em>
 	 * extension in its <em>CLIENT_HELLO</em> handshake message.
-	 *
+	 * 
 	 * @param serverNames The server names.
 	 * @return The new instance.
 	 * @throws NullPointerException if the server name list is {@code null}.
@@ -120,7 +120,7 @@ public final class ServerNameExtension extends HelloExtension {
 
 	/**
 	 * Creates a new instance from its byte representation.
-	 *
+	 * 
 	 * @param extensionData The byte representation.
 	 * @param peerAddress The IP address and port that the extension has been received from.
 	 * @return The instance.
@@ -183,7 +183,7 @@ public final class ServerNameExtension extends HelloExtension {
 
 	/**
 	 * Gets the server name list conveyed in this extension.
-	 *
+	 * 
 	 * @return The server names.
 	 */
 	public ServerNames getServerNames() {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerNameExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerNameExtension.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
- * 
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
- * 
+ *
  * The Eclipse Public License is available at
  *    http://www.eclipse.org/legal/epl-v10.html
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
- * 
+ *
  * Contributors:
  *    Bosch Software Innovations - initial creation
  ******************************************************************************/
@@ -34,6 +34,8 @@ import org.eclipse.californium.scandium.util.ServerNames;
  */
 public final class ServerNameExtension extends HelloExtension {
 
+	private static final int LIST_LENGTH_BITS = 16;
+
 	private ServerNames serverNames;
 
 	private ServerNameExtension() {
@@ -45,7 +47,7 @@ public final class ServerNameExtension extends HelloExtension {
 	 * <p>
 	 * This constructor should be used by a client who wants to include the <em>Server Name Indication</em>
 	 * extension in its <em>CLIENT_HELLO</em> handshake message.
-	 * 
+	 *
 	 * @param serverNames The server names.
 	 * @throws NullPointerException if the server name list is {@code null}.
 	 */
@@ -62,7 +64,7 @@ public final class ServerNameExtension extends HelloExtension {
 	 * <p>
 	 * This method should be used by a server that wants to include an empty <em>Server Name Indication</em>
 	 * extension in its <em>SERVER_HELLO</em> handshake message.
-	 * 
+	 *
 	 * @return The new instance.
 	 */
 	public static ServerNameExtension emptyServerNameIndication() {
@@ -74,7 +76,7 @@ public final class ServerNameExtension extends HelloExtension {
 	 * <p>
 	 * This method should be used by a client that wants to include the <em>Server Name Indication</em>
 	 * extension in its <em>CLIENT_HELLO</em> handshake message.
-	 * 
+	 *
 	 * @param hostName The host name of the server. NB: The host name MUST only contain ASCII characters,
 	 *                 non-ASCII characters will be replaced by {@code StandardCharsets.US_ASCII}'s default
 	 *                 replacement byte.
@@ -90,7 +92,7 @@ public final class ServerNameExtension extends HelloExtension {
 	 * <p>
 	 * This constructor should be used by a client who wants to include the <em>Server Name Indication</em>
 	 * extension in its <em>CLIENT_HELLO</em> handshake message.
-	 * 
+	 *
 	 * @param serverNames The server names.
 	 * @return The new instance.
 	 * @throws NullPointerException if the server name list is {@code null}.
@@ -105,7 +107,8 @@ public final class ServerNameExtension extends HelloExtension {
 		if (serverNames == null) {
 			writer.write(0, LENGTH_BITS);
 		} else {
-			writer.write(serverNames.getEncodedLength(), LENGTH_BITS);
+			writer.write(serverNames.getEncodedLength() + 2, LENGTH_BITS); //extension_length
+			writer.write(serverNames.getEncodedLength(), LIST_LENGTH_BITS); //server_names_list_length
 
 			for (ServerName serverName : serverNames) {
 				writer.writeByte(serverName.getType().getCode()); // name type
@@ -117,7 +120,7 @@ public final class ServerNameExtension extends HelloExtension {
 
 	/**
 	 * Creates a new instance from its byte representation.
-	 * 
+	 *
 	 * @param extensionData The byte representation.
 	 * @param peerAddress The IP address and port that the extension has been received from.
 	 * @return The instance.
@@ -138,12 +141,15 @@ public final class ServerNameExtension extends HelloExtension {
 			final InetSocketAddress peerAddress) throws HandshakeException {
 
 		ServerNames serverNames = ServerNames.newInstance();
-		while (reader.bytesAvailable()) {
+		int listLengthBytes = reader.read(LIST_LENGTH_BITS);
+		while (listLengthBytes > 0) {
 			if (reader.bitsLeft() >= 8) {
 				NameType nameType = NameType.fromCode(reader.readNextByte());
 				switch (nameType) {
 				case HOST_NAME:
-					serverNames.add(ServerName.from(nameType, readHostName(reader, peerAddress)));
+					byte[] hostname = readHostName(reader, peerAddress);
+					serverNames.add(ServerName.from(nameType, hostname));
+					listLengthBytes -= (hostname.length + 3);
 					break;
 				default:
 					throw new HandshakeException(
@@ -177,7 +183,7 @@ public final class ServerNameExtension extends HelloExtension {
 
 	/**
 	 * Gets the server name list conveyed in this extension.
-	 * 
+	 *
 	 * @return The server names.
 	 */
 	public ServerNames getServerNames() {
@@ -189,6 +195,7 @@ public final class ServerNameExtension extends HelloExtension {
 		int length = 2; // 2 bytes indicating extension type
 		length += 2; // overall extension length
 		if (serverNames != null) {
+			length += 2; // server_name_list_length
 			length += serverNames.getEncodedLength();
 		}
 		return length;

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DtlsTestTools.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DtlsTestTools.java
@@ -140,6 +140,7 @@ public final class DtlsTestTools {
 
 		byte[] name = hostName.getBytes(StandardCharsets.US_ASCII);
 		DatagramWriter writer = new DatagramWriter();
+		writer.write(name.length + 3, 16); //server_name_list_length
 		writer.writeByte((byte) 0x00);
 		writer.write(name.length, 16);
 		writer.writeBytes(name);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerNameExtensionTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerNameExtensionTest.java
@@ -87,7 +87,7 @@ public class ServerNameExtensionTest {
 		// GIVEN a serialized server name extension object
 		ServerNameExtension ext = ServerNameExtension.forHostName("iot.eclipse.org");
 		ByteBuffer b = ByteBuffer.allocate(1024);
-		writeLength(ext.getLength(), b);
+		writeLength(ext.getLength(), b); //extension length
 		b.put(ext.toByteArray());
 		b.flip();
 		serverNameStructure = new byte[b.limit()];
@@ -157,6 +157,7 @@ public class ServerNameExtensionTest {
 
 		ByteBuffer ext = ByteBuffer.allocate(1024);
 		ext.put((byte) 0x00).put((byte) 0x00); // type code 0x0000 = server_name
+		writeLength(nameEntry.limit() + 2, ext); //extension_data length
 		writeLength(nameEntry.limit(), ext); // server name list length
 		ext.put(nameEntry);
 		ext.flip();


### PR DESCRIPTION
Testing with mbedTLS reveals that mbed's client_hello sni extension cannot be decoded.
This is due to missing server_name_list length field (encoding and decoding) in extension (as required for vectors).
Please close/reject https://github.com/eclipse/californium/pull/157 as I made a mistake while rebasing...