### PR TITLE
Stop retransmissions when we receive expected message.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -1639,6 +1639,10 @@ public class DTLSConnector implements Connector {
 			public void sendFlight(DTLSFlight flight) {
 				sendHandshakeFlight(flight, connection);
 			}
+
+			public void cancelRetransmissions() {
+				connection.cancelPendingFlight();
+			}
 		};
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -1641,7 +1641,11 @@ public class DTLSConnector implements Connector {
 			}
 
 			public void cancelRetransmissions() {
-				connection.cancelPendingFlight();
+				// TODO remove this check when this experimental feature will be
+				// not experimental anymore ^^
+				if (config.isEarlyStopRetransmission()) {
+					connection.cancelPendingFlight();
+				}
 			}
 		};
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -67,6 +67,11 @@ public final class DtlsConnectorConfig {
 	private X509Certificate[] trustStore = new X509Certificate[0];
 
 	/**
+	 * Experimental feature : Stop retransmission at message receipt
+	 */
+	private boolean earlyStopRetransmission = true;
+
+	/**
 	 * The maximum fragment length this connector can process at once.
 	 */
 	private Integer maxFragmentLengthCode = null;
@@ -151,6 +156,14 @@ public final class DtlsConnectorConfig {
 	 */
 	public int getMaxRetransmissions() {
 		return maxRetransmissions;
+	}
+
+	/**
+	 * @return true if retransmissions should be stopped as soon as we receive
+	 *         handshake message
+	 */
+	public boolean isEarlyStopRetransmission() {
+		return earlyStopRetransmission;
 	}
 
 	/**
@@ -515,6 +528,18 @@ public final class DtlsConnectorConfig {
 				}
 			}
 			config.supportedCipherSuites = suites;
+			return this;
+		}
+
+		/**
+		 * Activate/Deactivate experimental feature : Stop retransmission at message receipt.
+		 * 
+		 * @param activate Set it to true if retransmissions should be stopped as soon as we receive
+		 *         handshake message
+		 * @return this builder for command chaining
+		 */
+		public Builder setEarlyStopRetransmission(boolean activate) {
+			config.earlyStopRetransmission = activate;
 			return this;
 		}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -204,6 +204,7 @@ public class ClientHandshaker extends Handshaker {
 			break;
 
 		case HANDSHAKE:
+			recordLayer.cancelRetransmissions();
 			HandshakeMessage handshakeMsg = (HandshakeMessage) message;
 
 			switch (handshakeMsg.getMessageType()) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordLayer.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordLayer.java
@@ -39,4 +39,9 @@ public interface RecordLayer {
 	 *                  timespan to wait between re-transmissions. 
 	 */
 	void sendFlight(DTLSFlight flight);
+
+	/**
+	 * Cancels any pending re-transmission of the previous outbound flight.
+	 */
+	public void cancelRetransmissions();
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
@@ -135,6 +135,7 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 			break;
 
 		case HANDSHAKE:
+			recordLayer.cancelRetransmissions();
 			HandshakeMessage handshakeMsg = (HandshakeMessage) message;
 			switch (handshakeMsg.getMessageType()) {
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingServerHandshaker.java
@@ -89,6 +89,7 @@ public class ResumingServerHandshaker extends ServerHandshaker {
 			break;
 
 		case HANDSHAKE:
+			recordLayer.cancelRetransmissions();
 			HandshakeMessage handshakeMsg = (HandshakeMessage) message;
 			switch (handshakeMsg.getMessageType()) {
 			case CLIENT_HELLO:

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -250,6 +250,7 @@ public class ServerHandshaker extends Handshaker {
 			break;
 
 		case HANDSHAKE:
+			recordLayer.cancelRetransmissions();
 			HandshakeMessage handshakeMsg = (HandshakeMessage) message;
 
 			switch (handshakeMsg.getMessageType()) {

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -142,6 +142,7 @@ public class DTLSConnectorTest {
 	DTLSSession establishedServerSession;
 	DTLSSession establishedClientSession;
 	InMemoryConnectionStore clientConnectionStore;
+	static int pskStoreLatency = 0; // in ms
 
 	@BeforeClass
 	public static void loadKeys() throws IOException, GeneralSecurityException {
@@ -154,7 +155,20 @@ public class DTLSConnectorTest {
 		serverConnectionStore = new InMemoryConnectionStore(SERVER_CONNECTION_STORE_CAPACITY, 5 * 60, serverSessionCache); // connection timeout 5mins
 		serverRawDataChannel = new SimpleRawDataChannel(serverRawDataProcessor);
 
-		InMemoryPskStore pskStore = new InMemoryPskStore();
+		InMemoryPskStore pskStore = new InMemoryPskStore() {
+
+			@Override
+			public byte[] getKey(String identity) {
+				if (pskStoreLatency != 0) {
+					try {
+						Thread.sleep(pskStoreLatency);
+					} catch (InterruptedException e) {
+						throw new RuntimeException(e);
+					}
+				}
+				return super.getKey(identity);
+			}
+		};
 		pskStore.setKey(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes());
 		serverConfig = new DtlsConnectorConfig.Builder(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0))
 			.setSupportedCipherSuites(
@@ -185,7 +199,7 @@ public class DTLSConnectorTest {
 
 	@Before
 	public void setUp() throws Exception {
-
+		pskStoreLatency = 0;
 		clientConnectionStore = new InMemoryConnectionStore(CLIENT_CONNECTION_STORE_CAPACITY, 60);
 		clientEndpoint = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 		clientConfig = newStandardConfig(clientEndpoint);
@@ -491,6 +505,73 @@ public class DTLSConnectorTest {
 			msg = (HandshakeMessage) record.getFragment();
 			assertThat("Expected SERVER_HELLO from server", msg.getMessageType(), is(HandshakeType.SERVER_HELLO));
 
+		} finally {
+			rawClient.stop();
+		}
+	}
+
+	/**
+	 * Verify we don't send retransmission after receiving the expected message.
+	 */
+	@Test
+	public void testNoRetransmissionIfMessageReceived() throws Exception {
+		// Configure UDP connector
+		RecordCollectorDataHandler collector = new RecordCollectorDataHandler();
+		UdpConnector rawClient = new UdpConnector(clientEndpoint, collector, clientConfig);
+
+		// Add latency to PSK store
+		pskStoreLatency = 1000;
+
+		try {
+			rawClient.start();
+			clientEndpoint = new InetSocketAddress(rawClient.socket.getLocalAddress(), rawClient.socket.getLocalPort());
+
+			// Send CLIENT_HELLO
+			ClientHello clientHello = createClientHello();
+			rawClient.sendRecord(serverEndpoint,
+					DtlsTestTools.newDTLSRecord(ContentType.HANDSHAKE.getCode(), 0, 0, clientHello.toByteArray()));
+
+			// Handle HELLO_VERIFY_REQUEST
+			List<Record> rs = collector.waitForRecords(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS);
+			assertNotNull("timeout", rs); // check there is no timeout
+			Record record = rs.get(0);
+			assertThat("Expected HANDSHAKE message from server", record.getType(), is(ContentType.HANDSHAKE));
+			HandshakeMessage msg = (HandshakeMessage) record.getFragment();
+			assertThat("Expected HELLO_VERIFY_REQUEST from server", msg.getMessageType(),
+					is(HandshakeType.HELLO_VERIFY_REQUEST));
+			Connection con = serverConnectionStore.get(clientEndpoint);
+			assertNull(con);
+			byte[] cookie = ((HelloVerifyRequest) msg).getCookie();
+			assertNotNull(cookie);
+
+			// Send CLIENT_HELLO with cookie
+			clientHello.setCookie(cookie);
+			clientHello.setFragmentLength(clientHello.getMessageLength());
+			rawClient.sendRecord(serverEndpoint,
+					DtlsTestTools.newDTLSRecord(ContentType.HANDSHAKE.getCode(), 0, 0, clientHello.toByteArray()));
+
+			// Handle SERVER HELLO
+			// assert that we have an ongoingHandshake for this connection
+			rs = collector.waitForRecords(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS);
+			assertNotNull("timeout", rs); // check there is no timeout
+			con = serverConnectionStore.get(clientEndpoint);
+			assertNotNull(con);
+			Handshaker ongoingHandshake = con.getOngoingHandshake();
+			assertNotNull(ongoingHandshake);
+			record = rs.get(0);
+			assertThat("Expected HANDSHAKE message from server", record.getType(), is(ContentType.HANDSHAKE));
+			msg = (HandshakeMessage) record.getFragment();
+			assertThat("Expected SERVER_HELLO from server", msg.getMessageType(), is(HandshakeType.SERVER_HELLO));
+
+			// Send CLIENT_KEY_EXCHANGE
+			ClientKeyExchange keyExchange = new PSKClientKeyExchange(CLIENT_IDENTITY, serverEndpoint);
+			keyExchange.setMessageSeq(clientHello.getMessageSeq() + 1);
+			rawClient.sendRecord(serverEndpoint,
+					DtlsTestTools.newDTLSRecord(ContentType.HANDSHAKE.getCode(), 0, 1, keyExchange.toByteArray()));
+
+			// Ensure there is no retransmission
+			assertNull(collector.waitForRecords((long) (serverConfig.getRetransmissionTimeout() * 1.1),
+					TimeUnit.MILLISECONDS));
 		} finally {
 			rawClient.stop();
 		}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -34,9 +34,8 @@
 package org.eclipse.californium.scandium;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.number.OrderingComparison.*;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.junit.Assert.*;
-
 
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -1815,6 +1814,10 @@ public class DTLSConnectorTest {
 			flight.setNewSequenceNumbers();
 			sendFlight(flight);
 		}
+
+		@Override
+		public void cancelRetransmissions() {
+		}
 	};
 
 	public class ReverseRecordLayer implements RecordLayer {
@@ -1839,6 +1842,10 @@ public class DTLSConnectorTest {
 					throw new RuntimeException(e);
 				}
 			}
+		}
+
+		@Override
+		public void cancelRetransmissions() {
 		}
 	};
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -429,6 +429,75 @@ public class DTLSConnectorTest {
 	}
 
 	/**
+	 * Verify we send retransmission.
+	 */
+	@Test
+	public void testRetransmission() throws Exception {
+		// Configure UDP connector
+		RecordCollectorDataHandler collector = new RecordCollectorDataHandler();
+		UdpConnector rawClient = new UdpConnector(clientEndpoint, collector, clientConfig);
+
+		try {
+			rawClient.start();
+			clientEndpoint = new InetSocketAddress(rawClient.socket.getLocalAddress(), rawClient.socket.getLocalPort());
+
+			// Send CLIENT_HELLO
+			ClientHello clientHello = createClientHello();
+			rawClient.sendRecord(serverEndpoint,
+					DtlsTestTools.newDTLSRecord(ContentType.HANDSHAKE.getCode(), 0, 0, clientHello.toByteArray()));
+
+			// Handle HELLO_VERIFY_REQUEST
+			List<Record> rs = collector.waitForRecords(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS);
+			assertNotNull("timeout", rs); // check there is no timeout
+			Record record = rs.get(0);
+			assertThat("Expected HANDSHAKE message from server", record.getType(), is(ContentType.HANDSHAKE));
+			HandshakeMessage msg = (HandshakeMessage) record.getFragment();
+			assertThat("Expected HELLO_VERIFY_REQUEST from server", msg.getMessageType(),
+					is(HandshakeType.HELLO_VERIFY_REQUEST));
+			Connection con = serverConnectionStore.get(clientEndpoint);
+			assertNull(con);
+			byte[] cookie = ((HelloVerifyRequest) msg).getCookie();
+			assertNotNull(cookie);
+
+			// Send CLIENT_HELLO with cookie
+			clientHello.setCookie(cookie);
+			clientHello.setFragmentLength(clientHello.getMessageLength());
+			rawClient.sendRecord(serverEndpoint,
+					DtlsTestTools.newDTLSRecord(ContentType.HANDSHAKE.getCode(), 0, 0, clientHello.toByteArray()));
+
+			// Handle SERVER HELLO
+			// assert that we have an ongoingHandshake for this connection
+			rs = collector.waitForRecords(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS);
+			assertNotNull("timeout", rs); // check there is no timeout
+			con = serverConnectionStore.get(clientEndpoint);
+			assertNotNull(con);
+			Handshaker ongoingHandshake = con.getOngoingHandshake();
+			assertNotNull(ongoingHandshake);
+			record = rs.get(0);
+			assertThat("Expected HANDSHAKE message from server", record.getType(), is(ContentType.HANDSHAKE));
+			msg = (HandshakeMessage) record.getFragment();
+			assertThat("Expected SERVER_HELLO from server", msg.getMessageType(), is(HandshakeType.SERVER_HELLO));
+
+			// Do not reply
+
+			// Handle retransmission of SERVER HELLO
+			rs = collector.waitForRecords(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS);
+			assertNotNull("timeout", rs); // check there is no timeout
+			con = serverConnectionStore.get(clientEndpoint);
+			assertNotNull(con);
+			ongoingHandshake = con.getOngoingHandshake();
+			assertNotNull(ongoingHandshake);
+			record = rs.get(0);
+			assertThat("Expected HANDSHAKE message from server", record.getType(), is(ContentType.HANDSHAKE));
+			msg = (HandshakeMessage) record.getFragment();
+			assertThat("Expected SERVER_HELLO from server", msg.getMessageType(), is(HandshakeType.SERVER_HELLO));
+
+		} finally {
+			rawClient.stop();
+		}
+	}
+
+	/**
 	 * Verifies behavior described in <a href="http://tools.ietf.org/html/rfc6347#section-4.2.8">
 	 * section 4.2.8 of RFC 6347 (DTLS 1.2)</a>.
 	 *  

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/SimpleRecordLayer.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/SimpleRecordLayer.java
@@ -36,4 +36,8 @@ public class SimpleRecordLayer implements RecordLayer {
 	public Record getSentRecord() {
 		return sentRecord;
 	}
+
+	@Override
+	public void cancelRetransmissions() {
+	}
 }


### PR DESCRIPTION
We should stop handshake message retransmission as soon as we receive the first message of the expected flight.
(see #228 for discussion about this)