### PR TITLE
Add TCP correlation context.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/RawData.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/RawData.java
@@ -17,6 +17,7 @@
  *    Bosch Software Innovations GmbH - add support for correlation context to provide
  *                                      additional information to application layer for
  *                                      matching messages (fix GitHub issue #1)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add onContextEstablished.
  ******************************************************************************/
 package org.eclipse.californium.elements;
 
@@ -293,8 +294,7 @@ public final class RawData {
 	/**
 	 * Gets the identity of the sender of the message.
 	 * 
-	 * This property is only meaningful for messages
-	 * received from a client.
+	 * This property is only meaningful for messages received from a client.
 	 * 
 	 * @return the identity or <code>null</code> if the
 	 *      sender has not been authenticated
@@ -304,7 +304,7 @@ public final class RawData {
 	}
 
 	/**
-	 * Gets additional information regarding the context this message has been 
+	 * Gets additional information regarding the context this message has been
 	 * received in.
 	 * 
 	 * @return the messageContext the correlation information or <code>null</code> if
@@ -330,4 +330,16 @@ public final class RawData {
 		return (correlationContext != null &&
 				correlationContext.get(DtlsCorrelationContext.KEY_SESSION_ID) != null);
 	}
+
+	/**
+	 * Callback, when context gets available. Used on sending an message.
+	 * 
+	 * @param context established context to be forwarded to the callback.
+	 */
+	public void onContextEstablished(CorrelationContext context) {
+		if (null != callback) {
+			callback.onContextEstablished(context);
+		}
+	}
+
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/TcpCorrelationContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/TcpCorrelationContext.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial support for correlation context to provide
+ *                                      additional information to application layer for
+ *                                      matching messages using TCP.
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+/**
+ * A correlation context that explicitly supports TCP specific properties.
+ */
+public class TcpCorrelationContext extends MapBasedCorrelationContext {
+
+	/**
+	 * Key for TCP connection ID.
+	 * 
+	 */
+	public static final String KEY_CONNECTION_ID = "CONNECTION_ID";
+
+	/**
+	 * Creates a new correlation context from TCP connection ID.
+	 * 
+	 * @param connectionId the connectionn's ID.
+	 * @throws NullPointerException if connectionId is <code>null</code>.
+	 */
+	public TcpCorrelationContext(String connectionId) {
+		if (connectionId == null) {
+			throw new NullPointerException("Connection ID must not be null");
+		} else {
+			put(KEY_CONNECTION_ID, connectionId);
+		}
+	}
+
+	public String getConnectionId() {
+		return get(KEY_CONNECTION_ID);
+	}
+
+	@Override
+	public String toString() {
+		return String.format("TCP(%s)", getConnectionId());
+	}
+
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/DatagramFramer.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/DatagramFramer.java
@@ -12,12 +12,16 @@
  * <p>
  * Contributors:
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ * Achim Kraus (Bosch Software Innovations GmbH) - add correlation context
  ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
+
+import org.eclipse.californium.elements.CorrelationContext;
 import org.eclipse.californium.elements.RawData;
 
 import java.math.BigInteger;
@@ -67,8 +71,10 @@ public class DatagramFramer extends ByteToMessageDecoder {
 			byte[] data = new byte[coapHeaderSize + bodyLength];
 			in.readBytes(data);
 			// This is TCP connector, so we know remote address is InetSocketAddress.
-			InetSocketAddress socketAddress = (InetSocketAddress) ctx.channel().remoteAddress();
-			RawData rawData = new RawData(data, socketAddress);
+			Channel channel = ctx.channel();
+			InetSocketAddress socketAddress = (InetSocketAddress) channel.remoteAddress();
+			CorrelationContext correlationContext = NettyContextUtils.buildCorrelationContext(channel);
+			RawData rawData = RawData.inbound(data, socketAddress, null, correlationContext, false);
 			out.add(rawData);
 		}
 	}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/NettyContextUtils.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/NettyContextUtils.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation. 
+ *                                      add support for correlation context
+ ******************************************************************************/
+package org.eclipse.californium.elements.tcp;
+
+import io.netty.channel.Channel;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.californium.elements.CorrelationContext;
+import org.eclipse.californium.elements.TcpCorrelationContext;
+
+/**
+ * Utils for building for TCP correlation context and principal from
+ * channel. To be extended in the future to support TLS also.
+ */
+public class NettyContextUtils {
+
+	private static final Logger LOGGER = Logger.getLogger(NettyContextUtils.class.getName());
+	private static final Level LEVEL = Level.FINER;
+
+	/**
+	 * Build correlation context related to the provided channel.
+	 * 
+	 * @param channel channel of correlation context
+	 * @return correlation context
+	 */
+	public static CorrelationContext buildCorrelationContext(Channel channel) {
+		String id = channel.id().asShortText();
+		LOGGER.log(LEVEL, "TCP({0})", id);
+		return new TcpCorrelationContext(id);
+	}
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpServerConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpServerConnector.java
@@ -14,6 +14,7 @@
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
  * Achim Kraus (Bosch Software Innovations GmbH) - adjust port when bound.
  * Achim Kraus (Bosch Software Innovations GmbH) - use CloseOnErrorHandler.
+ * Achim Kraus (Bosch Software Innovations GmbH) - add correlation context.
  ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
@@ -26,6 +27,7 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.timeout.IdleStateHandler;
 
 import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.CorrelationContext;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
 
@@ -122,8 +124,10 @@ public class TcpServerConnector implements Connector {
 					msg.getAddress());
 			return;
 		}
+		CorrelationContext context = NettyContextUtils.buildCorrelationContext(channel);
 
 		channel.writeAndFlush(Unpooled.wrappedBuffer(msg.getBytes()));
+		msg.onContextEstablished(context);
 	}
 
 	@Override

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/ConnectorTestUtil.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/ConnectorTestUtil.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - initial implementation
+ *                                                    stuff copied from TcpConnectorTest
+ ******************************************************************************/
+package org.eclipse.californium.elements.tcp;
+
+import java.io.ByteArrayOutputStream;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import org.eclipse.californium.elements.MessageCallback;
+import org.eclipse.californium.elements.RawData;
+
+/**
+ * Utils for TCP based connector tests.
+ */
+public class ConnectorTestUtil {
+
+	public static final int NUMBER_OF_THREADS = 1;
+	public static final int CONECTION_TIMEOUT_IN_MS = 100;
+	public static final int IDLE_TIMEOUT_IN_S = 100;
+	public static final int IDLE_TIMEOUT_RECONNECT_IN_S = 2;
+	public static final int CONTEXT_TIMEOUT_IN_MS = 1000;
+
+	private static final Random random = new Random(0);
+
+	public static RawData createMessage(InetSocketAddress address, int messageSize, MessageCallback callback)
+			throws Exception {
+		byte[] data = new byte[messageSize];
+		random.nextBytes(data);
+
+		try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
+			if (messageSize < 13) {
+				stream.write(messageSize << 4);
+			} else if (messageSize < (1 << 8) + 13) {
+				stream.write(13 << 4);
+				stream.write(messageSize - 13);
+			} else if (messageSize < (1 << 16) + 269) {
+				stream.write(14 << 4);
+
+				ByteBuffer buffer = ByteBuffer.allocate(2);
+				buffer.putShort((short) (messageSize - 269));
+				stream.write(buffer.array());
+			} else {
+				stream.write(15 << 4);
+
+				ByteBuffer buffer = ByteBuffer.allocate(4);
+				buffer.putInt(messageSize - 65805);
+				stream.write(buffer.array());
+			}
+
+			stream.write(1); // GET
+			stream.write(data);
+			stream.flush();
+			return RawData.outbound(stream.toByteArray(), address, callback, false);
+		}
+	}
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/SimpleMessageCallback.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/SimpleMessageCallback.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.elements.tcp;
+
+import org.eclipse.californium.elements.CorrelationContext;
+import org.eclipse.californium.elements.MessageCallback;
+
+/**
+ * A simple message callback to access the correlation context when sending a
+ * message.
+ */
+public class SimpleMessageCallback implements MessageCallback {
+
+	/**
+	 * Correlation context of sent message.
+	 */
+	private CorrelationContext context;
+
+	@Override
+	public synchronized void onContextEstablished(CorrelationContext context) {
+		this.context = context;
+		notifyAll();
+	}
+
+	/**
+	 * Get correlation context of sent message.
+	 * 
+	 * @return correlation context of sent message, or null, if not jet sent or
+	 *         no correlation context is available.
+	 * @see #getCorrelationContext(long)
+	 */
+	public synchronized CorrelationContext getCorrelationContext() {
+		return context;
+	}
+
+	/**
+	 * Get correlation context of sent message waiting with timeout.
+	 * 
+	 * @return correlation context of sent message, or null, if not sent within
+	 *         provided timeout or no correlation context is available.
+	 * @see #getCorrelationContext(long)
+	 */
+	public synchronized CorrelationContext getCorrelationContext(long timeout) throws InterruptedException {
+		if (null == context) {
+			wait(timeout);
+		}
+		return context;
+	}
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TcpCorrelationTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TcpCorrelationTest.java
@@ -1,0 +1,323 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation. 
+ ******************************************************************************/
+package org.eclipse.californium.elements.tcp;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.text.IsEmptyString.isEmptyOrNullString;
+import static org.junit.Assert.assertArrayEquals;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.CorrelationContext;
+import org.eclipse.californium.elements.RawData;
+import org.eclipse.californium.elements.TcpCorrelationContext;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+public class TcpCorrelationTest {
+
+	@Rule
+	public final Timeout timeout = new Timeout(20, TimeUnit.SECONDS);
+
+	private final List<Connector> cleanup = new ArrayList<>();
+
+	@After
+	public void cleanup() {
+		for (Connector connector : cleanup) {
+			connector.stop();
+		}
+	}
+
+	/**
+	 * Test, if the correlation context is determined proper.
+	 * Send a request and check, if the response has the same correlation context on the client side.
+	 * Send a second request and check, if this has the same correlation context on the client side.
+	 * Also check, if the server response is sent with the same context as the request was received.
+	 */
+	@Test
+	public void testCorrelationContext() throws Exception {
+		TcpServerConnector server = new TcpServerConnector(new InetSocketAddress(0),
+				ConnectorTestUtil.NUMBER_OF_THREADS, ConnectorTestUtil.IDLE_TIMEOUT_IN_S);
+		TcpClientConnector client = new TcpClientConnector(ConnectorTestUtil.NUMBER_OF_THREADS,
+				ConnectorTestUtil.CONECTION_TIMEOUT_IN_MS, ConnectorTestUtil.IDLE_TIMEOUT_IN_S);
+
+		cleanup.add(server);
+		cleanup.add(client);
+
+		Catcher serverCatcher = new Catcher();
+		Catcher clientCatcher = new Catcher();
+		server.setRawDataReceiver(serverCatcher);
+		client.setRawDataReceiver(clientCatcher);
+		server.start();
+		client.start();
+
+		SimpleMessageCallback clientCallback = new SimpleMessageCallback();
+		RawData msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, clientCallback);
+
+		client.send(msg);
+		serverCatcher.blockUntilSize(1);
+		CorrelationContext receivingServerContext = serverCatcher.getMessage(0).getCorrelationContext();
+		assertThat("Serverside received no TCP Correlation Context", receivingServerContext, is(instanceOf(TcpCorrelationContext.class)));
+		assertThat(receivingServerContext.get(TcpCorrelationContext.KEY_CONNECTION_ID), is(not(isEmptyOrNullString())));
+
+		CorrelationContext clientContext = clientCallback.getCorrelationContext();
+		assertThat("no TCP Correlation Context", clientContext, is(instanceOf(TcpCorrelationContext.class)));
+		assertThat(clientContext.get(TcpCorrelationContext.KEY_CONNECTION_ID), is(not(isEmptyOrNullString())));
+
+		// Response message must go over the same connection client already
+		// opened
+		SimpleMessageCallback serverCallback = new SimpleMessageCallback();
+		msg = ConnectorTestUtil.createMessage(serverCatcher.getMessage(0).getInetSocketAddress(), 100, serverCallback);
+		server.send(msg);
+		clientCatcher.blockUntilSize(1);
+
+		CorrelationContext serverContext = serverCallback.getCorrelationContext();
+		assertThat("Serverside no TCP Correlation Context", serverContext, is(instanceOf(TcpCorrelationContext.class)));
+		assertThat(serverContext, is(receivingServerContext));
+		assertThat(serverContext.get(TcpCorrelationContext.KEY_CONNECTION_ID), is(receivingServerContext.get(TcpCorrelationContext.KEY_CONNECTION_ID)));
+
+		// check response correlation context
+		CorrelationContext responseContext = clientCatcher.getMessage(0).getCorrelationContext();
+		assertThat("no response TCP Correlation Context", responseContext, is(instanceOf(TcpCorrelationContext.class)));
+		assertThat(responseContext, is(clientContext));
+		assertThat(responseContext.get(TcpCorrelationContext.KEY_CONNECTION_ID),
+				is(clientContext.get(TcpCorrelationContext.KEY_CONNECTION_ID)));
+
+		// send next message
+		clientCallback = new SimpleMessageCallback();
+		msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, clientCallback);
+
+		client.send(msg);
+
+		CorrelationContext context2 = clientCallback.getCorrelationContext(ConnectorTestUtil.CONTEXT_TIMEOUT_IN_MS);
+		assertThat("no TCP Correlation Context", context2, is(instanceOf(TcpCorrelationContext.class)));
+		assertThat(context2, is(clientContext));
+		assertThat(context2.get(TcpCorrelationContext.KEY_CONNECTION_ID),
+				is(clientContext.get(TcpCorrelationContext.KEY_CONNECTION_ID)));
+	}
+
+	/**
+	 * Test, if the correlation context is different when reconnect after timeout.
+	 * Send a request and fetch the correlation context on client and server side.
+	 * Wait for connection timeout.
+	 * Send a new request and fetch the correlation context on client and server side.
+	 * The correlation contexts must be different.
+	 */
+	@Test
+	public void testCorrelationContextWhenReconnectAfterTimeout() throws Exception {
+		TcpServerConnector server = new TcpServerConnector(new InetSocketAddress(0),
+				ConnectorTestUtil.NUMBER_OF_THREADS, ConnectorTestUtil.IDLE_TIMEOUT_RECONNECT_IN_S);
+		TcpClientConnector client = new TcpClientConnector(ConnectorTestUtil.NUMBER_OF_THREADS,
+				ConnectorTestUtil.CONECTION_TIMEOUT_IN_MS, ConnectorTestUtil.IDLE_TIMEOUT_RECONNECT_IN_S);
+
+		cleanup.add(server);
+		cleanup.add(client);
+
+		Catcher serverCatcher = new Catcher();
+		Catcher clientCatcher = new Catcher();
+		server.setRawDataReceiver(serverCatcher);
+		client.setRawDataReceiver(clientCatcher);
+		server.start();
+		client.start();
+
+		SimpleMessageCallback clientCallback = new SimpleMessageCallback();
+		RawData msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, clientCallback);
+
+		client.send(msg);
+		serverCatcher.blockUntilSize(1);
+		CorrelationContext serverContext = serverCatcher.getMessage(0).getCorrelationContext();
+
+		CorrelationContext clientContext = clientCallback.getCorrelationContext();
+
+		// timeout connection, hopefully this triggers a reconnect
+		Thread.sleep(TimeUnit.MILLISECONDS.convert(ConnectorTestUtil.IDLE_TIMEOUT_RECONNECT_IN_S * 2, TimeUnit.SECONDS));
+
+		clientCallback = new SimpleMessageCallback();
+		msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, clientCallback);
+
+		client.send(msg);
+		serverCatcher.blockUntilSize(2);
+
+		CorrelationContext clientContextAfterReconnect = clientCallback.getCorrelationContext();
+		assertThat("no TCP Correlation Context after reconnect", clientContextAfterReconnect,
+				is(instanceOf(TcpCorrelationContext.class)));
+		// new (different) client side connection id
+		assertThat(clientContextAfterReconnect, is(not(clientContext)));
+		assertThat(clientContextAfterReconnect.get(TcpCorrelationContext.KEY_CONNECTION_ID),
+				is(not(clientContext.get(TcpCorrelationContext.KEY_CONNECTION_ID))));
+
+		// new (different) server side connection id
+		CorrelationContext serverContextAfterReconnect = serverCatcher.getMessage(1).getCorrelationContext();
+		assertThat("Serverside no TCP Correlation Context after reconnect", serverContextAfterReconnect,
+				is(instanceOf(TcpCorrelationContext.class)));
+		// new (different) server side connection id
+		assertThat(serverContextAfterReconnect.get(TcpCorrelationContext.KEY_CONNECTION_ID),
+				is(not(serverContext.get(TcpCorrelationContext.KEY_CONNECTION_ID))));
+		assertThat(serverContextAfterReconnect, is(not(serverContext)));
+
+	}
+
+	/**
+	 * Test, if the correlation context is different when reconnect after server stop/start.
+	 * Send a request and fetch the correlation context on client and server side.
+	 * Stop/start the server.
+	 * Send a new request and fetch the correlation context on client and server side.
+	 * The correlation contexts must be different.
+	 */
+	@Test
+	public void testCorrelationContextWhenReconnectAfterStopStart() throws Exception {
+		TcpServerConnector server = new TcpServerConnector(new InetSocketAddress(0),
+				ConnectorTestUtil.NUMBER_OF_THREADS, ConnectorTestUtil.IDLE_TIMEOUT_RECONNECT_IN_S);
+		TcpClientConnector client = new TcpClientConnector(ConnectorTestUtil.NUMBER_OF_THREADS,
+				ConnectorTestUtil.CONECTION_TIMEOUT_IN_MS, ConnectorTestUtil.IDLE_TIMEOUT_RECONNECT_IN_S);
+
+		cleanup.add(server);
+		cleanup.add(client);
+
+		Catcher serverCatcher = new Catcher();
+		Catcher clientCatcher = new Catcher();
+		server.setRawDataReceiver(serverCatcher);
+		client.setRawDataReceiver(clientCatcher);
+		server.start();
+		client.start();
+
+		SimpleMessageCallback clientCallback = new SimpleMessageCallback();
+		RawData msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, clientCallback);
+
+		client.send(msg);
+		serverCatcher.blockUntilSize(1);
+		CorrelationContext serverContext = serverCatcher.getMessage(0).getCorrelationContext();
+
+		CorrelationContext clientContext = clientCallback.getCorrelationContext();
+
+		/* stop / start the server */
+		server.stop();
+		server.start();
+
+		clientCallback = new SimpleMessageCallback();
+		msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, clientCallback);
+
+		client.send(msg);
+		serverCatcher.blockUntilSize(2);
+
+		CorrelationContext clientContextAfterReconnect = clientCallback.getCorrelationContext();
+		assertThat("no TCP Correlation Context after reconnect", clientContextAfterReconnect,
+				is(instanceOf(TcpCorrelationContext.class)));
+		// new (different) client side connection id
+		assertThat(clientContextAfterReconnect, is(not(clientContext)));
+		assertThat(clientContextAfterReconnect.get(TcpCorrelationContext.KEY_CONNECTION_ID),
+				is(not(clientContext.get(TcpCorrelationContext.KEY_CONNECTION_ID))));
+
+		// Response message must go over the reconnected connection
+
+		CorrelationContext serverContextAfterReconnect = serverCatcher.getMessage(1).getCorrelationContext();
+		assertThat("Serverside no TCP Correlation Context after reconnect", serverContextAfterReconnect,
+				is(instanceOf(TcpCorrelationContext.class)));
+		// new (different) server side connection id
+		assertThat(serverContextAfterReconnect, is(not(serverContext)));
+		assertThat(serverContextAfterReconnect.get(TcpCorrelationContext.KEY_CONNECTION_ID),
+				is(not(serverContext.get(TcpCorrelationContext.KEY_CONNECTION_ID))));
+	}
+
+	/**
+	 * Test, if the correlation context is determined proper when connecting to different servers.
+	 * Send a message to different servers end determine the used correlation context on the client side.
+	 * Send a second message to different servers end determine the correlation context used then on the client side.
+	 * Compare the correlation contexts, they must be the same per server.
+	 */
+	@Test
+	public void testSingleClientManyServersCorrelationContext() throws Exception {
+		int serverCount = 3;
+		Map<InetSocketAddress, Catcher> servers = new IdentityHashMap<>();
+		for (int i = 0; i < serverCount; i++) {
+			TcpServerConnector server = new TcpServerConnector(new InetSocketAddress(0),
+					ConnectorTestUtil.NUMBER_OF_THREADS, ConnectorTestUtil.IDLE_TIMEOUT_IN_S);
+			cleanup.add(server);
+			Catcher serverCatcher = new Catcher();
+			server.setRawDataReceiver(serverCatcher);
+			server.start();
+
+			servers.put(server.getAddress(), serverCatcher);
+		}
+		Set<InetSocketAddress> serverAddresses = servers.keySet();
+
+		TcpClientConnector client = new TcpClientConnector(ConnectorTestUtil.NUMBER_OF_THREADS,
+				ConnectorTestUtil.CONECTION_TIMEOUT_IN_MS, ConnectorTestUtil.IDLE_TIMEOUT_IN_S);
+		cleanup.add(client);
+		Catcher clientCatcher = new Catcher();
+		client.setRawDataReceiver(clientCatcher);
+		client.start();
+
+		/* send messages to all servers */
+		List<RawData> messages = new ArrayList<>();
+		List<SimpleMessageCallback> callbacks = new ArrayList<>();
+		for (InetSocketAddress address : serverAddresses) {
+			SimpleMessageCallback callback = new SimpleMessageCallback();
+			RawData message = ConnectorTestUtil.createMessage(address, 100, callback);
+			callbacks.add(callback);
+			messages.add(message);
+			client.send(message);
+		}
+
+		/* receive messages for all servers */
+		for (RawData message : messages) {
+			Catcher catcher = servers.get(message.getInetSocketAddress());
+			catcher.blockUntilSize(1);
+			assertArrayEquals(message.getBytes(), catcher.getMessage(0).getBytes());
+		}
+
+		/* send 2. (follow up) messages to all servers */
+		List<RawData> followupMessages = new ArrayList<>();
+		List<SimpleMessageCallback>  followupCallbacks = new ArrayList<>();
+		for (InetSocketAddress address : serverAddresses) {
+			SimpleMessageCallback callback = new SimpleMessageCallback();
+			RawData message = ConnectorTestUtil.createMessage(address, 100, callback);
+			followupCallbacks.add(callback);
+			followupMessages.add(message);
+			client.send(message);
+		}
+
+		/* receive 2. (follow up) messages for all servers */
+		for (RawData followupMessage : followupMessages) {
+			Catcher catcher = servers.get(followupMessage.getInetSocketAddress());
+			catcher.blockUntilSize(2);
+			assertArrayEquals(followupMessage.getBytes(), catcher.getMessage(1).getBytes());
+		}
+
+		/* check matching correlation contexts for both messages sent to all servers */
+		for (int index = 0; index < messages.size(); ++index) {
+			CorrelationContext context1 = callbacks.get(index).getCorrelationContext();
+			CorrelationContext context2 = followupCallbacks.get(index).getCorrelationContext();
+			// same connection id used for follow up message
+			assertThat(context1, is(context2));
+			assertThat(context1.get(TcpCorrelationContext.KEY_CONNECTION_ID),
+					is(context2.get(TcpCorrelationContext.KEY_CONNECTION_ID)));
+		}
+	}
+
+}


### PR DESCRIPTION
Used to distinguish different connections between the same endpoints.
The "localhost/127.0.0.1" mainly used for logging in the TCP client is
replaced by "any/0.0.0.0" because it reaches also targets on other
hosts, what would not be possible with "localhost".
The ConnectorTestUtil introduces common functions for TCP test. The
already available tests may be adpated to use this in a follow up PR.
This PR is the first part for correlation contexts for TCP based
connections. The larger part would be TLS and will follow, when this
get's merged.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>