### PR TITLE
Reduce error logging for security errors to comprehesive messages.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/CloseOnErrorHandler.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/CloseOnErrorHandler.java
@@ -12,28 +12,59 @@
  * <p>
  * Contributors:
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ * Achim Kraus (Bosch Software Innovations GmbH) - use comprehensive message
+ *                                                 for security errors.
  ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 
+import java.security.GeneralSecurityException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.net.ssl.SSLException;
+
 /**
  * Channel handler that closes connection if an exception was raised.
+ * Use the logging level of {@link CloseOnErrorHandler} to specify the amount
+ * of stack-traces in cases of security errors.
+ * Level FINER, log all stack-traces, Level WARNING, log stack-trace of the
+ * root most cause, and SEVERE for message of root most cause only.
+ * All logging is done with Level SEVERE, so the level only determines the amount
+ * of information in cases of security errors.
  */
 class CloseOnErrorHandler extends ChannelHandlerAdapter {
 
 	private final static Logger LOGGER = Logger.getLogger(CloseOnErrorHandler.class.getName());
 
-	@Override public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+	@Override
+	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
 		// Since we use length based framing, any exception reading in TCP stream has the high likelihood of us
 		// getting out of sync on the stream, and not being able to recover. So close the connection and hope for the
 		// better luck next time.
-		LOGGER.log(Level.SEVERE, "Exception in channel handler chain for endpoint " + ctx.channel().remoteAddress() +
-				". Closing connection.", cause);
-		ctx.close();
+		try {
+			Throwable rootCause = cause;
+			while (null != rootCause.getCause()) {
+				rootCause = rootCause.getCause();
+			}
+			if (!LOGGER.isLoggable(Level.FINER)
+					&& (rootCause instanceof SSLException || rootCause instanceof GeneralSecurityException)) {
+				/* comprehensive message for security exceptions */
+				if (LOGGER.isLoggable(Level.WARNING)) {
+					LOGGER.log(Level.SEVERE, "Security Exception in channel handler chain for endpoint "
+							+ ctx.channel().remoteAddress() + ". Closing connection.", rootCause);
+				} else {
+					LOGGER.log(Level.SEVERE, "{0} in channel handler chain for endpoint {1}. Closing connection.",
+							new Object[] { rootCause, ctx.channel().remoteAddress() });
+				}
+			} else {
+				LOGGER.log(Level.SEVERE, "Exception in channel handler chain for endpoint "
+						+ ctx.channel().remoteAddress() + ". Closing connection.", cause);
+			}
+		} finally {
+			ctx.close();
+		}
 	}
 }


### PR DESCRIPTION
Current security/encryption errors are logged with many "caused by
stacktraces". This reduces the message into a comprehensive format.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>