### PR TITLE
Bugfix for NullPointerException on RST.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -215,7 +215,8 @@ public final class TcpMatcher extends BaseMatcher {
 				Response response = exchange.getCurrentResponse();
 
 				Request request = exchange.getCurrentRequest();
-				if (request != null && (request.getOptions().hasBlock1() || response.getOptions().hasBlock2())) {
+				if ((request != null && request.getOptions().hasBlock1())
+						|| (response != null && response.getOptions().hasBlock2())) {
 					Exchange.KeyUri uriKey = new Exchange.KeyUri(request.getURI(), request.getSource().getAddress(),
 							request.getSourcePort());
 					LOGGER.log(Level.FINE, "Remote ongoing completed, cleaning up ", uriKey);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -460,7 +460,8 @@ public final class UdpMatcher extends BaseMatcher {
 					LOGGER.log(Level.FINER, "Exchange [{0}, {1}] completed", new Object[]{midKey, exchange.getOrigin()});
 				}
 
-				if (request != null && (request.getOptions().hasBlock1() || response.getOptions().hasBlock2())) {
+				if ((request != null && request.getOptions().hasBlock1())
+						|| (response != null && response.getOptions().hasBlock2())) {
 					KeyUri uriKey = new KeyUri(request.getURI(), request.getSource().getAddress(),
 							request.getSourcePort());
 					LOGGER.log(Level.FINE, "Blockwise exchange with remote peer {0} completed, cleaning up ", uriKey);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/SmallServerClientTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/SmallServerClientTest.java
@@ -16,11 +16,14 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add test for RST
  ******************************************************************************/
 package org.eclipse.californium.core.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -40,66 +43,96 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-
 /**
  * This is a small test that tests the exchange of one request and one response.
  */
 @Category(Medium.class)
 public class SmallServerClientTest {
 
-	private static String SERVER_RESPONSE = "server responds hi";
-	
+	private static final String SERVER_RESPONSE = "server responds hi";
+
 	private int serverPort;
-	
+
 	@Before
 	public void initLogger() {
-		System.out.println("\nStart "+getClass().getSimpleName());
+		System.out.println("\nStart " + getClass().getSimpleName());
 		EndpointManager.clear();
 	}
-	
+
 	@After
 	public void after() {
-		System.out.println("End "+getClass().getSimpleName());
+		System.out.println("End " + getClass().getSimpleName());
 	}
-	
+
 	@Test
 	public void testNonconfirmable() throws Exception {
 		createSimpleServer();
-		
+
 		// send request
 		Request request = new Request(CoAP.Code.POST);
 		request.setConfirmable(false);
-		request.setDestination(InetAddress.getByName("localhost")); // InetAddress.getLocalHost() returns different address on Linux
+		// InetAddress.getLocalHost() returns different address on Linux
+		request.setDestination(InetAddress.getByName("localhost")); 
 		request.setDestinationPort(serverPort);
 		request.setPayload("client says hi");
 		request.send();
 		System.out.println("client sent request");
-		
+
 		// receive response and check
 		Response response = request.waitForResponse(1000);
 		assertNotNull("Client received no response", response);
 		System.out.println("client received response");
 		assertEquals(response.getPayloadString(), SERVER_RESPONSE);
 	}
-	
-	
+
+	@Test
+	public void testRst() throws Exception {
+		createSimpleServer();
+
+		// send request
+		Request request = new Request(CoAP.Code.POST);
+		request.setConfirmable(false);
+		// InetAddress.getLocalHost() returns different address on Linux
+		request.setDestination(InetAddress.getByName("localhost"));
+		request.setDestinationPort(serverPort);
+		request.setPayload("client says reset");
+		request.send();
+		System.out.println("client sent request");
+
+		// receive response and check
+		Response response = request.waitForResponse(1000);
+		assertTrue(request.isRejected());
+		assertNull("Client received response", response);
+	}
+
 	private void createSimpleServer() {
 		CoapEndpoint endpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		CoapServer server = new CoapServer();
 		server.addEndpoint(endpoint);
 		server.setMessageDeliverer(new MessageDeliverer() {
+
 			@Override
 			public void deliverRequest(Exchange exchange) {
 				System.out.println("server received request");
-				exchange.sendAccept();
-				try { Thread.sleep(500); } catch (Exception e) {}
-				Response response = new Response(ResponseCode.CONTENT);
-				response.setConfirmable(false);
-				response.setPayload(SERVER_RESPONSE);
-				exchange.sendResponse(response);
+				String message = exchange.getRequest().getPayloadString();
+				if (message.contains("reset")) {
+					exchange.sendReject();
+				} else {
+					exchange.sendAccept();
+					try {
+						Thread.sleep(500);
+					} catch (Exception e) {
+					}
+					Response response = new Response(ResponseCode.CONTENT);
+					response.setConfirmable(false);
+					response.setPayload(SERVER_RESPONSE);
+					exchange.sendResponse(response);
+				}
 			}
+
 			@Override
-			public void deliverResponse(Exchange exchange, Response response) { }
+			public void deliverResponse(Exchange exchange, Response response) {
+			}
 		});
 		server.start();
 		serverPort = endpoint.getAddress().getPort();


### PR DESCRIPTION
Issue #166.
TcpMatcher is changed accordingly, even if RST is not used there.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>