### PR TITLE
Add grouped message id tracker.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/GroupedMessageIdTracker.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/GroupedMessageIdTracker.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ *                                 (derived from MessageIdTracker)
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.californium.core.network.config.NetworkConfig;
+
+/**
+ * A helper for keeping track of message IDs.
+ * <p>
+ * According to the
+ * <a href="https://tools.ietf.org/html/rfc7252#section-4.4">CoAP spec</a>
+ * 
+ * <pre>
+ * The same Message ID MUST NOT be reused (in communicating with the
+   same endpoint) within the EXCHANGE_LIFETIME (Section 4.8.2).
+ * </pre>
+ * 
+ * This implementation groups the MIDs and only keeps the lease time for the
+ * last used MID of the group. This reduces the amount of memory but may take a
+ * little longer to use the first MIDs of a group because they freed with the
+ * lease of the last MID of the group.
+ */
+public class GroupedMessageIdTracker {
+
+	private static final int TOTAL_NO_OF_MIDS = 1 << 16;
+	/**
+	 * Number of groups.
+	 * 
+	 * Configurable using {@link NetworkConfig.Keys#MID_PROVIDER_GROUPS}.
+	 */
+	private final int numberOfGroups;
+	/**
+	 * Size of groups. Number of MIDs per group.
+	 */
+	private final int sizeOfGroups;
+	/**
+	 * Exchange lifetime. Value in nanoseconds.
+	 * 
+	 * @see System#nanoTime()
+	 */
+	private final long exchangeLifetime;
+	/**
+	 * Array with end of lease for MID groups. MID divided by
+	 * {@link #sizeOfGroups} is used as index. Values in nanoseconds.
+	 * 
+	 * @see System#nanoTime()
+	 */
+	private final long midLease[];
+	/**
+	 * Current MID.
+	 */
+	private int currentMID;
+
+	/**
+	 * Creates a new tracker based on configuration values.
+	 * <p>
+	 * The following configuration values are used:
+	 * <ul>
+	 * <li>{@link org.eclipse.californium.core.network.config.NetworkConfig.Keys#MID_PROVIDER_GROUPS}
+	 * - determine the group size for the message IDs. Each group is marked as
+	 * <em>in use</em>, if a MID within the group is used.</li>
+	 * <li>{@link org.eclipse.californium.core.network.config.NetworkConfig.Keys#EXCHANGE_LIFETIME}
+	 * - each group of a message ID returned by <em>getNextMessageId</em> is
+	 * marked as <em>in use</em> for this amount of time (ms).</li>
+	 * <li>{@link org.eclipse.californium.core.network.config.NetworkConfig.Keys#USE_RANDOM_MID_START}
+	 * - if this value is {@code true} then the message IDs returned by
+	 * <em>getNextMessageId</em> will start at a random index. Otherwise the
+	 * first message ID returned will be {@code 0}.</li>
+	 * </ul>
+	 * 
+	 * @param config the configuration to use.
+	 */
+	public GroupedMessageIdTracker(final NetworkConfig config) {
+		numberOfGroups = config.getInt(NetworkConfig.Keys.MID_PROVIDER_GROUPS);
+		sizeOfGroups = (TOTAL_NO_OF_MIDS + numberOfGroups - 1) / numberOfGroups;
+		exchangeLifetime = TimeUnit.MILLISECONDS.toNanos(config.getLong(NetworkConfig.Keys.EXCHANGE_LIFETIME));
+		boolean useRandomFirstMID = config.getBoolean(NetworkConfig.Keys.USE_RANDOM_MID_START);
+		if (useRandomFirstMID) {
+			currentMID = new SecureRandom().nextInt(TOTAL_NO_OF_MIDS);
+		} else {
+			currentMID = 0;
+		}
+		midLease = new long[numberOfGroups];
+	}
+
+	/**
+	 * Gets the next usable message ID.
+	 * 
+	 * @return a message ID or {@code -1} if all message IDs are in use
+	 *         currently.
+	 */
+	public int getNextMessageId() {
+		final long now = System.nanoTime();
+		synchronized (this) {
+			int mid = currentMID % TOTAL_NO_OF_MIDS;
+			int index = mid / sizeOfGroups;
+			int nextIndex = (index + 1) % numberOfGroups;
+			if (midLease[nextIndex] < now) {
+				midLease[index] = now + exchangeLifetime;
+				++currentMID;
+				return mid;
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * Get number of MIDs per group.
+	 * 
+	 * @return size of groups
+	 * @see #sizeOfGroups
+	 */
+	public int getGroupSize() {
+		return sizeOfGroups;
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -101,6 +101,7 @@ public final class NetworkConfig {
 		public static final String PROBING_RATE = "PROBING_RATE";
 
 		public static final String USE_RANDOM_MID_START = "USE_RANDOM_MID_START";
+		public static final String MID_PROVIDER_GROUPS = "MID_PROVIDER_GROUPS";
 		public static final String TOKEN_SIZE_LIMIT = "TOKEN_SIZE_LIMIT";
 
 		/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
@@ -21,6 +21,7 @@
 package org.eclipse.californium.core.network.config;
 
 import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.network.GroupedMessageIdTracker;
 import org.eclipse.californium.elements.UDPConnector;
 
 /**
@@ -55,6 +56,14 @@ public class NetworkConfigDefaults {
 	 */
 	public static final int DEFAULT_BLOCKWISE_STATUS_LIFETIME = 5 * 60 * 1000; // 5 mins
 
+	/**
+	 * The default number of MID groups.
+	 * <p>
+	 * The default value is 16.
+	 * @see GroupedMessageIdTracker
+	 */
+	public static final int DEFAULT_MID_PROVIDER_GROUPS = 16;
+
 	/*
 	 * Accept other message versions than 1
 	 * Refuse unknown options
@@ -85,6 +94,7 @@ public class NetworkConfigDefaults {
 		config.setFloat(NetworkConfig.Keys.PROBING_RATE, 1f);
 
 		config.setBoolean(NetworkConfig.Keys.USE_RANDOM_MID_START, true);
+		config.setInt(NetworkConfig.Keys.MID_PROVIDER_GROUPS, DEFAULT_MID_PROVIDER_GROUPS);
 		config.setInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT, 8);
 
 		config.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 512);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/GroupedMessageIdTrackerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/GroupedMessageIdTrackerTest.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ *                                 derived from MessageIdTrackerTest
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.californium.CheckCondition;
+import org.eclipse.californium.TestTools;
+import org.eclipse.californium.category.Small;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Verifies that GroupedMessageIdTracker correctly marks MIDs as <em>in use</em>.
+ */
+@Category(Small.class)
+public class GroupedMessageIdTrackerTest {
+
+	private static final int TOTAL_NO_OF_MIDS = 1 << 16;
+	private NetworkConfig config;
+
+	@Before
+	public void setUp() {
+		config = NetworkConfig.createStandardWithoutFile();
+	}
+
+	@Test
+	public void testGetNextMessageIdFailsIfAllMidsAreInUse() throws Exception {
+		// GIVEN a tracker whose MIDs are half in use
+		config.setBoolean(NetworkConfig.Keys.USE_RANDOM_MID_START, false);
+		GroupedMessageIdTracker tracker = new GroupedMessageIdTracker(config);
+		for (int i = 0; i < TOTAL_NO_OF_MIDS / 2; i++) {
+			int mid = tracker.getNextMessageId();
+			assertThat(mid, is(not(-1)));
+		}
+		// THEN using the complete other half should not be possible
+		for (int i = 0; i < TOTAL_NO_OF_MIDS / 2; i++) {
+			int mid = tracker.getNextMessageId();
+			if (0 > mid)
+				return;
+		}
+		fail("mids should run out.");
+	}
+
+	@Test
+	public void testGetNextMessageIdReusesIdAfterExchangeLifetime() throws Exception {
+		// GIVEN a tracker with an EXCHANGE_LIFETIME of 100ms
+		int exchangeLifetime = 100; // ms
+		config.setInt(NetworkConfig.Keys.EXCHANGE_LIFETIME, exchangeLifetime);
+		final GroupedMessageIdTracker tracker = new GroupedMessageIdTracker(config);
+		int groupSize = tracker.getGroupSize();
+
+		// WHEN retrieving all message IDs from the tracker
+		long start = System.nanoTime();
+		for (int i = 1; i < TOTAL_NO_OF_MIDS; i++) {
+			int nextMid = tracker.getNextMessageId();
+			if (nextMid < 0)
+				break;
+		}
+
+		// THEN the first message ID is re-used after EXCHANGE_LIFETIME has
+		// expired
+		exchangeLifetime += (exchangeLifetime >> 1); // a little longer
+		long timeLeft = exchangeLifetime - TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+		if (100 > timeLeft) {
+			timeLeft = 100;
+		}
+		
+		final AtomicInteger mid = new AtomicInteger(-1);
+		TestTools.waitForCondition(timeLeft, 100, TimeUnit.MILLISECONDS, new CheckCondition() {
+
+			@Override
+			public boolean isFulFilled() throws IllegalStateException {
+				mid.set(tracker.getNextMessageId());
+				return 0 <= mid.get();
+			}
+		});
+		assertThat(mid.get(), is(not(-1)));
+
+		for (int i = 1; i < groupSize; i++) {
+			int nextMid = tracker.getNextMessageId();
+			assertThat(nextMid, is(not(-1)));
+		}
+	}
+}


### PR DESCRIPTION
Use a group approach to save resources.
This not intended to merge, it's just a first idea to get rid of the "HashMap" with all recently used MID/timestamps.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>