### PR TITLE
Fix rare race condition in block1-blockwise transfe.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserver.java
@@ -18,6 +18,10 @@
  *    Kai Hudalla - logging
  *    Achim Kraus (Bosch Software Innovations GmbH) - add onSent() and onSendError()
  *                                                    issue #305
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add onReadyToSend() to fix rare
+ *                                                    race condition in block1wise
+ *                                                    when the generated token was 
+ *                                                    copied too late (after sending). 
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
@@ -88,6 +92,14 @@ public interface MessageObserver {
 	 * observed might cancel a response to send another one instead.
 	 */
 	void onCancel();
+
+	/**
+	 * Invoked when the message was built and is ready to send.
+	 * <p>
+	 * Triggered, before the message was sent by a connector. 
+	 * MID and token is prepared.
+	 */
+	void onReadyToSend();
 
 	/**
 	 * Invoked when the message has been sent.

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserverAdapter.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserverAdapter.java
@@ -20,6 +20,10 @@
  *                                                    implement onReject, onTimeout,
  *                                                    and onSendError calling failed().
  *                                                    issue #305
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add onReadyToSend() to fix rare
+ *                                                    race condition in block1wise
+ *                                                    when the generated token was 
+ *                                                    copied too late (after sending). 
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
@@ -67,6 +71,11 @@ public abstract class MessageObserverAdapter implements MessageObserver {
 	@Override
 	public void onTimeout() {
 		failed();
+	}
+
+	@Override
+	public void onReadyToSend() {
+		// empty default implementation
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -36,6 +36,10 @@
  *                                                    BaseMatcher final
  *    Achim Kraus (Bosch Software Innovations GmbH) - use new MessageCallback functions
  *                                                    issue #305
+ *    Achim Kraus (Bosch Software Innovations GmbH) - call Message.setReadyToSend() to fix
+ *                                                    rare race condition in block1wise
+ *                                                    when the generated token was copied
+ *                                                    too late (after sending). 
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -619,6 +623,7 @@ public class CoapEndpoint implements Endpoint {
 				messageInterceptor.sendRequest(request);
 			}
 
+			request.setReadyToSend();
 			// Request may have been canceled already, e.g. by one of the interceptors
 			// or client code
 			if (request.isCanceled()) {
@@ -652,6 +657,7 @@ public class CoapEndpoint implements Endpoint {
 			for (MessageInterceptor interceptor:interceptors) {
 				interceptor.sendResponse(response);
 			}
+			response.setReadyToSend();
 
 			// MessageInterceptor might have canceled
 			if (!response.isCanceled()) {
@@ -677,7 +683,7 @@ public class CoapEndpoint implements Endpoint {
 			for (MessageInterceptor interceptor:interceptors) {
 				interceptor.sendEmptyMessage(message);
 			}
-
+			message.setReadyToSend();
 			// MessageInterceptor might have canceled
 			if (!message.isCanceled()) {
 				CorrelationContext correlationContext = null;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -22,6 +22,11 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - use new introduced failed() 
  *                                                    instead of onReject() and
  *                                                    onTimeout(). Add onSendError()
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use onReadyToSend() to copy token
+ *                                                    to fix rare race condition in
+ *                                                    block1wise, when the generated
+ *                                                    token was copied too late 
+ *                                                    (after sending). 
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -210,7 +215,8 @@ public class BlockwiseLayer extends AbstractLayer {
 
 			block.addMessageObserver(new MessageObserverAdapter() {
 
-				private void copyToken() {
+				@Override
+				public void onReadyToSend() {
 					// when the request for transferring the first block
 					// has been sent out, we copy the token to the
 					// original request so that at the end of the
@@ -221,17 +227,6 @@ public class BlockwiseLayer extends AbstractLayer {
 
 				@Override
 				public void onCancel() {
-					failed();
-				}
-
-				@Override
-				public void onSent() {
-					copyToken();
-				}
-
-				@Override
-				public void onSendError(Throwable error) {
-					copyToken();
 					failed();
 				}
 


### PR DESCRIPTION
If the generated token is copied after sending the message, the response
may already being processed without that token in Block1BlockwiseStatus.
Therefore introduce setBuilt()/onBuilt() callback to MessageObservers.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>