### PR TITLE
[#155] Fix failure to detect overlapping blockwise notification transfers

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
@@ -18,7 +18,6 @@ import java.util.List;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.network.Exchange.KeyMID;
 import org.eclipse.californium.core.network.Exchange.KeyToken;
-import org.eclipse.californium.core.network.Exchange.KeyUri;
 import org.eclipse.californium.elements.CorrelationContext;
 
 /**
@@ -99,16 +98,6 @@ public interface MessageExchangeStore {
 	void registerOutboundResponse(Exchange exchange);
 
 	/**
-	 * Registers an exchange used for doing a blockwise transfer with a given URI.
-	 * 
-	 * @param requestUri the URI to register the exchange for.
-	 * @param exchange the exchange to register.
-	 * @throws NullPointerException if any of the given params is {@code null}.
-	 * @return the exchange previously registered with the given URI or {@code null}.
-	 */
-	Exchange registerBlockwiseExchange(KeyUri requestUri, Exchange exchange);
-
-	/**
 	 * Removes the exchange registered under a given token.
 	 * 
 	 * @param token the token of the exchange to remove.
@@ -125,13 +114,6 @@ public interface MessageExchangeStore {
 	Exchange remove(KeyMID messageId);
 
 	/**
-	 * Removes the exchange used for a blockwise transfer of a resource.
-	 * 
-	 * @param requestUri the URI under which the exchange has been registered.
-	 */
-	void remove(KeyUri requestUri);
-
-	/**
 	 * Gets the exchange registered under a given token.
 	 * 
 	 * @param token the token under which the exchange has been registered.
@@ -146,14 +128,6 @@ public interface MessageExchangeStore {
 	 * @return the exchange or {@code null} if no exchange exists for the given message ID.
 	 */
 	Exchange get(KeyMID messageId);
-
-	/**
-	 * Gets the blockwise transfer exchange registered under a given URI.
-	 * 
-	 * @param requestUri the URI under which the exchange has been registered.
-	 * @return the exchange or {@code null} if no exchange is registered for the given URI.
-	 */
-	Exchange get(KeyUri requestUri);
 
 	/**
 	 * Sets the correlation context on the exchange initiated by a request

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
@@ -38,8 +38,11 @@ public class NetworkConfigDefaults {
 	/**
 	 * The default maximum amount of time (in milliseconds) between transfers of individual
 	 * blocks in a blockwise transfer before the blockwise transfer state is discarded.
+	 * <p>
+	 * The default value of 5 minutes is chosen to be a little more than the default
+	 * EXCHANGE_LIFETIME of 247s.
 	 */
-	public static final int DEFAULT_BLOCKWISE_STATUS_LIFETIME = 30 * 1000; // 30 secs
+	public static final int DEFAULT_BLOCKWISE_STATUS_LIFETIME = 5 * 60 * 1000; // 5 mins
 
 	/*
 	 * Accept other message versions than 1
@@ -76,7 +79,7 @@ public class NetworkConfigDefaults {
 		config.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 512);
 		config.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 1024);
 		config.setInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE, DEFAULT_MAX_RESOURCE_BODY_SIZE);
-		config.setInt(NetworkConfig.Keys.BLOCKWISE_STATUS_LIFETIME, 10 * 60 * 1000); // ms
+		config.setInt(NetworkConfig.Keys.BLOCKWISE_STATUS_LIFETIME, DEFAULT_BLOCKWISE_STATUS_LIFETIME); // ms
 
 		config.setLong(NetworkConfig.Keys.NOTIFICATION_CHECK_INTERVAL_TIME, 24 * 60 * 60 * 1000); // ms
 		config.setInt(NetworkConfig.Keys.NOTIFICATION_CHECK_INTERVAL_COUNT, 100);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network.stack;
+
+import org.eclipse.californium.core.coap.BlockOption;
+import org.eclipse.californium.core.coap.OptionSet;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.Exchange;
+
+
+/**
+ * A tracker for the blockwise transfer of a request body.
+ *
+ */
+final class Block1BlockwiseStatus extends BlockwiseStatus {
+
+	private Request request;
+
+	private Block1BlockwiseStatus(final int bufferSize, final int contentFormat) {
+		super(bufferSize, contentFormat);
+	}
+
+	/**
+	 * Creates a new tracker for sending a request body.
+	 * 
+	 * @param exchange The message exchange the transfer is part of.
+	 * @param request The CoAP request containing the large body in its payload.
+	 * @param preferredBlockSize The size to use for individual blocks.
+	 * @return The tracker.
+	 */
+	static Block1BlockwiseStatus forOutboundRequest(final Exchange exchange, final Request request, final int preferredBlockSize) {
+		Block1BlockwiseStatus status = new Block1BlockwiseStatus(0, request.getOptions().getContentFormat());
+		status.request = request;
+		status.setCurrentSzx(BlockOption.size2Szx(preferredBlockSize));
+		return status;
+	}
+
+	/**
+	 * Creates a new tracker for receiving a request body.
+	 * 
+	 * @param exchange The message exchange the transfer is part of.
+	 * @param block The block of the request body.
+	 * @param maxBodySize The maximum body size that can be buffered.
+	 * @return The tracker.
+	 */
+	static Block1BlockwiseStatus forInboundRequest(final Exchange exchange, final Request block, final int maxBodySize) {
+		int contentFormat = block.getOptions().getContentFormat();
+		int bufferSize = maxBodySize;
+		if (block.getOptions().hasSize1()) {
+			bufferSize = block.getOptions().getSize1();
+		}
+		Block1BlockwiseStatus status = new Block1BlockwiseStatus(bufferSize, contentFormat);
+		status.setFirst(block);
+		return status;
+	}
+
+	/**
+	 * Gets a request or sending the next block of the body.
+	 * <p>
+	 * This method updates the <em>currentNum</em> and <em>currentSzx</em> properties
+	 * with the given block1 option's values and then invokes {@link #getNextRequestBlock()}.
+	 * 
+	 * @param num The block number to update this tracker with before
+	 *               determining the response block.
+	 * @param szx The adapted block size to update this tracker with before
+	 *               determining the response block.
+	 * @return The request.
+	 * @throws IllegalStateException if this tracker does not contain a request body.
+	 */
+	synchronized Request getNextRequestBlock(final int num, final int szx) {
+
+		if (request == null) {
+			throw new IllegalStateException("no request body");
+		}
+
+		setCurrentNum(num);
+		setCurrentSzx(szx);
+		return getNextRequestBlock();
+	}
+
+	/**
+	 * Gets a request or sending the next block of the body.
+	 * <p>
+	 * The returned request's payload is determined based on <em>currentNum</em>,
+	 * <em>currentSzx</em> and the original request's body.
+	 * 
+	 * @return The request.
+	 * @throws IllegalStateException if this tracker does not contain a request body.
+	 */
+	synchronized Request getNextRequestBlock() {
+
+		if (request == null) {
+			throw new IllegalStateException("no request body");
+		}
+
+		int num = getCurrentNum();
+		int szx = getCurrentSzx();
+
+		Request block = new Request(request.getCode());
+		// do not enforce CON, since NON could make sense over SMS or similar transports
+		block.setType(request.getType());
+		block.setDestination(request.getDestination());
+		block.setDestinationPort(request.getDestinationPort());
+		// copy options
+		block.setOptions(new OptionSet(request.getOptions()));
+		// copy message observers so that a failing blockwise request also notifies observers registered with
+		// the original request
+		block.addMessageObservers(request.getMessageObservers());
+		if (num == 0) {
+			// indicate overall body size to peer
+			block.getOptions().setSize1(request.getPayloadSize());
+		}
+
+		int currentSize = getCurrentSize();
+		int from = num * currentSize;
+		int to = Math.min((num + 1) * currentSize, request.getPayloadSize());
+		int length = to - from;
+		byte[] blockPayload = new byte[length];
+		System.arraycopy(request.getPayload(), from, blockPayload, 0, length);
+		block.setPayload(blockPayload);
+
+		boolean m = (to < request.getPayloadSize());
+		block.getOptions().setBlock1(szx, m, num);
+
+		setComplete(!m);
+		return block;
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
@@ -15,9 +15,12 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
+import java.util.Arrays;
+
 import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange;
 
 
@@ -137,5 +140,27 @@ final class Block1BlockwiseStatus extends BlockwiseStatus {
 
 		setComplete(!m);
 		return block;
+	}
+
+	/**
+	 * Cancels the request that started the block1 transfer that this is the tracker for.
+	 * <p>
+	 * This method simply invokes {@link Request#cancel()}.
+	 */
+	void cancelRequest() {
+		if (request != null) {
+			request.cancel();
+		}
+	}
+
+	/**
+	 * Checks whether a response has the same token as the request that initiated
+	 * the block1 transfer that this is the tracker for.
+	 * 
+	 * @param response The response to check.
+	 * @return {@code true} if the tokens match.
+	 */
+	boolean hasMatchingToken(final Response response) {
+		return request != null && Arrays.equals(request.getToken(), response.getToken());
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
@@ -1,0 +1,323 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network.stack;
+
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.californium.core.coap.BlockOption;
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
+import org.eclipse.californium.core.coap.OptionSet;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+
+
+/**
+ * A tracker for the blockwise transfer of a response body.
+ *
+ */
+final class Block2BlockwiseStatus extends BlockwiseStatus {
+
+	private static final Logger LOGGER = Logger.getLogger(Block2BlockwiseStatus.class.getName());
+
+	private Response response;
+	private byte[] etag;
+
+	private Block2BlockwiseStatus(final int bufferSize, final int contentFormat) {
+		super(bufferSize, contentFormat);
+	}
+
+	/**
+	 * Creates a new tracker for sending a response.
+	 * 
+	 * @param exchange The message exchange the transfer is part of.
+	 * @param response The CoAP response to be transferred blockwise.
+	 * @param preferredBlockSize The default size to use for individual blocks. If the exchange's request contains
+	 *                           an <em> early negotation</em> block2 option then the size indicated by that
+	 *                           option is used as the block size.
+	 * @return The tracker.
+	 */
+	static Block2BlockwiseStatus forOutboundResponse(final Exchange exchange, final Response response, final int preferredBlockSize) {
+		Block2BlockwiseStatus status = new Block2BlockwiseStatus(response.getPayloadSize(), response.getOptions().getContentFormat());
+		status.response = response;
+		status.buf.put(response.getPayload());
+		status.buf.flip();
+		if (response.isNotification()) {
+			status.observe = response.getOptions().getObserve();
+		}
+		status.setCurrentSzx(determineResponseBlock2Szx(exchange, preferredBlockSize));
+		return status;
+	}
+
+	/**
+	 * Creates a new tracker for receiving a response.
+	 * 
+	 * @param exchange The message exchange the transfer is part of.
+	 * @param block The block of the response body.
+	 * @param maxBodySize The maximum body size that can be buffered.
+	 * @return The tracker.
+	 */
+	static Block2BlockwiseStatus forInboundResponse(final Exchange exchange, final Response block, final int maxBodySize) {
+		int contentFormat = block.getOptions().getContentFormat();
+		int bufferSize = maxBodySize;
+		if (block.getOptions().hasSize2()) {
+			bufferSize = block.getOptions().getSize2();
+		}
+		Block2BlockwiseStatus status = new Block2BlockwiseStatus(bufferSize, contentFormat);
+		status.setFirst(block);
+		Integer observeCount = block.getOptions().getObserve();
+		if (observeCount != null && OptionSet.isValidObserveOption(observeCount)) {
+			// mark this tracker with the observe no of the block it has been created for
+			status.observe = observeCount;
+			exchange.setNotificationNumber(observeCount);
+		}
+		if (block.getOptions().getETagCount() > 0) {
+			// keep track of ETag included in response
+			status.etag = block.getOptions().getETags().get(0);
+		}
+		return status;
+	}
+
+	/**
+	 * Creates a new tracker for retrieving an arbitrary block of a resource.
+	 * 
+	 * @param exchange The message exchange the transfer is part of.
+	 * @param request The request for retrieving the block.
+	 * @param block2 The options for retrieving the block.
+	 * @return The tracker.
+	 * @throws IllegalArgumentException if the request does not contain a block2 option.
+	 */
+	static Block2BlockwiseStatus forRandomAccessRequest(final Exchange exchange, final Request request) {
+
+		BlockOption block2 = request.getOptions().getBlock2();
+		if (block2 == null) {
+			throw new IllegalArgumentException("request must contain block2 option");
+		}
+		int contentFormat = request.getOptions().getContentFormat();
+		Block2BlockwiseStatus status = new Block2BlockwiseStatus(0, contentFormat);
+		status.randomAccess = true;
+		status.setCurrentNum(block2.getNum());
+		status.setCurrentSzx(block2.getSzx());
+		return status;
+	}
+
+	private static int determineResponseBlock2Szx(final Exchange exchange, final int preferredBlockSize) {
+		if (exchange.getRequest() != null) {
+			BlockOption block2 = exchange.getRequest().getOptions().getBlock2();
+			if (block2 != null) {
+				LOGGER.log(Level.FINE, "using block2 szx from early negotiation in request: {0}", block2.getSize());
+				return block2.getSzx();
+			}
+		}
+		LOGGER.log(Level.FINE, "using default preferred block size for response: {0}", preferredBlockSize);
+		return BlockOption.size2Szx(preferredBlockSize);
+	}
+
+	/**
+	 * Checks if a given response is a notification that interferes with this
+	 * blockwise transfer.
+	 * 
+	 * @param responseBlock The response block to check.
+	 * @return {@code true} if the response is a new notification and this transfer's
+	 *         current block number is &gt; 0.
+	 * @throws NullPointerException if the response block is {@code null}.
+	 * @throws IllegalArgumentException if the response block has no block2 option.
+	 */
+	synchronized boolean isInterferingNotification(final Response responseBlock) {
+		if (responseBlock == null) {
+			throw new NullPointerException("response block must not be null");
+		} else {
+			BlockOption block2 = responseBlock.getOptions().getBlock2();
+			if (block2 == null) {
+				throw new IllegalArgumentException("response has no block2 option");
+			} else {
+				return responseBlock.isNotification() && block2.getNum() == 0 && getCurrentNum() > 0;
+			}
+		}
+	}
+
+	/**
+	 * Adds the payload of an incoming response to the buffer.
+	 * 
+	 * @param responseBlock The incoming response.
+	 * @param block2 The block2 option contained in the response.
+	 * @return {@code true} if the payload could be added.
+	 * @throws NullPointerException if response block is {@code null}.
+	 * @throws IllegalArgumentException if the response block has no block2 option.
+	 */
+	synchronized boolean addBlock(final Response responseBlock) {
+
+		if (responseBlock == null) {
+			throw new NullPointerException("response block must not be null");
+		} else {
+
+			final BlockOption block2 = responseBlock.getOptions().getBlock2();
+
+			if (block2 == null) {
+				throw new IllegalArgumentException("response block has no block2 option");
+			} else {
+				if (etag != null) {
+					// response must contain the same ETag
+					if (responseBlock.getOptions().getETagCount() != 1) {
+						LOGGER.log(Level.FINE, "response does not contain a single ETag");
+						return false;
+					} else if (!Arrays.equals(etag, responseBlock.getOptions().getETags().get(0))) {
+						LOGGER.log(Level.FINE, "response does not contain expected ETag");
+						return false;
+					}
+				}
+				boolean succeeded = addBlock(responseBlock.getPayload());
+				if (succeeded) {
+					setCurrentNum(block2.getNum());
+					setCurrentSzx(block2.getSzx());
+				}
+				return succeeded;
+			}
+		}
+
+	}
+
+	/**
+	 * Gets the next response block for this transfer.
+	 * <p>
+	 * This method updates the <em>currentNum</em> and <em>currentSzx</em> properties
+	 * with the given block2 option's values and then invokes {@link #getNextResponseBlock()}.
+	 * 
+	 * @param block2 The block number and size to update this transfer with before
+	 *               determining the response block.
+	 * @return The response block.
+	 * @throws IllegalStateException if this tracker does not contain a response.
+	 */
+	synchronized Response getNextResponseBlock(final BlockOption block2) {
+
+		if (response == null) {
+			throw new IllegalStateException("no response to track");
+		}
+
+		setCurrentNum(block2.getNum());
+		setCurrentSzx(block2.getSzx());
+		return getNextResponseBlock();
+	}
+
+	/**
+	 * Gets the next response block for this transfer.
+	 * <p>
+	 * The returned block's payload is determined based on <em>currentNum</em>,
+	 * <em>currentSzx</em> and the original response body.
+	 * 
+	 * @return The response block.
+	 * @throws IllegalStateException if this tracker does not contain a response.
+	 */
+	synchronized Response getNextResponseBlock() {
+
+		if (response == null) {
+			throw new IllegalStateException("no response to track");
+		}
+
+		Response block = null;
+		if (response.isNotification() && getCurrentNum() == 0) {
+			block = response;
+
+		} else {
+
+			block = new Response(response.getCode());
+			block.setDestination(response.getDestination());
+			block.setDestinationPort(response.getDestinationPort());
+			block.setOptions(new OptionSet(response.getOptions()));
+			// observe option must only be included in first block
+			block.getOptions().removeObserve();
+			block.addMessageObserver(new MessageObserverAdapter() {
+				@Override
+				public void onTimeout() {
+					response.setTimedOut(true);
+				}
+			});
+		}
+
+		if (getCurrentNum() == 0 && response.getOptions().getSize2() == null) {
+			// indicate overall size to peer
+			block.getOptions().setSize2(response.getPayloadSize());
+		}
+
+		int bodySize = getBufferSize();
+		int currentSize = BlockOption.szx2Size(getCurrentSzx());
+		int from = getCurrentNum() * currentSize;
+		boolean m = false;
+
+		if (0 < bodySize && from < bodySize) {
+			int to = Math.min((getCurrentNum() + 1) * currentSize, bodySize);
+			int length = to - from;
+			byte[] blockPayload = new byte[length];
+			m = to < bodySize;
+
+			// crop payload -- do after calculation of m in case block==response
+			buf.position(from);
+			buf.get(blockPayload, 0, length);
+			block.setPayload(blockPayload);
+
+			// do not complete notifications
+			block.setLast(!m && !response.getOptions().hasObserve());
+
+			setComplete(!m);
+
+		} else {
+
+			block.setLast(true);
+			setComplete(true);
+		}
+		block.getOptions().setBlock2(getCurrentSzx(), m, getCurrentNum());
+		return block;
+	}
+
+	/**
+	 * Crops a response's payload down to a given block.
+	 * 
+	 * @param responseToCrop The response containing the (large) payload.
+	 * @param requestedBlock The block to crop down to.
+	 * @throws NullPointerException if any of the parameters is {@code null}.
+	 * @throws IllegalArgumentException if the response does not contain the block. Clients
+	 *            can check whether a message contains a particular block using the
+	 *            {@link Response#hasBlock(BlockOption)} method.
+	 */
+	static final void crop(final Response responseToCrop, final BlockOption requestedBlock) {
+
+		if (responseToCrop == null) {
+			throw new NullPointerException("response message must not be null");
+		} else if (requestedBlock == null) {
+			throw new NullPointerException("block option must not be null");
+		} else if (!responseToCrop.hasBlock(requestedBlock)) {
+			throw new IllegalArgumentException("given response does not contain block");
+		} else {
+
+			int bodySize = responseToCrop.getPayloadSize();
+			int from = requestedBlock.getOffset();
+			int to = Math.min((requestedBlock.getNum() + 1) * requestedBlock.getSize(), bodySize);
+			int length = to - from;
+
+			LOGGER.log(Level.FINE, "cropping response body [size={0}] to block {1}", new Object[]{ bodySize, requestedBlock });
+
+			byte[] blockPayload = new byte[length];
+			boolean m = to < bodySize;
+			responseToCrop.getOptions().setBlock2(requestedBlock.getSzx(), m, requestedBlock.getNum());
+
+			// crop payload -- do after calculation of m in case block==response
+			System.arraycopy(responseToCrop.getPayload(), from, blockPayload, 0, length);
+			responseToCrop.setPayload(blockPayload);
+		}
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/KeyUri.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/KeyUri.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network.stack;
+
+import java.util.Arrays;
+
+import org.eclipse.californium.core.Utils;
+import org.eclipse.californium.core.coap.OptionSet;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+
+/**
+ * A key based on a CoAP message's target URI that is scoped to an endpoint address.
+ * <p>
+ * This class is used by the blockwise layer to correlate blockwise transfer exchanges.
+ */
+public final class KeyUri {
+
+	private static final int MAX_PORT_NO = (1 << 16) - 1;
+	private final String uri;
+	private final byte[] address;
+	private final int port;
+	private final int hash;
+	private byte[] eTag;
+
+	/**
+	 * Creates a new key for a URI scoped to an endpoint address.
+	 * 
+	 * @param requestUri The URI of the requested resource.
+	 * @param options The options contained in the message.
+	 * @param address the endpoint's address.
+	 * @param port the endpoint's port.
+	 * @throws NullPointerException if uri or address is {@code null}
+	 * @throws IllegalArgumentException if port &lt; 0 or port &gt; 65535.
+	 */
+	public KeyUri(final String requestUri, final OptionSet options, final byte[] address, final int port) {
+		if (requestUri == null) {
+			throw new NullPointerException("URI must not be null");
+		} else if (options == null) {
+			throw new NullPointerException("OptionSet must not be null");
+		} else if (address == null) {
+			throw new NullPointerException("address must not be null");
+		} else if (port < 0 || port > MAX_PORT_NO) {
+			throw new IllegalArgumentException("port must be an unsigned 16 bit int");
+		} else {
+			this.uri = requestUri;
+			this.address = address;
+			this.port = port;
+			int hashCode = (port * 31 + requestUri.hashCode()) * 31 + Arrays.hashCode(address);
+			if (options.getETagCount() > 0) {
+				this.eTag = options.getETags().get(0);
+				hashCode = hashCode * 31 + Arrays.hashCode(eTag);
+			}
+			this.hash = hashCode;
+		}
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		KeyUri other = (KeyUri) obj;
+		if (!Arrays.equals(address, other.address)) {
+			return false;
+		}
+		if (!Arrays.equals(eTag, other.eTag)) {
+			return false;
+		}
+		if (port != other.port) {
+			return false;
+		}
+		if (uri == null) {
+			if (other.uri != null) {
+				return false;
+			}
+		} else if (!uri.equals(other.uri)) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		return hash;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder b = new StringBuilder("KeyUri[");
+		b.append(uri);
+		if (eTag != null) {
+			b.append("[").append(Utils.toHexString(eTag)).append("]");
+		}
+		b.append(", ").append(Utils.toHexString(address)).append(":").append(port).append("]");
+		return b.toString();
+	}
+
+	/**
+	 * Creates a new key for an incoming response scoped to the response's source endpoint address.
+	 * 
+	 * @param requestUri The URI of the requested resource.
+	 * @param response The response.
+	 * @return The key.
+	 * @throws NullPointerException if any of the parameters is {@code null}.
+	 */
+	public static KeyUri fromInboundResponse(final String requestUri, final Response response) {
+		if (response == null) {
+			throw new NullPointerException("response must not be null");
+		} else if (requestUri == null) {
+			throw new NullPointerException("URI must not be null");
+		} else {
+			return new KeyUri(requestUri, response.getOptions(), response.getSource().getAddress(), response.getSourcePort());
+		}
+	}
+
+	/**
+	 * Creates a new key for an outgoing response scoped to the response's destination endpoint address.
+	 * 
+	 * @param requestUri The URI of the requested resource.
+	 * @param response The response.
+	 * @return The key.
+	 * @throws NullPointerException if any of the parameters is {@code null}.
+	 */
+	public static KeyUri fromOutboundResponse(final String requestUri, final Response response) {
+		if (response == null) {
+			throw new NullPointerException("response must not be null");
+		} else if (requestUri == null) {
+			throw new NullPointerException("URI must not be null");
+		} else {
+			return new KeyUri(requestUri, response.getOptions(), response.getDestination().getAddress(), response.getDestinationPort());
+		}
+	}
+
+	/**
+	 * Creates a new key for an incoming request scoped to the request's source endpoint address.
+	 * 
+	 * @param request The request.
+	 * @return The key.
+	 * @throws NullPointerException if the request is {@code null}.
+	 */
+	public static KeyUri fromInboundRequest(final Request request) {
+		if (request == null) {
+			throw new NullPointerException("request must not be null");
+		} else {
+			return new KeyUri(request.getURI(), request.getOptions(), request.getSource().getAddress(), request.getSourcePort());
+		}
+	}
+
+	/**
+	 * Creates a new key for an outgoing request scoped to the request's destination endpoint address.
+	 * 
+	 * @param request The request.
+	 * @return The key.
+	 * @throws NullPointerException if the request is {@code null}.
+	 */
+	public static KeyUri fromOutboundRequest(final Request request) {
+		if (request == null) {
+			throw new NullPointerException("request must not be null");
+		} else {
+			return new KeyUri(request.getURI(), request.getOptions(), request.getDestination().getAddress(), request.getDestinationPort());
+		}
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
@@ -21,17 +21,15 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
-import org.eclipse.californium.core.coap.EmptyMessage;
-import org.eclipse.californium.core.coap.Message;
-import org.eclipse.californium.core.coap.MessageObserverAdapter;
-import org.eclipse.californium.core.coap.Request;
-import org.eclipse.californium.core.coap.Response;
-
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
+import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
@@ -54,12 +52,8 @@ public class ObserveLayer extends AbstractLayer {
 	}
 
 	@Override
-	public void sendRequest(final Exchange exchange, final Request request) {
-		lower().sendRequest(exchange, request);
-	}
+	public void sendResponse(final Exchange exchange, final Response response) {
 
-	@Override
-	public void sendResponse(final Exchange exchange, Response response) {
 		final ObserveRelation relation = exchange.getRelation();
 		if (relation != null && relation.isEstablished()) {
 
@@ -145,7 +139,8 @@ public class ObserveLayer extends AbstractLayer {
 
 	@Override
 	public void receiveResponse(final Exchange exchange, final Response response) {
-		if (response.getOptions().hasObserve() && exchange.getRequest().isCanceled()) {
+
+		if (response.isNotification() && exchange.getRequest().isCanceled()) {
 			// The request was canceled and we no longer want notifications
 			LOGGER.finer("Rejecting notification for canceled Exchange");
 			EmptyMessage rst = EmptyMessage.newRST(response);

--- a/californium-core/src/test/java/org/eclipse/californium/core/coap/BlockOptionTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/coap/BlockOptionTest.java
@@ -169,5 +169,4 @@ public class BlockOptionTest {
 			ret[i] = (byte) a[i];
 		return ret;
 	}
-
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapTcpStackTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapTcpStackTest.java
@@ -68,6 +68,7 @@ public class CoapTcpStackTest {
 	@Test public void sendResponseExpectSent() {
 		Request request = new Request(CoAP.Code.GET);
 		Exchange exchange = new Exchange(request, Exchange.Origin.REMOTE);
+		exchange.setRequest(request);
 
 		Response response = new Response(CoAP.ResponseCode.CONTENT);
 		stack.sendResponse(exchange, response);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapUdpStackTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapUdpStackTest.java
@@ -59,6 +59,7 @@ public class CoapUdpStackTest {
 	@Test public void sendResponseExpectSent() {
 		Request request = new Request(CoAP.Code.GET);
 		Exchange exchange = new Exchange(request, Exchange.Origin.REMOTE);
+		exchange.setRequest(request);
 
 		Response response = new Response(CoAP.ResponseCode.CONTENT);
 		stack.sendResponse(exchange, response);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/BlockwiseTransferTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/BlockwiseTransferTest.java
@@ -214,8 +214,8 @@ public class BlockwiseTransferTest {
 			}
 		} finally {
 			Thread.sleep(100); // Quickly wait until last ACKs arrive
-			System.out.println("Client received "+payload
-				+ "\n" + interceptor.toString() + "\n");
+			System.out.println("Client received payload [" + payload + "]" + System.lineSeparator()
+				+ interceptor.toString() + System.lineSeparator());
 		}
 	}
 
@@ -248,7 +248,8 @@ public class BlockwiseTransferTest {
 			}
 		} finally {
 			Thread.sleep(100); // Quickly wait until last ACKs arrive
-			System.out.println("Client received " + payload + "\n" + interceptor.toString() + "\n");
+			System.out.println("Client received payload [" + payload + "]" + System.lineSeparator()
+				+ interceptor.toString() + System.lineSeparator());
 		}
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/RandomAccessBlockTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/RandomAccessBlockTest.java
@@ -1,70 +1,113 @@
 package org.eclipse.californium.core.test;
 
-import static org.eclipse.californium.TestTools.*;
+import static org.eclipse.californium.TestTools.generateRandomPayload;
+import static org.eclipse.californium.TestTools.getUri;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import org.eclipse.californium.category.Medium;
+import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.CoapResponse;
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.BlockOption;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 @Category(Medium.class)
+@RunWith(Parameterized.class)
 public class RandomAccessBlockTest {
 
-	public static String TARGET = "test";
-	public static String RESPONSE_PAYLOAD = generateRandomPayload(40);
-
+	private static final String TARGET = "test";
+	private static final String RESP_PAYLOAD = generateRandomPayload(87);
 	private InetSocketAddress serverAddress;
 	private CoapServer server;
+	@Parameter
+	public int maxBodySize;
+	private Endpoint clientEndpoint;
+
+	@Parameters(name = "MAX_RESOURCE_BODY_SIZE = {0}")
+	public static Iterable<Integer> maxBodySizeParams() {
+		return Arrays.asList(2048, 0);
+	}
 
 	@Before
 	public void startupServer() throws Exception {
-		System.out.println(System.lineSeparator() + "Start " + getClass().getSimpleName());
-		CoapEndpoint endpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		System.out.println(System.lineSeparator() + "Start " + RandomAccessBlockTest.class.getName());
+		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
+		config.setInt(Keys.MAX_RESOURCE_BODY_SIZE, maxBodySize);
+		CoapEndpoint endpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
 		server = new CoapServer();
 		server.addEndpoint(endpoint);
-		server.add(new CoapResource(TARGET) {
-			@Override
-			public void handleGET(CoapExchange exchange) {
-				exchange.respond(RESPONSE_PAYLOAD);
-			}
-		});
+		server.add(new BlockwiseResource(TARGET, RESP_PAYLOAD));
 		server.start();
 		serverAddress = endpoint.getAddress();
+		clientEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
 	}
 
 	@After
 	public void shutdownServer() {
+		clientEndpoint.destroy();
 		server.destroy();
-		System.out.println("End " + getClass().getSimpleName());
+		System.out.println("End " + RandomAccessBlockTest.class.getName());
 	}
 
 	@Test
-	public void testServer() throws Exception {
+	public void testServerReturnsBadOptionForNonExistingBlock() throws Exception {
+
+		int szx = BlockOption.size2Szx(16);
+		Request request = Request.newGet();
+		request.setURI(getUri(serverAddress, TARGET));
+		request.getOptions().setBlock2(szx, false, 6); // 6 * 16 = 96 is out of bounds
+
+		Response response = request.send().waitForResponse(1000);
+		assertThat("Client received no response", response, is(notNullValue()));
+		assertThat(response.getCode(), is(ResponseCode.BAD_OPTION));
+	}
+
+	@Test
+	public void testServerReturnsIndividualBlocks() throws Exception {
 		// We do not test for block 0 because the client is currently unable to
 		// know if the user attempts to just retrieve block 0 or if he wants to
 		// do early block negotiation with a specific size but actually wants to
 		// retrieve all blocks.
 
-		int[] blockOrder = {2,1,3};
+		int[] blockOrder = {2,1,5,3};
 		String[] expectations = {
-				RESPONSE_PAYLOAD.substring(32 /* until the end */),
-				RESPONSE_PAYLOAD.substring(16, 32),
-				"" // block is out of bounds
+				RESP_PAYLOAD.substring(32, 48),
+				RESP_PAYLOAD.substring(16, 32),
+				RESP_PAYLOAD.substring(80 /* until the end */),
+				RESP_PAYLOAD.substring(48, 64)
 		};
 
 		String uri = getUri(serverAddress, TARGET);
+		CoapClient client = new CoapClient();
+		client.setEndpoint(clientEndpoint);
+		client.setTimeout(1000);
+
 		for (int i = 0; i < blockOrder.length; i++) {
 			int num = blockOrder[i];
 			System.out.println("Request block number " + num);
@@ -74,12 +117,55 @@ public class RandomAccessBlockTest {
 			request.setURI(uri);
 			request.getOptions().setBlock2(szx, false, num);
 
-			Response response = request.send().waitForResponse(1000);
-			Assert.assertNotNull("Client received no response", response);
-			Assert.assertEquals(expectations[i], response.getPayloadString());
-			Assert.assertTrue(response.getOptions().hasBlock2());
-			Assert.assertEquals(num, response.getOptions().getBlock2().getNum());
-			Assert.assertEquals(szx, response.getOptions().getBlock2().getSzx());
+			CoapResponse response = client.advanced(request);
+			assertNotNull("Client received no response", response);
+			assertThat(response.getResponseText(), is(expectations[i]));
+			assertTrue(response.getOptions().hasBlock2());
+			assertThat(response.getOptions().getBlock2().getNum(), is(num));
+			assertThat(response.getOptions().getBlock2().getSzx(), is(szx));
+		}
+	}
+
+	private static class BlockwiseResource extends CoapResource {
+
+		private ByteBuffer buf;
+		private String responsePayload;
+		/**
+		 * @param name
+		 */
+		private BlockwiseResource(String name, String responsePayload) {
+			super(name);
+			this.responsePayload = responsePayload;
+			buf = ByteBuffer.wrap(responsePayload.getBytes(StandardCharsets.US_ASCII));
+		}
+
+		@Override
+		public void handleGET(final CoapExchange exchange) {
+
+			BlockOption block2 = exchange.getRequestOptions().getBlock2();
+			Response response = null;
+
+			if (block2 != null) {
+
+				int offset = block2.getOffset();
+				int to = Math.min(offset + block2.getSize(), buf.capacity());
+				int length = to - offset;
+
+				if (offset < buf.capacity() && length > 0) {
+					byte[] payload = new byte[length];
+					buf.position(offset);
+					buf.get(payload, 0, length);
+					response = new Response(ResponseCode.CONTENT);
+					response.setPayload(payload);
+				} else {
+					response = new Response(ResponseCode.BAD_OPTION);
+				}
+				response.getOptions().setBlock2(block2);
+				exchange.respond(response);
+
+			} else {
+				exchange.respond(responsePayload);
+			}
 		}
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -27,6 +27,7 @@ import static org.eclipse.californium.core.coap.CoAP.ResponseCode.*;
 import static org.eclipse.californium.core.coap.CoAP.Type.*;
 import static org.eclipse.californium.core.coap.OptionNumberRegistry.OBSERVE;
 import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.*;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import java.net.InetAddress;
@@ -39,6 +40,7 @@ import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.CoapHandler;
 import org.eclipse.californium.core.CoapResponse;
 import org.eclipse.californium.core.coap.BlockOption;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
@@ -53,10 +55,13 @@ import org.junit.experimental.categories.Category;
 
 
 /**
- * This test implements all examples from the blockwise draft 14 for a client.
+ * Test cases verifying the client side behavior of the examples from
+ * <a href="https://tools.ietf.org/html/rfc7959#section-3">RFC 7958, Section 3</em>.
  */
 @Category(Medium.class)
 public class BlockwiseClientSideTest {
+
+	private static final int MAX_RESOURCE_BODY_SIZE = 1024;
 
 	private static NetworkConfig config;
 
@@ -74,6 +79,7 @@ public class BlockwiseClientSideTest {
 		config = NetworkConfig.createStandardWithoutFile()
 				.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 128)
 				.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 128)
+				.setInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE, MAX_RESOURCE_BODY_SIZE)
 				.setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200) // client retransmits after 200 ms
 				.setInt(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1)
 				.setInt(NetworkConfig.Keys.MAX_RETRANSMIT, 2);
@@ -91,6 +97,7 @@ public class BlockwiseClientSideTest {
 
 	@After
 	public void shutdownEndpoints() {
+		printServerLog(clientInterceptor);
 		client.destroy();
 		server.destroy();
 	}
@@ -98,6 +105,27 @@ public class BlockwiseClientSideTest {
 	@AfterClass
 	public static void end() {
 		System.out.println("End " + BlockwiseClientSideTest.class.getSimpleName());
+	}
+
+	/**
+	 * Verifies that a client's request is cancelled if the response body exceeds
+	 * MAX_RESOURCE_BODY_SIZE.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testRequestIsCancelledIfBodyExceedsMaxBodySize() throws Exception {
+
+		respPayload = generateRandomPayload(128);
+		String path = "test";
+		Request request = createRequest(GET, path, server);
+
+		client.sendRequest(request);
+		server.expectRequest(CON, GET, path).storeBoth("A").go();
+		server.sendResponse(ACK, CONTENT).loadBoth("A").size2(MAX_RESOURCE_BODY_SIZE + 10).block2(0, true, 128).payload(respPayload).go();
+
+		request.waitForResponse(50);
+		assertTrue("Request should have been cancelled", request.isCanceled());
 	}
 
 	/**
@@ -120,27 +148,29 @@ public class BlockwiseClientSideTest {
      * |                                                            |
      * | <------   ACK [MID=1236], 2.05 Content, 2:2/0/128          |
      * </pre>
+	 * 
+	 * @throws Exception if the test fails.
 	 */
 	@Test
 	public void testGET() throws Exception {
 		System.out.println("Simple blockwise GET:");
 		respPayload = generateRandomPayload(300);
 		String path = "test";
+		byte[] etag = new byte[]{ 0x00, 0x01 };
 
 		Request request = createRequest(GET, path, server);
 		client.sendRequest(request);
 
 		server.expectRequest(CON, GET, path).storeBoth("A").go();
-		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
-		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 128).go();
-		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
-		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 128).go();
-		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 128).payload(respPayload.substring(256, 300)).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 128).size2(respPayload.length())
+			.etag(etag).payload(respPayload.substring(0, 128)).go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 128).hasEtag(etag).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 128).etag(etag).payload(respPayload.substring(128, 256)).go();
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 128).hasEtag(etag).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 128).etag(etag).payload(respPayload.substring(256, 300)).go();
 
 		Response response = request.waitForResponse(1000);
 		assertResponseContainsExpectedPayload(response, respPayload);
-
-		printServerLog(clientInterceptor);
 	}
 
 	/**
@@ -159,22 +189,18 @@ public class BlockwiseClientSideTest {
 	 * | CON [MID=1235], GET, /status, 2:1/0/64           ------> |
 	 * |                                                          |
 	 * | <------   ACK [MID=1235], 2.05 Content, 2:1/1/64         |
-	 * :                                                          :
-	 * :                          ...                             :
-	 * :                                                          :
-	 * | CON [MID=1238], GET, /status, 2:4/0/64           ------> |
 	 * |                                                          |
-	 * | <------   ACK [MID=1238], 2.05 Content, 2:4/1/64         |
+	 * | CON [MID=1236], GET, /status, 2:2/0/64           ------> |
 	 * |                                                          |
-	 * | CON [MID=1239], GET, /status, 2:5/0/64           ------> |
-	 * |                                                          |
-	 * | <------   ACK [MID=1239], 2.05 Content, 2:5/0/64         |
+	 * | <------   ACK [MID=1239], 2.05 Content, 2:2/0/64         |
 	 * </pre>
+	 * 
+	 * @throws Exception if the test fails.
 	 */
 	@Test
 	public void testGETEarlyNegotiation() throws Exception {
-		System.out.println("Blockwise GET with early negotiation: (low priority for Cf client)");
-		respPayload = generateRandomPayload(350);
+		System.out.println("Blockwise GET with early negotiation:");
+		respPayload = generateRandomPayload(170);
 		String path = "test";
 
 		Request request = createRequest(GET, path, server);
@@ -182,22 +208,14 @@ public class BlockwiseClientSideTest {
 		client.sendRequest(request);
 
 		server.expectRequest(CON, GET, path).storeBoth("A").block2(0, false, 64).go();
-		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 64).size2(respPayload.length()).payload(respPayload, 0, 64).go();
 		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 64).go();
-		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 64).payload(respPayload.substring(64, 128)).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 64).payload(respPayload, 64, 128).go();
 		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 64).go();
-		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, true, 64).payload(respPayload.substring(128, 192)).go();
-		server.expectRequest(CON, GET, path).storeBoth("D").block2(3, false, 64).go();
-		server.sendResponse(ACK, CONTENT).loadBoth("D").block2(3, true, 64).payload(respPayload.substring(192, 256)).go();
-		server.expectRequest(CON, GET, path).storeBoth("E").block2(4, false, 64).go();
-		server.sendResponse(ACK, CONTENT).loadBoth("E").block2(4, true, 64).payload(respPayload.substring(256, 320)).go();
-		server.expectRequest(CON, GET, path).storeBoth("F").block2(5, false, 64).go();
-		server.sendResponse(ACK, CONTENT).loadBoth("F").block2(5, false, 64).payload(respPayload.substring(320, 350)).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 64).payload(respPayload, 128, 170).go();
 
 		Response response = request.waitForResponse(1000);
 		assertResponseContainsExpectedPayload(response, respPayload);
-
-		printServerLog(clientInterceptor);
 	}
 
 	/**
@@ -206,27 +224,24 @@ public class BlockwiseClientSideTest {
      * |                                                          |
      * | CON [MID=1234], GET, /status                     ------> |
      * |                                                          |
-     * | <------   ACK [MID=1234], 2.05 Content, 2:0/1/128        |
+     * | <------   ACK [MID=1234], 2.05 Content, 2:0/1/256        |
      * |                                                          |
-     * | CON [MID=1235], GET, /status, 2:2/0/64           ------> |
+     * | CON [MID=1235], GET, /status, 2:2/0/128          ------> |
      * |                                                          |
-     * | //////////////////////////////////tent, 2:2/1/64         |
+     * | //////////////////////////////////tent, 2:2/1/128        |
      * |                                                          |
      * | (timeout)                                                |
      * |                                                          |
-     * | CON [MID=1235], GET, /status, 2:2/0/64           ------> |
+     * | CON [MID=1235], GET, /status, 2:2/0/128          ------> |
      * |                                                          |
-     * | <------   ACK [MID=1235], 2.05 Content, 2:2/1/64         |
-     * :                                                          :
-     * :                          ...                             :
-     * :                                                          :
-     * | CON [MID=1238], GET, /status, 2:5/0/64           ------> |
-     * |                                                          |
-     * | <------   ACK [MID=1238], 2.05 Content, 2:5/0/64         |
+     * | <------   ACK [MID=1235], 2.05 Content, 2:2/0/128        |
      * </pre>
+	 * 
+	 * @throws Exception if the test fails.
 	 */
 	@Test
 	public void testGETLateNegotiationAndLostACK() throws Exception {
+
 		System.out.println("Blockwise GET with late negotiation and lost ACK:");
 		respPayload = generateRandomPayload(300);
 		String path = "test";
@@ -235,31 +250,88 @@ public class BlockwiseClientSideTest {
 		client.sendRequest(request);
 
 		server.expectRequest(CON, GET, path).storeBoth("A").go();
-		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
-		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 128).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 256).size2(respPayload.length()).payload(respPayload, 0, 256).go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(2, false, 128).go();
 
 		// We lose this ACK, and therefore the client retransmits the CON
 		clientInterceptor.log(" // lost");
-		server.expectRequest(CON, GET, path).storeBoth("C").block2(1, false, 128).go();
+
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 128).go();
 		Object[] req1 = (Object[]) server.get("B");
 		Object[] req2 = (Object[]) server.get("C");
-		assertEquals("Retransmitted MID must be the same", req1[0], req2[0]);
-		assertArrayEquals(
-				"Retransmitted Token must be the same", (byte[]) req1[1], (byte[]) req2[1]);
+		assertThat("Retransmitted MID must be the same", req1[0], is(req2[0]));
+		assertThat("Retransmitted Token must be the same", req1[1], is(req2[1]));
 
-		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
-		server.expectRequest(CON, GET, path).storeBoth("D").block2(2, false, 128).go();
-		server.sendResponse(ACK, CONTENT).loadBoth("D").block2(2, false, 128).payload(respPayload.substring(256, 300)).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 128).payload(respPayload, 256, 300).go();
 
 		Response response = request.waitForResponse(1000);
 		assertResponseContainsExpectedPayload(response, respPayload);
+	}
 
-		printServerLog(clientInterceptor);
+	/**
+	 * Verifies that a block1 transfer fails with a 4.13 code if the body size exceeds
+	 * MAX_RESOURCE_BODY_SIZE.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testPUTFailsWith413IfBodyExceedsMaxBodySize() throws Exception {
+
+		System.out.println("Blockwise PUT fails for excessive body size");
+		reqtPayload = generateRandomPayload(MAX_RESOURCE_BODY_SIZE + 10);
+		String path = "test";
+
+		Request request = createRequest(PUT, path, server);
+		request.setPayload(reqtPayload);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, PUT, path).storeBoth("A").block1(0, true, 128).size1(reqtPayload.length()).payload(reqtPayload, 0, 128).go();
+		server.sendResponse(ACK, REQUEST_ENTITY_TOO_LARGE).loadBoth("A").size1(MAX_RESOURCE_BODY_SIZE).go();
+
+		Response response = request.waitForResponse(50);
+		assertThat(response.getPayloadSize(), is(0));
+		assertThat(response.getCode(), is(REQUEST_ENTITY_TOO_LARGE));
+		assertThat(response.getToken(), is(request.getToken()));
+		assertThat(response.getMID(), is(request.getMID()));
+	}
+
+	/**
+	 * Verifies that a block1 transfer fails with a 4.08 code if not all blocks are uploaded.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testPUTFailsWith408OnIncompleteTransfer() throws Exception {
+
+		System.out.println("Blockwise PUT fails for incomplete transfer");
+		reqtPayload = generateRandomPayload(300);
+		String path = "test";
+
+		Request request = createRequest(PUT, path, server);
+		request.setPayload(reqtPayload);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, PUT, path).storeBoth("A").block1(0, true, 128).size1(reqtPayload.length()).payload(reqtPayload, 0, 128).go();
+		server.sendResponse(ACK, CONTINUE).loadBoth("A").block1(0, true, 128).go();
+
+		server.expectRequest(CON, PUT, path).storeBoth("A").block1(1, true, 128).payload(reqtPayload, 128, 256).go();
+		server.sendResponse(ACK, CONTINUE).loadBoth("A").block1(1, true, 128).go();
+
+		// now let's assume that the transfer of the previous block did not happen
+		// but the client instead sends the last block without having sent the middle one at all
+		server.expectRequest(CON, PUT, path).storeBoth("A").block1(2, false, 128).payload(reqtPayload, 256, 300).go();
+		server.sendResponse(ACK, REQUEST_ENTITY_INCOMPLETE).loadBoth("A").go();
+
+		Response response = request.waitForResponse(50);
+		assertThat(response.getPayloadSize(), is(0));
+		assertThat(response.getCode(), is(REQUEST_ENTITY_INCOMPLETE));
+		assertThat(response.getToken(), is(request.getToken()));
+		assertThat(response.getMID(), is(request.getMID()));
 	}
 
 	/**
 	 * The following examples demonstrate a PUT exchange; a POST exchange looks
-	 * the same, with different requirements on atomicity/idempotence. Note
+	 * the same, with different requirements on atomicity/idempotency. Note
 	 * that, similar to GET, the responses to the requests that have a more bit
 	 * in the request Block1 Option are provisional and carry the response code
 	 * 2.31 (Continue); only the final response tells the client that the PUT
@@ -279,6 +351,8 @@ public class BlockwiseClientSideTest {
      * |                                                          |
      * | <------   ACK [MID=1236], 2.04 Changed, 1:2/0/128        |
 	 * </pre>
+	 * 
+	 * @throws Exception if the test fails.
 	 */
 	@Test
 	public void testSimpleAtomicBlockwisePUT() throws Exception {
@@ -298,16 +372,14 @@ public class BlockwiseClientSideTest {
 		server.sendResponse(ACK, CONTINUE).loadBoth("B").block1(1, true, 128).go();
 
 		server.expectRequest(CON, PUT, path).storeBoth("C").block1(2, false, 128).go();
-		server.sendResponse(ACK, CHANGED).loadBoth("C").block1(2, false, 128).payload(respPayload).go();	
+		server.sendResponse(ACK, CHANGED).loadBoth("C").block1(2, false, 128).payload(respPayload).go();
 
 		Response response = request.waitForResponse(1000);
 		assertResponseContainsExpectedPayload(response, CHANGED, respPayload);
-
-		printServerLog(clientInterceptor);
 	}
 
 	/**
-	 * a server receiving a block-wise PUT indicate a smaller block size
+	 * A server receiving a block-wise PUT indicates a smaller block size
 	 * preference. In this case, the client SHOULD continue with a smaller block
 	 * size; if it does, it MUST adjust the block number to properly count in
 	 * that smaller size.
@@ -331,6 +403,8 @@ public class BlockwiseClientSideTest {
 	 * |                                                          |
 	 * | <------   ACK [MID=1236], 2.04 Changed, 1:6/0/32         |
 	 * </pre>
+	 * 
+	 * @throws Exception if the test fails.
 	 */
 	@Test
 	public void testSimpleAtomicBlockwisePUTWithSmallerNegotiation() throws Exception {
@@ -359,12 +433,10 @@ public class BlockwiseClientSideTest {
 
 		Response response = request.waitForResponse(1000);
 		assertResponseContainsExpectedPayload(response, CHANGED, respPayload);
-
-		printServerLog(clientInterceptor);
 	}
 
 	/**
-	 * a server receiving a block-wise PUT and indicate a bigger block size
+	 * A server receiving a block-wise PUT and indicates a bigger block size
 	 * preference. In this case, the client SHOULD continue with the same block
 	 * size as requesting a bigger size is not allowed.
 	 * 
@@ -383,6 +455,8 @@ public class BlockwiseClientSideTest {
 	 * |                                                          |
 	 * | <------   ACK [MID=1236], 2.04 Changed, 1:2/0/256        |
 	 * </pre>
+	 * 
+	 * @throws Exception if the test fails.
 	 */
 	@Test
 	public void testSimpleAtomicBlockwisePUTWithBiggerNegotiation() throws Exception {
@@ -409,8 +483,6 @@ public class BlockwiseClientSideTest {
 
 		Response response = request.waitForResponse(1000);
 		assertResponseContainsExpectedPayload(response, CHANGED, respPayload);
-
-		printServerLog(clientInterceptor);
 	}
 
 	/**
@@ -444,6 +516,8 @@ public class BlockwiseClientSideTest {
      * |                                                              |
      * | <------   ACK [MID=1239], 2.04 Changed, 2:3/0/128            |
 	 * </pre>
+	 * 
+	 * @throws Exception if the test fails.
 	 */
 	@Test
 	public void testAtomicBlockwisePOSTWithBlockwiseResponse() throws Exception {
@@ -451,6 +525,7 @@ public class BlockwiseClientSideTest {
 		reqtPayload = generateRandomPayload(300);
 		respPayload = generateRandomPayload(500);
 		String path = "test";
+		byte[] tag = new byte[]{0x00, 0x01};
 
 		Request request = createRequest(POST, path, server);
 		request.setPayload(reqtPayload);
@@ -465,31 +540,44 @@ public class BlockwiseClientSideTest {
 
 		server.expectRequest(CON, POST, path).storeBoth("C").block1(2, false, 128).payload(reqtPayload.substring(256, 300)).go();
 		server.sendResponse(ACK, CHANGED).loadBoth("C").block1(2, false, 128).block2(0, true, 128).size2(respPayload.length())
-				.payload(respPayload.substring(0, 128)).go();
+				.etag(tag).payload(respPayload.substring(0, 128)).go();
 
-		server.expectRequest(CON, POST, path).storeBoth("D").block2(1, false, 128).go();
-		server.sendResponse(ACK, CHANGED).loadBoth("D").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
+		server.expectRequest(CON, POST, path).storeBoth("D").hasEtag(tag).block2(1, false, 128).go();
+		server.sendResponse(ACK, CHANGED).loadBoth("D").block2(1, true, 128).etag(tag).payload(respPayload.substring(128, 256)).go();
 
-		server.expectRequest(CON, POST, path).storeBoth("E").block2(2, false, 128).go();
-		server.sendResponse(ACK, CHANGED).loadBoth("E").block2(2, true, 128).payload(respPayload.substring(256, 384)).go();
+		server.expectRequest(CON, POST, path).storeBoth("E").hasEtag(tag).block2(2, false, 128).go();
+		server.sendResponse(ACK, CHANGED).loadBoth("E").block2(2, true, 128).etag(tag).payload(respPayload.substring(256, 384)).go();
 
-		server.expectRequest(CON, POST, path).storeBoth("F").block2(3, false, 128).go();
-		server.sendResponse(ACK, CHANGED).loadBoth("F").block2(3, false, 128).payload(respPayload.substring(384, 500)).go();
+		server.expectRequest(CON, POST, path).storeBoth("F").hasEtag(tag).block2(3, false, 128).go();
+		server.sendResponse(ACK, CHANGED).loadBoth("F").block2(3, false, 128).etag(tag).payload(respPayload.substring(384, 500)).go();
 
 		Response response = request.waitForResponse(1000);
 		printServerLog(clientInterceptor);
 		assertResponseContainsExpectedPayload(response, CHANGED, respPayload);
-
 	}
 
 	@Test
 	public void testRandomAccessGET() throws Exception {
-		System.out.println("TODO: Random access GET: (low priority for Cf client)");
-		// TODO: has low priority
+
+		System.out.println("Random access GET");
+		respPayload = generateRandomPayload(300);
+		String path = "test";
+
+		Request request = createRequest(GET, path, server);
+		request.getOptions().setBlock2(new BlockOption(BlockOption.size2Szx(128), false, 2));
+		client.sendRequest(request);
+
+		server.expectRequest(CON, GET, path).storeBoth("A").block2(2, false, 128).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(2, false, 128).payload(respPayload.substring(256)).go();
+
+		Response response = request.waitForResponse(1000);
+		printServerLog(clientInterceptor);
+		assertResponseContainsExpectedPayload(response, CONTENT, respPayload.substring(256));
 	}
 
 	@Test
 	public void testObserveWithBlockwiseResponse() throws Exception {
+
 		System.out.println("Observe sequence with blockwise response:");
 		respPayload = generateRandomPayload(300);
 		String path = "test1";
@@ -509,12 +597,12 @@ public class BlockwiseClientSideTest {
 		server.expectRequest(CON, GET, path).storeBoth("B").noOption(OBSERVE).block2(1, false, 128).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
 
-		// TODO: Is is mandatory that token C is the same as B?
 		server.expectRequest(CON, GET, path).storeBoth("C").noOption(OBSERVE).block2(2, false, 128).go();
-		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 128).payload(respPayload.substring(256, 300)).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 128).payload(respPayload.substring(256)).go();
 
 		Response response = request.waitForResponse(1000);
 		assertResponseContainsExpectedPayload(response, respPayload);
+		notificationListener.resetNotificationCount();
 
 		System.out.println("Server sends first notification...");
 		clientInterceptor.log(System.lineSeparator() + "... time passes ...");
@@ -530,10 +618,11 @@ public class BlockwiseClientSideTest {
 		server.sendResponse(ACK, CONTENT).loadBoth("D").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
 
 		server.expectRequest(CON, GET, path).storeBoth("E").noOption(OBSERVE).block2(2, false, 128).go();
-		server.sendResponse(ACK, CONTENT).loadBoth("E").block2(2, false, 128).payload(respPayload.substring(256, 280)).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("E").block2(2, false, 128).payload(respPayload.substring(256)).go();
 
 		Response notification1 = notificationListener.waitForResponse(1000);
 		assertResponseContainsExpectedPayload(notification1, respPayload);
+		assertNumberOfReceivedNotifications(notificationListener, 1, true);
 
 		System.out.println("Server sends second notification...");
 		clientInterceptor.log(System.lineSeparator() + "... time passes ...");
@@ -544,37 +633,43 @@ public class BlockwiseClientSideTest {
 		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 
-		// expect blockwise transfer for second notification
+		// expect blockwise transfer for second notification (17)
 		server.expectRequest(CON, GET, path).storeBoth("F").noOption(OBSERVE).block2(1, false, 128).go();
 		server.goMultiExpectation();
-		
+
 		System.out.println("Server sends third notification during transfer ");
 		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(19).block2(0, true, 128).size2(respPayload.length())
 			.payload(respPayload.substring(0, 128)).go();
+
+		// in between, server sends response for request for block 1 for observe 17
+		// this response will be discarded by the client because a newer notification (19) has arrived in the meantime
+		server.sendResponse(ACK, CONTENT).loadBoth("F").block2(1, true, 128).payload(respPayload.substring(128,  256)).go();
+
 		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
 
-		// expect blockwise transfer for third notification
+		// expect blockwise transfer for third notification (19)
 		server.expectRequest(CON, GET, path).storeBoth("G").noOption(OBSERVE).block2(1, false, 128).go();
 		server.goMultiExpectation();
-		
+
 		System.out.println("Send old notification during transfer");
+		// this old notification will be discarded by the client
 		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(18).block2(0, true, 128).size2(respPayload.length())
 			.payload(respPayload.substring(0, 128)).go();
+
+		// response for 2nd block of notification 19
+		server.sendResponse(ACK, CONTENT).loadBoth("G").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
 		server.startMultiExpectation();
 		server.expectEmpty(ACK, mid).go();
-		server.expectRequest(CON, GET, path).storeBoth("H").noOption(OBSERVE).block2(1, false, 128).go();
+		// client retrieves rest of body
+		server.expectRequest(CON, GET, path).storeBoth("I").noOption(OBSERVE).block2(2, false, 128).go();
 		server.goMultiExpectation();
 
-		server.sendResponse(ACK, CONTENT).loadBoth("G").block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
-
-		server.expectRequest(CON, GET, path).storeBoth("I").noOption(OBSERVE).block2(2, false, 128).go();
-		server.sendResponse(ACK, CONTENT).loadBoth("I").block2(2, false, 128).payload(respPayload.substring(256, 290)).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("I").block2(2, false, 128).payload(respPayload.substring(256)).go();
 
 		Response notification2 = notificationListener.waitForResponse(1000);
 		assertResponseContainsExpectedPayload(notification2, respPayload);
-
-		printServerLog(clientInterceptor);
+		assertNumberOfReceivedNotifications(notificationListener, 1, true);
 	}
 
 	@Test
@@ -638,8 +733,5 @@ public class BlockwiseClientSideTest {
 		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
 
 		assertTrue(latch.await(3, TimeUnit.SECONDS));
-
-		printServerLog(clientInterceptor);
 	}
-
 }


### PR DESCRIPTION
Refactored tracking of blockwise transfers so that the status is no
longer kept within the Exchange object but within BlockwiseLayer, thus
decoupling matcher from blockwise layer. Removed all knowledge about
(and special treatment of) blockwise transfer from Matchers.

Introduced support for using ETags for blockwise transfers. ETags
included in notifications are used in block2 transfers by clients.

Transparent blockwise transfer handling can now be disabled altogether
by setting MAX_RESOURCE_BODY_SIZE config property to 0.