### PR TITLE
Relax lifetime test to prevent sporadic test errors.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/network/MessageIdTrackerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/MessageIdTrackerTest.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *    Bosch Software Innovations - initial creation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - relax lifetime tests
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -67,9 +68,11 @@ public class MessageIdTrackerTest {
 		}
 
 		// THEN the first message ID is re-used after EXCHANGE_LIFETIME has expired
+		exchangeLifetime += (exchangeLifetime >> 1); // a little longer
 		long timeElapsed = System.currentTimeMillis() - start;
 		if (timeElapsed < exchangeLifetime) {
 			Thread.sleep(exchangeLifetime - timeElapsed);
+			timeElapsed = System.currentTimeMillis() - start;
 		}
 		int mid = tracker.getNextMessageId();
 		assertThat(mid, is(firstMid));


### PR DESCRIPTION
This test fails sporadically on windows. Therefore the tested
exchangeLifetime is increased and the elapsed time is ensured not only
relying on Thread.sleep().

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>