### PR TITLE
Introduce configurable message ID trackers.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageIdProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageIdProvider.java
@@ -15,11 +15,17 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - remove nested synchronize.
  *                                                    reduce blocking on 
  *                                                    tracker.getNextMessageId()
+ *    Achim Kraus (Bosch Software Innovations GmbH) - introduce MessageIdTracker
+ *                                                    interface and rename old
+ *                                                    MessageIdTracker to
+ *                                                    MapBasedMessageIdTracker.
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
 import java.net.InetSocketAddress;
+import java.util.Random;
 
+import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.elements.util.LeastRecentlyUsedCache;
 
@@ -31,25 +37,67 @@ import org.eclipse.californium.elements.util.LeastRecentlyUsedCache;
  */
 public class InMemoryMessageIdProvider implements MessageIdProvider {
 
+	enum TrackerMode {
+		NULL, GROUPED, MAPBASED
+	}
+
 	private final LeastRecentlyUsedCache<InetSocketAddress, MessageIdTracker> trackers;
+	private final TrackerMode mode;
+	private final Random random;
 	private final NetworkConfig config;
 
 	/**
 	 * Creates an new provider for configuration values.
 	 * 
-	 * @param config the configuration to use. In particular, the <em>EXCHANGE_LIFETIME</em>
-	 *         configuration parameter is used as the period of time a message ID is marked as
-	 *         <em>in use</em> when it is allocated for a message exchange.
+	 * The following configuration values are used direct or indirect:
+	 * <ul>
+	 * <li>{@link org.eclipse.californium.core.network.config.NetworkConfig.Keys#MID_TRACKER}
+	 * - determine the tracker mode. Supported values are "NULL" (for
+	 * {@link NullMessageIdTracker}), "GROUPED" (for
+	 * {@link GroupedMessageIdTracker}), and "MAPBASED" (for
+	 * {@link MapBasedMessageIdTracker}).</li>
+	 * <li>{@link org.eclipse.californium.core.network.config.NetworkConfig.Keys#MID_TRACKER_GROUPS}
+	 * - determine the group size for the message IDs, if the grouped tracker is
+	 * used. Each group is marked as <em>in use</em>, if a MID within the group
+	 * is used.</li>
+	 * <li>{@link org.eclipse.californium.core.network.config.NetworkConfig.Keys#EXCHANGE_LIFETIME}
+	 * - each (group of a) message ID returned by <em>getNextMessageId</em> is
+	 * marked as <em>in use</em> for this amount of time (ms).</li>
+	 * <li>{@link org.eclipse.californium.core.network.config.NetworkConfig.Keys#USE_RANDOM_MID_START}
+	 * - if this value is {@code true} then the message IDs returned by
+	 * <em>getNextMessageId</em> will start at a random index. Otherwise the
+	 * first message ID returned will be {@code 0}.</li>
+	 * </ul>
+	 * 
+	 * @param config the configuration to use.
 	 * @throws NullPointerException if the config is {@code null}.
+	 * @throws IllegalArgumentException if the config contains no value tracker
+	 *             mode.
 	 */
 	public InMemoryMessageIdProvider(final NetworkConfig config) {
 		if (config == null) {
 			throw new NullPointerException("Config must not be null");
 		}
+		String textualMode = null;
+		TrackerMode mode = TrackerMode.GROUPED;
+		try {
+			textualMode = config.getString(NetworkConfig.Keys.MID_TRACKER);
+			mode = TrackerMode.valueOf(textualMode);
+		} catch (IllegalArgumentException e) {
+			throw new IllegalArgumentException("Tracker mode '" + textualMode + "' not supported!");
+		} catch (NullPointerException e) {
+			throw new IllegalArgumentException("Tracker mode not provided/configured!");
+		}
 		this.config = config;
-		trackers = new LeastRecentlyUsedCache<>(
-				config.getInt(NetworkConfig.Keys.MAX_ACTIVE_PEERS, 150000),
-				config.getLong(NetworkConfig.Keys.MAX_PEER_INACTIVITY_PERIOD, 10 * 60)); // 10 minutes
+		this.mode = mode;
+		if (config.getBoolean(NetworkConfig.Keys.USE_RANDOM_MID_START)) {
+			random = new Random(System.currentTimeMillis());
+		} else {
+			random = null;
+		}
+		// 10 minutes
+		trackers = new LeastRecentlyUsedCache<>(config.getInt(NetworkConfig.Keys.MAX_ACTIVE_PEERS, 150000),
+				config.getLong(NetworkConfig.Keys.MAX_PEER_INACTIVITY_PERIOD, 10 * 60));
 	}
 
 	@Override
@@ -58,7 +106,7 @@ public class InMemoryMessageIdProvider implements MessageIdProvider {
 		if (tracker == null) {
 			// we have reached the maximum number of active peers
 			// TODO: throw an exception?
-			return -1;
+			return Message.NONE;
 		} else {
 			return tracker.getNextMessageId();
 		}
@@ -68,7 +116,19 @@ public class InMemoryMessageIdProvider implements MessageIdProvider {
 		MessageIdTracker tracker = trackers.get(destination);
 		if (tracker == null && 0 < trackers.remainingCapacity()) {
 			// create new tracker for destination lazily
-			tracker = new MessageIdTracker(config);
+			int mid = null == random ? 0 : random.nextInt(MessageIdTracker.TOTAL_NO_OF_MIDS);
+			switch (mode) {
+			case NULL:
+				tracker = new NullMessageIdTracker(mid);
+				break;
+			case MAPBASED:
+				tracker = new MapBasedMessageIdTracker(mid, config);
+				break;
+			case GROUPED:
+			default:
+				tracker = new GroupedMessageIdTracker(mid, config);
+				break;
+			}
 			trackers.put(destination, tracker);
 		}
 		return tracker;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MapBasedMessageIdTracker.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MapBasedMessageIdTracker.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - cleanup and use 
+ *                                                    System.nanoTime() instead
+ *                                                    of currentTimeMillis().
+ *    Achim Kraus (Bosch Software Innovations GmbH) - rename MessageIdTracker
+ *                                                    to MapBasedMessageIdTracker.
+ *                                                    introduce MessageIdTracker
+ *                                                    interface.
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+
+/**
+ * A helper for keeping track of message IDs using a map.
+ * <p>
+ * According to the
+ * <a href="https://tools.ietf.org/html/rfc7252#section-4.4">CoAP spec</a>
+ * 
+ * <pre>
+ * The same Message ID MUST NOT be reused (in communicating with the
+   same endpoint) within the EXCHANGE_LIFETIME (Section 4.8.2).
+ * </pre>
+ */
+public class MapBasedMessageIdTracker implements MessageIdTracker {
+
+	private final Map<Integer, Long> messageIds;
+	private final long exchangeLifetimeNanos; // milliseconds
+	private int counter;
+
+	/**
+	 * Creates a new tracker based on configuration values.
+	 * 
+	 * The following configuration value is used:
+	 * <ul>
+	 * <li>{@link org.eclipse.californium.core.network.config.NetworkConfig.Keys#EXCHANGE_LIFETIME}
+	 * - each message ID returned by <em>getNextMessageId</em> is marked as
+	 * <em>in use</em> for this amount of time (ms).</li>
+	 * </ul>
+	 * 
+	 * @param initialMid initial MID
+	 * @param config configuration
+	 */
+	public MapBasedMessageIdTracker(int initialMid, NetworkConfig config) {
+		exchangeLifetimeNanos = TimeUnit.MILLISECONDS.toNanos(config.getLong(NetworkConfig.Keys.EXCHANGE_LIFETIME));
+		counter = initialMid;
+		messageIds = new HashMap<>(TOTAL_NO_OF_MIDS);
+	}
+
+	/**
+	 * Gets the next usable message ID.
+	 * 
+	 * @return a message ID or {@code Message.NONE} if all message IDs are in
+	 *         use currently.
+	 */
+	public int getNextMessageId() {
+		int result = Message.NONE;
+		boolean wrapped = false;
+		long now = System.nanoTime();
+		synchronized (messageIds) {
+			// mask mid to the 16 low bits
+			int startIdx = counter & 0x0000FFFF;
+			while (result < 0 && !wrapped) {
+				// mask mid to the 16 low bits
+				int idx = counter++ & 0x0000FFFF;
+				Long earliestUsage = messageIds.get(idx);
+				if (earliestUsage == null || now >= earliestUsage) {
+					// message Id can be safely re-used
+					result = idx;
+					messageIds.put(idx, now + exchangeLifetimeNanos);
+				}
+				wrapped = (counter & 0x0000FFFF) == startIdx;
+			}
+		}
+		return result;
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessageIdTracker.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessageIdTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,91 +12,25 @@
  * 
  * Contributors:
  *    Bosch Software Innovations - initial creation
- *    Achim Kraus (Bosch Software Innovations GmbH) - cleanup and use 
- *                                                    System.nanoTime() instead
- *                                                    of currentTimeMillis().
+ *                                 (derived from MessageIdTracker)
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
-
-import org.eclipse.californium.core.coap.Message;
-import org.eclipse.californium.core.network.config.NetworkConfig;
-
 /**
- * A helper for keeping track of message IDs.
- * <p>
- * According to the <a href="https://tools.ietf.org/html/rfc7252#section-4.4">CoAP spec</a>
- * <pre>
- * The same Message ID MUST NOT be reused (in communicating with the
-   same endpoint) within the EXCHANGE_LIFETIME (Section 4.8.2).
-   </pre>
+ * A interface helper for keeping track of message IDs.
  */
-public class MessageIdTracker {
-
-	private static final int TOTAL_NO_OF_MIDS = 1 << 16;
-	private final long exchangeLifetime; // milliseconds
-	private final Map<Integer, Long> messageIds;
-	private int counter;
+public interface MessageIdTracker {
 
 	/**
-	 * Creates a new tracker based on configuration values.
-	 * <p>
-	 * The following configuration values are used:
-	 * <ul>
-	 * <li>{@link org.eclipse.californium.core.network.config.NetworkConfig.Keys#EXCHANGE_LIFETIME} - each
-	 * message ID returned by <em>getNextMessageId</em> is marked as <em>in use</em> for this amount of
-	 * time (ms).</li>
-	 * <li>{@link org.eclipse.californium.core.network.config.NetworkConfig.Keys#USE_RANDOM_MID_START} - if
-	 * this value is {@code true} then the message IDs returned by <em>getNextMessageId</em> will start at a
-	 * random index. Otherwise the first message ID returned will be {@code 0}.</li>
-	 * </ul>
-	 * 
-	 * @param config the configuration to use.
+	 * Total number of MIDs.
 	 */
-	public MessageIdTracker(final NetworkConfig config) {
-		exchangeLifetime = config.getLong(NetworkConfig.Keys.EXCHANGE_LIFETIME);
-		boolean useRandomFirstMID = config.getBoolean(NetworkConfig.Keys.USE_RANDOM_MID_START);
-		if (useRandomFirstMID) {
-			counter = new Random().nextInt(TOTAL_NO_OF_MIDS);
-		} else {
-			counter = 0;
-		}
-		messageIds = new HashMap<>(TOTAL_NO_OF_MIDS);
-	}
+	final int TOTAL_NO_OF_MIDS = 1 << 16;
 
 	/**
 	 * Gets the next usable message ID.
 	 * 
-	 * @return a message ID or {@code Message.NONE} if all message IDs are in use currently.
+	 * @return a message ID or {@code -1} if all message IDs are in use
+	 *         currently.
 	 */
-	public int getNextMessageId() {
-		int result = Message.NONE;
-		boolean wrapped = false;
-		long now = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
-		synchronized (messageIds) {
-			int startIdx = counter % TOTAL_NO_OF_MIDS;
-			while (result < 0 && !wrapped) {
-				int idx = counter++ % TOTAL_NO_OF_MIDS;
-				Long earliestUsage = messageIds.get(idx);
-				if (earliestUsage != null) {
-					// MID has been used before
-					if (now >= earliestUsage) {
-						// message Id can be safely re-used
-						result = idx;
-						messageIds.put(idx, now + exchangeLifetime);
-					}
-				} else {
-					// MID has not been used before
-					result = idx;
-					messageIds.put(idx, now + exchangeLifetime);
-				}
-				wrapped = counter % TOTAL_NO_OF_MIDS == startIdx;
-			}
-		}
-		return result;
-	}
+	int getNextMessageId();
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/NullMessageIdTracker.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/NullMessageIdTracker.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ *                                 (derived from MessageIdTracker)
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A helper for keeping track of message IDs.
+ * <p>
+ * According to the
+ * <a href="https://tools.ietf.org/html/rfc7252#section-4.4">CoAP spec</a>
+ * 
+ * <pre>
+ * The same Message ID MUST NOT be reused (in communicating with the
+   same endpoint) within the EXCHANGE_LIFETIME (Section 4.8.2).
+ * </pre>
+ * 
+ * This implementation just increments the MIDs and ignores the RFC7252, 4.8.2.
+ */
+public class NullMessageIdTracker implements MessageIdTracker {
+
+	/**
+	 * Current MID.
+	 */
+	private AtomicInteger currentMID = new AtomicInteger();
+
+	/**
+	 * Creates a new tracker based on configuration values.
+	 * 
+	 * @param initialMid initial MID.
+	 */
+	public NullMessageIdTracker(int initialMid) {
+		currentMID.set(initialMid);
+	}
+
+	/**
+	 * Gets the next message ID.
+	 * 
+	 * @return a message ID.
+	 */
+	public int getNextMessageId() {
+		// mask result to the 16 low bits
+		return currentMID.getAndIncrement() & 0x0000FFFF;
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -20,6 +20,7 @@
  *    Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
  *    Achim Kraus (Bosch Software Innovations GmbH) - add InputStream support for environments
  *                                                    without file access.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add new keys for MID tracker
  ******************************************************************************/
 package org.eclipse.californium.core.network.config;
 
@@ -101,7 +102,8 @@ public final class NetworkConfig {
 		public static final String PROBING_RATE = "PROBING_RATE";
 
 		public static final String USE_RANDOM_MID_START = "USE_RANDOM_MID_START";
-		public static final String MID_PROVIDER_GROUPS = "MID_PROVIDER_GROUPS";
+		public static final String MID_TRACKER = "MID_TACKER";
+		public static final String MID_TRACKER_GROUPS = "MID_TRACKER_GROUPS";
 		public static final String TOKEN_SIZE_LIMIT = "TOKEN_SIZE_LIMIT";
 
 		/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
@@ -17,6 +17,10 @@
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
  *    Bosch Software Innovations GmbH - don't use strict request/response matching by default 
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add defaults for
+ *                                                    DEFAULT_MID_TRACKER,
+ *                                                    DEFAULT_MID_TRACKER_GROUPS, and
+ *                                                    DEFAULT_EXCHANGE_LIFETIME
  ******************************************************************************/
 package org.eclipse.californium.core.network.config;
 
@@ -57,12 +61,27 @@ public class NetworkConfigDefaults {
 	public static final int DEFAULT_BLOCKWISE_STATUS_LIFETIME = 5 * 60 * 1000; // 5 mins
 
 	/**
+	 * The default MID tracker.
+	 * 
+	 * Supported values are {@code NULL}, {@code GROUPED}, or {@code MAPBASED}.
+	 * <p>
+	 * The default value is {@code GROUPED}.
+	 */
+	public static final String DEFAULT_MID_TRACKER = "GROUPED";
+
+	/**
 	 * The default number of MID groups.
 	 * <p>
-	 * The default value is 16.
-	 * @see GroupedMessageIdTracker
+	 * Used for {@link GroupedMessageIdTracker}. The default value is 16.
 	 */
-	public static final int DEFAULT_MID_PROVIDER_GROUPS = 16;
+	public static final int DEFAULT_MID_TRACKER_GROUPS = 16;
+
+	/**
+	 * The default exchange lifetime in milliseconds.
+	 * <p>
+	 * The default value is 247s.
+	 */
+	public static final long DEFAULT_EXCHANGE_LIFETIME = 247 * 1000;
 
 	/*
 	 * Accept other message versions than 1
@@ -86,7 +105,7 @@ public class NetworkConfigDefaults {
 		config.setFloat(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1.5f);
 		config.setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 2f);
 		config.setInt(NetworkConfig.Keys.MAX_RETRANSMIT, 4);
-		config.setLong(NetworkConfig.Keys.EXCHANGE_LIFETIME, 247 * 1000); // ms
+		config.setLong(NetworkConfig.Keys.EXCHANGE_LIFETIME, DEFAULT_EXCHANGE_LIFETIME); // ms
 		config.setLong(NetworkConfig.Keys.NON_LIFETIME, 145 * 1000); // ms
 		config.setLong(NetworkConfig.Keys.MAX_TRANSMIT_WAIT, 93 * 1000);
 		config.setInt(NetworkConfig.Keys.NSTART, 1);
@@ -94,7 +113,8 @@ public class NetworkConfigDefaults {
 		config.setFloat(NetworkConfig.Keys.PROBING_RATE, 1f);
 
 		config.setBoolean(NetworkConfig.Keys.USE_RANDOM_MID_START, true);
-		config.setInt(NetworkConfig.Keys.MID_PROVIDER_GROUPS, DEFAULT_MID_PROVIDER_GROUPS);
+		config.setString(NetworkConfig.Keys.MID_TRACKER, DEFAULT_MID_TRACKER);
+		config.setInt(NetworkConfig.Keys.MID_TRACKER_GROUPS, DEFAULT_MID_TRACKER_GROUPS);
 		config.setInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT, 8);
 
 		config.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 512);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/MapBasedMessageIdTrackerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/MapBasedMessageIdTrackerTest.java
@@ -14,11 +14,14 @@
  *    Bosch Software Innovations - initial creation
  *    Achim Kraus (Bosch Software Innovations GmbH) - relax lifetime tests
  *    Achim Kraus (Bosch Software Innovations GmbH) - use waitForCondition
+ *    Achim Kraus (Bosch Software Innovations GmbH) - rename MessageIdTrackerTest
+ *                                                    to MapBasedMessageIdTrackerTest.
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.eclipse.californium.core.network.MessageIdTracker.TOTAL_NO_OF_MIDS;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -26,27 +29,19 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.californium.CheckCondition;
 import org.eclipse.californium.TestTools;
 import org.eclipse.californium.core.network.config.NetworkConfig;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
  * Verifies that MessageIdTracker correctly marks MIDs as <em>in use</em>.
  *
  */
-public class MessageIdTrackerTest {
-
-	private static final int TOTAL_NO_OF_MIDS = 1 << 16;
-	private NetworkConfig config;
-
-	@Before
-	public void setUp() {
-		config = NetworkConfig.createStandardWithoutFile();
-	}
+public class MapBasedMessageIdTrackerTest {
 
 	@Test
 	public void testGetNextMessageIdFailsIfAllMidsAreInUse() throws Exception {
 		// GIVEN a tracker whose MIDs are all in use
-		MessageIdTracker tracker = new MessageIdTracker(config);
+		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
+		MapBasedMessageIdTracker tracker = new MapBasedMessageIdTracker(0, config);
 		for (int i = 0; i < TOTAL_NO_OF_MIDS; i++) {
 			tracker.getNextMessageId();
 		}
@@ -62,8 +57,9 @@ public class MessageIdTrackerTest {
 	public void testGetNextMessageIdReusesIdAfterExchangeLifetime() throws Exception {
 		// GIVEN a tracker with an EXCHANGE_LIFETIME of 100ms
 		int exchangeLifetime = 100; // ms
-		config.setInt(NetworkConfig.Keys.EXCHANGE_LIFETIME, exchangeLifetime);
-		final MessageIdTracker tracker = new MessageIdTracker(config);
+		NetworkConfig config = NetworkConfig.createStandardWithoutFile().setInt(NetworkConfig.Keys.EXCHANGE_LIFETIME,
+				exchangeLifetime);
+		final MapBasedMessageIdTracker tracker = new MapBasedMessageIdTracker(0, config);
 
 		// WHEN retrieving all message IDs from the tracker
 		int firstMid = tracker.getNextMessageId();

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/NullMessageIdTrackerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/NullMessageIdTrackerTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ *                                 derived from MessageIdTrackerTest
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.eclipse.californium.core.network.MessageIdTracker.TOTAL_NO_OF_MIDS;
+
+import org.eclipse.californium.category.Small;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Verifies that NullMessageIdTracker correctly generates MIDs.
+ */
+@Category(Small.class)
+public class NullMessageIdTrackerTest {
+
+	@Test
+	public void testGetNextMessage() {
+		NullMessageIdTracker tracker = new NullMessageIdTracker(0);
+		for (int count = 0; count < TOTAL_NO_OF_MIDS * 16; ++count) {
+			int mid = tracker.getNextMessageId();
+			assertThat(mid, is(count % TOTAL_NO_OF_MIDS));
+		}
+	}
+
+	@Test
+	public void testGetNextMessageOverflow() {
+		// GIVEN, a MessageIdTracker initialized with a large initial MID
+		NullMessageIdTracker tracker = new NullMessageIdTracker(Integer.MAX_VALUE);
+		int mid = tracker.getNextMessageId();
+		assertThat(mid, is(TOTAL_NO_OF_MIDS - 1));
+		mid = tracker.getNextMessageId();
+		assertThat(mid, is(0));
+		mid = tracker.getNextMessageId();
+		assertThat(mid, is(1));
+	}
+}


### PR DESCRIPTION
Rename MessageIdTracker to HashedMessageIdTracker. Introduce
MessageIdTracker interface to support different implementations.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>