### PR TITLE
Add StringUtil.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/StringUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/StringUtil.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+/**
+ * String utils (as there are so many already out).
+ */
+public class StringUtil {
+
+	/**
+	 * Convert hexadecimal String into decoded character array. Intended to be
+	 * used for passwords.
+	 * 
+	 * @param hex hexadecimal string. e.g. "4130010A"
+	 * @return character array with decoded hexadecimal input parameter. e.g.
+	 *         char[] { 'A', '0', 0x01, '\n' }.
+	 * @throws IllegalArgumentException if the parameter length is odd or
+	 *             contains non hexadecimal characters.
+	 */
+	public static char[] hex2CharArray(String hex) {
+		if (null == hex) {
+			return null;
+		}
+		int length = hex.length();
+		if ((1 & length) != 0) {
+			throw new IllegalArgumentException("'" + hex + "' has odd length!");
+		}
+		length /= 2;
+		char[] result = new char[length];
+		for (int indexDest = 0, indexSrc = 0; indexDest < length; ++indexDest) {
+			int digit = Character.digit(hex.charAt(indexSrc), 16);
+			if (0 > digit) {
+				throw new IllegalArgumentException("'" + hex + "' digit " + indexSrc + " is not hexadecimal!");
+			}
+			result[indexDest] = (char) (digit << 4);
+			++indexSrc;
+			digit = Character.digit(hex.charAt(indexSrc), 16);
+			if (0 > digit) {
+				throw new IllegalArgumentException("'" + hex + "' digit " + indexSrc + " is not hexadecimal!");
+			}
+			result[indexDest] |= (char) digit;
+			++indexSrc;
+		}
+		return result;
+	}
+
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/StringUtilTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/StringUtilTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class StringUtilTest {
+
+	@Test
+	public void testHex2CharArray() {
+		String line = "4130010A";
+		char[] result = StringUtil.hex2CharArray(line);
+
+		assertThat(result, is(new char[] { 'A', '0', 0x01, '\n' }));
+	}
+
+	@Test
+	public void testHex2CharArrayWithNull() {
+		String line = null;
+		char[] result = StringUtil.hex2CharArray(line);
+
+		assertThat(result, is((char[]) null));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testHex2CharArrayIllegalArgumentLength() {
+		String line = "4130010A0";
+		StringUtil.hex2CharArray(line);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testHex2CharArrayIllegalArgumentContent() {
+		String line = "4130010A0Z";
+		StringUtil.hex2CharArray(line);
+	}
+
+}


### PR DESCRIPTION
Currently provides only "hex2CharArray", which will then be used by
SslContextUtil. Intended to be extended in the future.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>