### PR TITLE
basic correlation strategy for matching responses and request

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CorrelationContextMatcherFactory.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CorrelationContextMatcherFactory.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - introduce CorrelationContextMatcher
+ *                                      (fix GitHub issue #104)
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.CorrelationContextMatcher;
+import org.eclipse.californium.elements.RelaxedCorrelationContextMatcher;
+import org.eclipse.californium.elements.StrictCorrelationContextMatcher;
+
+/**
+ * Factory for correlation context matcher.
+ */
+public class CorrelationContextMatcherFactory {
+
+	/**
+	 * Create correlation context matcher according the configuration. If
+	 * USE_STRICT_RESPONSE_MATCHING is set, use
+	 * {@link StrictCorrelationContextMatcher}, otherwise
+	 * {@link RelaxedCorrelationContextMatcher}.
+	 * 
+	 * @param config configuration.
+	 * @return correlation context matcher
+	 */
+	public static CorrelationContextMatcher create(NetworkConfig config) {
+		return config.getBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING) ? new StrictCorrelationContextMatcher()
+				: new RelaxedCorrelationContextMatcher();
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/TcpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/TcpMatcherTest.java
@@ -12,6 +12,8 @@
  * 
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add CorrelationContextMatcher
+ *                                                    (fix GitHub issue #104)
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -56,8 +58,7 @@ public class TcpMatcherTest {
 			}
 			
 		};
-		
-		TcpMatcher matcher = new TcpMatcher(config, notificationListener,  new InMemoryObservationStore());
+		TcpMatcher matcher = new TcpMatcher(config, notificationListener,  new InMemoryObservationStore(), CorrelationContextMatcherFactory.create(config));
 		matcher.start();
 		return matcher;
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -12,6 +12,8 @@
  * 
  * Contributors:
  *    Bosch Software Innovations GmbH - initial creation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add CorrelationContextMatcher
+ *                                                    (fix GitHub issue #104)
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -255,7 +257,7 @@ public class UdpMatcherTest {
 			
 		};
 		
-		UdpMatcher matcher = new UdpMatcher(config, notificationListener, observationStore);
+		UdpMatcher matcher = new UdpMatcher(config, notificationListener, observationStore, CorrelationContextMatcherFactory.create(config));
 
 		matcher.setMessageExchangeStore(messageExchangeStore);
 		matcher.start();

--- a/element-connector/src/main/java/org/eclipse/californium/elements/CorrelationContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/CorrelationContextMatcher.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - add flexible correlation context matching
+ *                                      (fix GitHub issue #104)
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+/**
+ * Interface for correlation context processing. Enable implementor to flexible
+ * decide on context correlation information.
+ */
+public interface CorrelationContextMatcher {
+
+	/**
+	 * Return matcher name. Used for logging.
+	 * 
+	 * @return name of strategy.
+	 */
+	String getName();
+
+	/**
+	 * Check, if responses is related to the request.
+	 * 
+	 * @param requestContext correlation context of request
+	 * @param responseContext correlation context of response
+	 * @return true, if response is related to the request, false, if response
+	 *         should not be considered for this request.
+	 */
+	boolean isResponseRelatedToRequest(CorrelationContext requestContext, CorrelationContext responseContext);
+
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/RelaxedCorrelationContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/RelaxedCorrelationContextMatcher.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - add flexible correlation context matching
+ *                                      (fix GitHub issue #104)
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Relaxed correlation context matcher. Matches DTLS without epoch.
+ */
+public class RelaxedCorrelationContextMatcher implements CorrelationContextMatcher {
+
+	private static final Logger LOGGER = Logger.getLogger(RelaxedCorrelationContextMatcher.class.getName());
+
+	@Override
+	public String getName() {
+		return "relaxed correlation";
+	}
+
+	@Override
+	public boolean isResponseRelatedToRequest(CorrelationContext requestContext, CorrelationContext responseContext) {
+		return internalMatch(requestContext, responseContext);
+	}
+
+	private final boolean internalMatch(CorrelationContext requestedContext, CorrelationContext availableContext) {
+		if (null == requestedContext) {
+			return true;
+		} else if (null == availableContext) {
+			return false;
+		}
+		if (requestedContext.get(DtlsCorrelationContext.KEY_SESSION_ID) != null) {
+			boolean match = requestedContext.get(DtlsCorrelationContext.KEY_SESSION_ID).equals(
+					availableContext.get(DtlsCorrelationContext.KEY_SESSION_ID))
+					&& requestedContext.get(DtlsCorrelationContext.KEY_CIPHER).equals(
+							availableContext.get(DtlsCorrelationContext.KEY_CIPHER));
+
+			LOGGER.log(
+					match ? Level.FINEST : Level.WARNING,
+					"(D)TLS session {0}, {1}",
+					new Object[] { requestedContext.get(DtlsCorrelationContext.KEY_SESSION_ID),
+							availableContext.get(DtlsCorrelationContext.KEY_SESSION_ID) });
+			LOGGER.log(
+					match ? Level.FINEST : Level.WARNING,
+					"(D)TLS cipher {0}, {1}",
+					new Object[] { requestedContext.get(DtlsCorrelationContext.KEY_CIPHER),
+							availableContext.get(DtlsCorrelationContext.KEY_CIPHER) });
+			return match;
+		}
+		return requestedContext.equals(availableContext);
+	}
+
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/StrictCorrelationContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/StrictCorrelationContextMatcher.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - add flexible correlation context matching
+ *                                      (fix GitHub issue #104)
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Strict correlation context matcher. Uses strictly matching for DTLS including
+ * the security epoch.
+ */
+public class StrictCorrelationContextMatcher implements CorrelationContextMatcher {
+
+	private static final Logger LOGGER = Logger.getLogger(RelaxedCorrelationContextMatcher.class.getName());
+
+	@Override
+	public String getName() {
+		return "strict correlation";
+	}
+
+	@Override
+	public boolean isResponseRelatedToRequest(CorrelationContext requestContext, CorrelationContext responseContext) {
+		return internalMatch(requestContext, responseContext);
+	}
+
+	private final boolean internalMatch(CorrelationContext requestedContext, CorrelationContext availableContext) {
+		if (null == requestedContext) {
+			return true;
+		} else if (null == availableContext) {
+			return false;
+		}
+		if (requestedContext.get(DtlsCorrelationContext.KEY_SESSION_ID) != null) {
+			boolean match = requestedContext.get(DtlsCorrelationContext.KEY_SESSION_ID).equals(
+					availableContext.get(DtlsCorrelationContext.KEY_SESSION_ID))
+					&& requestedContext.get(DtlsCorrelationContext.KEY_EPOCH).equals(
+							availableContext.get(DtlsCorrelationContext.KEY_EPOCH))
+					&& requestedContext.get(DtlsCorrelationContext.KEY_CIPHER).equals(
+							availableContext.get(DtlsCorrelationContext.KEY_CIPHER));
+
+			LOGGER.log(
+					match ? Level.FINEST : Level.WARNING,
+					"(D)TLS session {0}, {1}",
+					new Object[] { requestedContext.get(DtlsCorrelationContext.KEY_SESSION_ID),
+							availableContext.get(DtlsCorrelationContext.KEY_SESSION_ID) });
+			LOGGER.log(
+					match ? Level.FINEST : Level.WARNING,
+					"(D)TLS epoch {0}, {1}",
+					new Object[] { requestedContext.get(DtlsCorrelationContext.KEY_EPOCH),
+							availableContext.get(DtlsCorrelationContext.KEY_EPOCH) });
+			LOGGER.log(
+					match ? Level.FINEST : Level.WARNING,
+					"(D)TLS cipher {0}, {1}",
+					new Object[] { requestedContext.get(DtlsCorrelationContext.KEY_CIPHER),
+							availableContext.get(DtlsCorrelationContext.KEY_CIPHER) });
+			return match;
+		}
+		return requestedContext.equals(availableContext);
+	}
+
+}


### PR DESCRIPTION
Replaces the "isResponseRelatedToRequest" in the Matchers with
"CorrelationStrategy.match()". Intended to be extended with a followup PR
for matching messages on sending to fix issue #104.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>