### PR TITLE
Add remote peer to SSLEngine.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpClientConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpClientConnector.java
@@ -15,6 +15,9 @@
  * Achim Kraus (Bosch Software Innovations GmbH) - add correlation context
  *                                                 use "any/0.0.0.0" instead
  *                                                 of "localhost/127.0.0.1".
+ * Achim Kraus (Bosch Software Innovations GmbH) - add remote to onNewChannelCreated
+ *                                                 for "remote aware" SSLEngine
+ *                                                 correct "localhost" to "any".
  ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
@@ -141,8 +144,12 @@ public class TcpClientConnector implements Connector {
 
 	/**
 	 * Called when a new channel is created, Allows subclasses to add their own handlers first, like an SSL handler.
+	 * At this stage the channel is not connected, and therefore the {@link Channel#remoteAddress()} is null. To create
+	 * a "remote peer" aware SSLEngine, provide the remote address as additional parameter.
+	 * @param remote remote address the channel will be connected to.
+	 * @param ch new created channel
 	 */
-	protected void onNewChannelCreated(Channel ch) {
+	protected void onNewChannelCreated(SocketAddress remote, Channel ch) {
 	}
 
 	protected String getSupportedScheme() {
@@ -167,8 +174,9 @@ public class TcpClientConnector implements Connector {
 			this.key = key;
 		}
 
-		@Override public void channelCreated(Channel ch) throws Exception {
-			onNewChannelCreated(ch);
+		@Override
+		public void channelCreated(Channel ch) throws Exception {
+			onNewChannelCreated(key, ch);
 
 			// Handler order:
 			// 1. Generate Idle events

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TlsServerConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TlsServerConnector.java
@@ -12,6 +12,7 @@
  * <p>
  * Contributors:
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ * Achim Kraus (Bosch Software Innovations GmbH) - create "remote aware" SSLEngine
  ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
@@ -22,13 +23,18 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * A TCP client connector that establishes outbound TLS connections.
  */
 public class TlsServerConnector extends TcpServerConnector {
+
+	private static final Logger LOGGER = Logger.getLogger(TlsServerConnector.class.getName());
 
 	private final SSLContext sslContext;
 
@@ -57,7 +63,7 @@ public class TlsServerConnector extends TcpServerConnector {
 	}
 
 	@Override protected void onNewChannelCreated(Channel ch) {
-		SSLEngine sslEngine = sslContext.createSSLEngine();
+		SSLEngine sslEngine = createSllEngineForChannel(ch);
 		sslEngine.setUseClientMode(false);
 		ch.pipeline().addFirst(new SslHandler(sslEngine));
 	}
@@ -66,4 +72,23 @@ public class TlsServerConnector extends TcpServerConnector {
 	protected String getSupportedScheme() {
 		return "coaps+tcp";
 	}
+
+	/**
+	 * Create SSL engine for channel.
+	 * 
+	 * @param ch channel to determine remote host
+	 * @return created SSL engine
+	 */
+	private SSLEngine createSllEngineForChannel(Channel ch) {
+		SocketAddress remoteAddress = ch.remoteAddress();
+		if (remoteAddress instanceof InetSocketAddress) {
+			InetSocketAddress remote = (InetSocketAddress) remoteAddress;
+			LOGGER.log(Level.INFO, "Connection from inet {0}", remote);
+			return sslContext.createSSLEngine(remote.getHostString(), remote.getPort());
+		} else {
+			LOGGER.log(Level.INFO, "Connection from {0}", remoteAddress);
+			return sslContext.createSSLEngine();
+		}
+	}
+
 }


### PR DESCRIPTION
Enable session reuse, when TLS connection is established again.
Also enables the KeyManager/TrustManager to select credentials related to the remote peer. 

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>