### PR TITLE
Bugfix: Change checkServerTrusted to relaxed DN test.

### DIFF
--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TlsConnectorTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TlsConnectorTest.java
@@ -13,6 +13,8 @@
  * Contributors:
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
  * Achim Kraus (Bosch Software Innovations GmbH) - add more logging.
+ * Achim Kraus (Bosch Software Innovations GmbH) - implement checkServerTrusted
+ *                                                 to check the DN more relaxed.
  ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
@@ -263,8 +265,9 @@ public class TlsConnectorTest {
 		public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
 			for (X509Certificate cert : x509Certificates) {
 				cert.checkValidity();
+				/* only check, if the subject DN starts with the expected name */
 				if (cert.getSubjectDN().getName()
-						.equals("C=CA, L=Ottawa, O=Eclipse IoT, OU=Californium, CN=cf-server")) {
+						.startsWith("C=CA, L=Ottawa, O=Eclipse IoT, OU=Californium, CN=cf-")) {
 					return;
 				}
 			}


### PR DESCRIPTION
Though keyStore.jks contains both, the server and the client keys, it seems to be platform dependend, which on is used. Therefore relax the check of the subject DN. PR #148 contains a SslContextUtil, which would allow to select the credentials and trusts. To use the demo-certs for more deterministic tests, I would prepare that Util in a separate PR. 

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>