### PR TITLE
Fix for #178 (infinite ping-pong of empty messages)

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpAdaptionLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpAdaptionLayer.java
@@ -35,6 +35,7 @@ public class TcpAdaptionLayer extends AbstractLayer {
 
 		if (message.isConfirmable()) {
 			// CoAP over TCP uses empty messages as pings for keep alive.
+			// TODO: Should we isntead rely on TCP keep-alives configured via TCP Connector?
 			lower().sendEmptyMessage(exchange, message);
 		} else {
 			// Empty messages don't make sense when running over TCP connector.

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapStackTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapStackTest.java
@@ -2,6 +2,7 @@ package org.eclipse.californium.core.network.stack;
 
 import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.Outbox;
@@ -21,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @Category(Small.class) @RunWith(Parameterized.class)
 public class CoapStackTest {

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapTcpStackTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapTcpStackTest.java
@@ -1,0 +1,77 @@
+package org.eclipse.californium.core.network.stack;
+
+import org.eclipse.californium.category.Small;
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.Outbox;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.server.MessageDeliverer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@Category(Small.class) @RunWith(MockitoJUnitRunner.class)
+public class CoapTcpStackTest {
+
+	private static final NetworkConfig CONFIG = NetworkConfig.createStandardWithoutFile();
+
+	@Mock private Outbox outbox;
+	@Mock private MessageDeliverer deliverer;
+	@Mock private ScheduledExecutorService executor;
+
+	private CoapStack stack;
+
+	@Before
+	public void initialize() {
+		stack = new CoapTcpStack(CONFIG, outbox);
+		stack.setDeliverer(deliverer);
+		stack.setExecutor(executor);
+
+	}
+
+	@Test public void sendEmptyMessageExpectSent() {
+		EmptyMessage message = new EmptyMessage(CoAP.Type.CON);
+		stack.sendEmptyMessage(null, message);
+
+		verify(outbox).sendEmptyMessage(null, message);
+	}
+
+
+	@Test public void sendRstExpectNotSend() {
+		EmptyMessage message = new EmptyMessage(CoAP.Type.RST);
+		stack.sendEmptyMessage(null, message);
+
+		verify(outbox, never()).sendEmptyMessage(any(Exchange.class), any(EmptyMessage.class));
+	}
+
+	@Test public void sendRequestExpectSent() {
+		Request message = new Request(CoAP.Code.GET);
+		stack.sendRequest(message);
+
+		verify(outbox).sendRequest(any(Exchange.class), eq(message));
+	}
+
+
+	@Test public void sendResponseExpectSent() {
+		Request request = new Request(CoAP.Code.GET);
+		Exchange exchange = new Exchange(request, Exchange.Origin.REMOTE);
+
+		Response response = new Response(CoAP.ResponseCode.CONTENT);
+		stack.sendResponse(exchange, response);
+
+		verify(outbox).sendResponse(exchange, response);
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapUdpStackTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapUdpStackTest.java
@@ -1,0 +1,68 @@
+package org.eclipse.californium.core.network.stack;
+
+import org.eclipse.californium.category.Small;
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.Outbox;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.server.MessageDeliverer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+@Category(Small.class) @RunWith(MockitoJUnitRunner.class)
+public class CoapUdpStackTest {
+
+	private static final NetworkConfig CONFIG = NetworkConfig.createStandardWithoutFile();
+
+	@Mock private Outbox outbox;
+	@Mock private MessageDeliverer deliverer;
+	@Mock private ScheduledExecutorService executor;
+
+	private CoapStack stack;
+
+	@Before
+	public void initialize() {
+		stack = new CoapUdpStack(CONFIG, outbox);
+		stack.setDeliverer(deliverer);
+		stack.setExecutor(executor);
+
+	}
+
+	@Test public void sendEmptyMessageExpectSent() {
+		EmptyMessage message = new EmptyMessage(CoAP.Type.RST);
+		stack.sendEmptyMessage(null, message);
+
+		verify(outbox).sendEmptyMessage(null, message);
+	}
+
+	@Test public void sendRequestExpectSent() {
+		Request message = new Request(CoAP.Code.GET);
+		stack.sendRequest(message);
+
+		verify(outbox).sendRequest(any(Exchange.class), eq(message));
+	}
+
+
+	@Test public void sendResponseExpectSent() {
+		Request request = new Request(CoAP.Code.GET);
+		Exchange exchange = new Exchange(request, Exchange.Origin.REMOTE);
+
+		Response response = new Response(CoAP.ResponseCode.CONTENT);
+		stack.sendResponse(exchange, response);
+
+		verify(outbox).sendResponse(exchange, response);
+	}
+}


### PR DESCRIPTION
where an empty message would get deserialized as CON (because there's no TYPE on the wire in TCP), and then make it to endpoint where it will get rejected, resulting in another empty message going back to the friend. To avoid this ping pong, send RST through the stack rather than having endpoint send it directly through the collector. All layers in the stack will ignore sendEmpty message, so from there it will make its way to connector, just like it does today. The exception is TCP stack, where TcpAdaptation layer will drop RST message.

Since we do not have Exchange, using null exchange to send empty message. Could also create a "fake" one instead. Open to opinion on this.

Signed-off-by: Joe Magerramov <joe.magerramov@gmail.com>