### PR TITLE
Bugfix for MessageFormatException.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAPMessageFormatException.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAPMessageFormatException.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.coap;
+
+/**
+ * Indicates a problem while parsing the binary representation of a CoAP
+ * message.
+ * <p>
+ * The <em>message</em> property contains a description of the problem
+ * encountered. The other properties are parsed from the binary representation. 
+ * </p>
+ */
+public class CoAPMessageFormatException extends MessageFormatException {
+
+	private static final long serialVersionUID = 1L;
+	private static final int NO_MID = -1;
+	private final int mid;
+	private final int code;
+	private final boolean confirmable;
+
+	/**
+	 * Creates an exception for a description and message properties.
+	 * 
+	 * @param description a description of the error cause.
+	 * @param mid the message ID.
+	 * @param code the message code.
+	 * @param confirmable whether the message has been transferred reliably.
+	 */
+	public CoAPMessageFormatException(String description, int mid, int code, boolean confirmable) {
+		super(description);
+		this.mid = mid;
+		this.code = code;
+		this.confirmable = confirmable;
+	}
+
+	/**
+	 * Checks if the message's ID could be parsed successfully.
+	 * 
+	 * @return {@code true} if the value returned by <em>getMid</em> is the real
+	 *         message ID.
+	 */
+	public final boolean hasMid() {
+		return mid > NO_MID;
+	}
+
+	/**
+	 * @return the mid
+	 */
+	public final int getMid() {
+		return mid;
+	}
+
+	/**
+	 * @return the code
+	 */
+	public final int getCode() {
+		return code;
+	}
+
+	/**
+	 * Checks if the message has been transferred reliably.
+	 * 
+	 * @return {@code true} if the message type is CON.
+	 */
+	public final boolean isConfirmable() {
+		return confirmable;
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageFormatException.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageFormatException.java
@@ -12,22 +12,21 @@
  * 
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - move CoAP specific information 
+ *                                                    to CoAPMessageFormatException
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
 /**
- * Indicates a problem while parsing the binary representation of a CoAP message.
+ * Indicates a problem while parsing the binary representation of a message.
  * <p>
- * The <em>message</em> property contains a description of the problem encountered.
+ * The <em>message</em> property contains a description of the problem
+ * encountered.
  * </p>
  */
 public class MessageFormatException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
-	private static final int NO_MID = -1;
-	private int mid = NO_MID;
-	private int code;
-	private boolean confirmable;
 
 	/**
 	 * Creates an exception for a description.
@@ -38,52 +37,4 @@ public class MessageFormatException extends RuntimeException {
 		super(description);
 	}
 
-	/**
-	 * Creates an exception for a description and message properties.
-	 * 
-	 * @param description a description of the error cause.
-	 * @param mid the message ID.
-	 * @param code the message code.
-	 * @param confirmable whether the message has been transferred reliably.
-	 */
-	public MessageFormatException(String description, int mid, int code, boolean confirmable) {
-		super(description);
-		this.mid = mid;
-		this.code = code;
-		this.confirmable = confirmable;
-	}
-
-	/**
-	 * Checks if the message's ID could be parsed successfully.
-	 * 
-	 * @return {@code true} if the value returned by <em>getMid</em> is the
-	 *         real message ID.
-	 */
-	public boolean hasMid() {
-		return mid > NO_MID;
-	}
-
-	/**
-	 * @return the mid
-	 */
-	public final int getMid() {
-		return mid;
-	}
-
-	
-	/**
-	 * @return the code
-	 */
-	public final int getCode() {
-		return code;
-	}
-
-	/**
-	 * Checks if the message has been transferred reliably.
-	 * 
-	 * @return {@code true} if the message type is CON.
-	 */
-	public boolean isConfirmable() {
-		return confirmable;
-	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -48,6 +48,7 @@ import java.util.logging.Logger;
 import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.CoAPMessageFormatException;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.MessageFormatException;
@@ -753,7 +754,8 @@ public class CoapEndpoint implements Endpoint {
 					LOGGER.log(Level.FINER, "Silently ignoring non-CoAP message from {0}", raw.getInetSocketAddress());
 				}
 
-			} catch (MessageFormatException e) {
+			} catch (CoAPMessageFormatException e) {
+
 				if (e.isConfirmable() && e.hasMid()) {
 					// reject erroneous reliably transmitted message as mandated by CoAP spec
 					// https://tools.ietf.org/html/rfc7252#section-4.2
@@ -766,11 +768,16 @@ public class CoapEndpoint implements Endpoint {
 					// ignore erroneous messages that are not transmitted reliably
 					LOGGER.log(Level.FINER, "discarding malformed message from [{0}]", raw.getInetSocketAddress());
 				}
+			} catch (MessageFormatException e) {
+
+				// ignore erroneous messages that are not transmitted reliably
+				LOGGER.log(Level.FINER, "discarding malformed message from [{0}]", raw.getInetSocketAddress());
 			}
 		}
 
-		private void reject(final RawData raw, final MessageFormatException cause) {
-			// Generate RST, and send it if not cancelled by one of the interceptors
+		private void reject(final RawData raw, final CoAPMessageFormatException cause) {
+
+			// Generate RST
 			EmptyMessage rst = new EmptyMessage(Type.RST);
 			rst.setMID(cause.getMid());
 			rst.setDestination(raw.getAddress());


### PR DESCRIPTION
Introduce new CoAPMessageFormatException to distinguish between general
errors and errors related to CoAP message.
Add tests.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>