### PR TITLE
Fix #216: Introduce parallel processing of inbound records

### DIFF
--- a/element-connector/src/main/java/eu/javaspecialists/tjsn/concurrency/stripedexecutor/StripedCallable.java
+++ b/element-connector/src/main/java/eu/javaspecialists/tjsn/concurrency/stripedexecutor/StripedCallable.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2000-2013 Heinz Max Kabutz
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Heinz Max Kabutz licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.javaspecialists.tjsn.concurrency.stripedexecutor;
+
+import java.util.concurrent.*;
+
+/**
+ * All of the Callables in the same "Stripe" will be executed consecutively.
+ *
+ * @author Dr Heinz M. Kabutz
+ * @see StripedExecutorService
+ */
+public interface StripedCallable<V> extends Callable<V>, StripedObject {
+}

--- a/element-connector/src/main/java/eu/javaspecialists/tjsn/concurrency/stripedexecutor/StripedExecutorService.java
+++ b/element-connector/src/main/java/eu/javaspecialists/tjsn/concurrency/stripedexecutor/StripedExecutorService.java
@@ -1,0 +1,512 @@
+/*
+ * Copyright (C) 2000-2013 Heinz Max Kabutz
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Heinz Max Kabutz licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.javaspecialists.tjsn.concurrency.stripedexecutor;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.locks.*;
+
+/**
+ * The StripedExecutorService accepts Runnable/Callable objects
+ * that also implement the StripedObject interface.  It executes
+ * all the tasks for a single "stripe" consecutively.
+ * <p/>
+ * In this version, submitted tasks do not necessarily have to
+ * implement the StripedObject interface.  If they do not, then
+ * they will simply be passed onto the wrapped ExecutorService
+ * directly.
+ * <p/>
+ * Idea inspired by Glenn McGregor on the Concurrency-interest
+ * mailing list and using the SerialExecutor presented in the
+ * Executor interface's JavaDocs.
+ * <p/>
+ * http://cs.oswego.edu/mailman/listinfo/concurrency-interest
+ *
+ * @author Dr Heinz M. Kabutz
+ */
+public class StripedExecutorService extends AbstractExecutorService {
+    /**
+     * The wrapped ExecutorService that will actually execute our
+     * tasks.
+     */
+    private final ExecutorService executor;
+
+    /**
+     * The lock prevents shutdown from being called in the middle
+     * of a submit.  It also guards the executors IdentityHashMap.
+     */
+    private final ReentrantLock lock = new ReentrantLock();
+
+    /**
+     * This condition allows us to cleanly terminate this executor
+     * service.
+     */
+    private final Condition terminating = lock.newCondition();
+
+    /**
+     * Whenever a new StripedObject is submitted to the pool, it
+     * is added to this IdentityHashMap.  As soon as the
+     * SerialExecutor is empty, the entry is removed from the map,
+     * in order to avoid a memory leak.
+     */
+    private final Map<Object, SerialExecutor> executors =
+            new HashMap<>();
+
+    /**
+     * The default submit() method creates a new FutureTask and
+     * wraps our StripedRunnable with it.  We thus need to
+     * remember the stripe object somewhere.  In our case, we will
+     * do this inside the ThreadLocal "stripes".  Before the
+     * thread returns from submitting the runnable, it will always
+     * remove the thread local entry.
+     */
+    private final static ThreadLocal<Object> stripes =
+            new ThreadLocal<>();
+
+    /**
+     * Valid states are RUNNING and SHUTDOWN.  We rely on the
+     * underlying executor service for the remaining states.
+     */
+    private State state = State.RUNNING;
+
+    private static enum State {
+        RUNNING, SHUTDOWN
+    }
+
+    /**
+     * The constructor taking executors is private, since we do
+     * not want users to shutdown their executors directly,
+     * otherwise jobs might get stuck in our queues.
+     *
+     * @param executor the executor service that we use to execute
+     *                 the tasks
+     */
+    private StripedExecutorService(ExecutorService executor) {
+        this.executor = executor;
+    }
+
+    /**
+     * This constructs a StripedExecutorService that wraps a
+     * cached thread pool.
+     */
+    public StripedExecutorService() {
+        this(Executors.newCachedThreadPool());
+    }
+
+    /**
+     * This constructs a StripedExecutorService that wraps a fixed
+     * thread pool with the given number of threads.
+     */
+    public StripedExecutorService(int numberOfThreads) {
+        this(Executors.newFixedThreadPool(numberOfThreads));
+    }
+
+    /**
+     * If the runnable also implements StripedObject, we store the
+     * stripe object in a thread local, since the actual runnable
+     * will be wrapped with a FutureTask.
+     */
+    protected <T> RunnableFuture<T> newTaskFor(
+            Runnable runnable, T value) {
+        saveStripedObject(runnable);
+        return super.newTaskFor(runnable, value);
+    }
+
+    /**
+     * If the callable also implements StripedObject, we store the
+     * stripe object in a thread local, since the actual callable
+     * will be wrapped with a FutureTask.
+     */
+    protected <T> RunnableFuture<T> newTaskFor(
+            Callable<T> callable) {
+        saveStripedObject(callable);
+        return super.newTaskFor(callable);
+    }
+
+    /**
+     * Saves the stripe in a ThreadLocal until we can use it to
+     * schedule the task into our pool.
+     */
+    private void saveStripedObject(Object task) {
+        if (isStripedObject(task)) {
+            stripes.set(((StripedObject) task).getStripe());
+        }
+    }
+
+    /**
+     * Returns true if the object implements the StripedObject
+     * interface.
+     */
+    private static boolean isStripedObject(Object o) {
+        return o instanceof StripedObject;
+    }
+
+    /**
+     * Delegates the call to submit(task, null).
+     */
+    public Future<?> submit(Runnable task) {
+        return submit(task, null);
+    }
+
+    /**
+     * If the task is a StripedObject, we execute it in-order by
+     * its stripe, otherwise we submit it directly to the wrapped
+     * executor.  If the pool is not running, we throw a
+     * RejectedExecutionException.
+     */
+    public <T> Future<T> submit(Runnable task, T result) {
+        lock.lock();
+        try {
+            checkPoolIsRunning();
+            if (isStripedObject(task)) {
+                return super.submit(task, result);
+            } else { // bypass the serial executors
+                return executor.submit(task, result);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * If the task is a StripedObject, we execute it in-order by
+     * its stripe, otherwise we submit it directly to the wrapped
+     * executor.  If the pool is not running, we throw a
+     * RejectedExecutionException.
+     */
+    public <T> Future<T> submit(Callable<T> task) {
+        lock.lock();
+        try {
+            checkPoolIsRunning();
+            if (isStripedObject(task)) {
+                return super.submit(task);
+            } else { // bypass the serial executors
+                return executor.submit(task);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Throws a RejectedExecutionException if the state is not
+     * RUNNING.
+     */
+    private void checkPoolIsRunning() {
+        assert lock.isHeldByCurrentThread();
+        if (state != State.RUNNING) {
+            throw new RejectedExecutionException(
+                    "executor not running");
+        }
+    }
+
+    /**
+     * Executes the command.  If command implements StripedObject,
+     * we execute it with a SerialExecutor.  This method can be
+     * called directly by clients or it may be called by the
+     * AbstractExecutorService's submit() methods. In that case,
+     * we check whether the stripes thread local has been set.  If
+     * it is, we remove it and use it to determine the
+     * StripedObject and execute it with a SerialExecutor.  If no
+     * StripedObject is set, we instead pass the command to the
+     * wrapped ExecutorService directly.
+     */
+    public void execute(Runnable command) {
+        lock.lock();
+        try {
+            checkPoolIsRunning();
+            Object stripe = getStripe(command);
+            if (stripe != null) {
+                SerialExecutor ser_exec = executors.get(stripe);
+                if (ser_exec == null) {
+                    executors.put(stripe, ser_exec =
+                            new SerialExecutor(stripe));
+                }
+                ser_exec.execute(command);
+            } else {
+                executor.execute(command);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * We get the stripe object either from the Runnable if it
+     * also implements StripedObject, or otherwise from the thread
+     * local temporary storage.  Result may be null.
+     */
+    private Object getStripe(Runnable command) {
+        Object stripe;
+        if (command instanceof StripedObject) {
+            stripe = (((StripedObject) command).getStripe());
+        } else {
+            stripe = stripes.get();
+        }
+        stripes.remove();
+        return stripe;
+    }
+
+    /**
+     * Shuts down the StripedExecutorService.  No more tasks will
+     * be submitted.  If the map of SerialExecutors is empty, we
+     * shut down the wrapped executor.
+     */
+    public void shutdown() {
+        lock.lock();
+        try {
+            state = State.SHUTDOWN;
+            if (executors.isEmpty()) {
+                executor.shutdown();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * All the tasks in each of the SerialExecutors are drained
+     * to a list, as well as the tasks inside the wrapped
+     * ExecutorService.  This is then returned to the user.  Also,
+     * the shutdownNow method of the wrapped executor is called.
+     */
+    public List<Runnable> shutdownNow() {
+        lock.lock();
+        try {
+            shutdown();
+            List<Runnable> result = new ArrayList<>();
+            for (SerialExecutor ser_ex : executors.values()) {
+                ser_ex.tasks.drainTo(result);
+            }
+            result.addAll(executor.shutdownNow());
+            return result;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns true if shutdown() or shutdownNow() have been
+     * called; false otherwise.
+     */
+    public boolean isShutdown() {
+        lock.lock();
+        try {
+            return state == State.SHUTDOWN;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns true if this pool has been terminated, that is, all
+     * the SerialExecutors are empty and the wrapped
+     * ExecutorService has been terminated.
+     */
+    public boolean isTerminated() {
+        lock.lock();
+        try {
+            if (state == State.RUNNING) return false;
+            for (SerialExecutor executor : executors.values()) {
+                if (!executor.isEmpty()) return false;
+            }
+            return executor.isTerminated();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Returns true if the wrapped ExecutorService terminates
+     * within the allotted amount of time.
+     */
+    public boolean awaitTermination(long timeout, TimeUnit unit)
+            throws InterruptedException {
+        lock.lock();
+        try {
+            long waitUntil = System.nanoTime() + unit.toNanos(timeout);
+            long remainingTime;
+            while ((remainingTime = waitUntil - System.nanoTime()) > 0
+                    && !executors.isEmpty()) {
+                terminating.awaitNanos(remainingTime);
+            }
+            if (remainingTime <= 0) return false;
+            if (executors.isEmpty()) {
+                return executor.awaitTermination(
+                        remainingTime, TimeUnit.NANOSECONDS);
+            }
+            return false;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * As soon as a SerialExecutor is empty, we remove it from the
+     * executors map.  We might thus remove the SerialExecutors
+     * more quickly than necessary, but at least we can avoid a
+     * memory leak.
+     */
+    private void removeEmptySerialExecutor(Object stripe,
+                                           SerialExecutor ser_ex) {
+        assert ser_ex == executors.get(stripe);
+        assert lock.isHeldByCurrentThread();
+        assert ser_ex.isEmpty();
+
+        executors.remove(stripe);
+        terminating.signalAll();
+        if (state == State.SHUTDOWN && executors.isEmpty()) {
+            executor.shutdown();
+        }
+    }
+
+    /**
+     * Prints information about current state of this executor, the
+     * wrapped executor and the serial executors.
+     */
+    public String toString() {
+        lock.lock();
+        try {
+            return "StripedExecutorService: state=" + state + ", " +
+                    "executor=" + executor + ", " +
+                    "serialExecutors=" + executors;
+        } finally {
+            lock.unlock();
+        }
+
+    }
+
+    /**
+     * This field is used for conditional compilation.  If it is
+     * false, then the finalize method is an empty method, in
+     * which case the SerialExecutor will not be registered with
+     * the Finalizer.
+     */
+    private static boolean DEBUG = false;
+
+    /**
+     * SerialExecutor is based on the construct with the same name
+     * described in the {@link Executor} JavaDocs.  The difference
+     * with our SerialExecutor is that it can be terminated.  It
+     * also removes itself automatically once the queue is empty.
+     */
+    private class SerialExecutor implements Executor {
+        /**
+         * The queue of unexecuted tasks.
+         */
+        private final BlockingQueue<Runnable> tasks =
+                new LinkedBlockingQueue<>();
+        /**
+         * The runnable that we are currently busy with.
+         */
+        private Runnable active;
+        /**
+         * The stripe that this SerialExecutor was defined for.  It
+         * is needed so that we can remove this executor from the
+         * map once it is empty.
+         */
+        private final Object stripe;
+
+        /**
+         * Creates a SerialExecutor for a particular stripe.
+         */
+        private SerialExecutor(Object stripe) {
+            this.stripe = stripe;
+            if (DEBUG) {
+                System.out.println("SerialExecutor created " + stripe);
+            }
+        }
+
+        /**
+         * We use finalize() only for debugging purposes.  If
+         * DEBUG==false, the body of the method will be compiled
+         * away, thus rendering it a trivial finalize() method,
+         * which means that the object will not incur any overhead
+         * since it won't be registered with the Finalizer.
+         */
+        protected void finalize() throws Throwable {
+            if (DEBUG) {
+                System.out.println("SerialExecutor finalized " + stripe);
+                super.finalize();
+            }
+        }
+
+        /**
+         * For every task that is executed, we add() a wrapper to
+         * the queue of tasks that will run the current task and
+         * then schedule the next task in the queue.
+         */
+        public void execute(final Runnable r) {
+            lock.lock();
+            try {
+                tasks.add(new Runnable() {
+                    public void run() {
+                        try {
+                            r.run();
+                        } finally {
+                            scheduleNext();
+                        }
+                    }
+                });
+                if (active == null) {
+                    scheduleNext();
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        /**
+         * Schedules the next task for this stripe.  Should only be
+         * called if active == null or if we are finished executing
+         * the currently active task.
+         */
+        private void scheduleNext() {
+            lock.lock();
+            try {
+                if ((active = tasks.poll()) != null) {
+                    executor.execute(active);
+                    terminating.signalAll();
+                } else {
+                    removeEmptySerialExecutor(stripe, this);
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        /**
+         * Returns true if the list is empty and there is no task
+         * currently executing.
+         */
+        public boolean isEmpty() {
+            lock.lock();
+            try {
+                return active == null && tasks.isEmpty();
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        public String toString() {
+            assert lock.isHeldByCurrentThread();
+            return "SerialExecutor: active=" + active + ", " +
+                    "tasks=" + tasks;
+        }
+    }
+}

--- a/element-connector/src/main/java/eu/javaspecialists/tjsn/concurrency/stripedexecutor/StripedObject.java
+++ b/element-connector/src/main/java/eu/javaspecialists/tjsn/concurrency/stripedexecutor/StripedObject.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2000-2013 Heinz Max Kabutz
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Heinz Max Kabutz licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.javaspecialists.tjsn.concurrency.stripedexecutor;
+
+/**
+ * Used to indicate which "stripe" this Runnable or Callable belongs to.  The
+ * stripe is determined by the identity of the object, rather than its hash
+ * code and equals.
+ *
+ * @author Dr Heinz M. Kabutz
+ * @see StripedExecutorService
+ */
+public interface StripedObject {
+    Object getStripe();
+}

--- a/element-connector/src/main/java/eu/javaspecialists/tjsn/concurrency/stripedexecutor/StripedRunnable.java
+++ b/element-connector/src/main/java/eu/javaspecialists/tjsn/concurrency/stripedexecutor/StripedRunnable.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2000-2013 Heinz Max Kabutz
+ *
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Heinz Max Kabutz licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.javaspecialists.tjsn.concurrency.stripedexecutor;
+
+/**
+ * All of the Runnables in the same "Stripe" will be executed consecutively.
+ *
+ * @author Dr Heinz M. Kabutz
+ * @see StripedExecutorService
+ */
+public interface StripedRunnable extends Runnable, StripedObject {
+}

--- a/element-connector/src/main/resources/LICENSE-2.0.txt
+++ b/element-connector/src/main/resources/LICENSE-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/element-connector/src/main/resources/NOTICE.txt
+++ b/element-connector/src/main/resources/NOTICE.txt
@@ -1,0 +1,15 @@
+   Copyright 2000-2012 Heinz Max Kabutz
+
+   From The Java Specialists' Newsletter (http://www.javaspecialists.eu)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/element-connector/src/main/resources/about.html
+++ b/element-connector/src/main/resources/about.html
@@ -26,5 +26,23 @@ If no such license exists, contact the Redistributor. Unless otherwise indicated
 of the EPL and EDL still apply to any source code in the Content and such source code may be obtained at
 <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
 
+<h3>Third Party Content</h3>
+
+<p>The Content includes items that have been sourced from third parties as set out below.
+If you did not receive this Content directly from the Eclipse Foundation, the following is provided
+for informational purposes only, and you should look to the Redistributor's license for terms and
+conditions of use.</p>
+
+<h5>Heinz M. Kabutz' Striped Executor Service</h5>
+
+<p>This product includes the Striped Executor Service implementation developed by Heinz M. Kabutz.
+(<a href="http://www.javaspecialists.eu/archive/Issue206.html">206 Striped Executor Service</a>).</p>
+
+<p>Your use of the <em>Striped Executor Service</em> is subject to the terms and conditions of the Apache Software License 2.0.
+A copy of the license is contained in the file <a href="LICENSE-2.0.txt">LICENSE-2.0.txt</a> and is also available at
+<a href="http://www.apache.org/licenses/LICENSE-2.0.html">http://www.apache.org/licenses/LICENSE-2.0.html</a>.</p>
+
+<p>The source code is available from
+<a href="https://github.com/kabutz/javaspecialists">Heinz M. Kabutz' GitHub repository</a>.</p>
 </body>
 </html>

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
@@ -231,9 +231,9 @@ public final class Connection implements SessionListener {
 	}
 
 	@Override
-	public void sessionEstablished(Handshaker handshaker, DTLSSession establishedSession) throws HandshakeException {
-		this.establishedSession = establishedSession;
-		LOGGER.log(Level.FINE, "Session with [{0}] has been established", establishedSession.getPeer());
+	public void sessionEstablished(Handshaker handshaker, DTLSSession session) throws HandshakeException {
+		this.establishedSession = session;
+		LOGGER.log(Level.FINE, "Session with [{0}] has been established", session.getPeer());
 	}
 
 	@Override


### PR DESCRIPTION
This is the initial step to fix #216.
The overall idea is to introduce an inbound Record buffer to Connection which is processed one-by-one using a thread pool based Executor. This way we achieve two things:

make sure that all incoming records are processed in order
allow multiple Handshake/Application records being processed in parallel
A next step could also be to re-factor the record processing logic into a separate class (i.e. puling it out of DTLSConnector which is already an ugly beast) implementing RecordProcessor ...

Created from a branch on eclipse/californium so that @sbernard31 and other committers can collaborate on it. Replaces #229 