### PR TITLE
Fix #216: Introduce queue for buffering inbound records

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/DaemonThreadFactory.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/DaemonThreadFactory.java
@@ -1,0 +1,34 @@
+package org.eclipse.californium.elements.util;
+
+/**
+ * A factory to create executor services with daemon threads.
+ */
+public class DaemonThreadFactory extends NamedThreadFactory {
+
+	/**
+	 * Creates a new factory and sets the thread group to Californium
+	 * default group.
+	 *
+	 * @param threadPrefix the prefix, that becomes part of the name of all
+	 *            threads, created by this factory.
+	 */
+	public DaemonThreadFactory(final String threadPrefix) {
+		super(threadPrefix, null);
+	}
+
+	/**
+	 * Creates a new factory.
+	 *
+	 * @param threadPrefix the prefix, that becomes part of the name of all
+	 *            threads, created by this factory.
+	 * @param threadGroup the thread group or <code>null</code>
+	 */
+	public DaemonThreadFactory(final String threadPrefix, final ThreadGroup threadGroup) {
+		super(threadPrefix, threadGroup);
+	}
+
+	@Override
+	protected boolean createDaemonThreads() {
+		return false;
+	}
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/NamedThreadFactory.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/NamedThreadFactory.java
@@ -1,0 +1,74 @@
+package org.eclipse.californium.elements.util;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The default thread factory
+ */
+public class NamedThreadFactory implements ThreadFactory {
+
+	static final ThreadGroup COAP_THREAD_GROUP = new ThreadGroup("Californium"); //$NON-NLS-1$
+
+	private final ThreadGroup group;
+	private final AtomicInteger index = new AtomicInteger(1);
+	private final String prefix;
+
+	/**
+	 * Creates a new factory and sets the thread group to Californium
+	 * default group.
+	 *
+	 * @param threadPrefix the prefix, that becomes part of the name of all
+	 *            threads, created by this factory.
+	 */
+	public NamedThreadFactory(final String threadPrefix) {
+		this(threadPrefix, null);
+	}
+
+	/**
+	 * Creates a new factory.
+	 *
+	 * @param threadPrefix the prefix, that becomes part of the name of all
+	 *            threads, created by this factory.
+	 * @param threadGroup the thread group or <code>null</code>
+	 */
+	public NamedThreadFactory(final String threadPrefix, final ThreadGroup threadGroup) {
+		group = null == threadGroup ? COAP_THREAD_GROUP : threadGroup;
+		prefix = threadPrefix;
+	}
+
+	/**
+	 * Creates a new thread for executing a runnable.
+	 * <p>
+	 * The thread created will be a member of the thread group set during instantiation of this
+	 * factory. The thread's priority will be set to {@link Thread#NORM_PRIORITY}.
+	 * 
+	 * @param runnable The runnable that should be executed by the created thread.
+	 * @return The newly created thread.
+	 * @see #createDaemonThreads()
+	 */
+	@Override
+	public final Thread newThread(Runnable runnable) {
+		final Thread ret = new Thread(group, runnable, prefix + index.getAndIncrement(), 0);
+		ret.setDaemon(createDaemonThreads());
+		if (ret.getPriority() != Thread.NORM_PRIORITY) {
+			ret.setPriority(Thread.NORM_PRIORITY);
+		}
+		return ret;
+	}
+
+	/**
+	 * Checks whether this factory creates daemon threads.
+	 * <p>
+	 * This method is invoked by {@link #newThread(Runnable)} right after a new thread has
+	 * been created. The {@link Thread#setDaemon(boolean)} method is invoked with this method's
+	 * return value.
+	 * 
+	 * @return {@code true} if all threads created by this factory are daemon threads. This implementation
+	 *         returns {@code false}. Subclasses should override this method and return {@code true} in order
+	 *         to create daemon threads.
+	 */
+	protected boolean createDaemonThreads() {
+		return false;
+	}
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -70,6 +70,7 @@ import org.eclipse.californium.elements.CorrelationContext;
 import org.eclipse.californium.elements.DtlsCorrelationContext;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
+import org.eclipse.californium.elements.util.DaemonThreadFactory;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.AlertMessage;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
@@ -94,6 +95,7 @@ import org.eclipse.californium.scandium.dtls.MaxFragmentLengthExtension;
 import org.eclipse.californium.scandium.dtls.ProtocolVersion;
 import org.eclipse.californium.scandium.dtls.Record;
 import org.eclipse.californium.scandium.dtls.RecordLayer;
+import org.eclipse.californium.scandium.dtls.RecordProcessor;
 import org.eclipse.californium.scandium.dtls.ResumingClientHandshaker;
 import org.eclipse.californium.scandium.dtls.ResumingServerHandshaker;
 import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
@@ -111,7 +113,7 @@ import org.eclipse.californium.scandium.util.ByteArrayUtils;
  * <a href="http://tools.ietf.org/html/rfc6347">RFC 6347</a> for securing data
  * exchanged between networked clients and a server application.
  */
-public class DTLSConnector implements Connector {
+public class DTLSConnector implements Connector, RecordProcessor {
 
 	/**
 	 * The {@code CorrelationContext} key used to store the host name indicated by a
@@ -129,7 +131,7 @@ public class DTLSConnector implements Connector {
 			+ 13 // DTLS record headers
 			+ MAX_CIPHERTEXT_EXPANSION;
 
-	private static final ThreadGroup SCANDIUM_THREAD_GROUP = new ThreadGroup("Californium/Scandium"); //$NON-NLS-1$
+	static final ThreadGroup SCANDIUM_THREAD_GROUP = new ThreadGroup("Californium/Scandium"); //$NON-NLS-1$
 	/** all the configuration options for the DTLS connector */ 
 	private final DtlsConnectorConfig config;
 
@@ -214,6 +216,17 @@ public class DTLSConnector implements Connector {
 		}
 	}
 
+	/**
+	 * Sets the executor to use for processing inbound records.
+	 * <p>
+	 * If this property is not set before invoking the {@linkplain #start() start method},
+	 * a {@code ThreadPoolExecutor} is used with a maximum of #CPU cores threads.
+	 * <p>
+	 * If this method is used to set an executor, the executor will <em>not</em> be stopped
+	 * by the {@linkplain #stop() stop method}.
+	 * 
+	 * @param executor The executor.
+	 */
 	public void setHandshakeTaskExecutor(ExecutorService executor) {
 
 		this.handshakerTaskExecutor = executor;
@@ -437,35 +450,90 @@ public class DTLSConnector implements Connector {
 
 		for (Record record : records) {
 			try {
-				LOGGER.log(Level.FINEST, "Received DTLS record of type [{0}]", record.getType());
+				LOGGER.log(Level.FINER, "Received DTLS record [type: {0}, peer: {1}]",
+						new Object[]{record.getType(), record.getPeerAddress()});
 
 				switch(record.getType()) {
-				case APPLICATION_DATA:
-					processApplicationDataRecord(record);
-					break;
-				case ALERT:
-					processAlertRecord(record);
-					break;
-				case CHANGE_CIPHER_SPEC:
-					processChangeCipherSpecRecord(record);
-					break;
 				case HANDSHAKE:
 					processHandshakeRecord(record);
+					break;
+				case APPLICATION_DATA:
+				case ALERT:
+				case CHANGE_CIPHER_SPEC:
+					addRecordToBuffer(record);
 					break;
 				default:
 					LOGGER.log(
 						Level.FINE,
-						"Discarding record of unsupported type [{0}] from peer [{1}]",
+						"Discarding unsupported record [type: {0}, peer: {1}]",
 						new Object[]{record.getType(), record.getPeerAddress()});
 				}
 			} catch (RuntimeException e) {
 				LOGGER.log(
 					Level.INFO,
-					String.format("Unexpected error occurred while processing record from peer [%s]", peerAddress),
+					String.format("Unexpected error occurred while processing record [type: %s, peer: %s]",
+							record.getType(), peerAddress),
 					e);
 				terminateConnection(peerAddress, e, AlertLevel.FATAL, AlertDescription.INTERNAL_ERROR);
 				break;
 			}
+		}
+	}
+
+	private void addRecordToBuffer(Record record) {
+
+		Connection connection = connectionStore.get(record.getPeerAddress());
+		if (connection == null) {
+			LOGGER.log(Level.FINE, "discarding unexpected record [type: {0}, peer: {1}]",
+					new Object[]{record.getType(), record.getPeerAddress()});
+		} else {
+			addRecordToBuffer(record, connection);
+		}
+	}
+
+	private void addRecordToBuffer(Record record, Connection connection) {
+
+		if (connection.addInbound(record)) {
+			LOGGER.log(Level.FINER, "added record [type: {0}, peer: {1}] to inbound buffer",
+					new Object[]{record.getType(), record.getPeerAddress()});
+			connection.processNextMessage(this, handshakerTaskExecutor);
+		} else {
+			LOGGER.log(Level.FINE, "inbound record buffer full, discarding record [type: {0}, peer: {1}]",
+					new Object[]{record.getType(), record.getPeerAddress()});
+		}
+	}
+
+	@Override
+	public void process(Record record, Connection connection) {
+
+		try {
+			switch(record.getType()) {
+			case APPLICATION_DATA:
+				processApplicationDataRecord(record, connection);
+				break;
+			case ALERT:
+				processAlertRecord(record, connection);
+				break;
+			case CHANGE_CIPHER_SPEC:
+				processChangeCipherSpecRecord(record, connection);
+				break;
+			case HANDSHAKE:
+				processHandshakeRecordWithConnection(record, connection);
+				break;
+			default:
+				LOGGER.log(
+					Level.FINE,
+					"Discarding record of unsupported type [{0}] from peer [{1}]",
+					new Object[]{record.getType(), record.getPeerAddress()});
+			}
+		} catch (HandshakeException e) {
+			handleExceptionDuringHandshake(e, e.getAlert().getLevel(), e.getAlert().getDescription(), record);
+		} catch (RuntimeException e) {
+			LOGGER.log(
+				Level.INFO,
+				String.format("Unexpected error occurred while processing record from peer [%s]", record.getPeerAddress()),
+				e);
+			terminateConnection(record.getPeerAddress(), e, AlertLevel.FATAL, AlertDescription.INTERNAL_ERROR);
 		}
 	}
 
@@ -574,10 +642,9 @@ public class DTLSConnector implements Connector {
 		connectionClosed(connection.getPeerAddress());
 	}
 
-	private void processApplicationDataRecord(final Record record) {
+	private void processApplicationDataRecord(final Record record, final Connection connection) {
 
-		Connection connection = connectionStore.get(record.getPeerAddress());
-		if (connection != null && connection.hasEstablishedSession()) {
+		if (connection.hasEstablishedSession()) {
 			DTLSSession session = connection.getEstablishedSession();
 			synchronized (session) {
 				// The DTLS 1.2 spec (section 4.1.2.6) advises to do replay detection
@@ -618,31 +685,6 @@ public class DTLSConnector implements Connector {
 					String.valueOf(session.getReadEpoch()),
 					session.getReadStateCipher());
 			messageHandler.receiveData(RawData.inbound(message.getData(), message.getPeer(), session.getPeerIdentity(), context, false));
-		}
-	}
-
-	/**
-	 * Processes an <em>ALERT</em> message received from the peer.
-	 * <p>
-	 * Terminates the connection with the peer if either
-	 * <ul>
-	 * <li>the ALERT's level is FATAL or</li>
-	 * <li>the ALERT is a <em>closure alert</em></li>
-	 * </ul>
-	 * 
-	 * Also notifies a registered {@link #errorHandler} about the alert message.
-	 * </p>
-	 * @param record the record containing the ALERT message
-	 * @see ErrorHandler
-	 * @see #terminateConnection(Connection, AlertMessage, DTLSSession)
-	 */
-	private void processAlertRecord(Record record) {
-
-		Connection connection = connectionStore.get(record.getPeerAddress());
-		if (connection == null) {
-			LOGGER.log(Level.FINER, "Discarding ALERT record from [{0}] received without existing connection", record.getPeerAddress());
-		} else {
-			processAlertRecord(record, connection);
 		}
 	}
 
@@ -696,9 +738,9 @@ public class DTLSConnector implements Connector {
 		}
 	}
 
-	private void processChangeCipherSpecRecord(Record record) {
-		Connection connection = connectionStore.get(record.getPeerAddress());
-		if (connection != null && connection.hasOngoingHandshake()) {
+	private void processChangeCipherSpecRecord(Record record, Connection connection) {
+
+		if (connection.hasOngoingHandshake()) {
 			// processing a CCS message does not result in any additional flight to be sent
 			try {
 				connection.getOngoingHandshake().processMessage(record);
@@ -714,17 +756,11 @@ public class DTLSConnector implements Connector {
 
 	private void processHandshakeRecord(final Record record) {
 
-		LOGGER.log(Level.FINE, "Received {0} record from peer [{1}]",
-				new Object[]{record.getType(), record.getPeerAddress()});
 		final Connection con = connectionStore.get(record.getPeerAddress());
-		try {
-			if (con == null) {
-				processHandshakeRecordWithoutConnection(record);
-			} else {
-				processHandshakeRecordWithConnection(record, con);
-			}
-		} catch (HandshakeException e) {
-			handleExceptionDuringHandshake(e, e.getAlert().getLevel(), e.getAlert().getDescription(), record);
+		if (con == null) {
+			processHandshakeRecordWithoutConnection(record);
+		} else {
+			addRecordToBuffer(record, con);
 		}
 	}
 
@@ -733,7 +769,7 @@ public class DTLSConnector implements Connector {
 	 * @param record
 	 * @throws HandshakeException if the handshake record cannot be parsed or processed successfully
 	 */
-	private void processHandshakeRecordWithoutConnection(final Record record) throws HandshakeException {
+	private void processHandshakeRecordWithoutConnection(final Record record) {
 		if (record.getEpoch() > 0) {
 			LOGGER.log(
 				Level.FINE,
@@ -752,6 +788,8 @@ public class DTLSConnector implements Connector {
 							"Discarding unexpected {0} message from peer [{1}]",
 							new Object[]{handshakeMessage.getMessageType(), handshakeMessage.getPeer()});
 				}
+			} catch (HandshakeException e) {
+				handleExceptionDuringHandshake(e, e.getAlert().getLevel(), e.getAlert().getDescription(), record);
 			} catch (GeneralSecurityException e) {
 				discardRecord(record, e);
 			}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordProcessor.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordProcessor.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Kai Hudalla (Bosch Software Innovations GmbH) - Initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+/**
+ * A strategy for processing DTLS records.
+ *
+ */
+public interface RecordProcessor {
+
+	/**
+	 * Processes a DTLS record.
+	 * 
+	 * @param record The record to process.
+	 * @param connection The DTLS connection that the record has been received on.
+	 */
+	void process(Record record, Connection connection);
+}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -43,6 +43,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -52,6 +54,7 @@ import org.eclipse.californium.elements.DtlsCorrelationContext;
 import org.eclipse.californium.elements.MessageCallback;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
+import org.eclipse.californium.elements.util.DaemonThreadFactory;
 import org.eclipse.californium.scandium.auth.PreSharedKeyIdentity;
 import org.eclipse.californium.scandium.auth.RawPublicKeyIdentity;
 import org.eclipse.californium.scandium.auth.X509CertPath;
@@ -108,6 +111,7 @@ public class DTLSConnectorTest {
 	private static InMemorySessionCache serverSessionCache;
 	private static SimpleRawDataChannel serverRawDataChannel;
 	private static RawDataProcessor serverRawDataProcessor;
+	private static ExecutorService handshakeTaskExecutor;
 
 	DtlsConnectorConfig clientConfig;
 	DTLSConnector client;
@@ -119,6 +123,10 @@ public class DTLSConnectorTest {
 
 	@BeforeClass
 	public static void loadKeys() throws IOException, GeneralSecurityException {
+
+		handshakeTaskExecutor = Executors.newFixedThreadPool(
+				Runtime.getRuntime().availableProcessors(),
+				new DaemonThreadFactory("DTLS Handshaker Task", DTLSConnector.SCANDIUM_THREAD_GROUP));
 		// load the key store
 
 		serverRawDataProcessor = new MessageCapturingProcessor();
@@ -143,6 +151,7 @@ public class DTLSConnectorTest {
 
 		server = new DTLSConnector(serverConfig, serverConnectionStore);
 		server.setRawDataReceiver(serverRawDataChannel);
+		server.setHandshakeTaskExecutor(handshakeTaskExecutor);
 		server.start();
 		serverEndpoint = server.getAddress();
 		assertTrue(server.isRunning());
@@ -150,6 +159,7 @@ public class DTLSConnectorTest {
 
 	@AfterClass
 	public static void tearDown() {
+		handshakeTaskExecutor.shutdownNow();
 		server.destroy();
 	}
 
@@ -161,6 +171,7 @@ public class DTLSConnectorTest {
 		clientConfig = newStandardConfig(clientEndpoint);
 
 		client = new DTLSConnector(clientConfig, clientConnectionStore);
+		client.setHandshakeTaskExecutor(handshakeTaskExecutor);
 
 		clientRawDataChannel = new LatchDecrementingRawDataChannel();
 	}


### PR DESCRIPTION
This is the initial step to fix #216.
The overall idea is to introduce an inbound Record buffer to `Connection` which is processed one-by-one using a thread pool based `Executor`. This way we achieve two things:
- make sure that all incoming records are processed in order
- allow multiple Handshake/Application records being processed in parallel

A next step could also be to re-factor the record processing logic into a separate class (i.e. puling it out of `DTLSConnector` which is already an ugly beast) implementing `RecordProcessor` ...