### PR TITLE
Increase waiting time and destroy server.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/test/SmallServerClientTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/SmallServerClientTest.java
@@ -18,6 +18,7 @@
  *    Kai Hudalla - logging
  *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
  *                                                    setup of test-network
+ *    Achim Kraus (Bosch Software Innovations GmbH) - destroy server after test
  ******************************************************************************/
 package org.eclipse.californium.core.test;
 
@@ -55,6 +56,8 @@ public class SmallServerClientTest {
 
 	private static String SERVER_RESPONSE = "server responds hi";
 
+	private CoapServer server;
+
 	private int serverPort;
 
 	@Before
@@ -65,6 +68,9 @@ public class SmallServerClientTest {
 
 	@After
 	public void after() {
+		if (null != server) {
+			server.destroy();
+		}
 		System.out.println("End " + getClass().getSimpleName());
 	}
 
@@ -90,7 +96,7 @@ public class SmallServerClientTest {
 
 	private void createSimpleServer() {
 		CoapEndpoint endpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
-		CoapServer server = new CoapServer();
+		server = new CoapServer();
 		server.addEndpoint(endpoint);
 		server.setMessageDeliverer(new MessageDeliverer() {
 			@Override


### PR DESCRIPTION
Fixes for this rarely failing test. Executing the test on other host, it
could be repeated for more then 100.000 times without failing. So I
currently recommend to enlarge the waiting time. There have been some
failures, which indicate, that even 2s are not enough, but we will see.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>