### PR TITLE
Fix issue 275 2

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -28,6 +28,13 @@
  *                                                    remove exchange by MID on notify. 
  *                                                    Add Exchange for save remove.
  *    Achim Kraus (Bosch Software Innovations GmbH) - make exchangeStore final
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use deduplicator for all message types.
+ *                                                    RFC7252 limits deduplication to CON/NON
+ *                                                    but this seems to cover the message flow 
+ *                                                    for responses and such request. The 
+ *                                                    internal processing of ACK/RST is not 
+ *                                                    covered, because it doesn't influence 
+ *                                                    the message exchange.
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -235,11 +242,8 @@ public final class UdpMatcher extends BaseMatcher {
 		} else if (correlationContextMatcher.isResponseRelatedToRequest(exchange.getCorrelationContext(), responseContext)) {
 
 			// we have received a Response matching the token of an ongoing Exchange's Request
-			// according to the CoAP spec (https://tools.ietf.org/html/rfc7252#section-4.5),
-			// message deduplication is relevant for CON and NON messages only
 
-			if ((response.getType() == Type.CON || response.getType() == Type.NON) &&
-					exchangeStore.findPrevious(idByMID, exchange) != null) {
+			if (exchangeStore.findPrevious(idByMID, exchange) != null) {
 				LOGGER.log(Level.FINER, "Received duplicate response for open exchange: {0}", response);
 				response.setDuplicate(true);
 			} else if (!isNotify) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
@@ -18,6 +18,8 @@
  *    Kai Hudalla - logging
  *    Kai Hudalla (Bosch Software Innovations GmbH) - use Logger's message formatting instead of
  *                                                    explicit String concatenation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - stop retransmission only for
+ *                                                    none duplicate responses.
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -221,9 +223,11 @@ public class ReliabilityLayer extends AbstractLayer {
 	@Override
 	public void receiveResponse(final Exchange exchange, final Response response) {
 
-		exchange.setFailedTransmissionCount(0);
-		exchange.getCurrentRequest().setAcknowledged(true);
-		exchange.setRetransmissionHandle(null);
+		if (!response.isDuplicate()) {
+			exchange.setFailedTransmissionCount(0);
+			exchange.getCurrentRequest().setAcknowledged(true);
+			exchange.setRetransmissionHandle(null);
+		}
 
 		if (response.getType() == Type.CON && !exchange.getRequest().isCanceled()) {
 			LOGGER.finer("acknowledging CON response");

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -20,6 +20,8 @@
  *                                      separate test cases, remove wait cycles
  *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
  *                                                    setup of test-network
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add testGETMissOrderedResponses
+ *                                                    (see hudson 2.0.x/146, issue #275)
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
@@ -268,6 +270,66 @@ public class BlockwiseClientSideTest {
 		assertThat("Retransmitted Token must be the same", req1[1], is(req2[1]));
 
 		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 128).payload(respPayload, 256, 300).go();
+
+		Response response = request.waitForResponse(1000);
+		assertResponseContainsExpectedPayload(response, respPayload);
+	}
+
+	/**
+	 * In the second example, the client anticipates the blockwise transfer
+	 * (e.g., because of a size indication in the link- format description
+	 * [RFC6690]) and sends a size proposal. All ACK messages except for the
+	 * last carry 64 bytes of payload; the last one carries between 1 and 64
+	 * bytes.
+	 * <pre>
+	 * CLIENT                                                     SERVER
+	 * |                                                          |
+	 * | CON [MID=1234], GET, /status, 2:0/0/64           ------> |
+	 * | {CON [MID=1234], GET, /status, 2:0/0/64 (repeat)  ---->} | (skipped, we just send 2 ACKs)
+	 * | <------   ACK [MID=1234], 2.05 Content, 2:0/1/64         |
+	 * |                                                          |
+	 * | CON [MID=1235], GET, /status, 2:1/0/64           ------> |
+	 * | <------   ACK [MID=1234], 2.05 Content, 2:0/1/64 (repeat)| (the wrong ACK for the repeat)
+	 * |                                                          |
+	 * | {<-----   ACK [MID=1235], 2.05 Content, 2:1/1/64 }       | (lost)
+	 * |                                                          |
+	 * | CON [MID=1235], GET, /status, 2:1/0/64           ------> | (should repeat, but currently missing!)
+	 * | <------   ACK [MID=1235], 2.05 Content, 2:1/1/64         |
+	 * |                                                          |
+	 * | CON [MID=1236], GET, /status, 2:2/0/64           ------> |
+	 * |                                                          |
+	 * | <------   ACK [MID=1239], 2.05 Content, 2:2/0/64         |
+	 * </pre>
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testGETWithMissOrderedResponses() throws Exception {
+		System.out.println("Blockwise GET with responses miss ordered:");
+		respPayload = generateRandomPayload(170);
+		String path = "test";
+
+		Request request = createRequest(GET, path, server);
+		request.getOptions().setBlock2(BlockOption.size2Szx(64), false, 0);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, GET, path).storeBoth("A").block2(0, false, 64).go();
+		// either wait for repeat, or just send two ACK :-)
+		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 64).size2(respPayload.length()).payload(respPayload, 0, 64).go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 64).go();
+		// retransmitted ACK, as if the GET 0 would have been repeated.
+		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 64).size2(respPayload.length()).payload(respPayload, 0, 64).go();
+		// lost ACK
+		//server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 64).payload(respPayload, 64, 128).go();
+		// give client a chance to repeat
+		int timeout = config.getInt(NetworkConfig.Keys.ACK_TIMEOUT, 100);
+		Thread.sleep(timeout * 2);
+		// repeat GET 1
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(1, false, 64).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(1, true, 64).payload(respPayload, 64, 128).go();
+
+		server.expectRequest(CON, GET, path).storeBoth("D").block2(2, false, 64).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("D").block2(2, false, 64).payload(respPayload, 128, 170).go();
 
 		Response response = request.waitForResponse(1000);
 		assertResponseContainsExpectedPayload(response, respPayload);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/DeduplicationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/DeduplicationTest.java
@@ -18,6 +18,8 @@
  *    Kai Hudalla - logging
  *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
  *                                                    setup of test-network
+ *    Achim Kraus (Bosch Software Innovations GmbH) - don't reuse MID for different 
+ *                                                    messages!
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
@@ -109,12 +111,12 @@ public class DeduplicationTest {
 		server.expectEmpty(RST, 42).go();
 
 		request = createRequest(GET, path, server);
-		request.setMID(4711);
+		request.setMID(4712);
 		client.sendRequest(request);
 
 		server.expectRequest(CON, GET, path).storeBoth("B").storeToken("C").go();
-		server.sendResponse(ACK, CONTENT).loadBoth("B").payload("possible conflict").go();
-		server.sendResponse(ACK, CONTENT).loadBoth("B").payload("possible conflict").go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").payload(payload).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").payload(payload).go();
 
 		Response response = request.waitForResponse(500);
 		assertResponseContainsExpectedPayload(response, CONTENT, payload);


### PR DESCRIPTION
Use deduplications for ACKs also.

If duplicate ACKs are not used to stop the retransmission, issue #275 will also be fixed.
This is an alternative to #279 

This changes the behavior of "reused" MIDs before there end of time.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>
