### PR TITLE
Use "localhost" as destination instead of "any.

### DIFF
--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/ConnectorTestUtil.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/ConnectorTestUtil.java
@@ -16,10 +16,13 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - adjust creation of oubound message
  *                                                    with null correlation context.
  *    Achim Kraus (Bosch Software Innovations GmbH) - add sending correlation context.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace "any/0.0.0.0" with 
+ *                                                    "localhost/127.0.0.1" in destination.
  ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
 import java.io.ByteArrayOutputStream;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Random;
@@ -40,6 +43,14 @@ public class ConnectorTestUtil {
 	public static final int CONTEXT_TIMEOUT_IN_MS = 1000;
 
 	private static final Random random = new Random(0);
+
+	public static InetSocketAddress getDestination(InetSocketAddress server) {
+		if (server.getAddress().isAnyLocalAddress()) {
+			// for destination replace any by localhost
+			server = new InetSocketAddress(InetAddress.getLoopbackAddress(), server.getPort());
+		}
+		return server;
+	}
 
 	public static RawData createMessage(InetSocketAddress address, int messageSize, CorrelationContext contextToSent,
 			MessageCallback callback) throws Exception {
@@ -69,7 +80,8 @@ public class ConnectorTestUtil {
 			stream.write(1); // GET
 			stream.write(data);
 			stream.flush();
-			return RawData.outbound(stream.toByteArray(), address, contextToSent, callback, false);
+
+			return RawData.outbound(stream.toByteArray(), getDestination(address), contextToSent, callback, false);
 		}
 	}
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TcpConnectorTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TcpConnectorTest.java
@@ -11,22 +11,19 @@
  * http://www.eclipse.org/org/documents/edl-v10.html.
  * <p>
  * Contributors:
- * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ *    Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use ConnectorTestUtil
  ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.eclipse.californium.elements.tcp.ConnectorTestUtil.*;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.ServerSocket;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.californium.elements.Connector;
@@ -48,7 +45,6 @@ public class TcpConnectorTest {
 	public final Timeout timeout = new Timeout(20, TimeUnit.SECONDS);
 
 	private final int messageSize;
-	private final Random random = new Random();
 	private final List<Connector> cleanup = new ArrayList<>();
 
 	@Parameterized.Parameters
@@ -81,8 +77,7 @@ public class TcpConnectorTest {
 
 	@Test
 	public void serverClientPingPong() throws Exception {
-		int port = findEphemeralPort();
-		TcpServerConnector server = new TcpServerConnector(new InetSocketAddress(port), NUMBER_OF_THREADS,
+		TcpServerConnector server = new TcpServerConnector(new InetSocketAddress(0), NUMBER_OF_THREADS,
 				IDLE_TIMEOUT);
 		TcpClientConnector client = new TcpClientConnector(NUMBER_OF_THREADS, 100, IDLE_TIMEOUT);
 
@@ -96,7 +91,7 @@ public class TcpConnectorTest {
 		server.start();
 		client.start();
 
-		RawData msg = createMessage(new InetSocketAddress(port));
+		RawData msg = createMessage(server.getAddress(), messageSize, null, null);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(1);
@@ -104,7 +99,7 @@ public class TcpConnectorTest {
 
 		// Response message must go over the same connection client already
 		// opened
-		msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress());
+		msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress(), messageSize, null, null);
 		server.send(msg);
 		clientCatcher.blockUntilSize(1);
 		assertArrayEquals(msg.getBytes(), clientCatcher.getMessage(0).getBytes());
@@ -112,9 +107,8 @@ public class TcpConnectorTest {
 
 	@Test
 	public void singleServerManyClients() throws Exception {
-		int port = findEphemeralPort();
 		int clients = 100;
-		TcpServerConnector server = new TcpServerConnector(new InetSocketAddress(port), NUMBER_OF_THREADS,
+		TcpServerConnector server = new TcpServerConnector(new InetSocketAddress(0), NUMBER_OF_THREADS,
 				IDLE_TIMEOUT);
 		assertThat(server.getUri().getScheme(), is("coap+tcp"));
 		cleanup.add(server);
@@ -131,7 +125,7 @@ public class TcpConnectorTest {
 			client.setRawDataReceiver(clientCatcher);
 			client.start();
 
-			RawData msg = createMessage(new InetSocketAddress(port));
+			RawData msg = createMessage(server.getAddress(), messageSize, null, null);
 			messages.add(msg);
 			client.send(msg);
 		}
@@ -149,45 +143,6 @@ public class TcpConnectorTest {
 				}
 			}
 			assertTrue("Received unexpected message: " + received, matched);
-		}
-	}
-
-	private static int findEphemeralPort() {
-		try (ServerSocket socket = new ServerSocket(0)) {
-			return socket.getLocalPort();
-		} catch (IOException e) {
-			throw new IllegalStateException("Unable to bind to ephemeral port");
-		}
-	}
-
-	private RawData createMessage(InetSocketAddress address) throws Exception {
-		byte[] data = new byte[messageSize];
-		random.nextBytes(data);
-
-		try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
-			if (messageSize < 13) {
-				stream.write(messageSize << 4);
-			} else if (messageSize < (1 << 8) + 13) {
-				stream.write(13 << 4);
-				stream.write(messageSize - 13);
-			} else if (messageSize < (1 << 16) + 269) {
-				stream.write(14 << 4);
-
-				ByteBuffer buffer = ByteBuffer.allocate(2);
-				buffer.putShort((short) (messageSize - 269));
-				stream.write(buffer.array());
-			} else {
-				stream.write(15 << 4);
-
-				ByteBuffer buffer = ByteBuffer.allocate(4);
-				buffer.putInt(messageSize - 65805);
-				stream.write(buffer.array());
-			}
-
-			stream.write(1); // GET
-			stream.write(data);
-			stream.flush();
-			return new RawData(stream.toByteArray(), address);
 		}
 	}
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TcpCorrelationTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TcpCorrelationTest.java
@@ -11,17 +11,18 @@
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  * 
  * Contributors:
- *    Bosch Software Innovations GmbH - initial implementation. 
+ *    Bosch Software Innovations GmbH - initial implementation.
  *    Achim Kraus (Bosch Software Innovations GmbH) - add test for sending correlation context.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use import static ConnectorTestUtil.*
  ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.text.IsEmptyString.isEmptyOrNullString;
 import static org.junit.Assert.assertArrayEquals;
+import static org.eclipse.californium.elements.tcp.ConnectorTestUtil.*;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -85,7 +86,7 @@ public class TcpCorrelationTest {
 		client.start();
 
 		SimpleMessageCallback clientCallback = new SimpleMessageCallback();
-		RawData msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, null, clientCallback);
+		RawData msg = createMessage(server.getAddress(), 100, null, clientCallback);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(1);
@@ -101,7 +102,7 @@ public class TcpCorrelationTest {
 		// Response message must go over the same connection client already
 		// opened
 		SimpleMessageCallback serverCallback = new SimpleMessageCallback();
-		msg = ConnectorTestUtil.createMessage(serverCatcher.getMessage(0).getInetSocketAddress(), 100, null,
+		msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress(), 100, null,
 				serverCallback);
 		server.send(msg);
 		clientCatcher.blockUntilSize(1);
@@ -121,7 +122,7 @@ public class TcpCorrelationTest {
 
 		// send next message
 		clientCallback = new SimpleMessageCallback();
-		msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, null, clientCallback);
+		msg = createMessage(server.getAddress(), 100, null, clientCallback);
 
 		client.send(msg);
 
@@ -162,7 +163,7 @@ public class TcpCorrelationTest {
 		client.start();
 
 		SimpleMessageCallback clientCallback = new SimpleMessageCallback();
-		RawData msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, null, clientCallback);
+		RawData msg = createMessage(server.getAddress(), 100, null, clientCallback);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(1);
@@ -174,7 +175,7 @@ public class TcpCorrelationTest {
 		Thread.sleep(TimeUnit.MILLISECONDS.convert(ConnectorTestUtil.IDLE_TIMEOUT_RECONNECT_IN_S * 2, TimeUnit.SECONDS));
 
 		clientCallback = new SimpleMessageCallback();
-		msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, null, clientCallback);
+		msg = createMessage(server.getAddress(), 100, null, clientCallback);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(2);
@@ -228,7 +229,7 @@ public class TcpCorrelationTest {
 		client.start();
 
 		SimpleMessageCallback clientCallback = new SimpleMessageCallback();
-		RawData msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, null, clientCallback);
+		RawData msg = createMessage(server.getAddress(), 100, null, clientCallback);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(1);
@@ -241,7 +242,7 @@ public class TcpCorrelationTest {
 		server.start();
 
 		clientCallback = new SimpleMessageCallback();
-		msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, null, clientCallback);
+		msg = createMessage(server.getAddress(), 100, null, clientCallback);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(2);
@@ -301,14 +302,14 @@ public class TcpCorrelationTest {
 		client.start();
 
 		SimpleMessageCallback clientCallback = new SimpleMessageCallback();
-		RawData msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, context, clientCallback);
+		RawData msg = createMessage(server.getAddress(), 100, context, clientCallback);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(1, 2000);
 		assertThat("Serverside received unexpected message", !serverCatcher.hasMessage(0));
 
 		clientCallback = new SimpleMessageCallback();
-		msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, null, clientCallback);
+		msg = createMessage(server.getAddress(), 100, null, clientCallback);
 		client.send(msg);
 		serverCatcher.blockUntilSize(1);
 
@@ -317,12 +318,12 @@ public class TcpCorrelationTest {
 				is(instanceOf(TcpCorrelationContext.class)));
 		assertThat(clientContext.get(TcpCorrelationContext.KEY_CONNECTION_ID), is(not(isEmptyOrNullString())));
 
-		msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, clientContext, clientCallback);
+		msg = createMessage(server.getAddress(), 100, clientContext, clientCallback);
 		client.send(msg);
 		serverCatcher.blockUntilSize(2);
 
 		clientCallback = new SimpleMessageCallback();
-		msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, context, clientCallback);
+		msg = createMessage(server.getAddress(), 100, context, clientCallback);
 		client.send(msg);
 
 		serverCatcher.blockUntilSize(3, 2000);
@@ -365,7 +366,7 @@ public class TcpCorrelationTest {
 		client.start();
 
 		SimpleMessageCallback clientCallback = new SimpleMessageCallback();
-		RawData msg = ConnectorTestUtil.createMessage(server.getAddress(), 100, null, clientCallback);
+		RawData msg = createMessage(server.getAddress(), 100, null, clientCallback);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(1);
@@ -377,19 +378,19 @@ public class TcpCorrelationTest {
 		assertThat(serverContext.get(TcpCorrelationContext.KEY_CONNECTION_ID), is(not(isEmptyOrNullString())));
 
 		SimpleMessageCallback serverCallback = new SimpleMessageCallback();
-		msg = ConnectorTestUtil.createMessage(receivedMsg.getInetSocketAddress(), 100, serverContext, serverCallback);
+		msg = createMessage(receivedMsg.getInetSocketAddress(), 100, serverContext, serverCallback);
 		server.send(msg);
 
 		clientCatcher.blockUntilSize(1);
 
 		serverCallback = new SimpleMessageCallback();
-		msg = ConnectorTestUtil.createMessage(receivedMsg.getInetSocketAddress(), 100, null, serverCallback);
+		msg = createMessage(receivedMsg.getInetSocketAddress(), 100, null, serverCallback);
 		server.send(msg);
 
 		clientCatcher.blockUntilSize(2);
 
 		serverCallback = new SimpleMessageCallback();
-		msg = ConnectorTestUtil.createMessage(receivedMsg.getInetSocketAddress(), 100, context, serverCallback);
+		msg = createMessage(receivedMsg.getInetSocketAddress(), 100, context, serverCallback);
 		server.send(msg);
 
 		clientCatcher.blockUntilSize(3, 2000);
@@ -421,7 +422,7 @@ public class TcpCorrelationTest {
 			server.setRawDataReceiver(serverCatcher);
 			server.start();
 
-			servers.put(server.getAddress(), serverCatcher);
+			servers.put(ConnectorTestUtil.getDestination(server.getAddress()), serverCatcher);
 		}
 		Set<InetSocketAddress> serverAddresses = servers.keySet();
 
@@ -437,7 +438,7 @@ public class TcpCorrelationTest {
 		List<SimpleMessageCallback> callbacks = new ArrayList<>();
 		for (InetSocketAddress address : serverAddresses) {
 			SimpleMessageCallback callback = new SimpleMessageCallback();
-			RawData message = ConnectorTestUtil.createMessage(address, 100, null, callback);
+			RawData message = createMessage(address, 100, null, callback);
 			callbacks.add(callback);
 			messages.add(message);
 			client.send(message);
@@ -455,7 +456,7 @@ public class TcpCorrelationTest {
 		List<SimpleMessageCallback> followupCallbacks = new ArrayList<>();
 		for (InetSocketAddress address : serverAddresses) {
 			SimpleMessageCallback callback = new SimpleMessageCallback();
-			RawData message = ConnectorTestUtil.createMessage(address, 100, null, callback);
+			RawData message = createMessage(address, 100, null, callback);
 			followupCallbacks.add(callback);
 			followupMessages.add(message);
 			client.send(message);

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TlsConnectorTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TlsConnectorTest.java
@@ -15,18 +15,16 @@
  * Achim Kraus (Bosch Software Innovations GmbH) - add more logging.
  * Achim Kraus (Bosch Software Innovations GmbH) - implement checkServerTrusted
  *                                                 to check the DN more relaxed.
+ * Achim Kraus (Bosch Software Innovations GmbH) - use ConnectorTestUtil
  ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.eclipse.californium.elements.tcp.ConnectorTestUtil.*;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
-import java.net.ServerSocket;
-import java.nio.ByteBuffer;
 import java.security.KeyStore;
 import java.security.Security;
 import java.security.cert.CertificateException;
@@ -37,7 +35,6 @@ import java.util.Enumeration;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -66,7 +63,6 @@ public class TlsConnectorTest {
 	private static TrustManager[] trustManager;
 	private static SSLContext serverContext;
 	private static SSLContext clientContext;
-	private final Random random = new Random(0);
 
 	@Rule
 	public final Timeout timeout = new Timeout(10, TimeUnit.SECONDS);
@@ -110,8 +106,7 @@ public class TlsConnectorTest {
 
 	@Test
 	public void pingPongMessage() throws Exception {
-		int port = findEphemeralPort();
-		TlsServerConnector server = new TlsServerConnector(serverContext, new InetSocketAddress(port),
+		TlsServerConnector server = new TlsServerConnector(serverContext, new InetSocketAddress(0),
 				NUMBER_OF_THREADS, IDLE_TIMEOUT);
 		TlsClientConnector client = new TlsClientConnector(clientContext, NUMBER_OF_THREADS, 100, 10);
 
@@ -124,7 +119,7 @@ public class TlsConnectorTest {
 		server.start();
 		client.start();
 
-		RawData msg = createMessage(new InetSocketAddress(port), 100);
+		RawData msg = createMessage(server.getAddress(), 100, null, null);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(1);
@@ -132,7 +127,7 @@ public class TlsConnectorTest {
 
 		// Response message must go over the same connection client already
 		// opened
-		msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress(), 10000);
+		msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress(), 10000, null, null);
 		server.send(msg);
 		clientCatcher.blockUntilSize(1);
 		assertArrayEquals(msg.getBytes(), clientCatcher.getMessage(0).getBytes());
@@ -140,9 +135,8 @@ public class TlsConnectorTest {
 
 	@Test
 	public void singleServerManyClients() throws Exception {
-		int port = findEphemeralPort();
 		int clients = 100;
-		TlsServerConnector server = new TlsServerConnector(serverContext, new InetSocketAddress(port),
+		TlsServerConnector server = new TlsServerConnector(serverContext, new InetSocketAddress(0),
 				NUMBER_OF_THREADS, IDLE_TIMEOUT);
 		assertThat(server.getUri().getScheme(), is("coaps+tcp"));
 		cleanup.add(server);
@@ -159,7 +153,7 @@ public class TlsConnectorTest {
 			client.setRawDataReceiver(clientCatcher);
 			client.start();
 
-			RawData msg = createMessage(new InetSocketAddress(port), 100);
+			RawData msg = createMessage(server.getAddress(), 100, null, null);
 			messages.add(msg);
 			client.send(msg);
 		}
@@ -185,15 +179,14 @@ public class TlsConnectorTest {
 		int serverCount = 3;
 		Map<InetSocketAddress, Catcher> servers = new IdentityHashMap<>();
 		for (int i = 0; i < serverCount; i++) {
-			int port = findEphemeralPort();
-			TlsServerConnector server = new TlsServerConnector(serverContext, new InetSocketAddress(port),
+			TlsServerConnector server = new TlsServerConnector(serverContext, new InetSocketAddress(0),
 					NUMBER_OF_THREADS, IDLE_TIMEOUT);
 			cleanup.add(server);
 			Catcher serverCatcher = new Catcher();
 			server.setRawDataReceiver(serverCatcher);
 			server.start();
 
-			servers.put(server.getAddress(), serverCatcher);
+			servers.put(getDestination(server.getAddress()), serverCatcher);
 		}
 
 		TlsClientConnector client = new TlsClientConnector(clientContext, NUMBER_OF_THREADS, 100, IDLE_TIMEOUT);
@@ -204,7 +197,7 @@ public class TlsConnectorTest {
 
 		List<RawData> messages = new ArrayList<>();
 		for (InetSocketAddress address : servers.keySet()) {
-			RawData message = createMessage(address, 100);
+			RawData message = createMessage(address, 100, null, null);
 			messages.add(message);
 			client.send(message);
 		}
@@ -213,45 +206,6 @@ public class TlsConnectorTest {
 			Catcher catcher = servers.get(message.getInetSocketAddress());
 			catcher.blockUntilSize(1);
 			assertArrayEquals(message.getBytes(), catcher.getMessage(0).getBytes());
-		}
-	}
-
-	private int findEphemeralPort() {
-		try (ServerSocket socket = new ServerSocket(0)) {
-			return socket.getLocalPort();
-		} catch (IOException e) {
-			throw new IllegalStateException("Unable to bind to ephemeral port");
-		}
-	}
-
-	private RawData createMessage(InetSocketAddress address, int messageSize) throws Exception {
-		byte[] data = new byte[messageSize];
-		random.nextBytes(data);
-
-		try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {
-			if (messageSize < 13) {
-				stream.write(messageSize << 4);
-			} else if (messageSize < (1 << 8) + 13) {
-				stream.write(13 << 4);
-				stream.write(messageSize - 13);
-			} else if (messageSize < (1 << 16) + 269) {
-				stream.write(14 << 4);
-
-				ByteBuffer buffer = ByteBuffer.allocate(2);
-				buffer.putShort((short) (messageSize - 269));
-				stream.write(buffer.array());
-			} else {
-				stream.write(15 << 4);
-
-				ByteBuffer buffer = ByteBuffer.allocate(4);
-				buffer.putInt(messageSize - 65805);
-				stream.write(buffer.array());
-			}
-
-			stream.write(1); // GET
-			stream.write(data);
-			stream.flush();
-			return new RawData(stream.toByteArray(), address);
 		}
 	}
 


### PR DESCRIPTION
Use "localhost/127.0.0.1" as destination instead of "any/0.0.0.0".
Use the ConnectorTestUtil for this replacment and unified message
creation.

Fixes the broken 2.0.x builds on hudson.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>