### PR TITLE
Introduce polling waitForCondition.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/CheckCondition.java
+++ b/californium-core/src/test/java/org/eclipse/californium/CheckCondition.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium;
+
+/**
+ * Interface to "poll" on conditions, where the API doesn't support a
+ * notification.
+ */
+public interface CheckCondition {
+
+	/**
+	 * Check, if the condition is fulfilled.
+	 * 
+	 * Intended to be implemented in a non blocking and very fast fashion!
+	 * 
+	 * @return {@code true}, if the condition is fulfilled, {@code false},
+	 *         otherwise
+	 * @throws IllegalStateException if the condition will not be fulfilled.
+	 *             Caused, if something occurs, which makes it impossible, that
+	 *             the condition is going to be fulfilled.
+	 */
+	boolean isFulFilled() throws IllegalStateException;
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.californium.CheckCondition;
 import org.eclipse.californium.category.Medium;
 import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.CoapHandler;
@@ -129,7 +130,12 @@ public class MemoryLeakingHashMapTest {
 	@After
 	public void assertAllExchangesAreCompleted() {
 		try {
-			waitUntilDeduplicatorShouldBeEmpty(TEST_EXCHANGE_LIFETIME, TEST_SWEEP_DEDUPLICATOR_INTERVAL);
+			waitUntilDeduplicatorShouldBeEmpty(TEST_EXCHANGE_LIFETIME, TEST_SWEEP_DEDUPLICATOR_INTERVAL, new CheckCondition() {
+				@Override
+				public boolean isFulFilled() throws IllegalStateException {
+					return clientExchangeStore.isEmpty() && serverExchangeStore.isEmpty();
+				}
+			});
 			assertTrue("Client side message exchange store still contains exchanges", clientExchangeStore.isEmpty());
 			assertTrue("Server side message exchange store still contains exchanges", serverExchangeStore.isEmpty());
 		} finally {

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.*;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
+import org.eclipse.californium.CheckCondition;
 import org.eclipse.californium.category.Large;
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapServer;
@@ -330,7 +331,12 @@ public class BlockwiseServerSideTest {
 		client.expectResponse(ACK, CONTENT, tok, mid).block2(1, true, 128).payload(respPayload.substring(128, 256)).go();
 		serverInterceptor.log(System.lineSeparator() + "//////// Missing last GET ////////");
 
-		waitUntilDeduplicatorShouldBeEmpty(TEST_EXCHANGE_LIFETIME, TEST_SWEEP_DEDUPLICATOR_INTERVAL);
+		waitUntilDeduplicatorShouldBeEmpty(TEST_EXCHANGE_LIFETIME, TEST_SWEEP_DEDUPLICATOR_INTERVAL, new CheckCondition() {
+			@Override
+			public boolean isFulFilled() throws IllegalStateException {
+				return exchangeStore.isEmpty();
+			}
+		});
 		assertTrue(
 				"Incomplete ongoing blockwise exchange should have been evicted from message exchange store",
 				exchangeStore.isEmpty());
@@ -371,7 +377,12 @@ public class BlockwiseServerSideTest {
 
 		serverInterceptor.log(System.lineSeparator() + "//////// Missing last PUT ////////");
 
-		waitUntilDeduplicatorShouldBeEmpty(TEST_EXCHANGE_LIFETIME, TEST_SWEEP_DEDUPLICATOR_INTERVAL);
+		waitUntilDeduplicatorShouldBeEmpty(TEST_EXCHANGE_LIFETIME, TEST_SWEEP_DEDUPLICATOR_INTERVAL, new CheckCondition() {
+			@Override
+			public boolean isFulFilled() throws IllegalStateException {
+				return exchangeStore.isEmpty();
+			}
+		});
 		assertTrue(
 				"Incomplete ongoing blockwise exchange should have been evicted from message exchange store",
 				exchangeStore.isEmpty());

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/IntegrationTestTools.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/IntegrationTestTools.java
@@ -22,7 +22,10 @@ import static org.junit.Assert.*;
 
 import java.net.InetSocketAddress;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
+import org.eclipse.californium.CheckCondition;
+import org.eclipse.californium.TestTools;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.CoAP.Code;
@@ -102,10 +105,11 @@ public final class IntegrationTestTools {
 		return bytes;
 	}
 
-	public static void waitUntilDeduplicatorShouldBeEmpty(final int exchangeLifetime, final int sweepInterval) {
+	public static void waitUntilDeduplicatorShouldBeEmpty(final int exchangeLifetime, final int sweepInterval, CheckCondition check) {
 		try {
 			int timeToWait = exchangeLifetime + sweepInterval + 300; // milliseconds
 			System.out.println("Wait until deduplicator should be empty (" + timeToWait/1000f + " seconds)");
+			TestTools.waitForCondition(timeToWait, timeToWait / 10, TimeUnit.MILLISECONDS, check);
 			Thread.sleep(timeToWait);
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();


### PR DESCRIPTION
Some tests depend on time-depending states (e.g.
exchangeStore.isEmpty()), where the API doesn't offer a notification
API. Therefore this polling waitForCondition is introduced.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>