### PR TITLE
Bugfix use CloseOnErrorHandler.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpServerConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpServerConnector.java
@@ -13,6 +13,7 @@
  * Contributors:
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
  * Achim Kraus (Bosch Software Innovations GmbH) - adjust port when bound.
+ * Achim Kraus (Bosch Software Innovations GmbH) - use CloseOnErrorHandler.
  ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
@@ -173,7 +174,7 @@ public class TcpServerConnector implements Connector {
 			ch.pipeline().addLast(new CloseOnIdleHandler());
 			ch.pipeline().addLast(new DatagramFramer());
 			ch.pipeline().addLast(new DispatchHandler(rawDataChannel));
-			ch.pipeline().addLast(new CloseOnIdleHandler());
+			ch.pipeline().addLast(new CloseOnErrorHandler());
 		}
 	}
 


### PR DESCRIPTION
Use the CloseOnErrorHandler instead of the second CloseOnIdleHandler.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>