### PR TITLE
Correct exchange states thread visibility

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -21,12 +21,15 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - add calculateRTT
  *                                                    use nanoTime instead of 
  *                                                    currentTimeMillis
+ *    Achim Kraus (Bosch Software Innovations GmbH) - ensure states visibility for
+ *                                                    different threads
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
 import java.util.Arrays;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.core.coap.BlockOption;
@@ -60,6 +63,17 @@ import org.eclipse.californium.elements.CorrelationContext;
  * {@link CoapExchange#advanced()}.
  * <p>
  * This class might change with the implementation of CoAP extensions.
+ * <p>
+ * Even if above mentions, that this class is not thread safe, its used from
+ * several different threads! Generally the Exchanges are hand over via a
+ * concurrent collections in the matcher and therefore establish a "happens
+ * before" order (as long as threads accessing the exchange via the matcher).
+ * But some methods are out of scope of that and use Exchange directly (e.g.
+ * {@link #setCorrelationContext(CorrelationContext) the "sender thread" or
+ * {@link #setFailedTransmissionCount(int)} the "retransmission thread
+ * (executor)"). Therefore use at least volatile for the fields. This doesn't
+ * ensure, that Exchange is thread safe, it only ensures the visibility of the
+ * states.
  */
 public class Exchange {
 
@@ -85,14 +99,18 @@ public class Exchange {
 		REMOTE;
 	}
 
-	/** The endpoint that processes this exchange */
-	private Endpoint endpoint;
+	/**
+	 * The endpoint that processes this exchange.
+	 * 
+	 * Set on receiving a message.
+	 */
+	private volatile Endpoint endpoint;
 
 	/** An observer to be called when a request is complete */
-	private ExchangeObserver observer;
+	private volatile ExchangeObserver observer;
 
 	/** Indicates if the exchange is complete */
-	private boolean complete = false;
+	private volatile boolean complete = false;
 
 	/** The nano timestamp when this exchange has been created */
 	private final long nanoTimestamp;
@@ -102,7 +120,7 @@ public class Exchange {
 	 * {@link BlockwiseLayer} should only work with the {@link #currentRequest}
 	 * while layers above should work with the {@link #request}.
 	 */
-	private Request request; // the initial request we have to exchange
+	private volatile Request request; // the initial request we have to exchange
 
 	/**
 	 * The current block of the request that is being processed. This is a
@@ -110,7 +128,7 @@ public class Exchange {
 	 * {@link #request} in case of a normal transfer.
 	 */
 	// Matching needs to know for what we expect a response
-	private Request currentRequest;
+	private volatile Request currentRequest;
 
 	/**
 	 * The actual response that is supposed to be sent to the client. Layers
@@ -118,43 +136,43 @@ public class Exchange {
 	 * {@link #currentResponse} while layers above should work with the
 	 * {@link #response}.
 	 */
-	private Response response;
+	private volatile Response response;
 
 	/** The current block of the response that is being transferred. */
 	// Matching needs to know when receiving duplicate
-	private Response currentResponse;
+	private volatile Response currentResponse;
 
 	// indicates where the request of this exchange has been initiated.
 	// (as suggested by effective Java, item 40.)
 	private final Origin origin;
 
 	// true if the exchange has failed due to a timeout
-	private boolean timedOut;
+	private volatile boolean timedOut;
 
 	// the timeout of the current request or response set by reliability layer
-	private int currentTimeout;
+	private volatile int currentTimeout;
 
 	// the amount of attempted transmissions that have not succeeded yet
-	private int failedTransmissionCount = 0;
+	private volatile int failedTransmissionCount = 0;
 
 	// handle to cancel retransmission
-	private ScheduledFuture<?> retransmissionHandle = null;
+	private AtomicReference<ScheduledFuture<?>> retransmissionHandle = new AtomicReference<ScheduledFuture<?>>();
 
 	// If the request was sent with a block1 option the response has to send its
 	// first block piggy-backed with the Block1 option of the last request block
-	private BlockOption block1ToAck;
+	private volatile BlockOption block1ToAck;
 
-	private Integer notificationNumber;
+	private volatile Integer notificationNumber;
 
 	// The relation that the target resource has established with the source
-	private ObserveRelation relation;
+	private volatile ObserveRelation relation;
 
 	// When the request is handled by an executor different than the protocol
 	// stage set to true. The endpoint will hand sending responses over to the
 	// protocol stage executor
-	private boolean customExecutor = false;
+	private volatile boolean customExecutor = false;
 
-	private CorrelationContext correlationContext;
+	private volatile CorrelationContext correlationContext;
 
 	/**
 	 * Creates a new exchange with the specified request and origin.
@@ -346,6 +364,11 @@ public class Exchange {
 		return endpoint;
 	}
 
+	/**
+	 * Set endpoint of received message.
+	 * 
+	 * @param endpoint endpoint, which received the message.
+	 */
 	public void setEndpoint(Endpoint endpoint) {
 		this.endpoint = endpoint;
 	}
@@ -380,16 +403,16 @@ public class Exchange {
 		this.currentTimeout = currentTimeout;
 	}
 
-	public synchronized ScheduledFuture<?> getRetransmissionHandle() {
-		return retransmissionHandle;
+	public ScheduledFuture<?> getRetransmissionHandle() {
+		return retransmissionHandle.get();
 	}
 
-	public synchronized void setRetransmissionHandle(ScheduledFuture<?> retransmissionHandle) {
+	public void setRetransmissionHandle(ScheduledFuture<?> retransmissionHandle) {
 		// avoid race condition of multiple responses (e.g., notifications)
-		if (this.retransmissionHandle != null) {
-			this.retransmissionHandle.cancel(false);
+		ScheduledFuture<?> previous = this.retransmissionHandle.getAndSet(retransmissionHandle);
+		if (previous != null) {
+			previous.cancel(false);
 		}
-		this.retransmissionHandle = retransmissionHandle;
 	}
 
 	/**
@@ -402,7 +425,7 @@ public class Exchange {
 	 * @throws IllegalArgumentException if the given number is &lt; 0 or &gt;
 	 *             2^24 - 1.
 	 */
-	public synchronized void setNotificationNumber(final int notificationNo) {
+	public void setNotificationNumber(final int notificationNo) {
 		if (notificationNo < 0 || notificationNo > MAX_OBSERVE_NO) {
 			throw new IllegalArgumentException("illegal observe number");
 		}
@@ -418,7 +441,7 @@ public class Exchange {
 	 * @return The observe number of the notification or {@code null} if this
 	 *         exchange is not associated with a notification.
 	 */
-	public synchronized Integer getNotificationNumber() {
+	public Integer getNotificationNumber() {
 		return notificationNumber;
 	}
 
@@ -466,8 +489,9 @@ public class Exchange {
 	public void setComplete() {
 		this.complete = true;
 		ExchangeObserver obs = this.observer;
-		if (obs != null)
+		if (obs != null) {
 			obs.completed(this);
+		}
 	}
 
 	/**
@@ -479,8 +503,9 @@ public class Exchange {
 	 */
 	public void completeCurrentRequest() {
 		ExchangeObserver obs = this.observer;
-		if (obs != null)
+		if (obs != null) {
 			obs.completed(this);
+		}
 	}
 
 	/**
@@ -559,8 +584,9 @@ public class Exchange {
 	 */
 	public void setCorrelationContext(final CorrelationContext ctx) {
 		correlationContext = ctx;
-		if (observer != null) {
-			observer.contextEstablished(this);
+		ExchangeObserver obs = this.observer;
+		if (obs != null) {
+			obs.contextEstablished(this);
 		}
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -45,15 +45,15 @@ import org.eclipse.californium.elements.CorrelationContext;
  * An exchange represents the complete state of an exchange of one request and
  * one or more responses. The lifecycle of an exchange ends when either the last
  * response has arrived and is acknowledged, when a request or response has been
- * rejected from the remote endpoint, when the request has been canceled, or when
- * a request or response timed out, i.e., has reached the retransmission
+ * rejected from the remote endpoint, when the request has been canceled, or
+ * when a request or response timed out, i.e., has reached the retransmission
  * limit without being acknowledged.
  * <p>
- * The framework internally uses the class Exchange to manage an exchange
- * of {@link Request}s and {@link Response}s. The Exchange only contains state,
- * no functionality. The CoAP Stack contains the functionality of the CoAP
- * protocol and modifies the exchange appropriately. The class Exchange and its
- * fields are <em>NOT</em> thread-safe.
+ * The framework internally uses the class Exchange to manage an exchange of
+ * {@link Request}s and {@link Response}s. The Exchange only contains state, no
+ * functionality. The CoAP Stack contains the functionality of the CoAP protocol
+ * and modifies the exchange appropriately. The class Exchange and its fields
+ * are <em>NOT</em> thread-safe.
  * <p>
  * The class {@link CoapExchange} provides the corresponding API for developers.
  * Proceed with caution when using this class directly, e.g., through
@@ -68,10 +68,9 @@ public class Exchange {
 	/**
 	 * The origin of an exchange.
 	 * <p>
-	 * If Cf receives a new request and creates a new
-	 * exchange the origin is REMOTE since the request has been initiated from a
-	 * remote endpoint. If Cf creates a new request and sends it, the origin is
-	 * LOCAL.
+	 * If Cf receives a new request and creates a new exchange the origin is
+	 * REMOTE since the request has been initiated from a remote endpoint. If Cf
+	 * creates a new request and sends it, the origin is LOCAL.
 	 */
 	public enum Origin {
 
@@ -106,11 +105,12 @@ public class Exchange {
 	private Request request; // the initial request we have to exchange
 
 	/**
-	 * The current block of the request that is being processed. This is a single
-	 * block in case of a blockwise transfer or the same as {@link #request} in
-	 * case of a normal transfer.
+	 * The current block of the request that is being processed. This is a
+	 * single block in case of a blockwise transfer or the same as
+	 * {@link #request} in case of a normal transfer.
 	 */
-	private Request currentRequest; // Matching needs to know for what we expect a response
+	// Matching needs to know for what we expect a response
+	private Request currentRequest;
 
 	/**
 	 * The actual response that is supposed to be sent to the client. Layers
@@ -121,7 +121,8 @@ public class Exchange {
 	private Response response;
 
 	/** The current block of the response that is being transferred. */
-	private Response currentResponse; // Matching needs to know when receiving duplicate
+	// Matching needs to know when receiving duplicate
+	private Response currentResponse;
 
 	// indicates where the request of this exchange has been initiated.
 	// (as suggested by effective Java, item 40.)
@@ -148,8 +149,9 @@ public class Exchange {
 	// The relation that the target resource has established with the source
 	private ObserveRelation relation;
 
-	// When the request is handled by an executor different than the protocol stage set to true.
-	// The endpoint will hand sending responses over to the protocol stage executor
+	// When the request is handled by an executor different than the protocol
+	// stage set to true. The endpoint will hand sending responses over to the
+	// protocol stage executor
 	private boolean customExecutor = false;
 
 	private CorrelationContext correlationContext;
@@ -161,11 +163,12 @@ public class Exchange {
 	 * @param origin the origin of the request (LOCAL or REMOTE)
 	 */
 	public Exchange(final Request request, final Origin origin) {
-		this.currentRequest = request; // might only be the first block of the whole request
+		// might only be the first block of the whole request
+		this.currentRequest = request;
 		this.origin = origin;
 		this.nanoTimestamp = System.nanoTime();
 	}
-	
+
 	/**
 	 * Creates a new exchange with the specified request, origin and context.
 	 * 
@@ -174,7 +177,8 @@ public class Exchange {
 	 * @param ctx the correlation context of this exchange
 	 */
 	public Exchange(Request request, Origin origin, CorrelationContext ctx) {
-		this.currentRequest = request; // might only be the first block of the whole request
+		// might only be the first block of the whole request
+		this.currentRequest = request;
 		this.origin = origin;
 		this.correlationContext = ctx;
 		this.nanoTimestamp = System.nanoTime();
@@ -186,7 +190,7 @@ public class Exchange {
 	 * yet, it sends an ACK to the client.
 	 */
 	public void sendAccept() {
-		assert(origin == Origin.REMOTE);
+		assert (origin == Origin.REMOTE);
 		if (request.getType() == Type.CON && !request.isAcknowledged()) {
 			request.setAcknowledged(true);
 			EmptyMessage ack = EmptyMessage.newACK(request);
@@ -199,7 +203,7 @@ public class Exchange {
 	 * client.
 	 */
 	public void sendReject() {
-		assert(origin == Origin.REMOTE);
+		assert (origin == Origin.REMOTE);
 		request.setRejected(true);
 		EmptyMessage rst = EmptyMessage.newRST(request);
 		endpoint.sendEmptyMessage(this, rst);
@@ -237,7 +241,7 @@ public class Exchange {
 	public Request getRequest() {
 		return request;
 	}
-	
+
 	/**
 	 * Sets the request that this exchange is associated with.
 	 * 
@@ -261,8 +265,8 @@ public class Exchange {
 	}
 
 	/**
-	 * Sets the current request block. If a request is not being sent
-	 * blockwise, the origin request (equal to getRequest()) should be set.
+	 * Sets the current request block. If a request is not being sent blockwise,
+	 * the origin request (equal to getRequest()) should be set.
 	 * 
 	 * @param currentRequest the current request block
 	 */
@@ -280,7 +284,7 @@ public class Exchange {
 	public Response getResponse() {
 		return response;
 	}
-	
+
 	/**
 	 * Sets the response.
 	 * 
@@ -324,16 +328,15 @@ public class Exchange {
 	}
 
 	/**
-	 * Sets the block option of the last block of a blockwise sent request.
-	 * When the server sends the response, this block option has to be
-	 * acknowledged.
+	 * Sets the block option of the last block of a blockwise sent request. When
+	 * the server sends the response, this block option has to be acknowledged.
 	 * 
 	 * @param block1ToAck the block option of the last request block
 	 */
 	public void setBlock1ToAck(BlockOption block1ToAck) {
 		this.block1ToAck = block1ToAck;
 	}
-	
+
 	/**
 	 * Returns the endpoint which has created and processed this exchange.
 	 * 
@@ -383,7 +386,7 @@ public class Exchange {
 
 	public synchronized void setRetransmissionHandle(ScheduledFuture<?> retransmissionHandle) {
 		// avoid race condition of multiple responses (e.g., notifications)
-		if (this.retransmissionHandle!=null) {
+		if (this.retransmissionHandle != null) {
 			this.retransmissionHandle.cancel(false);
 		}
 		this.retransmissionHandle = retransmissionHandle;
@@ -392,11 +395,12 @@ public class Exchange {
 	/**
 	 * Sets the number of the notification this exchange is associated with.
 	 * <p>
-	 * This number can be used to match responses of a blockwise
-	 * transfer triggered by a notification.
+	 * This number can be used to match responses of a blockwise transfer
+	 * triggered by a notification.
 	 * 
 	 * @param notificationNo The observe number of the notification.
-	 * @throws IllegalArgumentException if the given number is &lt; 0 or &gt; 2^24 - 1.
+	 * @throws IllegalArgumentException if the given number is &lt; 0 or &gt;
+	 *             2^24 - 1.
 	 */
 	public synchronized void setNotificationNumber(final int notificationNo) {
 		if (notificationNo < 0 || notificationNo > MAX_OBSERVE_NO) {
@@ -408,8 +412,8 @@ public class Exchange {
 	/**
 	 * Gets the number of the notification this exchange is associated with.
 	 * <p>
-	 * This number can be used to match responses of a blockwise
-	 * transfer triggered by a notification.
+	 * This number can be used to match responses of a blockwise transfer
+	 * triggered by a notification.
 	 * 
 	 * @return The observe number of the notification or {@code null} if this
 	 *         exchange is not associated with a notification.
@@ -451,8 +455,8 @@ public class Exchange {
 	 * <p>
 	 * This means that both request and response have been sent/received.
 	 * <p>
-	 * This method invokes the {@linkplain ExchangeObserver#completed(Exchange) completed}
-	 * method on the observer registered on this exchange (if any).
+	 * This method invokes the {@linkplain ExchangeObserver#completed(Exchange)
+	 * completed} method on the observer registered on this exchange (if any).
 	 * <p>
 	 * Call this method to trigger a clean-up in the Matcher through its
 	 * ExchangeObserverImpl. Usually, it is called automatically when reaching
@@ -465,13 +469,13 @@ public class Exchange {
 		if (obs != null)
 			obs.completed(this);
 	}
-	
+
 	/**
 	 * This method is only needed when the same {@link Exchange} instance uses
 	 * different tokens during its lifetime, e.g., when using a different token
 	 * for retrieving the rest of a blockwise notification (when not altered,
-	 * Californium reuses the same token for this).
-	 * See {@link BlockwiseLayer} for an example use case.
+	 * Californium reuses the same token for this). See {@link BlockwiseLayer}
+	 * for an example use case.
 	 */
 	public void completeCurrentRequest() {
 		ExchangeObserver obs = this.observer;
@@ -500,7 +504,6 @@ public class Exchange {
 		return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - nanoTimestamp);
 	}
 
-
 	/**
 	 * Returns the CoAP observe relation that this exchange has established.
 	 * 
@@ -521,8 +524,9 @@ public class Exchange {
 
 	/**
 	 * Checks if this exchange was delivered to a handler with custom Executor.
-	 * If so, the protocol stage must hand the processing over to its own Executor.
-	 * Otherwise the exchange was handled directly by a protocol stage thread.
+	 * If so, the protocol stage must hand the processing over to its own
+	 * Executor. Otherwise the exchange was handled directly by a protocol stage
+	 * thread.
 	 * 
 	 * @return true if for handler with custom executor
 	 */
@@ -532,20 +536,23 @@ public class Exchange {
 
 	/**
 	 * Marks that this exchange was delivered to a handler with custom Executor.
-	 * If so, the protocol stage must hand the processing over to its own Executor.
-	 * Otherwise the exchange was handled directly by a protocol stage thread.
+	 * If so, the protocol stage must hand the processing over to its own
+	 * Executor. Otherwise the exchange was handled directly by a protocol stage
+	 * thread.
 	 */
 	public void setCustomExecutor() {
 		this.customExecutor = true;
 	}
 
 	/**
-	 * Sets additional information about the context this exchange's request has been sent in.
+	 * Sets additional information about the context this exchange's request has
+	 * been sent in.
 	 * <p>
-	 * The information is usually obtained from the <code>Connector</code> this exchange is using
-	 * to send and receive data. The information contained in the context can be used in addition
-	 * to the message ID and token of this exchange to increase security when matching an incoming
-	 * response to this exchange's request.
+	 * The information is usually obtained from the <code>Connector</code> this
+	 * exchange is using to send and receive data. The information contained in
+	 * the context can be used in addition to the message ID and token of this
+	 * exchange to increase security when matching an incoming response to this
+	 * exchange's request.
 	 * </p>
 	 * 
 	 * @param ctx the correlation information
@@ -558,10 +565,11 @@ public class Exchange {
 	}
 
 	/**
-	 * Gets transport layer specific information that can be used to correlate a response with
-	 * this exchange's original request.
-	 *  
-	 * @return the correlation information or <code>null</code> if no information is available.
+	 * Gets transport layer specific information that can be used to correlate a
+	 * response with this exchange's original request.
+	 * 
+	 * @return the correlation information or <code>null</code> if no
+	 *         information is available.
 	 */
 	public CorrelationContext getCorrelationContext() {
 		return correlationContext;
@@ -570,7 +578,8 @@ public class Exchange {
 	/**
 	 * A CoAP message ID scoped to a remote endpoint.
 	 * <p>
-	 * This class is used by the matcher to correlate messages by MID and endpoint address.
+	 * This class is used by the matcher to correlate messages by MID and
+	 * endpoint address.
 	 */
 	public static final class KeyMID {
 
@@ -639,17 +648,16 @@ public class Exchange {
 
 		@Override
 		public String toString() {
-			return new StringBuilder("KeyMID[").append(MID)
-				.append(", ").append(Utils.toHexString(address)).append(":").append(port)
-				.append("]").toString();
+			return new StringBuilder("KeyMID[").append(MID).append(", ").append(Utils.toHexString(address)).append(":")
+					.append(port).append("]").toString();
 		}
 
 		/**
 		 * Creates a key from an inbound CoAP message.
 		 * 
 		 * @param message the message.
-		 * @return the key derived from the message. The key's <em>mid</em> is scoped to the message's
-		 *         source address and port.
+		 * @return the key derived from the message. The key's <em>mid</em> is
+		 *         scoped to the message's source address and port.
 		 */
 		public static KeyMID fromInboundMessage(Message message) {
 			return new KeyMID(message.getMID(), message.getSource().getAddress(), message.getSourcePort());
@@ -659,8 +667,8 @@ public class Exchange {
 		 * Creates a key from an outbound CoAP message.
 		 * 
 		 * @param message the message.
-		 * @return the key derived from the message. The key's <em>mid</em> is scoped to the message's
-		 *         destination address and port.
+		 * @return the key derived from the message. The key's <em>mid</em> is
+		 *         scoped to the message's destination address and port.
 		 */
 		public static KeyMID fromOutboundMessage(Message message) {
 			return new KeyMID(message.getMID(), message.getDestination().getAddress(), message.getDestinationPort());
@@ -670,8 +678,8 @@ public class Exchange {
 	/**
 	 * A CoAP message token scoped to a remote endpoint.
 	 * <p>
-	 * This class is used by the matcher to correlate messages by their token and
-	 * endpoint address.
+	 * This class is used by the matcher to correlate messages by their token
+	 * and endpoint address.
 	 */
 	public static final class KeyToken {
 
@@ -699,7 +707,7 @@ public class Exchange {
 		 * Creates a new key for an inbound CoAP message.
 		 * <p>
 		 * The key will be scoped to the message's source endpoint.
-		 *  
+		 * 
 		 * @param msg the message.
 		 * @return the key.
 		 */
@@ -711,7 +719,7 @@ public class Exchange {
 		 * Creates a new key for an outbound CoAP message.
 		 * <p>
 		 * The key will be scoped to the message's destination endpoint.
-		 *  
+		 * 
 		 * @param msg the message.
 		 * @return the key.
 		 */
@@ -721,7 +729,7 @@ public class Exchange {
 
 		/**
 		 * Creates a new key for a token and an endpoint address.
-		 *  
+		 * 
 		 * @param token the token.
 		 * @param address the endpoint's address.
 		 * @param port the endpoint's port.
@@ -744,9 +752,8 @@ public class Exchange {
 
 		@Override
 		public String toString() {
-			return new StringBuilder("KeyToken[").append(Utils.toHexString(token))
-				.append(", ").append(Utils.toHexString(address)).append(":").append(port)
-				.append("]").toString();
+			return new StringBuilder("KeyToken[").append(Utils.toHexString(token)).append(", ")
+					.append(Utils.toHexString(address)).append(":").append(port).append("]").toString();
 		}
 
 		@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
@@ -18,6 +18,8 @@
  *    Kai Hudalla - logging
  *    Kai Hudalla (Bosch Software Innovations GmbH) - use Logger's message formatting instead of
  *                                                    explicit String concatenation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use final for fields and adjust
+ *                                                    thread safe random usage
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -44,12 +46,12 @@ public class ReliabilityLayer extends AbstractLayer {
 	protected final static Logger LOGGER = Logger.getLogger(ReliabilityLayer.class.getCanonicalName());
 
 	/** The random numbers generator for the back-off timer */
-	private Random rand = new Random();
+	private final Random rand = new Random();
 
-	private int ack_timeout;
-	private float ack_random_factor;
-	private float ack_timeout_scale;
-	private int max_retransmit;
+	private final int ack_timeout;
+	private final float ack_random_factor;
+	private final float ack_timeout_scale;
+	private final int max_retransmit;
 
 	/**
 	 * Constructs a new reliability layer. Changes to the configuration are
@@ -282,7 +284,9 @@ public class ReliabilityLayer extends AbstractLayer {
 		if (min == max) {
 			return min;
 		}
-		return min + rand.nextInt(max - min);
+		synchronized (rand) {
+			return min + rand.nextInt(max - min);
+		}
 	}
 
 	/*


### PR DESCRIPTION
Exchange is documented as not "thread safe", but used from different threads. This PR could not provide thread safety, it just intend to provided thread visibility for the fields.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>