### PR TITLE
Bugfix exchange management.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
@@ -12,6 +12,11 @@
  * 
  * Contributors:
  *    Bosch Software Innovations - initial creation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - remove ExchangeObserver.
+ *                                                    Notify exchanges are not 
+ *                                                    stored within the matcher
+ *                                                    and therefore don't require
+ *                                                    a cleanup.
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -161,14 +166,12 @@ public abstract class BaseMatcher implements Matcher {
 	 * Special matching for notify reponses. Check, is a observe is stored in
 	 * {@link #observationStore} and if found, recreate a exchange.
 	 * 
-	 * @param exchangeObserver exchange observer for the new exchange
 	 * @param response notify response
 	 * @param responseContext correlation context of response
 	 * @return exchange, if a new one is create of the stored observe
 	 *         informations, null, otherwise.
 	 */
-	protected final Exchange matchNotifyResponse(final ExchangeObserver exchangeObserver, final Response response,
-			final CorrelationContext responseContext) {
+	protected final Exchange matchNotifyResponse(final Response response, final CorrelationContext responseContext) {
 
 		final Exchange.KeyToken idByToken = Exchange.KeyToken.fromInboundMessage(response);
 		Exchange exchange = null;
@@ -184,7 +187,6 @@ public abstract class BaseMatcher implements Matcher {
 			request.setDestinationPort(response.getSourcePort());
 			exchange = new Exchange(request, Origin.LOCAL, obs.getContext());
 			exchange.setRequest(request);
-			exchange.setObserver(exchangeObserver);
 			LOG.log(Level.FINER, "re-created exchange from original observe request: {0}", request);
 			request.addMessageObserver(new MessageObserverAdapter() {
 
@@ -224,7 +226,6 @@ public abstract class BaseMatcher implements Matcher {
 				public void onCancel() {
 					observationStore.remove(request.getToken());
 					exchangeStore.releaseToken(idByToken);
-
 				}
 			});
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
@@ -12,6 +12,13 @@
  * 
  * Contributors:
  *    Bosch Software Innovations - initial creation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - remove only provided Exchange
+ *                                                    Observes and blockwise 
+ *                                                    exchanges may be used 
+ *                                                    longer, so that MID (observe)
+ *                                                    or token (blockwise) may
+ *                                                    be reused for an other
+ *                                                    exchange. 
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -253,26 +260,38 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 	}
 
 	@Override
-	public void remove(final KeyToken token) {
+	public void remove(final KeyToken token, final Exchange exchange) {
+		boolean removed;
+		int size;
 		synchronized (exchangesByToken) {
-			exchangesByToken.remove(token);
-			LOGGER.log(
-					Level.FINE,
-					"removing exchange for token {0}, remaining exchanges by tokens: {1}",
-					new Object[]{token, exchangesByToken.size()});
+			removed = exchangesByToken.remove(token, exchange);
+			size = exchangesByToken.size();
+		}
+		if (removed) {
+			LOGGER.log(Level.FINE, "removing exchange for token {0}, remaining exchanges by tokens: {1}",
+					new Object[] { token, size });
 		}
 	}
 
 	@Override
-	public Exchange remove(final KeyMID messageId) {
+	public Exchange remove(final KeyMID messageId, final Exchange exchange) {
+		Exchange removedExchange;
+		int size;
 		synchronized (messageIdProvider) {
-			Exchange removedExchange = exchangesByMID.remove(messageId);
-			LOGGER.log(
-					Level.FINE,
-					"removing exchange for MID {0}, remaining exchanges by MIDs: {1}",
-					new Object[]{messageId, exchangesByMID.size()});
-			return removedExchange;
+			if (null == exchange) {
+				removedExchange = exchangesByMID.remove(messageId);
+			} else if (exchangesByMID.remove(messageId, exchange)) {
+				removedExchange = exchange;
+			} else {
+				removedExchange = null;
+			}
+			size = exchangesByMID.size();
 		}
+		if (null != removedExchange) {
+			LOGGER.log(Level.FINE, "removing exchange for MID {0}, remaining exchanges by MIDs: {1}", new Object[] {
+					messageId, size });
+		}
+		return removedExchange;
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
@@ -9,7 +9,10 @@
  *    http://www.eclipse.org/legal/epl-v10.html
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
- * 
+ *
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add Exchange to remove for
+ *                                                    save cleanup.
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -107,17 +110,21 @@ public interface MessageExchangeStore {
 	 * Removes the exchange registered under a given token.
 	 * 
 	 * @param token the token of the exchange to remove.
+	 * @param exchange Exchange to be removed, if registered with provided token.
 	 */
-	void remove(KeyToken token);
+	void remove(KeyToken token, Exchange exchange);
 
 	/**
 	 * Removes the exchange registered under a given message ID.
 	 * 
 	 * @param messageId the message ID to remove the exchange for.
-	 * @return the exchange that was registered under the given message ID or {@code null}
-	 * if no exchange was registered under the ID.
+	 * @param exchange Exchange to be removed. If {@code null}, the current
+	 *                 exchange with the MID is removed. If not {@code null},
+	 *                 only this exchange is removed, if it's registered with
+	 *                 the MID.
+	 * @return the removed exchange, or {@code null}, if no exchange was removed.
 	 */
-	Exchange remove(KeyMID messageId);
+	Exchange remove(KeyMID messageId, Exchange exchange);
 
 	/**
 	 * Gets the exchange registered under a given token.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -25,6 +25,9 @@
  * Achim Kraus (Bosch Software Innovations GmbH) - replace isResponseRelatedToRequest
  *                                                 with CorrelationContextMatcher
  *                                                 (fix GitHub issue #104)
+ * Achim Kraus (Bosch Software Innovations GmbH) - remove obsolete ExchangeObserver
+ *                                                 from matchNotifyResponse.
+ *                                                 Add Exchange for save remove.
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -126,7 +129,7 @@ public final class TcpMatcher extends BaseMatcher {
 			// because we do not check that the notification's sender is
 			// the same as the receiver of the original observe request
 			// TODO: assert that notification's source endpoint is correct
-			exchange = matchNotifyResponse(exchangeObserver, response, responseContext);
+			exchange = matchNotifyResponse(response, responseContext);
 		}
 
 		if (exchange == null) {
@@ -155,7 +158,7 @@ public final class TcpMatcher extends BaseMatcher {
 			if (exchange.getOrigin() == Exchange.Origin.LOCAL) {
 				// this endpoint created the Exchange by issuing a request
 				Exchange.KeyToken idByToken = Exchange.KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
-				exchangeStore.remove(idByToken);
+				exchangeStore.remove(idByToken, exchange);
 				if (!exchange.getCurrentRequest().getOptions().hasObserve()) {
 					exchangeStore.releaseToken(idByToken);
 				}


### PR DESCRIPTION
Save remove of exchanges by token or MID.
For longterm exchange the MID or token may have been reused.
Don't use ExchangeObserver for notify Exchanges, not usefull there.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>