### PR TITLE
[#226] Do not register ExchangeObserver on unsent requests.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -157,11 +157,24 @@ public final class TcpMatcher extends BaseMatcher {
 		public void completed(final Exchange exchange) {
 			if (exchange.getOrigin() == Exchange.Origin.LOCAL) {
 				// this endpoint created the Exchange by issuing a request
-				Exchange.KeyToken idByToken = Exchange.KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
-				exchangeStore.remove(idByToken, exchange);
-				if (!exchange.getCurrentRequest().getOptions().hasObserve()) {
-					exchangeStore.releaseToken(idByToken);
+				Request originRequest = exchange.getCurrentRequest();
+				if (originRequest.getToken() == null) {
+					// this should not happen because we only register the observer
+					// if we have successfully registered the exchange
+					LOGGER.log(
+							Level.WARNING,
+							"exchange observer has been completed on unregistered exchange [peer: {0}:{1}, origin: {2}]",
+							new Object[]{ originRequest.getDestination(), originRequest.getDestinationPort(),
+									exchange.getOrigin()});
+				} else {
+					KeyToken idByToken = KeyToken.fromOutboundMessage(originRequest);
+					exchangeStore.remove(idByToken, exchange);
+					if(!originRequest.getOptions().hasObserve()) {
+						exchangeStore.releaseToken(idByToken);
+					}
+					LOGGER.log(Level.FINER, "Exchange [{0}, origin: {1}] completed", new Object[]{idByToken, exchange.getOrigin()});
 				}
+
 			} else { // Origin.REMOTE
 				// nothing to do
 			}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTestUtils.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTestUtils.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.net.InetSocketAddress;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.network.Exchange.Origin;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.observe.InMemoryObservationStore;
+import org.eclipse.californium.core.observe.NotificationListener;
+import org.eclipse.californium.core.observe.ObservationStore;
+import org.eclipse.californium.elements.CorrelationContext;
+
+/**
+ * Helper methods for testing {@code Matcher}s.
+ *
+ */
+public final class MatcherTestUtils {
+
+	private MatcherTestUtils() {
+	}
+
+	static TcpMatcher newTcpMatcher(boolean useStrictMatching) {
+		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
+		config.setBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING, useStrictMatching);
+		NotificationListener notificationListener = new NotificationListener() {
+
+			@Override
+			public void onNotification(Request request, Response response) {
+			}
+			
+		};
+		TcpMatcher matcher = new TcpMatcher(config, notificationListener,  new InMemoryObservationStore(), CorrelationContextMatcherFactory.create(null, config));
+		matcher.start();
+		return matcher;
+	}
+
+	static UdpMatcher newUdpMatcher(boolean useStrictMatching, MessageExchangeStore exchangeStore, ObservationStore observationStore) {
+		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
+		config.setBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING, useStrictMatching);
+		NotificationListener notificationListener = new NotificationListener() {
+
+			@Override
+			public void onNotification(Request request, Response response) {
+			}
+			
+		};
+		UdpMatcher matcher = new UdpMatcher(config, notificationListener, observationStore, CorrelationContextMatcherFactory.create(null, config));
+
+		matcher.setMessageExchangeStore(exchangeStore);
+		matcher.start();
+		return matcher;
+	}
+
+	static Exchange sendRequest(InetSocketAddress dest, Matcher matcher, CorrelationContext ctx) {
+		Request request = Request.newGet();
+		request.setDestination(dest.getAddress());
+		request.setDestinationPort(dest.getPort());
+		Exchange exchange = new Exchange(request, Origin.LOCAL);
+		exchange.setRequest(request);
+		matcher.sendRequest(exchange, request);
+		exchange.setCorrelationContext(ctx);
+		return exchange;
+	}
+
+	static Exchange sendObserveRequest(InetSocketAddress dest, Matcher matcher) {
+		Request request = Request.newGet();
+		request.setDestination(dest.getAddress());
+		request.setDestinationPort(dest.getPort());
+		request.setObserve();
+		Exchange exchange = new Exchange(request, Origin.LOCAL);
+		exchange.setRequest(request);
+		matcher.sendRequest(exchange, request);
+		return exchange;
+	}
+
+	static Response responseFor(final Request request) {
+		Response response = new Response(ResponseCode.CONTENT);
+		response.setMID(request.getMID());
+		response.setToken(request.getToken());
+		response.setBytes(new byte[]{});
+		response.setSource(request.getDestination());
+		response.setSourcePort(request.getDestinationPort());
+		response.setDestination(request.getSource());
+		response.setDestinationPort(request.getSourcePort());
+		return response;
+	}
+}


### PR DESCRIPTION
Made sure that the Matchers register their ExchangeObservers only on
outbound Exchanges that have been registered with the
MessageExchangeStore successfully.

When canceling a request that has not been registered successfully, e.g.
because there are no MIDs left to be used, there is no ExchangeObserver
to be invoked at all.

WDYT, @sbernard31 ?