### PR TITLE
Use System nanoTime() instead of currentTimeMillis().

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -31,6 +31,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - use CorrelationContext when
  *                                                     sending a message
  *                                                    (fix GitHub issue #104)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use exchange.calculateRTT
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -45,7 +46,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.CoAPMessageFormatException;
@@ -833,7 +833,7 @@ public class CoapEndpoint implements Endpoint {
 				Exchange exchange = matcher.receiveResponse(response, raw.getCorrelationContext());
 				if (exchange != null) {
 					exchange.setEndpoint(CoapEndpoint.this);
-					response.setRTT(System.currentTimeMillis() - exchange.getTimestamp());
+					response.setRTT(exchange.calculateRTT());
 					coapstack.receiveResponse(exchange, response);
 				} else if (response.getType() != Type.ACK) {
 					LOGGER.log(Level.FINE, "Rejecting unmatchable response from {0}", raw.getInetSocketAddress());

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -18,6 +18,7 @@
  *    Kai Hudalla - logging
  *    Kai Hudalla (Bosch Software Innovations GmbH) - use Logger's message formatting instead of
  *                                                    explicit String concatenation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use exchange.calculateRTT
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -842,7 +843,7 @@ public class BlockwiseLayer extends AbstractLayer {
 						status.assembleMessage(assembled);
 
 						// set overall transfer RTT
-						assembled.setRTT(System.currentTimeMillis() - exchange.getTimestamp());
+						assembled.setRTT(exchange.calculateRTT());
 
 						if (status.isNotification()) {
 


### PR DESCRIPTION
Reduce influence of system time adjustments, which would affect
currentTimeMillis but not nanoTime.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>