### PR TITLE
Introduce direct datagram socket

### DIFF
--- a/californium-core/pom.xml
+++ b/californium-core/pom.xml
@@ -4,7 +4,7 @@
 	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
 	<modelVersion>4.0.0</modelVersion>
-	
+
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
@@ -26,6 +26,12 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>element-connector</artifactId>
+			<classifier>tests</classifier>
+			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -75,6 +81,7 @@
 						   by means of the Californium-logging.properties file
 						-->
 						<java.util.logging.config.file>${project.build.testOutputDirectory}/Californium-logging.properties</java.util.logging.config.file>
+						<org.eclipse.californium.junit.socketmode>DIRECT</org.eclipse.californium.junit.socketmode>
 					</systemPropertyVariables>
 					<excludes>
 						<exclude>**/*$*</exclude>

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/EndpointManagerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/EndpointManagerTest.java
@@ -14,6 +14,8 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - initial creation (465073)
  *    Achim Kraus (Bosch Software Innovations GmbH) - dummy setCorrelationContextMatcher
  *                                                    (fix GitHub issue #104)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -29,17 +31,20 @@ import java.net.URI;
 
 import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.coap.CoAP;
-import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.CorrelationContextMatcher;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(Small.class)
 public class EndpointManagerTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	@Before
 	public void setUp() throws Exception {
@@ -78,7 +83,7 @@ public class EndpointManagerTest {
 	@Test
 	public void testSetDefaultEndpointSchemeFailure() throws Exception {
 		// GIVEN an new endpoint with http:
-		Endpoint endpoint = new CoapEndpoint(new DummyHttpConnector(), NetworkConfig.getStandard());
+		Endpoint endpoint = new CoapEndpoint(new DummyHttpConnector(), network.getStandardTestConfig());
 
 		// THEN set with null or unsupported scheme fails
 		try {

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/BlockwiseTransferTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/BlockwiseTransferTest.java
@@ -17,6 +17,8 @@
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
  *    Achim Kraus (Bosch Software Innovations GmbH) - test stop transfer on cancel
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test;
 
@@ -41,10 +43,12 @@ import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.core.test.lockstep.ServerBlockwiseInterceptor;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -59,6 +63,8 @@ import org.junit.experimental.categories.Category;
 // because of pending BlockCleanupTask
 @Category(Medium.class)
 public class BlockwiseTransferTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	private static final String PARAM_SHORT_RESP = "srr";
 	private static final String PARAM_SHORT_REQ = "sr";
@@ -83,7 +89,7 @@ public class BlockwiseTransferTest {
 	@BeforeClass
 	public static void prepare() {
 		System.out.println(System.lineSeparator() + "Start " + BlockwiseTransferTest.class.getSimpleName());
-		config = NetworkConfig.createStandardWithoutFile()
+		config = network.getStandardTestConfig()
 			.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 32)
 			.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 32)
 			.setInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE, 500);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ClientAsynchronousTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ClientAsynchronousTest.java
@@ -18,6 +18,8 @@
  *    Kai Hudalla - logging
  *    Bosch Software Innovations GmbH - refactor into separate test cases, remove
  *                                      wait cycles
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test;
 
@@ -47,15 +49,19 @@ import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(Medium.class)
 public class ClientAsynchronousTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	public static final String TARGET = "storage";
 	public static final String CONTENT_1 = "one";
@@ -74,7 +80,7 @@ public class ClientAsynchronousTest {
 	@BeforeClass
 	public static void init() {
 		System.out.println(System.lineSeparator() + "Start " + ClientAsynchronousTest.class.getSimpleName());
-		NetworkConfig.getStandard()
+		network.getStandardTestConfig()
 			.setLong(NetworkConfig.Keys.MAX_TRANSMIT_WAIT, 100);
 		createServer();
 		uri = String.format("coap://%s:%d/%s", serverAddress.getHostString(), serverAddress.getPort(), TARGET);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ClientSynchronousTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ClientSynchronousTest.java
@@ -16,6 +16,8 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test;
 
@@ -42,14 +44,18 @@ import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(Medium.class)
 public class ClientSynchronousTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	private static final String TARGET = "storage";
 	private static final String CONTENT_1 = "one";
@@ -69,7 +75,7 @@ public class ClientSynchronousTest {
 
 	@BeforeClass
 	public static void startupServer() {
-		NetworkConfig.getStandard().setLong(NetworkConfig.Keys.MAX_TRANSMIT_WAIT, 100);
+		network.getStandardTestConfig().setLong(NetworkConfig.Keys.MAX_TRANSMIT_WAIT, 100);
 		createServer();
 		System.out.println(System.lineSeparator() + "Start " + ClientSynchronousTest.class.getSimpleName() +
 				" on " + serverEndpoint.getUri());

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
@@ -1,3 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Martin Lanter - creator
+ *    (a lot of changes from different authors, please refer to gitlog).
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
+ ******************************************************************************/
 package org.eclipse.californium.core.test;
 
 import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.waitUntilDeduplicatorShouldBeEmpty;
@@ -35,10 +53,12 @@ import org.eclipse.californium.core.network.MessageExchangeStore;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -49,6 +69,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Medium.class)
 public class MemoryLeakingHashMapTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	// Configuration for this test
 	private static final int TEST_EXCHANGE_LIFETIME = 247; // milliseconds
@@ -316,7 +338,7 @@ public class MemoryLeakingHashMapTest {
 
 	private static void createServerAndClientEndpoints() throws Exception {
 
-		NetworkConfig config = NetworkConfig.createStandardWithoutFile()
+		NetworkConfig config = network.getStandardTestConfig()
 			// We make sure that the sweep deduplicator is used
 			.setString(NetworkConfig.Keys.DEDUPLICATOR, NetworkConfig.Keys.DEDUPLICATOR_MARK_AND_SWEEP)
 			.setInt(NetworkConfig.Keys.MARK_AND_SWEEP_INTERVAL, TEST_SWEEP_DEDUPLICATOR_INTERVAL)

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MessageTypeTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MessageTypeTest.java
@@ -16,6 +16,8 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for 
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test;
 
@@ -35,8 +37,10 @@ import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.EndpointManager;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -46,6 +50,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Medium.class)
 public class MessageTypeTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	private static final String SERVER_RESPONSE = "server responds hi";
 	private static final String ACC_RESOURCE = "acc-res";

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ObserveTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ObserveTest.java
@@ -17,6 +17,8 @@
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
  *    Achim Kraus - fixing race condition and visibility
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for 
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test;
 
@@ -48,8 +50,10 @@ import org.eclipse.californium.core.network.EndpointManager;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -80,7 +84,7 @@ import org.junit.experimental.categories.Category;
  * <pre>
  *   19 INFO [ReliabilityLayer$RetransmissionTask]: Timeout: retransmit message, failed: 1, ...
  *   11 INFO [ReliabilityLayer$RetransmissionTask]: Timeout: retransmit message, failed: 2, ...
- *   Resource resX changed to "resX sais hi for the 3 time"
+ *   Resource resX changed to "resX says hi for the 3 time"
  *   19 INFO [ReliabilityLayer$RetransmissionTask]: Timeout: retransmit message, failed: 3, ...
  *   11 INFO [ReliabilityLayer$RetransmissionTask]: Timeout: retransmit message, failed: 4, ...
  *   17 INFO [ReliabilityLayer$RetransmissionTask]: Timeout: retransmission limit reached, exchange failed, ...
@@ -88,6 +92,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Medium.class)
 public class ObserveTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	static final String TARGET_X = "resX";
 	static final String TARGET_Y = "resY";
@@ -284,7 +290,7 @@ public class ObserveTest {
 
 	private void createServer() {
 		// retransmit constantly all 200 milliseconds
-		NetworkConfig config = new NetworkConfig().setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200)
+		NetworkConfig config = network.createTestConfig().setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200)
 				.setFloat(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1f).setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f);
 
 		CoapEndpoint endpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/RandomAccessBlockTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/RandomAccessBlockTest.java
@@ -1,3 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Martin Lanter - creator
+ *    (a lot of changes from different authors, please refer to gitlog).
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
+ ******************************************************************************/
 package org.eclipse.californium.core.test;
 
 import static org.eclipse.californium.TestTools.generateRandomPayload;
@@ -28,8 +46,10 @@ import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -40,6 +60,8 @@ import org.junit.runners.Parameterized.Parameters;
 @Category(Medium.class)
 @RunWith(Parameterized.class)
 public class RandomAccessBlockTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	private static final String TARGET = "test";
 	private static final String RESP_PAYLOAD = generateRandomPayload(87);
@@ -57,8 +79,8 @@ public class RandomAccessBlockTest {
 	@Before
 	public void startupServer() throws Exception {
 		System.out.println(System.lineSeparator() + "Start " + RandomAccessBlockTest.class.getName());
-		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
-		config.setInt(Keys.MAX_RESOURCE_BODY_SIZE, maxBodySize);
+		NetworkConfig config = network.getStandardTestConfig()
+			.setInt(Keys.MAX_RESOURCE_BODY_SIZE, maxBodySize);
 		CoapEndpoint endpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
 		server = new CoapServer();
 		server.addEndpoint(endpoint);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceTreeTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceTreeTest.java
@@ -16,6 +16,8 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test;
 
@@ -29,14 +31,18 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(Medium.class)
 public class ResourceTreeTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	public static final String RES_A = "A";
 	public static final String RES_AA = "AA";

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/SmallServerClientTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/SmallServerClientTest.java
@@ -16,6 +16,8 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test;
 
@@ -35,8 +37,10 @@ import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.EndpointManager;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.server.MessageDeliverer;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -46,6 +50,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Medium.class)
 public class SmallServerClientTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	private static String SERVER_RESPONSE = "server responds hi";
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/StartStopTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/StartStopTest.java
@@ -16,6 +16,8 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test;
 
@@ -28,8 +30,10 @@ import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.network.EndpointManager;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -45,6 +49,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Medium.class)
 public class StartStopTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	public static final String SERVER_1_RESPONSE = "This is server one";
 	public static final String SERVER_2_RESPONSE = "This is server two";

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -18,6 +18,8 @@
  *    Kai Hudalla - logging
  *    Bosch Software Innovations GmbH - reduce code duplication, split up into
  *                                      separate test cases, remove wait cycles
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
@@ -40,16 +42,17 @@ import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.CoapHandler;
 import org.eclipse.californium.core.CoapResponse;
 import org.eclipse.californium.core.coap.BlockOption;
-import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -60,6 +63,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Medium.class)
 public class BlockwiseClientSideTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	private static final int MAX_RESOURCE_BODY_SIZE = 1024;
 
@@ -76,7 +81,7 @@ public class BlockwiseClientSideTest {
 	public static void init() {
 		System.out.println(System.lineSeparator() + "Start " + BlockwiseClientSideTest.class.getSimpleName());
 
-		config = NetworkConfig.createStandardWithoutFile()
+		config = network.getStandardTestConfig()
 				.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 128)
 				.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 128)
 				.setInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE, MAX_RESOURCE_BODY_SIZE)

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
@@ -18,6 +18,8 @@
  *    Kai Hudalla - logging
  *    Bosch Software Innovations GmbH - reduce code duplication, split up into
  *                                      separate test cases, remove wait cycles
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
@@ -43,10 +45,12 @@ import org.eclipse.californium.core.network.InMemoryMessageExchangeStore;
 import org.eclipse.californium.core.network.MessageExchangeStore;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -57,6 +61,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Large.class)
 public class BlockwiseServerSideTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	private static final int TEST_EXCHANGE_LIFETIME = 247; // milliseconds
 	private static final int TEST_SWEEP_DEDUPLICATOR_INTERVAL = 100; // milliseconds
@@ -81,7 +87,7 @@ public class BlockwiseServerSideTest {
 	@BeforeClass
 	public static void init() {
 		System.out.println(System.lineSeparator() + "Start " + BlockwiseServerSideTest.class.getSimpleName());
-		CONFIG = new NetworkConfig()
+		CONFIG = network.createTestConfig()
 				.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 128)
 				.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, TEST_PREFERRED_BLOCK_SIZE)
 				.setInt(NetworkConfig.Keys.BLOCKWISE_STATUS_LIFETIME, 100)

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
@@ -14,6 +14,8 @@
  *    Sierra Wireless - initial implementation
  *    Achim Kraus (Bosch Software Innovations GmbH) - use localhost for windows compatibility
  *                                                    sending to "any" doesn't work on windows
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
@@ -40,8 +42,10 @@ import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
 import org.eclipse.californium.core.observe.InMemoryObservationStore;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -51,6 +55,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Medium.class)
 public class ClusteringTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	private LockstepEndpoint server;
 
@@ -70,7 +76,7 @@ public class ClusteringTest {
 
 		System.out.println(System.lineSeparator() + "Start " + getClass().getSimpleName());
 
-		NetworkConfig config = new NetworkConfig()
+		NetworkConfig config = network.createTestConfig()
 				.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 16)
 				.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 16)
 				.setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200) // client retransmits after 200ms

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/DeduplicationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/DeduplicationTest.java
@@ -16,6 +16,8 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
@@ -37,8 +39,10 @@ import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -48,6 +52,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Medium.class)
 public class DeduplicationTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	private LockstepEndpoint server;
 
@@ -58,7 +64,7 @@ public class DeduplicationTest {
 	public void setupServer() throws Exception {
 		System.out.println(System.lineSeparator() + "Start " + getClass().getSimpleName());
 
-		NetworkConfig config = new NetworkConfig()
+		NetworkConfig config = network.createTestConfig()
 			.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 128)
 			.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 128)
 			.setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200) // client retransmits after 200 ms

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -18,6 +18,8 @@
  *    Kai Hudalla - logging
  *    Bosch Software Innovations GmbH - reduce code duplication, split up into
  *                                      separate test cases, remove wait cycles
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
@@ -42,10 +44,12 @@ import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -55,6 +59,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Large.class)
 public class ObserveClientSideTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	private static NetworkConfig CONFIG;
 
@@ -67,7 +73,7 @@ public class ObserveClientSideTest {
 	@BeforeClass
 	public static void init() {
 		System.out.println(System.lineSeparator() + "Start " + ObserveClientSideTest.class.getSimpleName());
-		CONFIG = new NetworkConfig()
+		CONFIG = network.createTestConfig()
 				.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 16)
 				.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 16)
 				.setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200) // client retransmits after 200 ms

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveServerSideTest.java
@@ -18,6 +18,8 @@
  *    Kai Hudalla - logging
  *    Bosch Software Innovations GmbH - reduce code duplication, split up into
  *                                      separate test cases, remove wait cycles
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
@@ -49,16 +51,20 @@ import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.elements.UDPConnector;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(Medium.class)
 public class ObserveServerSideTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	private static final int ACK_TIMEOUT = 100;
 	private static final String RESOURCE_PATH = "obs";
@@ -82,7 +88,7 @@ public class ObserveServerSideTest {
 		Logger ul = Logger.getLogger(UDPConnector.class.getName());
 		ul.setLevel(Level.OFF);
 
-		CONFIG = new NetworkConfig()
+		CONFIG = network.createTestConfig()
 				.setInt(NetworkConfig.Keys.ACK_TIMEOUT, ACK_TIMEOUT)
 				.setFloat(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1f)
 				.setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f)

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ServerDeduplicationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ServerDeduplicationTest.java
@@ -16,6 +16,8 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
@@ -36,9 +38,11 @@ import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -48,6 +52,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Medium.class)
 public class ServerDeduplicationTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	private static final int DEDUPLICATOR_SWEEP_INTERVAL = 200; // ms
 	private static final String resourceName = "test";
@@ -61,7 +67,7 @@ public class ServerDeduplicationTest {
 	@BeforeClass
 	public static void setupServer() throws Exception {
 
-		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
+		NetworkConfig config = network.getStandardTestConfig();
 		config.setString(NetworkConfig.Keys.DEDUPLICATOR, NetworkConfig.Keys.DEDUPLICATOR_MARK_AND_SWEEP);
 		config.setInt(NetworkConfig.Keys.MARK_AND_SWEEP_INTERVAL, DEDUPLICATOR_SWEEP_INTERVAL);
 		Endpoint ep = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/maninmiddle/LossyBlockwiseTransferTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/maninmiddle/LossyBlockwiseTransferTest.java
@@ -16,6 +16,8 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
  ******************************************************************************/
 package org.eclipse.californium.core.test.maninmiddle;
 
@@ -38,8 +40,10 @@ import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -50,6 +54,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Large.class)
 public class LossyBlockwiseTransferTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
 	private CoapServer server;
 	private Endpoint clientEndpoint;
@@ -68,7 +74,7 @@ public class LossyBlockwiseTransferTest {
 
 		System.out.println(System.lineSeparator() + "Start" + getClass().getSimpleName());
 
-		NetworkConfig config = NetworkConfig.createStandardWithoutFile()
+		NetworkConfig config = network.getStandardTestConfig()
 			.setInt(NetworkConfig.Keys.ACK_TIMEOUT, 300)
 			.setFloat(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1f)
 			.setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f)

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/maninmiddle/ManInTheMiddle.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/maninmiddle/ManInTheMiddle.java
@@ -16,6 +16,9 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - get MAX_RETRANSMIT without
+ *                                                    changing the NetworkConfig 
+ *                                                    standard.
  ******************************************************************************/
 package org.eclipse.californium.core.test.maninmiddle;
 
@@ -46,7 +49,7 @@ public class ManInTheMiddle implements Runnable {
 	private int current = 0;
 
 	// drop bursts longer than MAX_RETRANSMIT must be avoided
-	private static final int MAX = NetworkConfig.createStandardWithoutFile().getInt(NetworkConfig.Keys.MAX_RETRANSMIT);
+	private static final int MAX = new NetworkConfig().getInt(NetworkConfig.Keys.MAX_RETRANSMIT);
 	private int last = -3;
 	private int burst = 1;
 

--- a/californium-core/src/test/java/org/eclipse/californium/rule/CoapNetworkRule.java
+++ b/californium-core/src/test/java/org/eclipse/californium/rule/CoapNetworkRule.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.rule;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.network.EndpointManager;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.serialization.DataParser;
+import org.eclipse.californium.core.network.serialization.UdpDataParser;
+import org.eclipse.californium.elements.rule.NetworkRule;
+import org.eclipse.californium.elements.util.DatagramFormatter;
+
+/**
+ * CoAP network rules for junit test using datagram sockets.
+ * 
+ * Though {@link NetworkConfig} and {@link EndpointManager} depend on some
+ * internal state, this rule manages these states by setup and cleanup the
+ * values. Therefore it's intended, that test code uses the provided methods to
+ * access {@link NetworkConfig}, {@link #getStandardTestConfig()},
+ * {@link #createStandardTestConfig()}, and {@link #createTestConfig()}.
+ *
+ * The rule is intended to be mainly used as <code>&#64;ClassRule<code>
+ * 
+ * <pre>
+ * public class AbcNetworkTest {
+ *    &#64;ClassRule
+ *    public static CoapNetworkRule network = new CoapNetworkRule(Mode.DIRECT, Mode.NATIVE);
+ *    ...
+ *    &#64;BeforeClass
+ *    public static void init() {
+ *       network.getStandardTestConfig().setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 32);
+ *    ...
+ * </pre>
+ * 
+ * The {@link NetworkConfig} access methods then are valid from the
+ * <code>&#64;BeforeClass</code> until <code>&#64;AfterClass</code> method.
+ * 
+ * If used as
+ * <code>&#64;Rule<code>, the {@link NetworkConfig} access methods then are valid from the
+ * <code>&#64;Before</code> until <code>&#64;After</code> method.
+ * 
+ * For the DIRECT mode there are additional parameters available
+ * {@link #setMessageThreads(int)}, and {@link #setDelay(int)}.
+ * 
+ * In rare cases nested rules are allowed, but be careful when accessing the
+ * {@link NetworkConfig} to choose the active rule. The inner will overwrite the
+ * outer {@link NetworkConfig} and detach from that.
+
+ * <pre>
+ * public class AbcNetworkTest {
+ *    &#64;ClassRule
+ *    public static CoapNetworkRule network = new CoapNetworkRule(Mode.DIRECT, Mode.NATIVE);
+ *    &#64;Rule
+ *    public static CoapNetworkRule inner = new CoapNetworkRule(Mode.DIRECT, Mode.NATIVE);
+ *    ...
+ *    &#64;BeforeClass
+ *    public static void init() {
+ *       network.getStandardTestConfig().setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 32);
+ *    ...
+ *    
+ *    &#64;Before
+ *    public void before() {
+ *       inner.getStandardTestConfig().setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 64);
+ *    
+ * </pre>
+ * 
+ */
+public class CoapNetworkRule extends NetworkRule {
+
+	public static final Logger LOGGER = Logger.getLogger(CoapNetworkRule.class.getName());
+	private static final int DEFAULT_MESSAGE_THREADS = 1;
+	/**
+	 * CoAP datagram formatter. Used for logging.
+	 */
+	private static final DatagramFormatter FORMATTER = new DatagramFormatter() {
+
+		private DataParser parser = new UdpDataParser();
+
+		@Override
+		public String format(byte[] data) {
+			Message message = parser.parseMessage(data);
+			return message.toString();
+		}
+
+	};
+
+	/**
+	 * Number of message processing threads. Used to setup test
+	 * {@link NetworkConfig}.
+	 * 
+	 * @see #createTestConfig()
+	 * @see #createStandardTestConfig()
+	 * @see #getStandardTestConfig()
+	 */
+	private final AtomicInteger messageThreads = new AtomicInteger(DEFAULT_MESSAGE_THREADS);
+
+	/**
+	 * Create rule supporting provided modes.
+	 * 
+	 * @param modes
+	 *            supported datagram socket implementation modes.
+	 */
+	public CoapNetworkRule(Mode... modes) {
+		super(FORMATTER, modes);
+		this.messageThreads.set(DEFAULT_MESSAGE_THREADS);
+	}
+
+	/**
+	 * Set number of message processing threads. Using multiple threads for
+	 * sending and receiving may result in reordering of messages. Therefore the
+	 * default is {@link #DEFAULT_MESSAGE_THREADS} to ensure, that no such
+	 * reorder happens.
+	 * 
+	 * @param threads
+	 *            number of threads.
+	 * @return this rule
+	 */
+	public CoapNetworkRule setMessageThreads(int threads) {
+		if (1 > threads) {
+			throw new IllegalArgumentException("number of message threads must be at least 1, not " + threads + "!");
+		}
+		messageThreads.set(threads);
+		return this;
+	}
+
+	@Override
+	protected void initNetwork(boolean first) {
+		if (first) {
+			EndpointManager.reset();
+		}
+		createStandardTestConfig();
+		super.initNetwork(first);
+	}
+
+	@Override
+	protected void closeNetwork() {
+		super.closeNetwork();
+		EndpointManager.reset();
+		messageThreads.set(DEFAULT_MESSAGE_THREADS);
+		NetworkConfig.setStandard(null);
+	}
+
+	/**
+	 * Create new standard network configuration for testing.
+	 * 
+	 * @return fresh standard network configurations. Changes are visible to
+	 *         other usage of the standard configuration.
+	 * @see NetworkConfig#getStandard()
+	 */
+	public NetworkConfig createStandardTestConfig() {
+		NetworkConfig config = createTestConfig();
+		NetworkConfig.setStandard(config);
+		return config;
+	}
+
+	/**
+	 * Get standard network configuration for testing.
+	 * 
+	 * @return standard network configurations. Changes are visible to other
+	 *         usage of the standard configuration.
+	 * @see NetworkConfig#getStandard()
+	 */
+	public NetworkConfig getStandardTestConfig() {
+		ensureThisRuleIsActive();
+		return NetworkConfig.getStandard();
+	}
+
+	/**
+	 * Create new network configuration for testing.
+	 * 
+	 * @return network configurations. Detached from the standard network
+	 *         configuration.
+	 */
+	public NetworkConfig createTestConfig() {
+		ensureThisRuleIsActive();
+		int threads = messageThreads.get();
+		NetworkConfig config = new NetworkConfig();
+		config.setInt(NetworkConfig.Keys.NETWORK_STAGE_RECEIVER_THREAD_COUNT, threads);
+		config.setInt(NetworkConfig.Keys.NETWORK_STAGE_SENDER_THREAD_COUNT, threads);
+		return config;
+	}
+}

--- a/element-connector/pom.xml
+++ b/element-connector/pom.xml
@@ -63,6 +63,17 @@
 					</instructions>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/element-connector/src/test/java/org/eclipse/californium/elements/category/NativeDatagramSocketImplRequired.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/category/NativeDatagramSocketImplRequired.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - Initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.elements.category;
+
+/**
+ * A marker interface for test cases that requires the native DatagamSocketImpl for
+ * real network operations.
+ * 
+ * Be careful when design such test, so that dropping and reordering of messages
+ * doesn't break your test!
+ */
+public interface NativeDatagramSocketImplRequired {
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/NetworkRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/NetworkRule.java
@@ -1,0 +1,433 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.elements.rule;
+
+import java.io.IOError;
+import java.net.DatagramSocket;
+import java.net.DatagramSocketImpl;
+import java.net.SocketException;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.californium.elements.category.NativeDatagramSocketImplRequired;
+import org.eclipse.californium.elements.util.DatagramFormatter;
+import org.eclipse.californium.elements.util.DirectDatagramSocketImpl;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Network rule for datagram junit tests.
+ * 
+ * Defines, if the test should be execute with native datagram sockets (NATIVE),
+ * and/or direct datagram sockets using "in process" messaging (DIRECT). The
+ * supported modes of the test are provided as parameter of the constructor. If
+ * DIRECT is supported, additional parameter may also be used.
+ * 
+ * Though the {@link DatagramSocket#setDatagramSocketImplFactory} could only be
+ * called once, all executed tests must use the same DatagramSocketImpl.
+ * Therefore this rule doesn't setup the DatagramSocketImpl, it just filters the
+ * test according the supported modes. For usage within maven, a category
+ * {@link NativeDatagramSocketImplRequired} is also available.
+ * 
+ * The used socket mode is setup on the first usage, according the definition of
+ * the property "org.eclipse.californium.junit.socketmode". The value must be
+ * either "NATIVE" or "DIRECT". When tests are executed, it's checked, if the
+ * test supports the used mode, and, if not the test is skipped.
+ * 
+ * The intended use within maven is therefore to use the introduced category
+ * {@link NativeDatagramSocketImplRequired} to select the tests running DIRECT
+ * and run the NATIVE test in a separate execution.
+ * 
+ * The intended use within eclipse is setup two configurations, one for DIRECT
+ * using "-Dorg.eclipse.californium.junit.socketmode=DIRECT", and one for NATIVE
+ * using "-Dorg.eclipse.californium.junit.socketmode=NATIVE". Currently the
+ * default is NATIVE. I hope, after a introduction period, it could be changed
+ * to DIRECT.
+ * 
+ * If the rule scope is left, the rule checks for left open DatagramSockets.
+ * Therefore it's important to chose the right scope for the rule. The
+ * <code>&#64;ClassRule<code> is required for tests, which starts a server once
+ * and then reuse it on several tests. <code>&#64;Rule<code> could be used, if
+ * every test cleans up on its own.
+ * 
+ * <pre>
+ * public class AbcNetworkTest {
+ *    &#64;ClassRule
+ *    public static NetworkRule network = new NetworkRule(Mode.DIRECT, Mode.NATIVE);
+ * 
+ * </pre>
+ * 
+ */
+public class NetworkRule implements TestRule {
+
+	public static final Logger LOGGER = Logger.getLogger(NetworkRule.class.getName());
+	/**
+	 * Name of configuration property. Supported values of property "NATIVE" and
+	 * "DIRECT".
+	 */
+	public static final String PROPERTY_NAME = "org.eclipse.californium.junit.socketmode";
+
+	/**
+	 * Default datagram formatter.
+	 */
+	private static final DatagramFormatter DEFAULT_FORMATTER = null;
+	/**
+	 * Default message processing delay.
+	 */
+	private static final int DEFAULT_DELAY_IN_MILLIS = 0;
+
+	/**
+	 * Used datagram socket implementation mode.
+	 */
+	private static final Mode usedMode;
+	/**
+	 * Stack of rules. Support class rules and nested method rules.
+	 */
+	private static final Deque<NetworkRule> RULES_STACK = new LinkedList<NetworkRule>();
+
+	static {
+		Mode mode = Mode.NATIVE;
+		String envMode = System.getProperty(PROPERTY_NAME);
+		if (null != envMode) {
+			try {
+				mode = Mode.valueOf(envMode);
+			} catch (IllegalArgumentException ex) {
+				LOGGER.log(Level.SEVERE, "Value {0} for property {1} not supported!",
+						new Object[] { envMode, PROPERTY_NAME });
+			}
+		}
+		usedMode = mode;
+		if (Mode.DIRECT == usedMode) {
+			DirectDatagramSocketImpl.initialize(new DirectDatagramSocketImpl.DirectDatagramSocketImplFactory() {
+
+				@Override
+				public DatagramSocketImpl createDatagramSocketImpl() {
+					if (!isActive()) {
+						String message = "Use " + NetworkRule.class.getName() + " to define DatagramSocket behaviour!";
+						LOGGER.log(Level.SEVERE, message);
+						/*
+						 * check, if datagram socket is created in the scope of
+						 * a NetworkRule.
+						 */
+						throw new IOError(new SocketException(message));
+					}
+					return super.createDatagramSocketImpl();
+				}
+			});
+		}
+	}
+
+	/**
+	 * Statement to skip test. Used to filter test which not supports the
+	 * {@link #usedMode}.
+	 */
+	private static final Statement SKIP = new Statement() {
+
+		@Override
+		public void evaluate() throws Throwable {
+			/* skip, do nothing */
+		}
+	};
+
+	/**
+	 * DatagramSocketImpl modes.
+	 */
+	public enum Mode {
+		/**
+		 * Native datagram socket implementation (using operation system).
+		 */
+		NATIVE,
+		/**
+		 * Direct datagram socket implementation.
+		 * 
+		 * @see DirectDatagramSocketImpl
+		 */
+		DIRECT
+	}
+
+	/**
+	 * Array of supported modes.
+	 */
+	private final Mode[] supportedModes;
+
+	/**
+	 * Datagram formatter to be used.
+	 * 
+	 * @see #DEFAULT_FORMATTER
+	 */
+	private DatagramFormatter formatter;
+	/**
+	 * Delay for message processing.
+	 * 
+	 * @see #DEFAULT_DELAY_IN_MILLIS
+	 */
+	private int delayInMillis;
+
+	/**
+	 * Description of current test.
+	 */
+	private Description description;
+
+	/**
+	 * Create rule supporting provided modes.
+	 * 
+	 * @param modes
+	 *            supported datagram socket implementation modes.
+	 */
+	public NetworkRule(Mode... modes) {
+		this(DEFAULT_FORMATTER, modes);
+	}
+
+	/**
+	 * Create rule supporting provided modes and formatter.
+	 * 
+	 * @param formatter
+	 *            datagram formatter to be used
+	 * @param modes
+	 *            supported datagram socket implementation modes.
+	 */
+	protected NetworkRule(DatagramFormatter formatter, Mode... modes) {
+		this.supportedModes = modes;
+		this.formatter = formatter;
+		this.delayInMillis = DEFAULT_DELAY_IN_MILLIS;
+	}
+
+	@Override
+	public String toString() {
+		Description description;
+		synchronized (RULES_STACK) {
+			description = this.description;
+		}
+		if (null == description) {
+			return super.toString();
+		} else if (description.isTest()) {
+			return description.getDisplayName() + " (@Rule)";
+		} else {
+			return description.getDisplayName() + " (@ClassRule)";
+		}
+	}
+
+	/**
+	 * Check, if provided mode is in {@link #supportedModes}.
+	 * 
+	 * @param mode
+	 *            mode to check
+	 * @return true, if provided mode is supported, false, otherwise
+	 */
+	private boolean supports(final Mode mode) {
+		for (Mode supportedMode : supportedModes) {
+			if (mode == supportedMode) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Set delay for processing messages.
+	 * 
+	 * Only used in DIRECT mode.
+	 * 
+	 * @param delayInMillis
+	 *            delay in milliseconds
+	 * @return this rule
+	 * @throws IllegalArgumentException,
+	 *             if the value is smaller then 0 or DIRECT is not within the
+	 *             supported modes.
+	 */
+	public NetworkRule setDelay(int delayInMillis) {
+		if (0 > delayInMillis) {
+			throw new IllegalArgumentException("delays must be at least 0, not " + delayInMillis + "!");
+		}
+		if (!supports(Mode.DIRECT)) {
+			throw new IllegalArgumentException("delays could only be used for DIRECT DatagramSockets!");
+		}
+		this.delayInMillis = delayInMillis;
+		return this;
+	}
+
+	/**
+	 * Apply configuration of rule.
+	 * 
+	 * Handles nesting of rules pushing rule to stack and setup configuration
+	 * calling {@link #initNetwork(boolean)}.
+	 */
+	private final void applyConfig(final Description description) {
+		int size;
+		boolean first;
+		synchronized (RULES_STACK) {
+			this.description = description;
+			first = RULES_STACK.isEmpty();
+			RULES_STACK.push(this);
+			size = RULES_STACK.size();
+		}
+		LOGGER.log(Level.INFO, "{0} rules active.", size);
+		initNetwork(first);
+	}
+
+	/**
+	 * Close configuration of rule.
+	 * 
+	 * Handles nesting of rules by removing the top rule from the stack and
+	 * setup configuration of the next rule calling
+	 * {@link #initNetwork(boolean)}, when available. When the last rule is
+	 * removed from stack and no next rule is available, calls
+	 * {@link #closeNetwork()}.
+	 */
+	private final void closeConfig() {
+		int size;
+		NetworkRule closedRule;
+		NetworkRule activeRule;
+		synchronized (RULES_STACK) {
+			closedRule = RULES_STACK.pop();
+			activeRule = RULES_STACK.peek();
+			size = RULES_STACK.size();
+		}
+		LOGGER.log(Level.INFO, "{0} rules active.", size);
+		if (this != closedRule) {
+			throw new IllegalStateException("closed rule differs!");
+		}
+		if (null == activeRule) {
+			closeNetwork();
+		} else {
+			activeRule.initNetwork(false);
+		}
+	}
+
+	@Override
+	public Statement apply(final Statement base, final Description description) {
+		if (supports(usedMode)) {
+			return new Statement() {
+
+				@Override
+				public void evaluate() throws Throwable {
+					applyConfig(description);
+					try {
+						base.evaluate();
+					} finally {
+						closeConfig();
+					}
+				}
+			};
+		} else {
+			LOGGER.log(Level.WARNING, "Skip {0} not applicable with socket mode {1}",
+					new Object[] { description, usedMode });
+			return SKIP;
+		}
+	}
+
+	/**
+	 * Initialize network for testing.
+	 * 
+	 * Configure network using
+	 * {@link DirectDatagramSocketImpl#configure(DatagramFormatter, int)}, if
+	 * {@link #usedMode} is {@link Mode#DIRECT}.
+	 * 
+	 * @param outerScope
+	 *            true, if called from the outer most rule. Usually the rule is
+	 *            used as class rule and my use nested method rules. If that's
+	 *            the case, outerScope is true for the class rule and false for
+	 *            the method rule. If only method rules are used, it's always
+	 *            true. If true, all open DIRECT sockets are cleaned up and
+	 *            warnings are logged. This indicator is introduced to cover
+	 *            situations, where the class setup starts a server, which is
+	 *            then reused by several tests.
+	 */
+	protected void initNetwork(boolean outerScope) {
+		if (Mode.DIRECT == usedMode) {
+			if (outerScope && !DirectDatagramSocketImpl.isEmpty()) {
+				LOGGER.info("Previous test didn't 'closeNetwork()'!");
+				DirectDatagramSocketImpl.clearAll();
+			}
+			DirectDatagramSocketImpl.configure(formatter, delayInMillis);
+		}
+	}
+
+	/**
+	 * Close network after testing.
+	 * 
+	 * Ensure, that all sockets are closed. Reset network configuration to their
+	 * defaults.
+	 * 
+	 * @see #DEFAULT_FORMATTER
+	 * @see #DEFAULT_DELAY_IN_MILLIS
+	 */
+	protected void closeNetwork() {
+		if (Mode.DIRECT == usedMode) {
+			if (!DirectDatagramSocketImpl.isEmpty()) {
+				LOGGER.info("Test didn't close all DatagramSockets!");
+				DirectDatagramSocketImpl.clearAll();
+			}
+			DirectDatagramSocketImpl.configure(DEFAULT_FORMATTER, DEFAULT_DELAY_IN_MILLIS);
+		}
+	}
+
+	/**
+	 * Ensure, that this rule is the currently active rule.
+	 * 
+	 * @throws IllegalStateException,
+	 *             if this rule is not currently active.
+	 */
+	protected void ensureThisRuleIsActive() throws IllegalStateException {
+		NetworkRule activeRule;
+		synchronized (RULES_STACK) {
+			activeRule = RULES_STACK.peek();
+		}
+		if (this != activeRule) {
+			Description description;
+			synchronized (RULES_STACK) {
+				description = this.description;
+			}
+			String message;
+
+			if (null == description) {
+				message = this + " rule is not applied!";
+			} else {
+				message = this + " rule is not active!";
+			}
+			if (null == activeRule) {
+				message += " No active rule!";
+			} else {
+				message += " Instead " + activeRule + " is active!";
+
+			}
+			LOGGER.log(Level.SEVERE, message);
+			throw new IllegalStateException(message);
+		}
+	}
+
+	/**
+	 * Check, is a network rule is active.
+	 * 
+	 * used to determine, if all DIRECT sockets are created within the scope of
+	 * a {@link NetworkRule}.
+	 * 
+	 * @return true, if a network rule is active, false, otherwise.
+	 */
+	public static boolean isActive() {
+		int size;
+		boolean active;
+		synchronized (RULES_STACK) {
+			size = RULES_STACK.size();
+			active = !RULES_STACK.isEmpty();
+		}
+		LOGGER.log(Level.INFO, "{0} rules active.", size);
+		return active;
+	}
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/AbstractDatagramSocketImpl.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/AbstractDatagramSocketImpl.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation.
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocketImpl;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Implementation for simple basic methods.
+ * 
+ * Intended to be extended by an implementation for
+ * "in process message exchange". Throws IOException with message containing
+ * "not supported" on {@link #peek(InetAddress)},
+ * {@link #peekData(DatagramPacket)}, {@link #setTTL(byte)}, {@link #getTTL()},
+ * {@link #join(InetAddress)}, {@link #leave(InetAddress)},
+ * {@link #joinGroup(SocketAddress, NetworkInterface)}, and
+ * {@link #leaveGroup(SocketAddress, NetworkInterface)}
+ */
+public abstract class AbstractDatagramSocketImpl extends DatagramSocketImpl {
+
+	/**
+	 * Map for socket options.
+	 * 
+	 * @see #setOption(int, Object)
+	 * @see #getOption(int)
+	 */
+	private Map<Integer, Object> options = new ConcurrentHashMap<Integer, Object>();
+	/**
+	 * Time to live of socket.
+	 * 
+	 * @see #setTimeToLive(int)
+	 * @see #getTimeToLive()
+	 */
+	private volatile int ttl;
+
+	@Override
+	public void setOption(int optID, Object value) throws SocketException {
+		options.put(optID, value);
+	}
+
+	@Override
+	public Object getOption(int optID) throws SocketException {
+		return options.get(optID);
+	}
+
+	@Override
+	protected void create() throws SocketException {
+	}
+
+	@Override
+	protected int peek(InetAddress i) throws IOException {
+		throw new IOException("peek(InetAddress) not supported!");
+	}
+
+	@Override
+	protected int peekData(DatagramPacket p) throws IOException {
+		throw new IOException("peekData(DatagramPacket) not supported!");
+	}
+
+	@Override
+	protected void setTTL(byte ttl) throws IOException {
+		throw new IOException("setTTL(byte) not supported!");
+	}
+
+	@Override
+	protected byte getTTL() throws IOException {
+		throw new IOException("getTTL() not supported!");
+	}
+
+	@Override
+	protected void setTimeToLive(int ttl) throws IOException {
+		this.ttl = ttl;
+	}
+
+	@Override
+	protected int getTimeToLive() throws IOException {
+		return ttl;
+	}
+
+	@Override
+	protected void join(InetAddress inetaddr) throws IOException {
+		throw new IOException("join(InetAddress) not supported!");
+	}
+
+	@Override
+	protected void leave(InetAddress inetaddr) throws IOException {
+		throw new IOException("leave(InetAddress) not supported!");
+	}
+
+	@Override
+	protected void joinGroup(SocketAddress mcastaddr, NetworkInterface netIf) throws IOException {
+		throw new IOException("joinGroup(SocketAddress, NetworkInterface) not supported!");
+	}
+
+	@Override
+	protected void leaveGroup(SocketAddress mcastaddr, NetworkInterface netIf) throws IOException {
+		throw new IOException("leaveGroup(SocketAddress, NetworkInterface) not supported!");
+	}
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/DatagramFormatter.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/DatagramFormatter.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation.
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+/**
+ * Formatter for datagram bytes.
+ */
+public interface DatagramFormatter {
+
+	/**
+	 * Format datagram bytes
+	 * 
+	 * @param data bytes of the datagram
+	 * @return formatted textual datagram
+	 */
+	String format(byte[] data);
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/DirectDatagramSocketImpl.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/DirectDatagramSocketImpl.java
@@ -1,0 +1,479 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation.
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.DatagramSocketImpl;
+import java.net.DatagramSocketImplFactory;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.SocketOptions;
+import java.net.SocketTimeoutException;
+import java.util.Arrays;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Reliable "in process" message exchange implementation.
+ * 
+ * Uses internal queues instead of operation system IP stack. If port 0 is used
+ * for the datagram socket, the implementation tries to assign a next unused
+ * port in range {@link #AUTO_PORT_RANGE_MIN} to {@link #AUTO_PORT_RANGE_MAX}.
+ * The full range is used before any free port is reused.
+ * 
+ * Currently neither multicast nor specific/multi network interfaces are
+ * supported.
+ */
+public class DirectDatagramSocketImpl extends AbstractDatagramSocketImpl {
+
+	public static final Logger LOGGER = Logger.getLogger(DirectDatagramSocketImpl.class.getName());
+
+	/**
+	 * Starting port number for automatic port binding.
+	 */
+	public static final int AUTO_PORT_RANGE_MIN = 8192;
+	/**
+	 * Last port number for automatic port binding.
+	 */
+	public static final int AUTO_PORT_RANGE_MAX = 65535;
+	/**
+	 * Number of ports for automatic port binding.
+	 */
+	public static final int AUTO_PORT_RANGE_SIZE = AUTO_PORT_RANGE_MAX - AUTO_PORT_RANGE_MIN + 1;
+
+	private static final DatagramSocketImplFactory DEFAULT = new DirectDatagramSocketImplFactory();
+
+	/**
+	 * Map of sockets.
+	 */
+	private static final ConcurrentMap<Integer, DirectDatagramSocketImpl> map = new ConcurrentHashMap<Integer, DirectDatagramSocketImpl>();
+
+	/**
+	 * Initialization indicator.
+	 * 
+	 * @see #initialize(int, DatagramFormatter)
+	 * @see #isEnabled()
+	 */
+	private static final AtomicReference<DatagramSocketImplFactory> init = new AtomicReference<DatagramSocketImplFactory>();
+
+	/**
+	 * Port counter for new port on bind.
+	 */
+	private static final AtomicInteger nextPort = new AtomicInteger(0);
+
+	/**
+	 * Initialization indicator.
+	 * 
+	 * @see #initialize(int, DatagramFormatter)
+	 * @see #isEnabled()
+	 */
+	private static final AtomicReference<Setup> setup = new AtomicReference<Setup>();
+
+	/**
+	 * The inbound message queue.
+	 */
+	private final BlockingQueue<DatagramExchange> incomingQueue = new LinkedBlockingQueue<DatagramExchange>();
+
+	/**
+	 * Local address of socket.
+	 */
+	private InetAddress localAddress;
+
+	/**
+	 * Indicate, that the socket is closed.
+	 * 
+	 * @see #close()
+	 */
+	private boolean closed;
+
+	/**
+	 * Create instance of this socket implementation.
+	 */
+	private DirectDatagramSocketImpl() {
+	}
+
+	@Override
+	protected void bind(int lport, InetAddress laddr) throws SocketException {
+		LOGGER.log(Level.INFO, "port {0}, address {1}", new Object[] { lport, laddr });
+		int port = bind(lport);
+		synchronized (this) {
+			this.localPort = port;
+			this.localAddress = laddr;
+		}
+		setOption(SocketOptions.SO_BINDADDR, laddr);
+	}
+
+	@Override
+	protected void close() {
+		boolean closed;
+		int port;
+		InetAddress addr;
+		synchronized (this) {
+			closed = this.closed;
+			port = this.localPort;
+			addr = this.localAddress;
+			this.closed = true;
+		}
+		LOGGER.log(Level.INFO, "port {0}, address {1}", new Object[] { port, addr });
+		if (!closed) {
+			if (!map.remove(port, this)) {
+				LOGGER.log(Level.WARNING, "close unknown port {0}, address {1}", new Object[] { port, addr });
+			}
+		}
+	}
+
+	@Override
+	protected void receive(DatagramPacket packet) throws IOException {
+		int port;
+		InetAddress addr;
+		synchronized (this) {
+			port = this.localPort;
+			addr = this.localAddress;
+		}
+		try {
+			final int timeout = getSoTimeout();
+			final DatagramExchange exchange;
+			final Setup currentSetup = setup.get();
+			if (0 < timeout) {
+				exchange = incomingQueue.poll(timeout, TimeUnit.MILLISECONDS);
+				if (null == exchange) {
+					throw new SocketTimeoutException();
+				}
+			} else {
+				exchange = incomingQueue.take();
+			}
+			if (0 < currentSetup.delayInMs) {
+				// intended for special test conditions
+				Thread.sleep(currentSetup.delayInMs);
+			}
+			boolean closed;
+			synchronized (this) {
+				closed = this.closed;
+				port = this.localPort;
+				addr = this.localAddress;
+			}
+			if (closed) {
+				LOGGER.log(Level.INFO, "already closed {0}", exchange.format(currentSetup));
+				throw new SocketException("Socket " + addr + ":" + port + " closed!");
+			} else {
+				if (LOGGER.isLoggable(Level.FINE)) {
+					LOGGER.log(Level.INFO, "incoming {0}", exchange.format(currentSetup));
+				} else {
+					LOGGER.log(Level.INFO, exchange.format(currentSetup));
+				}
+			}
+			int receivedLength = exchange.data.length;
+			int packetLength = packet.getLength();
+			byte[] packetData = packet.getData();
+			if (packetLength < receivedLength) {
+				if (packetData.length > packetLength) {
+					LOGGER.log(Level.WARNING, "DatagramPacket.length {0} < buffer.length {1}!",
+							new Object[] { packetLength, packetData.length });
+					packetLength = packetData.length;
+				}
+				if (packetLength < receivedLength) {
+					receivedLength = packetLength;
+				}
+			}
+			packet.setLength(receivedLength);
+			System.arraycopy(exchange.data, 0, packetData, 0, receivedLength);
+			packet.setPort(exchange.sourcePort);
+			packet.setAddress(exchange.sourceAddress);
+		} catch (InterruptedException exception) {
+			if (!incomingQueue.isEmpty()) {
+				LOGGER.log(Level.WARNING, "interrupted while receiving!");
+			}
+			throw new SocketException(exception.getMessage() + addr + ":" + port);
+		}
+	}
+
+	@Override
+	protected void send(DatagramPacket packet) throws IOException {
+		boolean closed;
+		int port;
+		InetAddress local;
+		synchronized (this) {
+			closed = this.closed;
+			port = this.localPort;
+			local = this.localAddress;
+		}
+		if (local.isAnyLocalAddress()) {
+			// adjust any to destination host
+			local = packet.getAddress();
+		}
+		Setup currentSetup = setup.get();
+		DatagramExchange exchange = new DatagramExchange(local, port, packet);
+		DirectDatagramSocketImpl destination = map.get(exchange.destinationPort);
+		if (null == destination) {
+			LOGGER.log(Level.SEVERE, "destination (port {0}) not available! {1}",
+					new Object[] { exchange.destinationPort, exchange.format(currentSetup) });
+		} else if (closed) {
+			LOGGER.log(Level.WARNING, "closed/packet dropped! {0}", exchange.format(currentSetup));
+		} else if (!destination.incomingQueue.offer(exchange)) {
+			LOGGER.log(Level.SEVERE, "packet dropped! {0}", exchange.format(currentSetup));
+		} else {
+			LOGGER.log(Level.FINE, "outgoing {0}", exchange.format(currentSetup));
+		}
+	}
+
+	/**
+	 * Datagram information for in process exchange.
+	 */
+	private static class DatagramExchange {
+
+		/**
+		 * Counter for datagram exchanges.
+		 */
+		private static final AtomicInteger ID = new AtomicInteger();
+
+		/**
+		 * Source address.
+		 */
+		public final InetAddress sourceAddress;
+		/**
+		 * Destination address.
+		 */
+		public final InetAddress destinationAddress;
+		/**
+		 * Source port.
+		 */
+		public final int sourcePort;
+		/**
+		 * Destination port.
+		 */
+		public final int destinationPort;
+		/**
+		 * ID of datagram exchange. Used for logging.
+		 */
+		public final int id;
+		/**
+		 * Data of datagram.
+		 */
+		public final byte[] data;
+
+		/**
+		 * Create datagram exchange.
+		 * 
+		 * @param address
+		 *            local address
+		 * @param port
+		 *            local port
+		 * @param packet
+		 *            datagram packet with destination and data
+		 */
+		public DatagramExchange(InetAddress address, int port, DatagramPacket packet) {
+			this.sourceAddress = address;
+			this.destinationAddress = packet.getAddress();
+			this.sourcePort = port;
+			this.destinationPort = packet.getPort();
+			this.id = ID.incrementAndGet();
+			this.data = Arrays.copyOf(packet.getData(), packet.getLength());
+		}
+
+		/**
+		 * 
+		 * @param direction
+		 */
+		public String format(final Setup setup) {
+			long tid = Thread.currentThread().getId();
+			String delay = "";
+			String content = "";
+			if (null != setup) {
+				if (null != setup.formatter) {
+					content = setup.formatter.format(data);
+				}
+				if (0 < setup.delayInMs) {
+					delay = Integer.toString(setup.delayInMs);
+				}
+			}
+			return java.text.MessageFormat.format("(E{0},T{1}) {2}:{3} ={4}=> {5}:{6} [{7}]", new Object[] { id, tid,
+					sourceAddress, sourcePort, delay, destinationAddress, destinationPort, content });
+		}
+	}
+
+	/**
+	 * Bind socket to provided port. Register socket at {@link #map}.
+	 * 
+	 * @param lport
+	 *            provided local port. if 0, choose a free one from the
+	 *            automatic range.
+	 * @return local port
+	 * @throws SocketException
+	 *             if provided port is not free or, if lport was -1, no free
+	 *             port is available.
+	 */
+	private int bind(int lport) throws SocketException {
+		if (0 >= lport) {
+			int count = AUTO_PORT_RANGE_SIZE;
+			int port = AUTO_PORT_RANGE_MIN + nextPort.getAndIncrement() % AUTO_PORT_RANGE_SIZE;
+			while (null != map.putIfAbsent(port, this)) {
+				port = AUTO_PORT_RANGE_MIN + nextPort.getAndIncrement() % AUTO_PORT_RANGE_SIZE;
+				if (0 >= --count) {
+					throw new SocketException("No left free port!");
+				}
+			}
+			LOGGER.log(Level.INFO, "assigned port {0}", port);
+			return port;
+		} else {
+			if (null != map.putIfAbsent(lport, this)) {
+				throw new SocketException("Port " + lport + " already used!");
+			}
+			return lport;
+		}
+	}
+
+	/**
+	 * Get socket timeout.
+	 * 
+	 * @return timeout in milliseconds. 0, doen't wait.
+	 * @throws SocketException
+	 *             not used
+	 */
+	private int getSoTimeout() throws SocketException {
+		Object option = getOption(SocketOptions.SO_TIMEOUT);
+		if (option instanceof Integer) {
+			return ((Integer) option).intValue();
+		} else {
+			return 0;
+		}
+	}
+
+	/**
+	 * Initialize DatagramSocketImplFactory.
+	 * 
+	 * @param factory
+	 *            factory for datagram socket. if null, {@link #DEFAULT} factory
+	 *            is used, which creates {@link DirectDatagramSocketImpl}.
+	 * @return true, if initialization is executed, false, if it was already
+	 *         executed.
+	 * @see DatagramSocket#setDatagramSocketImplFactory(DatagramSocketImplFactory)
+	 */
+	public static boolean initialize(DatagramSocketImplFactory factory) {
+		boolean calledFromTest = false;
+		StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+		for (StackTraceElement call : stack) {
+			if (call.getClassName().startsWith("junit.") || call.getClassName().startsWith("org.junit.")) {
+				calledFromTest = true;
+				break;
+			}
+		}
+		if (!calledFromTest) {
+			throw new IllegalAccessError("The DirectDatagramSocketImpl is intended to be used for tests only!");
+		}
+		if (null == factory) {
+			factory = DEFAULT;
+		}
+		if (init.compareAndSet(null, factory)) {
+			try {
+				DatagramSocket.setDatagramSocketImplFactory(factory);
+				return true;
+			} catch (IOException ex) {
+				LOGGER.log(Level.SEVERE, "DatagramSocketImplFactory", ex);
+			}
+		} else if (factory != init.get()) {
+			LOGGER.log(Level.WARNING, "DatagramSocketImplFactory already set to {0}", init.get().getClass());
+		}
+		return false;
+	}
+
+	/**
+	 * Configure DatagramSocketImplFactory.
+	 * 
+	 * @param formatter
+	 *            datagram formatter.
+	 * @param delayInMs
+	 *            delay processing of incoming message. Value in milliseconds. 0
+	 *            for no delay.
+	 */
+	public static void configure(final DatagramFormatter formatter, final int delayInMs) {
+		setup.set(new Setup(formatter, delayInMs));
+	}
+
+	/**
+	 * Check, if IP stack is initialized to use this DatagramSocketImpl.
+	 * 
+	 * @return true, stack uses this implementation, false otherwise.
+	 * @see #initialize(int, DatagramFormatter)
+	 */
+	public static boolean isEnabled() {
+		return null != init.get();
+	}
+
+	/**
+	 * Check, if no open socket exists.
+	 * 
+	 * @return true, if no socket exists, false, otherwise
+	 */
+	public static boolean isEmpty() {
+		return map.isEmpty();
+	}
+
+	/**
+	 * Force socket cleanup.
+	 */
+	public static void clearAll() {
+		map.clear();
+	}
+
+	private static class Setup {
+
+		/**
+		 * Datagram formatter.
+		 */
+		public final DatagramFormatter formatter;
+
+		/**
+		 * Delay processing of incoming message. Value in milliseconds. 0 for no
+		 * delay.
+		 */
+		public final int delayInMs;
+
+		/**
+		 * Create new setup.
+		 * 
+		 * @param formatter
+		 *            datagram formatter.
+		 * @param delayInMs
+		 *            delay processing of incoming message. Value in
+		 *            milliseconds. 0 for no delay.
+		 */
+		public Setup(final DatagramFormatter formatter, final int delayInMs) {
+			this.formatter = formatter;
+			this.delayInMs = delayInMs;
+		}
+
+	}
+
+	/**
+	 * Basic factory implementation using this {@link DirectDatagramSocketImpl}.
+	 */
+	public static class DirectDatagramSocketImplFactory implements DatagramSocketImplFactory {
+
+		@Override
+		public DatagramSocketImpl createDatagramSocketImpl() {
+			return new DirectDatagramSocketImpl();
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,13 @@
 				<groupId>${project.groupId}</groupId>
 				<artifactId>element-connector</artifactId>
 				<version>${project.version}</version>
+				<scope>test</scope>
+				<classifier>tests</classifier>
+			</dependency>
+			<dependency>
+				<groupId>${project.groupId}</groupId>
+				<artifactId>element-connector</artifactId>
+				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mockito</groupId>


### PR DESCRIPTION
Introduce DirectDatagramSocketImpl and add network handling in
TestTools. Use "in process" datagramm passing to omit potential "message loss"
using the UPD stack.
Second commit adjust most tests (except those, that need additional changes). 

Signed-off-by: Achim Kraus achim.kraus@bosch-si.com