### PR TITLE
Add endpoint identifier.

### DIFF
--- a/californium-core/pom.xml
+++ b/californium-core/pom.xml
@@ -51,6 +51,7 @@
 						<Export-Package>
 							org.eclipse.californium.core,
 							org.eclipse.californium.core.coap,
+							org.eclipse.californium.core.identifier,
 							org.eclipse.californium.core.network,
 							org.eclipse.californium.core.network.config,
 							org.eclipse.californium.core.network.interceptors,

--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
@@ -172,7 +172,7 @@ public class CoapObserveRelation {
 	private void cancel() {
 		Request request = this.request;
 		request.cancel();
-		endpoint.cancelObservation(request.getToken());
+		endpoint.cancelObservation(request.getDestinationEndpoint(), request.getToken());
 		setCanceled(true);
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
@@ -40,6 +40,7 @@ import java.util.logging.Logger;
 
 import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.identifier.EndpointIdentifier;
 import org.eclipse.californium.core.observe.ObserveManager;
 
 /**
@@ -146,6 +147,16 @@ public abstract class Message {
 	 * has happened yet. The {@link Matcher} sets the timestamp.
 	 */
 	private long timestamp;
+
+	/**
+	 * An identifier of for the source endpoint.
+	 */
+	private EndpointIdentifier sourceEndpoint;
+	
+	/**
+	 * An identifier of for the destination endpoint.
+	 */
+	private EndpointIdentifier destinationEndpoint;
 
 	/**
 	 * Creates a new message with no specified message type.
@@ -732,6 +743,45 @@ public abstract class Message {
 	 */
 	public void setTimestamp(long timestamp) {
 		this.timestamp = timestamp;
+	}
+
+	/**
+	 * Gets the identifier of the endpoint this message originates from.
+	 * 
+	 * @return The source endpoint.
+	 */
+	public final EndpointIdentifier getSourceEndpoint() {
+		return sourceEndpoint;
+	}
+
+	/**
+	 * Sets the identifier of the endpoint this message originates from.
+	 * 
+	 * @param source The source endpoint.
+	 */
+	public final void setSourceEndpoint(EndpointIdentifier source) {
+		this.sourceEndpoint = source;
+	}
+
+	/**
+	 * Gets the identifier of the endpoint this message is destined to.
+	 * 
+	 * @return The destination endpoint.
+	 */
+	public final EndpointIdentifier getDestinationEndpoint() {
+		return destinationEndpoint;
+	}
+
+	/**
+	 * Sets the identifier of the endpoint this message is destined to.
+	 * 
+	 * @param destination The destination endpoint.
+	 */
+	public final void setDestinationEndpoint(EndpointIdentifier destination) {
+		this.destinationEndpoint = destination;
+		for (MessageObserver observer : getMessageObservers()) {
+			observer.onDestinationEndpointDefined(destination);
+		}
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserver.java
@@ -21,6 +21,7 @@
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
+import org.eclipse.californium.core.identifier.EndpointIdentifier;
 
 /**
  * A callback that gets invoked on a message's lifecycle events.
@@ -103,4 +104,8 @@ public interface MessageObserver {
 	 */
 	void onSendError(Throwable error);
 	
+	/**
+	 * Invoked when the destination endpoint is defined.
+	 */
+	void onDestinationEndpointDefined(EndpointIdentifier destination);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserverAdapter.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserverAdapter.java
@@ -23,6 +23,7 @@
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
+import org.eclipse.californium.core.identifier.EndpointIdentifier;
 /**
  * An abstract adapter class for reacting to a message's lifecylce events.
  * <p>
@@ -90,4 +91,9 @@ public abstract class MessageObserverAdapter implements MessageObserver {
 		// empty default implementation
 	}
 
+
+	@Override
+	public void onDestinationEndpointDefined(EndpointIdentifier destination) {
+		// empty default implementation
+	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/identifier/DefaultIdentifierFactory.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/identifier/DefaultIdentifierFactory.java
@@ -1,0 +1,35 @@
+package org.eclipse.californium.core.identifier;
+
+import java.net.InetSocketAddress;
+
+import org.eclipse.californium.elements.CorrelationContext;
+import org.eclipse.californium.elements.DtlsCorrelationContext;
+import org.eclipse.californium.elements.MapBasedCorrelationContext;
+
+public class DefaultIdentifierFactory implements IdentifierFactory {
+
+	@Override
+	public EndpointIdentifier extractIdentifier(CorrelationContext context, InetSocketAddress address) {
+		if (context != null) {
+			Object object = context.get(DtlsCorrelationContext.KEY_SESSION_ID);
+			if (object != null) {
+				return new SessionEndpointIdentifier((String) object);
+			}
+		}
+		return new InetEndpointIdentifier(address);
+	}
+
+	@Override
+	public CorrelationContext createContext(EndpointIdentifier identifier) {
+		if (identifier == null)
+			return null;
+
+		MapBasedCorrelationContext context = new MapBasedCorrelationContext();
+		if (identifier instanceof SessionEndpointIdentifier) {
+			context.put(DtlsCorrelationContext.KEY_SESSION_ID, ((SessionEndpointIdentifier) identifier).getSessionId());
+		}
+
+		throw new IllegalStateException(
+				String.format("Unsuppoted endpoint identifier  %s:%s", identifier.getClass(), identifier));
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/identifier/EndpointIdentifier.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/identifier/EndpointIdentifier.java
@@ -1,0 +1,11 @@
+package org.eclipse.californium.core.identifier;
+
+public interface EndpointIdentifier {
+
+	@Override
+	boolean equals(Object obj);
+
+	@Override
+	int hashCode();
+}
+

--- a/californium-core/src/main/java/org/eclipse/californium/core/identifier/IdentifierFactory.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/identifier/IdentifierFactory.java
@@ -1,0 +1,12 @@
+package org.eclipse.californium.core.identifier;
+
+import java.net.InetSocketAddress;
+
+import org.eclipse.californium.elements.CorrelationContext;
+
+public interface IdentifierFactory {
+
+	CorrelationContext createContext(EndpointIdentifier identifier);
+
+	EndpointIdentifier extractIdentifier(CorrelationContext context, InetSocketAddress address);
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/identifier/InetEndpointIdentifier.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/identifier/InetEndpointIdentifier.java
@@ -1,0 +1,46 @@
+package org.eclipse.californium.core.identifier;
+
+import java.net.InetSocketAddress;
+
+public class InetEndpointIdentifier implements EndpointIdentifier {
+
+	private InetSocketAddress address;
+
+	public InetEndpointIdentifier(InetSocketAddress address) {
+		this.address = address;
+	}
+
+	public InetSocketAddress getAddress() {
+		return address;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((address == null) ? 0 : address.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		InetEndpointIdentifier other = (InetEndpointIdentifier) obj;
+		if (address == null) {
+			if (other.address != null)
+				return false;
+		} else if (!address.equals(other.address))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return address.toString();
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/identifier/SessionEndpointIdentifier.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/identifier/SessionEndpointIdentifier.java
@@ -1,0 +1,45 @@
+package org.eclipse.californium.core.identifier;
+
+
+public class SessionEndpointIdentifier implements EndpointIdentifier {
+
+	private String sessionId;
+
+	public SessionEndpointIdentifier(String sessionID) {
+		this.sessionId = sessionID;
+	}
+
+	public String getSessionId() {
+		return sessionId;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((sessionId == null) ? 0 : sessionId.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SessionEndpointIdentifier other = (SessionEndpointIdentifier) obj;
+		if (sessionId == null) {
+			if (other.sessionId != null)
+				return false;
+		} else if (!sessionId.equals(other.sessionId))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("SessionID : %s", sessionId);
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.identifier.EndpointIdentifier;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
 import org.eclipse.californium.core.observe.NotificationListener;
@@ -194,11 +195,10 @@ public interface Endpoint {
 	NetworkConfig getConfig();
 
 	/**
-	 * Cancel observation for this request.
+	 * Cancels an observation created for this endpoint.
 	 * 
-	 * @param token
-	 *            the token of the original request which establishes the
-	 *            observe relation to cancel.
+	 * @param remoteEndpoint The identifier of the remote endpoint  the observation has been established for.
+	 * @param token The token of the original request which established the observe relation.
 	 */
-	void cancelObservation(byte[] token);
+	void cancelObservation(EndpointIdentifier remoteEndpoint, byte[] token);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
@@ -21,6 +21,7 @@ package org.eclipse.californium.core.network;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.identifier.EndpointIdentifier;
 import org.eclipse.californium.elements.CorrelationContext;
 
 /**
@@ -148,10 +149,11 @@ public interface Matcher {
 	void clear();
 
 	/**
-	 * Cancels all pending blockwise requests that have been induced by a notification
-	 * we have received indicating a blockwise transfer of the resource.
+	 * Cancels all pending blockwise requests that have been triggered by notifications
+	 * received from an endpoint.
 	 * 
-	 * @param token the token of the observation.
+	 * @param endpoint The identifier or the endpoint the notifications originate from.
+	 * @param token The token of the observation the notifications have been received for.
 	 */
-	void cancelObserve(byte[] token);
+	void cancelObserve(EndpointIdentifier endpoint, byte[] token);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -85,7 +85,7 @@ public final class TcpMatcher extends BaseMatcher {
 		LOGGER.log(Level.FINE, "Tracking open request using {0}", new Object[] { request.getTokenString() });
 
 		if (request.isObserve()) {
-			registerObserve(request);
+			registerObserve(exchange, request);
 		}
 	}
 
@@ -155,7 +155,7 @@ public final class TcpMatcher extends BaseMatcher {
 		return null;
 	}
 
-	private class ExchangeObserverImpl implements ExchangeObserver {
+	private class ExchangeObserverImpl extends BaseExchangeObserver {
 
 		@Override
 		public void completed(final Exchange exchange) {
@@ -182,15 +182,6 @@ public final class TcpMatcher extends BaseMatcher {
 			} else { // Origin.REMOTE
 				// nothing to do
 			}
-		}
-
-		@Override
-		public void contextEstablished(final Exchange exchange) {
-			if (exchange.getRequest() != null) {
-				observationStore.setContext(exchange.getRequest().getToken(), exchange.getCorrelationContext());
-			}
-			KeyToken token = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
-			exchangeStore.setContext(token, exchange.getCorrelationContext());
 		}
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -93,7 +93,7 @@ public final class UdpMatcher extends BaseMatcher {
 
 			// for observe request.
 			if (request.isObserve() && 0 == exchange.getFailedTransmissionCount()) {
-				registerObserve(request);
+				registerObserve(exchange, request);
 			}
 
 			if (LOGGER.isLoggable(Level.FINER)) {
@@ -308,7 +308,7 @@ public final class UdpMatcher extends BaseMatcher {
 		}
 	}
 
-	private class ExchangeObserverImpl implements ExchangeObserver {
+	private class ExchangeObserverImpl extends BaseExchangeObserver  {
 
 		@Override
 		public void completed(final Exchange exchange) {
@@ -392,16 +392,6 @@ public final class UdpMatcher extends BaseMatcher {
 					removeNotificationsOf(relation, exchange);
 				}
 			}
-		}
-
-		@Override
-		public void contextEstablished(final Exchange exchange) {
-
-			if (exchange.getRequest() != null) {
-				observationStore.setContext(exchange.getRequest().getToken(), exchange.getCorrelationContext());
-			}
-			KeyToken token = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
-			exchangeStore.setContext(token, exchange.getCorrelationContext());
 		}
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationStore.java
@@ -13,7 +13,7 @@
  ******************************************************************************/
 package org.eclipse.californium.core.observe;
 
-import org.eclipse.californium.elements.CorrelationContext;
+import org.eclipse.californium.core.identifier.EndpointIdentifier;
 
 /**
  * A registry for keeping information about resources observed on other peers.
@@ -29,39 +29,28 @@ public interface ObservationStore {
 	/**
 	 * Adds an observation to the store.
 	 * 
+	 * @param endpoint The endpoint identifier of the peer that the observe
+	 *            relation exists with.
 	 * @param obs The observation to add.
 	 * @throws NullPointerException if observation is {@code null}.
 	 */
-	void add(Observation obs);
+	void add(EndpointIdentifier endpoint, Observation obs);
 
 	/**
-	 * Removes the observation initiated by the request with the given token.
+	 * Removes an observation.
 	 * 
-	 * @param token The token of the observation to remove.
+	 * @param endpoint The endpoint identifier of the peer that the observe relation exists with.
+	 * @param token The token of the request that initiated the observe relation.
 	 */
-	void remove(byte[] token);
+	void remove(EndpointIdentifier endpoint, byte[] token);
 
 	/**
-	 * Gets the observation initiated by the request with the given token.
+	 * Gets an observation.
 	 * 
-	 * @param token The token of the initiating request.
-	 * @return The corresponding observation or {@code null} if no observation is registered for the given token.
+	 * @param endpoint The endpoint identifier of the peer that the observe relation exists with.
+	 * @param token The token of the request that initiated the observe relation.
+	 * @return The corresponding observation or {@code null} if no observation is registered for the given
+	 *         endpoint and token.
 	 */
-	Observation get(byte[] token);
-
-	/**
-	 * Sets the correlation context on the observation initiated by the request
-	 * with the given token.
-	 * <p>
-	 * This method is necessary because the correlation context may not be known
-	 * when the observation is originally registered. This is due to the fact
-	 * that the information contained in the correlation context is gathered by
-	 * the transport layer when the request establishing the observation is sent
-	 * to the peer.
-	 * </p>
-	 * 
-	 * @param token The token of the observation to set the context on.
-	 * @param correlationContext The context to set.
-	 */
-	void setContext(byte[] token, CorrelationContext correlationContext);
+	Observation get(EndpointIdentifier endpoint, byte[] token);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationUtil.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationUtil.java
@@ -45,6 +45,7 @@ public final class ObservationUtil {
 		clonedRequest.setOptions(request.getOptions());
 		clonedRequest.setPayload(request.getPayload());
 		clonedRequest.setUserContext(request.getUserContext());
+		clonedRequest.setDestinationEndpoint(request.getDestinationEndpoint());
 		return new Observation(clonedRequest, observation.getContext());
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -17,11 +17,10 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.eclipse.californium.core.network.MatcherTestUtils.*;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-import static org.eclipse.californium.core.network.MatcherTestUtils.*;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -242,7 +241,7 @@ public class UdpMatcherTest {
 		Exchange exchange = sendObserveRequest(dest, matcher);
 
 		// WHEN canceling any observe relations for the exchange's token
-		matcher.cancelObserve(exchange.getCurrentRequest().getToken());
+		matcher.cancelObserve(exchange.getRequest().getDestinationEndpoint(), exchange.getCurrentRequest().getToken());
 
 		// THEN the token has been released for re-use
 		KeyToken keyToken = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());

--- a/californium-core/src/test/java/org/eclipse/californium/core/observe/ObservationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/observe/ObservationTest.java
@@ -19,11 +19,10 @@
  ******************************************************************************/
 package org.eclipse.californium.core.observe;
 
-import static org.hamcrest.core.Is.*;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.core.IsSame.theInstance;
-import static org.hamcrest.core.IsSame.sameInstance;
+import static org.hamcrest.core.IsSame.*;
 import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
@@ -302,7 +302,7 @@ public class ClusteringTest {
 		// cancel observation
 		System.out.println();
 		System.out.println(System.lineSeparator() + "Cancel Observation.");
-		store.remove(request.getToken());
+		store.remove(request.getDestinationEndpoint(), request.getToken());
 
 		// server send new response to client 1
 		System.out.println();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -33,6 +33,8 @@ import static org.junit.Assert.assertThat;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.logging.Handler;
+import java.util.logging.Logger;
 
 import org.eclipse.californium.category.Large;
 import org.eclipse.californium.core.coap.Request;
@@ -56,6 +58,30 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Large.class)
 public class ObserveClientSideTest {
+
+	static Logger logger;
+	static Logger cflog;
+	static {
+        Logger globalLogger = Logger.getLogger("");
+        globalLogger.setLevel(java.util.logging.Level.OFF);
+        for (Handler handler : globalLogger.getHandlers()) {
+            handler.setLevel(java.util.logging.Level.ALL);
+        }
+
+		cflog = Logger.getLogger("org.eclipse.californium.core.network");
+		cflog.setLevel(java.util.logging.Level.FINER);
+        for (Handler handler : cflog.getHandlers()) {
+            handler.setLevel(java.util.logging.Level.ALL);
+        }
+
+		// logger = Logger.getLogger(BaseMatcher.class.getCanonicalName());
+		// logger.setLevel(java.util.logging.Level.FINER);
+		// for (Handler handler : logger.getHandlers()) {
+		// handler.setLevel(java.util.logging.Level.ALL);
+		// }
+	}
+	
+	
 	@ClassRule
 	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 
@@ -373,6 +399,81 @@ public class ObserveClientSideTest {
 		server.sendResponse(CON, CONTENT).loadToken("OBS_TOK").observe(4).mid(++mid_notif).payload(notifpayload).go();
 		response = notificationListener.waitForResponse(1000);
 		assertResponseContainsExpectedPayload(response, notifpayload);
+
+		printServerLog(clientInterceptor);
+	}
+
+	@Test
+	public void testSameTokenForDifferentPeer() throws Exception {
+		System.out.println("Same Token can be used by different peer:");
+		respPayload = generatePayload(1);
+		byte[] sameToken = generateNextToken();
+		String path = "test";
+		int obs = 100;
+		LockstepEndpoint server2 = createLockstepEndpoint(client.getAddress());
+
+		// established observe relation
+		Request request = createRequest(GET, path, server);
+		request.setToken(sameToken);
+		SynchronousNotificationListener notificationListener = new SynchronousNotificationListener(request);
+		client.addNotificationListener(notificationListener);
+		request.setObserve();
+		client.sendRequest(request);
+
+		server.expectRequest(CON, GET, path).storeMID("A").storeToken("B").observe(0).go();
+		server.sendResponse(ACK, CONTENT).loadMID("A").loadToken("B").payload(respPayload).go();
+		Thread.sleep(50);
+		Response response = request.waitForResponse(1000);
+		assertResponseContainsExpectedPayload(response, respPayload);
+
+		// send a notification
+		respPayload = generatePayload(2);
+		server.sendResponse(CON, CONTENT).loadToken("B").payload(respPayload).mid(++mid).observe(obs).go();
+		server.expectEmpty(ACK, mid).go();
+		Response notification1 = notificationListener.waitForResponse(1000);
+		assertResponseContainsExpectedPayload(notification1, respPayload);
+		assertNumberOfReceivedNotifications(notificationListener, 1, true);
+
+		// established observe relation with the same token to another server
+		Request request2 = createRequest(GET, path, server2);
+		request2.setToken(sameToken);
+		SynchronousNotificationListener notificationListener2 = new SynchronousNotificationListener(request2);
+		client.addNotificationListener(notificationListener2);
+		request2.setObserve();
+		client.sendRequest(request2);
+		System.out.println(server2.getPort());
+
+		respPayload = generatePayload(3);
+		server2.expectRequest(CON, GET, path).storeMID("A").storeToken("B").observe(0).go();
+		server2.sendResponse(ACK, CONTENT).loadMID("A").loadToken("B").payload(respPayload).go();
+		Thread.sleep(50);
+		Response response2 = request2.waitForResponse(1000);
+		assertResponseContainsExpectedPayload(response2, respPayload);
+
+		// send a notification from the 2nd server
+		respPayload = generatePayload(4);
+		server2.sendResponse(CON, CONTENT).loadToken("B").payload(respPayload).mid(++mid).observe(++obs).go();
+		server2.expectEmpty(ACK, mid).go();
+		Response notification2 = notificationListener2.waitForResponse(1000);
+		assertResponseContainsExpectedPayload(notification2, respPayload);
+		assertNumberOfReceivedNotifications(notificationListener2, 1, true);
+
+		// send a notification from the both servers
+		respPayload = generatePayload(5);
+		server.sendResponse(CON, CONTENT).loadToken("B").payload(respPayload).mid(++mid).observe(++obs).go();
+		server.expectEmpty(ACK, mid).go();
+		String respPayload2 = generatePayload(6);
+		server2.sendResponse(CON, CONTENT).loadToken("B").payload(respPayload2).mid(++mid).observe(++obs).go();
+		server2.expectEmpty(ACK, mid).go();
+
+		// check each notification is handle by the right notification listener.
+		Response notification3 = notificationListener.waitForResponse(1000);
+		assertResponseContainsExpectedPayload(notification3, respPayload);
+		assertNumberOfReceivedNotifications(notificationListener, 1, true);
+
+		Response notification4 = notificationListener2.waitForResponse(1000);
+		assertResponseContainsExpectedPayload(notification4, respPayload2);
+		assertNumberOfReceivedNotifications(notificationListener2, 1, true);
 
 		printServerLog(clientInterceptor);
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -291,7 +291,7 @@ public class ObserveClientSideTest {
 		server.goMultiExpectation();
 
 		// canceling in the middle of blockwise transfer
-		client.cancelObservation(request.getToken());
+		client.cancelObservation(request.getDestinationEndpoint(), request.getToken());
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
 
 		// notification must not be delivered

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/SynchronousNotificationListener.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/SynchronousNotificationListener.java
@@ -58,7 +58,8 @@ public class SynchronousNotificationListener implements NotificationListener {
 
 	@Override
 	public void onNotification(final Request req, final Response resp) {
-		if (request == null || Arrays.equals(request.getToken(), req.getToken())) {
+		if (request == null || Arrays.equals(request.getToken(), req.getToken())
+				&& request.getDestinationEndpoint().equals(req.getDestinationEndpoint())) {
 			synchronized (lock) {
 				response = resp;
 				notificationCount.incrementAndGet();

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
@@ -338,6 +338,7 @@ public class UDPConnector implements Connector {
 					LOGGER.log(Level.FINER, "UDPConnector ({0}) sends {1} bytes to {2}:{3}",
 							new Object[] { getUri(), datagram.getLength(), datagram.getAddress(), datagram.getPort() });
 				}
+				raw.onContextEstablished(null);
 				socket.send(datagram);
 				raw.onSent();
 			} catch (IOException ex) {


### PR DESCRIPTION
Here is a try to define an identifier for foreign endpoint.
The PR was largely inspired by this long [discussion](https://github.com/eclipse/californium/issues/173#issuecomment-290360652).

This is a work in progress and should not be merged now.
This first step introduces the concept of endpoint identifier and uses it to identify observation.

Next step : Adding `Principal` to `CorrelationContext` to be able to define `PrincipalEndpointIdentifier` to be able to test that in Leshan.

While this first step, I had the feeling that maybe `CorrelationContext` could be not necessary at CoAP side anymore (only at Connector side). This is a track I would explore. This could simplify the code and also solve some questions like #311.

Another point will be to change TokenProvider (replace `reserve/release` by `random generation`)  to solve issue raised by Achim in #173.

Even, if this is a work in progress, I strongly advice to try to review this PR each time I add new commits. This is the only way to make this review digestible.