### PR TITLE
SslContextUtil for managing plain credentials and javax implementations.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
@@ -1,0 +1,565 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation. 
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStore.Entry;
+import java.security.KeyStore.PrivateKeyEntry;
+import java.security.PrivateKey;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * Utility functions for {@link javax.net.ssl.SSLContext}.
+ * 
+ * This utility converts between the informations used by the javax SSL
+ * implementation and the plain credentials used by scandium. It offers reading
+ * KeyStores, extracting credentials, and creating KeyManager and TrustManager
+ * from the KeyStores or extracted credentials. Java SSLContext is able to
+ * maintain different key-certificate pairs for different key and signing
+ * algorithms. The californium-scandium concentrates on embedded client and
+ * therefore supports only one key-signing algorithm. This utility therefore
+ * helps, to select the right credentials or create a javax security classes for
+ * javax SSL implementation from that selected credentials.
+ */
+public class SslContextUtil {
+
+	/**
+	 * Pseudo protocol for key store URI. Used to load the key store from
+	 * classpath.
+	 */
+	public static final String CLASSPATH_PROTOCOL = "classpath://";
+	/**
+	 * Separator for parameters.
+	 * 
+	 * @see #loadTrustedCertificates(String)
+	 * @see #loadCredentials(String)
+	 */
+	public static final String PARAMETER_SEPARATOR = "#";
+
+	/**
+	 * Load trusted certificates from key store.
+	 * 
+	 * @param trust trust definition keystore#hexstorepwd#aliaspattern. If no
+	 *            aliaspattern should be used, just leave it blank
+	 *            keystore#hexstorepwd#
+	 * @return array with trusted certificates.
+	 * @throws IOException if key store could not be loaded.
+	 * @throws GeneralSecurityException if security setup failed.
+	 * @throws IllegalArgumentException if trust doesn't match
+	 *             keystore#hexstorepwd#aliaspattern or no matching trusts are
+	 *             found
+	 * @throws NullPointerException if trust is null.
+	 * @see #PARAMETER_SEPARATOR
+	 */
+	public static Certificate[] loadTrustedCertificates(String trust) throws IOException, GeneralSecurityException {
+		if (null == trust) {
+			throw new NullPointerException("trust must be provided!");
+		}
+		String[] parameters = trust.split(PARAMETER_SEPARATOR, 3);
+		if (3 != parameters.length) {
+			throw new IllegalArgumentException("trust must comply the pattern <keystore" + PARAMETER_SEPARATOR
+					+ "hexstorepwd" + PARAMETER_SEPARATOR + "aliaspattern>");
+		}
+		return loadTrustedCertificates(parameters[0], parameters[2], StringUtil.hex2CharArray(parameters[1]));
+	}
+
+	/**
+	 * Load credentials from key store.
+	 * 
+	 * @param keys keys definition keystore#hexstorepwd#hexkeypwd#alias.
+	 * @return credentials
+	 * @throws IOException if key store could not be loaded.
+	 * @throws GeneralSecurityException if security setup failed.
+	 * @throws IllegalArgumentException if keys doesn't match
+	 *             keystore#hexstorepwd#hexkeypwd#alias or no matching trusts
+	 *             are found
+	 * @throws NullPointerException if trust is null.
+	 * @see #PARAMETER_SEPARATOR
+	 */
+	public static Credentials loadCredentials(String credentials) throws IOException, GeneralSecurityException {
+		if (null == credentials) {
+			throw new NullPointerException("credentials must be provided!");
+		}
+		String[] parameters = credentials.split(PARAMETER_SEPARATOR, 4);
+		if (4 != parameters.length) {
+			throw new IllegalArgumentException("credentials must comply the pattern <keystore" + PARAMETER_SEPARATOR
+					+ "hexstorepwd" + PARAMETER_SEPARATOR + "hexkeypwd" + PARAMETER_SEPARATOR + "alias>");
+		}
+		return loadCredentials(parameters[0], parameters[3], StringUtil.hex2CharArray(parameters[1]),
+				StringUtil.hex2CharArray(parameters[2]));
+	}
+
+	/**
+	 * Load TrustManager from key store.
+	 * 
+	 * @param keyStoreUri key store URI. If {@link #CLASSPATH_PROTOCOL} is used,
+	 *            loaded from classpath.
+	 * @param aliasPattern regular expression for aliases to load only specific
+	 *            certificates for the TrustManager. null to load all
+	 *            certificates.
+	 * @param storePassword password for key store.
+	 * @return array with TrustManager
+	 * @throws IOException if key store could not be loaded.
+	 * @throws GeneralSecurityException if security setup failed.
+	 * @throws IllegalArgumentException if no matching trusts are found
+	 * @throws NullPointerException if keyStoreUri or storePassword is null.
+	 */
+	public static TrustManager[] loadTrustManager(String keyStoreUri, String aliasPattern, char[] storePassword)
+			throws IOException, GeneralSecurityException {
+		Certificate[] trustedCertificates = loadTrustedCertificates(keyStoreUri, aliasPattern, storePassword);
+		return createTrustManager("trusts", trustedCertificates);
+	}
+
+	/**
+	 * Load KeyManager from key store.
+	 * 
+	 * @param keyStoreUri key store URI. If {@link #CLASSPATH_PROTOCOL} is used,
+	 *            loaded from classpath.
+	 * @param alias alias to load only specific credentials into the KeyManager.
+	 *            null to load all credentials into the KeyManager.
+	 * @param storePassword password for key store.
+	 * @param keyPassword password for private key.
+	 * @return array with KeyManager
+	 * @throws IOException if key store could not be loaded.
+	 * @throws GeneralSecurityException if security setup failed.
+	 * @throws IllegalArgumentException if no matching credentials are found
+	 * @throws NullPointerException if keyStoreUri, storePassword, or
+	 *             keyPassword is null.
+	 */
+	public static KeyManager[] loadKeyManager(String keyStoreUri, String alias, char[] storePassword, char[] keyPassword)
+			throws IOException, GeneralSecurityException {
+		if (null == keyPassword) {
+			throw new NullPointerException("keyPassword must be provided!");
+		}
+		KeyStore ks = loadKeyStore(keyStoreUri, alias, storePassword, keyPassword);
+		return createKeyManager(ks, keyPassword);
+	}
+
+	/**
+	 * Load trusted certificates from key store.
+	 * 
+	 * @param keyStoreUri key store URI. If {@link #CLASSPATH_PROTOCOL} is used,
+	 *            loaded from classpath.
+	 * @param aliasPattern regular expression for aliases to load only specific
+	 *            certificates for trusting. null to load all certificates.
+	 * @param storePassword password for key store.
+	 * @return array with trusted certificates.
+	 * @throws IOException if key store could not be loaded.
+	 * @throws GeneralSecurityException if security setup failed.
+	 * @throws IllegalArgumentException if no matching certificates are found
+	 * @throws NullPointerException if keyStoreUri or storePassword is null.
+	 */
+	public static Certificate[] loadTrustedCertificates(String keyStoreUri, String aliasPattern, char[] storePassword)
+			throws IOException, GeneralSecurityException {
+		KeyStore ks = loadKeyStore(keyStoreUri, storePassword);
+
+		Pattern pattern = null;
+		if (null != aliasPattern && !aliasPattern.isEmpty()) {
+			pattern = Pattern.compile(aliasPattern);
+		}
+		List<Certificate> trustedCertificates = new ArrayList<Certificate>();
+		for (Enumeration<String> e = ks.aliases(); e.hasMoreElements();) {
+			String alias = e.nextElement();
+			if (null != pattern) {
+				Matcher matcher = pattern.matcher(alias);
+				if (!matcher.matches()) {
+					continue;
+				}
+			}
+			Certificate certificate = ks.getCertificate(alias);
+			if (null != certificate) {
+				trustedCertificates.add(certificate);
+			}
+		}
+		if (trustedCertificates.isEmpty()) {
+			throw new IllegalArgumentException("no trusted x509 certificates found in '" + keyStoreUri + "' for '"
+					+ aliasPattern + "'!");
+		}
+		return trustedCertificates.toArray(new Certificate[trustedCertificates.size()]);
+	}
+
+	/**
+	 * Load credentials from key store.
+	 * 
+	 * @param keyStoreUri key store URI. If {@link #CLASSPATH_PROTOCOL} is used,
+	 *            loaded from classpath.
+	 * @param alias alias to load specific credentials.
+	 * @param storePassword password for key store.
+	 * @param keyPassword password for private key.
+	 * @return credentials for the alias.
+	 * @throws IOException if key store could not be loaded.
+	 * @throws GeneralSecurityException if security setup failed.
+	 * @throws IllegalArgumentException if alias is empty, or no matching
+	 *             credentials are found.
+	 * @throws NullPointerException if keyStoreUri, storePassword, keyPassword,
+	 *             or alias is null.
+	 */
+	public static Credentials loadCredentials(String keyStoreLocation, String alias, char[] storePassword,
+			char[] keyPassword) throws IOException, GeneralSecurityException {
+		if (null == alias) {
+			throw new NullPointerException("alias must be provided!");
+		}
+		if (alias.isEmpty()) {
+			throw new IllegalArgumentException("alias must not be empty!");
+		}
+		if (null == keyPassword) {
+			throw new NullPointerException("keyPassword must be provided!");
+		}
+		KeyStore ks = loadKeyStore(keyStoreLocation, storePassword);
+		if (ks.entryInstanceOf(alias, PrivateKeyEntry.class)) {
+			Entry entry = ks.getEntry(alias, new KeyStore.PasswordProtection(keyPassword));
+			if (entry instanceof PrivateKeyEntry) {
+				PrivateKeyEntry pkEntry = (PrivateKeyEntry) entry;
+				Certificate[] chain = pkEntry.getCertificateChain();
+				X509Certificate[] x509Chain = ensureX509Certificates(chain);
+				return new Credentials(pkEntry.getPrivateKey(), x509Chain);
+			}
+		}
+		throw new IllegalArgumentException("no credentials found for '" + alias + "' in '" + keyStoreLocation + "'!");
+	}
+
+	/**
+	 * Load certificate chain from key store.
+	 * 
+	 * @param keyStoreUri key store URI. If {@link #CLASSPATH_PROTOCOL} is used,
+	 *            loaded from classpath.
+	 * @param alias alias to load the certificate chain.
+	 * @param storePassword password for key store.
+	 * @return certificate chain for the alias.
+	 * @throws IOException if key store could not be loaded.
+	 * @throws GeneralSecurityException if security setup failed.
+	 * @throws IllegalArgumentException if alias is empty, or no matching
+	 *             certificate chain is found.
+	 * @throws NullPointerException if keyStoreUri, storePassword, or alias is
+	 *             null.
+	 */
+	public static X509Certificate[] loadCertificateChain(String keyStoreLocation, String alias, char[] storePassword)
+			throws IOException, GeneralSecurityException {
+		if (null == alias) {
+			throw new NullPointerException("alias must be provided!");
+		}
+		if (alias.isEmpty()) {
+			throw new IllegalArgumentException("alias must not be empty!");
+		}
+		KeyStore ks = loadKeyStore(keyStoreLocation, storePassword);
+		Certificate[] chain = ks.getCertificateChain(alias);
+		return ensureX509Certificates(chain);
+	}
+
+	/**
+	 * Load key store.
+	 * 
+	 * @param keyStoreUri key store URI. If {@link #CLASSPATH_PROTOCOL} is used,
+	 *            loaded from classpath.
+	 * @param alias alias to load only the specific entries to the key store.
+	 *            null to load the complete key store.
+	 * @param storePassword password for key store.
+	 * @param keyPassword password for private key. Not required for
+	 *            certificates.
+	 * @return key store.
+	 * @throws IOException if key store could not be loaded.
+	 * @throws GeneralSecurityException if security setup failed, or no
+	 *             credentials or certificates are available for the provided
+	 *             alias.
+	 * @throws NullPointerException if keyStoreUri or storePassword is null.
+	 */
+	private static KeyStore loadKeyStore(String keyStoreUri, String alias, char[] storePassword, char[] keyPassword)
+			throws IOException, GeneralSecurityException {
+		KeyStore ks = loadKeyStore(keyStoreUri, storePassword);
+		if (null == alias || alias.isEmpty()) {
+			return ks;
+		}
+		if (null == keyPassword) {
+			Certificate certificate = ks.getCertificate(alias);
+			if (null != certificate) {
+				KeyStore ksAlias = KeyStore.getInstance("JKS");
+				ksAlias.load(null);
+				ksAlias.setCertificateEntry(alias, certificate);
+				return ksAlias;
+			}
+			throw new GeneralSecurityException("key stores '" + keyStoreUri + "' doesn't contain certificates for '"
+					+ alias + "'");
+		} else {
+			Entry entry = ks.getEntry(alias, new KeyStore.PasswordProtection(keyPassword));
+			if (null != entry) {
+				KeyStore ksAlias = KeyStore.getInstance("JKS");
+				ksAlias.load(null);
+				ksAlias.setEntry(alias, entry, new KeyStore.PasswordProtection(keyPassword));
+				return ksAlias;
+			}
+			throw new GeneralSecurityException("key stores '" + keyStoreUri + "' doesn't contain credentials for '"
+					+ alias + "'");
+		}
+	}
+
+	/**
+	 * Load key store.
+	 * 
+	 * @param keyStoreUri key store URI. If {@link #CLASSPATH_PROTOCOL} is used,
+	 *            loaded from classpath.
+	 * @param storePassword password for key store.
+	 * @return key store
+	 * @throws IOException if key store could not be loaded.
+	 * @throws GeneralSecurityException if security setup failed.
+	 * @throws NullPointerException if keyStoreUri or storePassword is null.
+	 */
+	private static KeyStore loadKeyStore(String keyStoreUri, char[] storePassword) throws GeneralSecurityException,
+			IOException {
+		if (null == keyStoreUri) {
+			throw new NullPointerException("keyStoreUri must be provided!");
+		}
+		if (null == storePassword) {
+			throw new NullPointerException("storePassword must be provided!");
+		}
+		InputStream inStream;
+		if (keyStoreUri.startsWith(CLASSPATH_PROTOCOL)) {
+			String resource = keyStoreUri.substring(CLASSPATH_PROTOCOL.length());
+			inStream = SslContextUtil.class.getClassLoader().getResourceAsStream(resource);
+			if (null == inStream) {
+				throw new IOException("'" + keyStoreUri + "' not found!");
+			}
+		} else {
+			URL url = new URL(keyStoreUri);
+			inStream = url.openStream();
+		}
+		try {
+			KeyStore keyStore = KeyStore.getInstance("JKS");
+			keyStore.load(inStream, storePassword);
+			return keyStore;
+		} finally {
+			inStream.close();
+		}
+	}
+
+	/**
+	 * Ensure, that all provided certificates are x509.
+	 * 
+	 * @param certificates to check
+	 * @return array with x509 certificates.
+	 * @throws IllegalArgumentException if null, a empty array is provided or a
+	 *             none x509 certificate was found or a array entry was null.
+	 */
+	private static X509Certificate[] ensureX509Certificates(Certificate[] certificates) {
+		if (null == certificates || 0 == certificates.length) {
+			throw new IllegalArgumentException("certificates missing!");
+		}
+		X509Certificate[] x509Certificates = new X509Certificate[certificates.length];
+		for (int index = 0; certificates.length > index; ++index) {
+			if (null == certificates[index]) {
+				throw new IllegalArgumentException("[" + index + "] is null!");
+			}
+			try {
+				x509Certificates[index] = (X509Certificate) certificates[index];
+			} catch (ClassCastException e) {
+				throw new IllegalArgumentException("[" + index + "] is not a x509 certificate! Instead it's a "
+						+ certificates[index].getClass().getName());
+			}
+		}
+		return x509Certificates;
+	}
+
+	/**
+	 * Create SSLContext with provided credentials and trusts.
+	 * 
+	 * @param alias alias to be used in KeyManager. Used for identification
+	 *            according the X509ExtendedKeyManager API to select the
+	 *            credentials matching the provided key. Though the create
+	 *            KeyManager currently only supports on set of credentials, the
+	 *            alias is only used to select that. If null, its replaced by a
+	 *            default "californium".
+	 * @param privateKey private key
+	 * @param trustChain certificate trust chain related to private key.
+	 * @param trusts trusted certificates.
+	 * @return created SSLContext.
+	 * @throws GeneralSecurityException if security setup failed.
+	 * @throws IllegalArgumentException, if private key is null, or the chain is
+	 *             null or empty, or the trusts null or empty.
+	 */
+	public static SSLContext createSSLContext(String alias, PrivateKey privateKey, X509Certificate[] chain,
+			Certificate[] trusts) throws GeneralSecurityException {
+		if (null == alias) {
+			alias = "californium";
+		}
+		KeyManager[] keyManager = createKeyManager(alias, privateKey, chain);
+		TrustManager[] trustManager = createTrustManager(alias, trusts);
+		SSLContext sslContext = SSLContext.getInstance("TLS");
+		sslContext.init(keyManager, trustManager, null);
+		return sslContext;
+	}
+
+	/**
+	 * Create key manager from private key and certificate path. Creates a
+	 * {@link KeyStore} to use {@link KeyManagerFactory}.
+	 * 
+	 * @param alias alias to be used for key store
+	 * @param privateKey private key
+	 * @param chain certificate chain.
+	 * @return key manager.
+	 * @throws GeneralSecurityException if security setup failed.
+	 * @throws IllegalArgumentException, if private key is null, or the chain is
+	 *             null or empty.
+	 */
+	public static KeyManager[] createKeyManager(String alias, PrivateKey privateKey, X509Certificate[] chain)
+			throws GeneralSecurityException {
+		if (null == privateKey) {
+			throw new NullPointerException("private key must be provided!");
+		}
+		if (null == chain) {
+			throw new NullPointerException("certificate chain must be provided!");
+		}
+		if (0 == chain.length) {
+			throw new IllegalArgumentException("certificate chain must not be empty!");
+		}
+		if (null == alias) {
+			alias = "californium";
+		}
+		try {
+			/* key used for creating a none persistent KeyStore */
+			char[] key = "intern".toCharArray();
+			KeyStore ks = KeyStore.getInstance("JKS");
+			ks.load(null);
+			ks.setKeyEntry(alias, privateKey, key, chain);
+			return createKeyManager(ks, key);
+		} catch (IOException e) {
+			throw new GeneralSecurityException(e.getMessage());
+		}
+	}
+
+	/**
+	 * Create trust manager from trusted certificates. Creates a
+	 * {@link KeyStore} to use {@link TrustManagerFactory}.
+	 * 
+	 * @param alias alias to be used for key store.
+	 * @param trusts trusted certificates
+	 * @return trust manager
+	 * @throws GeneralSecurityException if security setup failed.
+	 * @throws NullPointerException, if trusted certificates is null.
+	 * @throws IllegalArgumentException, if trusted certificates is empty.
+	 */
+	public static TrustManager[] createTrustManager(String alias, Certificate[] trusts) throws GeneralSecurityException {
+		if (null == trusts) {
+			throw new NullPointerException("trusted certificates must be provided!");
+		}
+		if (0 == trusts.length) {
+			throw new IllegalArgumentException("trusted certificates must not be empty!");
+		}
+		if (null == alias) {
+			alias = "californium";
+		}
+		try {
+			int index = 1;
+			KeyStore ks = KeyStore.getInstance("JKS");
+			ks.load(null);
+			for (Certificate certificate : trusts) {
+				ks.setCertificateEntry(alias + index, certificate);
+				++index;
+			}
+			return createTrustManager(ks);
+		} catch (IOException e) {
+			throw new GeneralSecurityException(e.getMessage());
+		}
+	}
+
+	/**
+	 * Create key manager from key store.
+	 *
+	 * @param store key store
+	 * @param keyPassword password for private key
+	 * @return key manager
+	 * @throws GeneralSecurityException if security setup failed.
+	 */
+	private static KeyManager[] createKeyManager(KeyStore store, char[] keyPassword) throws GeneralSecurityException {
+		String algorithm = Security.getProperty("ssl.KeyManagerFactory.algorithm");
+		KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
+		kmf.init(store, keyPassword);
+		return kmf.getKeyManagers();
+	}
+
+	/**
+	 * Create trust manager from key store.
+	 * 
+	 * @param store key store
+	 * @return trust manager
+	 * @throws GeneralSecurityException if security setup failed.
+	 */
+	private static TrustManager[] createTrustManager(KeyStore store) throws GeneralSecurityException {
+		String algorithm = Security.getProperty("ssl.TrustManagerFactory.algorithm");
+		TrustManagerFactory tmf = TrustManagerFactory.getInstance(algorithm);
+		tmf.init(store);
+		return tmf.getTrustManagers();
+	}
+
+	/**
+	 * Credentials. Pair of private key and certificate trustedChain.
+	 */
+	public static class Credentials {
+
+		/**
+		 * Private key.
+		 */
+		private final PrivateKey privateKey;
+		/**
+		 * Certificate trustedChain.
+		 */
+		private final X509Certificate[] chain;
+
+		/**
+		 * Create credentials.
+		 * 
+		 * @param privateKey private key
+		 * @param trustedChain certificate trustedChain
+		 */
+		private Credentials(PrivateKey privateKey, X509Certificate[] chain) {
+			this.privateKey = privateKey;
+			this.chain = chain;
+		}
+
+		/**
+		 * Get private key.
+		 * 
+		 * @return private key
+		 */
+		public PrivateKey getPrivateKey() {
+			return privateKey;
+		}
+
+		/**
+		 * Get certificate trustedChain.
+		 * 
+		 * @return certificate trustedChain
+		 */
+		public X509Certificate[] getCertificateChain() {
+			return chain;
+		}
+	}
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/StringUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/StringUtil.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+/**
+ * String utils (as there are so many already out).
+ */
+public class StringUtil {
+
+	/**
+	 * Convert hexadecimal String into decoded character array. Intended to be
+	 * used for passwords.
+	 * 
+	 * @param hex hexadecimal string. e.g. "4130010A"
+	 * @return character array with decoded hexadecimal input parameter. e.g.
+	 *         char[] { 'A', '0', 0x01, '\n' }.
+	 * @throws IllegalArgumentException if the parameter length is odd or
+	 *             contains non hexadecimal characters.
+	 */
+	public static char[] hex2CharArray(String hex) {
+		if (null == hex) {
+			return null;
+		}
+		int length = hex.length();
+		if ((1 & length) != 0) {
+			throw new IllegalArgumentException("'" + hex + "' has odd length!");
+		}
+		length /= 2;
+		char[] result = new char[length];
+		for (int indexDest = 0, indexSrc = 0; indexDest < length; ++indexDest) {
+			int digit = Character.digit(hex.charAt(indexSrc), 16);
+			if (0 > digit) {
+				throw new IllegalArgumentException("'" + hex + "' digit " + indexSrc + " is not hexadecimal!");
+			}
+			result[indexDest] = (char) (digit << 4);
+			++indexSrc;
+			digit = Character.digit(hex.charAt(indexSrc), 16);
+			if (0 > digit) {
+				throw new IllegalArgumentException("'" + hex + "' digit " + indexSrc + " is not hexadecimal!");
+			}
+			result[indexDest] |= (char) digit;
+			++indexSrc;
+		}
+		return result;
+	}
+
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/SslContextUtilCredentialsTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/SslContextUtilCredentialsTest.java
@@ -1,0 +1,209 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.X509KeyManager;
+
+import org.eclipse.californium.elements.util.SslContextUtil.Credentials;
+import org.junit.Test;
+
+public class SslContextUtilCredentialsTest {
+
+	public static final char[] KEY_STORE_PASSWORD = "endPass".toCharArray();
+	public static final String KEY_STORE_PASSWORD_HEX = "656E6450617373";
+	public static final String KEY_STORE_LOCATION = SslContextUtil.CLASSPATH_PROTOCOL + "certs/keyStore.jks";
+
+	public static final String ALIAS_SERVER = "server";
+	public static final String ALIAS_CLIENT = "client";
+	public static final String ALIAS_MISSING = "missing";
+	public static final String DN_SERVER = "C=CA, L=Ottawa, O=Eclipse IoT, OU=Californium, CN=cf-server";
+
+	@Test
+	public void testLoadCredentials() throws IOException, GeneralSecurityException {
+		Credentials credentials = SslContextUtil.loadCredentials(KEY_STORE_LOCATION, ALIAS_SERVER, KEY_STORE_PASSWORD,
+				KEY_STORE_PASSWORD);
+		assertThat(credentials, is(notNullValue()));
+		assertThat(credentials.getPrivateKey(), is(notNullValue()));
+		assertThat(credentials.getCertificateChain(), is(notNullValue()));
+		assertThat(credentials.getCertificateChain().length, is(greaterThan(0)));
+		assertThat(credentials.getCertificateChain()[0], is(instanceOf(X509Certificate.class)));
+		X509Certificate x509 = (X509Certificate) credentials.getCertificateChain()[0];
+		assertThat(x509.getPublicKey(), is(notNullValue()));
+		assertThat(x509.getSubjectDN().getName(), is(DN_SERVER));
+	}
+
+	/**
+	 * Test, if a exception is thrown, when no credentials matches the alias.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testLoadCredentialsNotFound() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadCredentials(KEY_STORE_LOCATION, ALIAS_MISSING, KEY_STORE_PASSWORD, KEY_STORE_PASSWORD);
+	}
+
+	/**
+	 * Test, if a exception is thrown, when the keyStoreUri doesn't point to a
+	 * keystore.
+	 */
+	@Test(expected = IOException.class)
+	public void testLoadCredentialsNoFile() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadCredentials(KEY_STORE_LOCATION + "no-file", ALIAS_SERVER, KEY_STORE_PASSWORD,
+				KEY_STORE_PASSWORD);
+	}
+
+	/**
+	 * Test, if a exception is thrown, when the keyStoreUri is null.
+	 */
+	@Test(expected = NullPointerException.class)
+	public void testLoadCredentialsNullUri() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadCredentials(null, ALIAS_SERVER, KEY_STORE_PASSWORD, KEY_STORE_PASSWORD);
+	}
+
+	/**
+	 * Test, if a exception is thrown, when the store password is null.
+	 */
+	@Test(expected = NullPointerException.class)
+	public void testLoadCredentialsNoStorePassword() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadCredentials(KEY_STORE_LOCATION, ALIAS_SERVER, null, KEY_STORE_PASSWORD);
+	}
+
+	/**
+	 * Test, if a exception is thrown, when the key password is null.
+	 */
+	@Test(expected = NullPointerException.class)
+	public void testLoadCredentialsNoKeyPassword() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadCredentials(KEY_STORE_LOCATION, ALIAS_SERVER, KEY_STORE_PASSWORD, null);
+	}
+
+	/**
+	 * Test, if a exception is thrown, when the store password is wrong.
+	 */
+	@Test(expected = IOException.class)
+	public void testLoadCredentialsWrongStorePassword() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadCredentials(KEY_STORE_LOCATION, ALIAS_SERVER, KEY_STORE_PASSWORD_HEX.toCharArray(),
+				KEY_STORE_PASSWORD);
+	}
+
+	/**
+	 * Test, if a exception is thrown, when the key password is wrong.
+	 */
+	@Test(expected = GeneralSecurityException.class)
+	public void testLoadCredentialsWrongKeyPassword() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadCredentials(KEY_STORE_LOCATION, ALIAS_SERVER, KEY_STORE_PASSWORD,
+				KEY_STORE_PASSWORD_HEX.toCharArray());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testLoadCredentialsSingleParameterWithoutAlias() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadCredentials(KEY_STORE_LOCATION + SslContextUtil.PARAMETER_SEPARATOR + KEY_STORE_PASSWORD_HEX
+				+ SslContextUtil.PARAMETER_SEPARATOR + KEY_STORE_PASSWORD_HEX + SslContextUtil.PARAMETER_SEPARATOR);
+	}
+
+	@Test
+	public void testLoadCredentialsSingleParameter() throws IOException, GeneralSecurityException {
+		Credentials credentials = SslContextUtil.loadCredentials(KEY_STORE_LOCATION
+				+ SslContextUtil.PARAMETER_SEPARATOR + KEY_STORE_PASSWORD_HEX + SslContextUtil.PARAMETER_SEPARATOR
+				+ KEY_STORE_PASSWORD_HEX + SslContextUtil.PARAMETER_SEPARATOR + ALIAS_SERVER);
+		assertThat(credentials, is(notNullValue()));
+		assertThat(credentials.getPrivateKey(), is(notNullValue()));
+		assertThat(credentials.getCertificateChain(), is(notNullValue()));
+		assertThat(credentials.getCertificateChain().length, is(greaterThan(0)));
+		assertThat(credentials.getCertificateChain()[0], is(instanceOf(X509Certificate.class)));
+		X509Certificate x509 = (X509Certificate) credentials.getCertificateChain()[0];
+		assertThat(x509.getPublicKey(), is(notNullValue()));
+		assertThat(x509.getSubjectDN().getName(), is(DN_SERVER));
+	}
+
+	@Test
+	public void testLoadCertificateChain() throws IOException, GeneralSecurityException {
+		X509Certificate[] chain = SslContextUtil.loadCertificateChain(KEY_STORE_LOCATION, ALIAS_SERVER,
+				KEY_STORE_PASSWORD);
+		assertThat(chain, is(notNullValue()));
+		assertThat(chain.length, is(greaterThan(0)));
+		assertThat(chain[0].getPublicKey(), is(notNullValue()));
+		assertThat(chain[0].getSubjectDN().getName(), is(DN_SERVER));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testLoadCertificateChainMissingAlias() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadCertificateChain(KEY_STORE_LOCATION, null, KEY_STORE_PASSWORD);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testLoadCertificateChainEmptyAlias() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadCertificateChain(KEY_STORE_LOCATION, "", KEY_STORE_PASSWORD);
+	}
+
+	@Test
+	public void testLoadKeyManager() throws IOException, GeneralSecurityException {
+		KeyManager[] manager = SslContextUtil.loadKeyManager(KEY_STORE_LOCATION, null, KEY_STORE_PASSWORD,
+				KEY_STORE_PASSWORD);
+		assertThat(manager, is(notNullValue()));
+		assertThat(manager.length, is(greaterThan(0)));
+		assertThat(manager[0], is(instanceOf(X509KeyManager.class)));
+	}
+
+	/**
+	 * Test, if a exception is thrown, when no certificate matches the filter.
+	 */
+	@Test(expected = GeneralSecurityException.class)
+	public void testLoadKeyManagerCertificateNotFound() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadKeyManager(KEY_STORE_LOCATION, "missing", KEY_STORE_PASSWORD, KEY_STORE_PASSWORD);
+	}
+
+	@Test
+	public void testCreateKeyManager() throws IOException, GeneralSecurityException {
+		Credentials credentials = SslContextUtil.loadCredentials(KEY_STORE_LOCATION, ALIAS_SERVER, KEY_STORE_PASSWORD,
+				KEY_STORE_PASSWORD);
+		KeyManager[] manager = SslContextUtil.createKeyManager("test", credentials.getPrivateKey(),
+				credentials.getCertificateChain());
+		assertThat(manager, is(notNullValue()));
+		assertThat(manager.length, is(greaterThan(0)));
+		assertThat(manager[0], is(instanceOf(X509KeyManager.class)));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testCreateKeytManagerNullPrivateKey() throws IOException, GeneralSecurityException {
+		Credentials credentials = SslContextUtil.loadCredentials(KEY_STORE_LOCATION, ALIAS_SERVER, KEY_STORE_PASSWORD,
+				KEY_STORE_PASSWORD);
+		SslContextUtil.createKeyManager("test", null, credentials.getCertificateChain());
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testCreateKeytManagerNullCertChain() throws IOException, GeneralSecurityException {
+		Credentials credentials = SslContextUtil.loadCredentials(KEY_STORE_LOCATION, ALIAS_SERVER, KEY_STORE_PASSWORD,
+				KEY_STORE_PASSWORD);
+		SslContextUtil.createKeyManager("test", credentials.getPrivateKey(), null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testCreateKeyManagerEmptyCertChain() throws IOException, GeneralSecurityException {
+		Credentials credentials = SslContextUtil.loadCredentials(KEY_STORE_LOCATION, ALIAS_SERVER, KEY_STORE_PASSWORD,
+				KEY_STORE_PASSWORD);
+		SslContextUtil.createKeyManager("test", credentials.getPrivateKey(), new X509Certificate[0]);
+	}
+
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/SslContextUtilTrustTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/SslContextUtilTrustTest.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.junit.Test;
+
+public class SslContextUtilTrustTest {
+
+	public static final char[] TRUST_STORE_PASSWORD = "rootPass".toCharArray();
+	public static final String TRUST_STORE_PASSWORD_HEX = "726F6F7450617373";
+	public static final String TRUST_STORE_LOCATION = SslContextUtil.CLASSPATH_PROTOCOL + "certs/trustStore.jks";
+
+	public static final char[] TRUST_STORE_WRONG_PASSWORD = "wrongPass".toCharArray();
+
+	public static final String ALIAS_CA = "ca";
+	public static final String ALIAS_MISSING = "missing";
+	public static final String DN_CA = "C=CA, L=Ottawa, O=Eclipse IoT, OU=Californium, CN=cf-ca";
+
+	@Test
+	public void testLoadTrustedCertificates() throws IOException, GeneralSecurityException {
+		Certificate[] trustedCertificates = SslContextUtil.loadTrustedCertificates(TRUST_STORE_LOCATION, null,
+				TRUST_STORE_PASSWORD);
+		assertThat(trustedCertificates, is(notNullValue()));
+		assertThat(trustedCertificates.length, is(greaterThan(0)));
+		assertThat(trustedCertificates[0], is(instanceOf(X509Certificate.class)));
+		assertThat(trustedCertificates[0].getPublicKey(), is(notNullValue()));
+	}
+
+	@Test
+	public void testLoadFilteredTrustedCertificates() throws IOException, GeneralSecurityException {
+		Certificate[] trustedCertificates = SslContextUtil.loadTrustedCertificates(TRUST_STORE_LOCATION, ALIAS_CA,
+				TRUST_STORE_PASSWORD);
+		assertThat(trustedCertificates, is(notNullValue()));
+		assertThat(trustedCertificates.length, is(1));
+		assertThat(trustedCertificates[0], is(instanceOf(X509Certificate.class)));
+		X509Certificate x509 = (X509Certificate) trustedCertificates[0];
+		assertThat(x509.getSubjectDN().getName(), is(DN_CA));
+	}
+
+	/**
+	 * Test, if a exception is thrown, when no certificate matches the filter.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testLoadFilteredTrustedCertificatesNotFound() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadTrustedCertificates(TRUST_STORE_LOCATION, ALIAS_MISSING, TRUST_STORE_PASSWORD);
+	}
+
+	/**
+	 * Test, if a exception is thrown, when the keyStoreUri doesn't point to a
+	 * keystore.
+	 */
+	@Test(expected = IOException.class)
+	public void testLoadTrustedCertificatesNoFile() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadTrustedCertificates(TRUST_STORE_LOCATION + "no-file", null, TRUST_STORE_PASSWORD);
+	}
+
+	/**
+	 * Test, if a exception is thrown, when the keyStoreUri is null.
+	 */
+	@Test(expected = NullPointerException.class)
+	public void testLoadTrustedCertificatesNullUri() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadTrustedCertificates(null, null, TRUST_STORE_PASSWORD);
+	}
+
+	/**
+	 * Test, if a exception is thrown, when the password is null.
+	 */
+	@Test(expected = NullPointerException.class)
+	public void testLoadTrustedCertificatesNoPassword() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadTrustedCertificates(TRUST_STORE_LOCATION, null, null);
+	}
+
+	/**
+	 * Test, if a exception is thrown, when the password is wrong.
+	 */
+	@Test(expected = IOException.class)
+	public void testLoadTrustedCertificatesWrongPassword() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadTrustedCertificates(TRUST_STORE_LOCATION, null, TRUST_STORE_WRONG_PASSWORD);
+	}
+
+	@Test
+	public void testLoadTrustedCertificatesSingleParameterWithoutAlias() throws IOException, GeneralSecurityException {
+		Certificate[] trustedCertificates = SslContextUtil.loadTrustedCertificates(TRUST_STORE_LOCATION
+				+ SslContextUtil.PARAMETER_SEPARATOR + TRUST_STORE_PASSWORD_HEX + SslContextUtil.PARAMETER_SEPARATOR);
+		assertThat(trustedCertificates, is(notNullValue()));
+		assertThat(trustedCertificates.length, is(greaterThan(0)));
+		assertThat(trustedCertificates[0], is(instanceOf(X509Certificate.class)));
+		assertThat(trustedCertificates[0].getPublicKey(), is(notNullValue()));
+	}
+
+	@Test
+	public void testLoadTrustedCertificatesSingleParameter() throws IOException, GeneralSecurityException {
+		Certificate[] trustedCertificates = SslContextUtil.loadTrustedCertificates(TRUST_STORE_LOCATION
+				+ SslContextUtil.PARAMETER_SEPARATOR + TRUST_STORE_PASSWORD_HEX + SslContextUtil.PARAMETER_SEPARATOR
+				+ ALIAS_CA);
+		assertThat(trustedCertificates, is(notNullValue()));
+		assertThat(trustedCertificates.length, is(1));
+		assertThat(trustedCertificates[0], is(instanceOf(X509Certificate.class)));
+		X509Certificate x509 = (X509Certificate) trustedCertificates[0];
+		assertThat(x509.getSubjectDN().getName(), is(DN_CA));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testLoadTrustedCertificatesSingleParameterError() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadTrustedCertificates(TRUST_STORE_LOCATION
+				+ SslContextUtil.PARAMETER_SEPARATOR + TRUST_STORE_PASSWORD_HEX);
+	}
+
+	@Test
+	public void testLoadTrustManager() throws IOException, GeneralSecurityException {
+		TrustManager[] manager = SslContextUtil.loadTrustManager(TRUST_STORE_LOCATION, null, TRUST_STORE_PASSWORD);
+		assertThat(manager, is(notNullValue()));
+		assertThat(manager.length, is(greaterThan(0)));
+		assertThat(manager[0], is(instanceOf(X509TrustManager.class)));
+	}
+
+	/**
+	 * Test, if a exception is thrown, when no certificate matches the filter.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testLoadTrustManagerCertificateNotFound() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadTrustManager(TRUST_STORE_LOCATION, ALIAS_MISSING, TRUST_STORE_PASSWORD);
+	}
+
+	@Test
+	public void testCreateTrustManager() throws IOException, GeneralSecurityException {
+		Certificate[] trustedCertificates = SslContextUtil.loadTrustedCertificates(TRUST_STORE_LOCATION, null,
+				TRUST_STORE_PASSWORD);
+		TrustManager[] manager = SslContextUtil.createTrustManager("test", trustedCertificates);
+		assertThat(manager, is(notNullValue()));
+		assertThat(manager.length, is(greaterThan(0)));
+		assertThat(manager[0], is(instanceOf(X509TrustManager.class)));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testCreateTrustManagerNullCertificates() throws IOException, GeneralSecurityException {
+		SslContextUtil.createTrustManager("test", null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testCreateTrustManagerEmptyCertificates() throws IOException, GeneralSecurityException {
+		SslContextUtil.createTrustManager("test", new Certificate[0]);
+	}
+
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/StringUtilTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/StringUtilTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class StringUtilTest {
+
+	@Test
+	public void testHex2CharArray() {
+		String line = "4130010A";
+		char[] result = StringUtil.hex2CharArray(line);
+
+		assertThat(result, is(new char[] { 'A', '0', 0x01, '\n' }));
+	}
+
+	@Test
+	public void testHex2CharArrayWithNull() {
+		String line = null;
+		char[] result = StringUtil.hex2CharArray(line);
+
+		assertThat(result, is((char[]) null));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testHex2CharArrayIllegalArgumentLength() {
+		String line = "4130010A0";
+		StringUtil.hex2CharArray(line);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testHex2CharArrayIllegalArgumentContent() {
+		String line = "4130010A0Z";
+		StringUtil.hex2CharArray(line);
+	}
+
+}


### PR DESCRIPTION
This utility converts between the informations used by the javax SSL
implementation and the plain credentials used by scandium. It offers
reading KeyStores, extracting credentials, and creating KeyManager and
TrustManager from the KeyStores or extracted credentials.

A folowup PR will use this for setup unit tests.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>