### PR TITLE
Adjust logging levels for unit test.

### DIFF
--- a/californium-core/src/test/resources/Californium-logging.properties
+++ b/californium-core/src/test/resources/Californium-logging.properties
@@ -72,3 +72,4 @@ org.eclipse.californium.core.network.stack.ReliabilityLayer.level = INFO
 org.eclipse.californium.elements.handlers = java.util.logging.ConsoleHandler
 org.eclipse.californium.elements.useParentHandlers = false
 org.eclipse.californium.elements.level = INFO
+org.eclipse.californium.elements.util.DirectDatagramSocketImpl.level = FINE

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/NetworkRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/NetworkRule.java
@@ -48,7 +48,10 @@ import org.junit.runners.model.Statement;
  * The used socket mode is setup on the first usage, according the definition of
  * the property "org.eclipse.californium.junit.socketmode". The value must be
  * either "NATIVE" or "DIRECT". When tests are executed, it's checked, if the
- * test supports the used mode, and, if not the test is skipped.
+ * test supports the used mode, and, if not the test is skipped. For executing
+ * the junit test within eclipse, you may provide the mode either at
+ * project/runner level as VM arguments, or general for a JRE as default VM
+ * arguments (Window->Preferences | Java -> Installed JREs | select and EDIT).
  * 
  * The intended use within maven is therefore to use the introduced category
  * {@link NativeDatagramSocketImplRequired} to select the tests running DIRECT
@@ -171,7 +174,7 @@ public class NetworkRule implements TestRule {
 	 * 
 	 * @see #DEFAULT_FORMATTER
 	 */
-	private DatagramFormatter formatter;
+	private final DatagramFormatter formatter;
 	/**
 	 * Delay for message processing.
 	 * 
@@ -187,8 +190,7 @@ public class NetworkRule implements TestRule {
 	/**
 	 * Create rule supporting provided modes.
 	 * 
-	 * @param modes
-	 *            supported datagram socket implementation modes.
+	 * @param modes supported datagram socket implementation modes.
 	 */
 	public NetworkRule(Mode... modes) {
 		this(DEFAULT_FORMATTER, modes);
@@ -197,10 +199,8 @@ public class NetworkRule implements TestRule {
 	/**
 	 * Create rule supporting provided modes and formatter.
 	 * 
-	 * @param formatter
-	 *            datagram formatter to be used
-	 * @param modes
-	 *            supported datagram socket implementation modes.
+	 * @param formatter datagram formatter to be used
+	 * @param modes supported datagram socket implementation modes.
 	 */
 	protected NetworkRule(DatagramFormatter formatter, Mode... modes) {
 		this.supportedModes = modes;
@@ -226,8 +226,7 @@ public class NetworkRule implements TestRule {
 	/**
 	 * Check, if provided mode is in {@link #supportedModes}.
 	 * 
-	 * @param mode
-	 *            mode to check
+	 * @param mode mode to check
 	 * @return true, if provided mode is supported, false, otherwise
 	 */
 	private boolean supports(final Mode mode) {
@@ -244,12 +243,10 @@ public class NetworkRule implements TestRule {
 	 * 
 	 * Only used in DIRECT mode.
 	 * 
-	 * @param delayInMillis
-	 *            delay in milliseconds
+	 * @param delayInMillis delay in milliseconds
 	 * @return this rule
-	 * @throws IllegalArgumentException,
-	 *             if the value is smaller then 0 or DIRECT is not within the
-	 *             supported modes.
+	 * @throws IllegalArgumentException, if the value is smaller then 0 or
+	 *             DIRECT is not within the supported modes.
 	 */
 	public NetworkRule setDelay(int delayInMillis) {
 		if (0 > delayInMillis) {
@@ -339,13 +336,12 @@ public class NetworkRule implements TestRule {
 	 * {@link DirectDatagramSocketImpl#configure(DatagramFormatter, int)}, if
 	 * {@link #usedMode} is {@link Mode#DIRECT}.
 	 * 
-	 * @param outerScope
-	 *            true, if called from the outer most rule. Usually the rule is
-	 *            used as class rule and my use nested method rules. If that's
-	 *            the case, outerScope is true for the class rule and false for
-	 *            the method rule. If only method rules are used, it's always
-	 *            true. If true, all open DIRECT sockets are cleaned up and
-	 *            warnings are logged. This indicator is introduced to cover
+	 * @param outerScope true, if called from the outer most rule. Usually the
+	 *            rule is used as class rule and my use nested method rules. If
+	 *            that's the case, outerScope is true for the class rule and
+	 *            false for the method rule. If only method rules are used, it's
+	 *            always true. If true, all open DIRECT sockets are cleaned up
+	 *            and warnings are logged. This indicator is introduced to cover
 	 *            situations, where the class setup starts a server, which is
 	 *            then reused by several tests.
 	 */
@@ -381,8 +377,7 @@ public class NetworkRule implements TestRule {
 	/**
 	 * Ensure, that this rule is the currently active rule.
 	 * 
-	 * @throws IllegalStateException,
-	 *             if this rule is not currently active.
+	 * @throws IllegalStateException, if this rule is not currently active.
 	 */
 	protected void ensureThisRuleIsActive() throws IllegalStateException {
 		NetworkRule activeRule;


### PR DESCRIPTION
Add property for default level for DirectDatagramSocketImpl LOGGER.

Using a property for the default enable "easy" handling when running the tests in eclipse. The property may be defined in the VM arguments of projects runner or as default VM arguments for the JRE. 

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>