### PR TITLE
Restart executor on start() after stop().

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -38,6 +38,7 @@
  *                                                    (fix GitHub issue #104)
  *    Achim Kraus (Bosch Software Innovations GmbH) - introduce synchronized getSocket()
  *                                                    as pair to synchronized releaseSocket().
+ *    Achim Kraus (Bosch Software Innovations GmbH) - restart internal executor
  ******************************************************************************/
 package org.eclipse.californium.scandium;
 
@@ -437,6 +438,7 @@ public class DTLSConnector implements Connector {
 			timer.shutdownNow();
 			if (hasInternalExecutor) {
 				executor.shutdownNow();
+				executor = null;
 				hasInternalExecutor = false;
 			}
 			releaseSocket();

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -26,6 +26,7 @@
  *    Bosch Software Innovations GmbH - add test cases for GitHub issue #1
  *    Achim Kraus (Bosch Software Innovations GmbH) - add tests for
  *                                                    CorrelationContextMatcher
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add restart test with internal executor
  ******************************************************************************/
 package org.eclipse.californium.scandium;
 
@@ -815,6 +816,39 @@ public class DTLSConnectorTest {
 
 	@Test
 	public void testStartStopWithSameAddress() throws Exception {
+		// Do a first handshake
+		givenAnEstablishedSession(false);
+		byte[] sessionId = establishedServerSession.getSessionIdentifier().getId();
+		InetSocketAddress firstAddress = client.getAddress();
+
+		// Stop the client
+		client.stop();
+		Connection connection = clientConnectionStore.get(serverEndpoint);
+		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getId());
+
+		// Restart it
+		client.restart();
+		assertEquals(firstAddress, client.getAddress());
+
+		// Prepare message sending
+		final String msg = "Hello Again";
+		CountDownLatch latch = new CountDownLatch(1);
+		clientRawDataChannel.setLatch(latch);
+
+		// send message
+		client.send(new RawData(msg.getBytes(), serverEndpoint));
+		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
+
+		// check we use the same session id
+		connection = clientConnectionStore.get(serverEndpoint);
+		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getId());
+		assertClientIdentity(RawPublicKeyIdentity.class);
+	}
+
+	@Test
+	public void testStartStopWithSameAddressAndInternalExecutor() throws Exception {
+		// use internal executor
+		client.setExecutor(null);
 		// Do a first handshake
 		givenAnEstablishedSession(false);
 		byte[] sessionId = establishedServerSession.getSessionIdentifier().getId();


### PR DESCRIPTION
Reset "internal" executor to null in stop(), to restart it on start().
Add unit test for restart() using an internal executor. 

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>