### PR TITLE
Fixed LinkFormat.matches() for multiple queries, added tests.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/LinkFormat.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/LinkFormat.java
@@ -161,7 +161,10 @@ public class LinkFormat {
 	 *
 	 * Queries are interpreted according to <a href="https://tools.ietf.org/html/rfc6690#section-4.1">RFC 6690</a>,
 	 * section 4.1, with the important difference that more than one query can be passed to the function. The
-	 * resource only matches the list of queries if the resource matches every query in the list.
+	 * resource only matches the list of queries if the resource matches every query in the list. This functionality
+	 * is required to implement resource directory filtering according to the
+	 * <a href="https://tools.ietf.org/html/draft-ietf-core-resource-directory-11#section-7">Resource directory</a>
+	 * draft, which requires support for matching multiple attributes.
 	 *
 	 * @param resource The resource to match.
 	 * @param queries The list of queries to match the resource with.

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/LinkFormat.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/LinkFormat.java
@@ -193,10 +193,12 @@ public class LinkFormat {
 							// Wildcard query
 							if (actual.equals(shortened)) {
 								matched = true;
+								break;
 							}
 						} else if (actual.equals(expected)) {
 							// Regular query
 							matched = true;
+							break;
 						}
 					}
 					if (!matched) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/LinkFormat.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/LinkFormat.java
@@ -156,6 +156,17 @@ public class LinkFormat {
 		return linkFormat;
 	}
 
+	/**
+	 * Check whether the given resource matches the given list of queries.
+	 *
+	 * Queries are interpreted according to <a href="https://tools.ietf.org/html/rfc6690#section-4.1">RFC 6690</a>,
+	 * section 4.1, with the important difference that more than one query can be passed to the function. The
+	 * resource only matches the list of queries if the resource matches every query in the list.
+	 *
+	 * @param resource The resource to match.
+	 * @param queries The list of queries to match the resource with.
+	 * @return True if the resource matches all queries, false otherwise.
+	 */
 	public static boolean matches(Resource resource, List<String> queries) {
 
 		if (resource == null)

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/AttributeMultiQueryTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/AttributeMultiQueryTest.java
@@ -1,0 +1,83 @@
+package org.eclipse.californium.core.test;
+
+import org.eclipse.californium.category.Small;
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.EndpointManager;
+import org.eclipse.californium.core.server.resources.DiscoveryResource;
+import org.eclipse.californium.core.server.resources.Resource;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Small.class)
+public class AttributeMultiQueryTest {
+    private Resource root;
+
+    @Before
+    public void setup() {
+        try {
+            System.out.println(System.lineSeparator() + "Start " + getClass().getSimpleName());
+            EndpointManager.clear();
+
+            root = new CoapResource("");
+            Resource sensors = new CoapResource("sensors");
+            Resource temp = new CoapResource("temp");
+            Resource light = new CoapResource("light");
+            root.add(sensors);
+            sensors.add(temp);
+            sensors.add(light);
+
+            sensors.getAttributes().setTitle("Sensor Index");
+            temp.getAttributes().addResourceType("temperature-c");
+            temp.getAttributes().addInterfaceDescription("sensor");
+            temp.getAttributes().addAttribute("foo");
+            temp.getAttributes().addAttribute("bar", "one");
+            temp.getAttributes().addAttribute("bar", "two");
+
+            light.getAttributes().addResourceType("light-lux");
+            light.getAttributes().addInterfaceDescription("sensor");
+            light.getAttributes().addAttribute("foo");
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+    }
+
+    private void testFiltering(String query, String expected) {
+        Request request = Request.newGet();
+        request.setURI("/.well-known/core?" + query);
+
+        DiscoveryResource discovery = new DiscoveryResource(root);
+        String serialized = discovery.discoverTree(root, request.getOptions().getUriQuery());
+        System.out.println(serialized);
+
+        Assert.assertEquals(expected, serialized);
+    }
+
+    @Test
+    public void testComplexMultiValueFiltering() {
+        // bar=one and if=sensor should return only /sensors/temp.
+        testFiltering("bar=one&if=sensor","</sensors/temp>;bar=\"one two\";foo;if=\"sensor\";rt=\"temperature-c\"");
+    }
+
+    @Test
+    public void testComplexFlagAttributeFiltering() {
+        testFiltering("bar=one&foo",
+                "</sensors/temp>;bar=\"one two\";foo;if=\"sensor\";rt=\"temperature-c\"");
+    }
+
+
+    @Test
+    public void testComplexMultiValueFilteringReversed() {
+        // bar=one and if=sensor should return only /sensors/temp.
+        testFiltering("if=sensor&bar=one","</sensors/temp>;bar=\"one two\";foo;if=\"sensor\";rt=\"temperature-c\"");
+    }
+
+    @Test
+    public void testComplexFlagAttributeFilteringReversed() {
+        // bar=one and foo should return only /sensors/temp
+        testFiltering("foo&bar=one",
+                "</sensors/temp>;bar=\"one two\";foo;if=\"sensor\";rt=\"temperature-c\"");
+    }
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/AttributeMultiQueryTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/AttributeMultiQueryTest.java
@@ -80,4 +80,14 @@ public class AttributeMultiQueryTest {
         testFiltering("foo&bar=one",
                 "</sensors/temp>;bar=\"one two\";foo;if=\"sensor\";rt=\"temperature-c\"");
     }
+
+    @Test
+    public void testMultipleSameAttributeFiltering() {
+        // bar=one and bar=two should match /sensors/temp
+        testFiltering("bar=one&bar=two",
+                "</sensors/temp>;bar=\"one two\";foo;if=\"sensor\";rt=\"temperature-c\"");
+        // bar=one and bar=three should match nothing.
+        testFiltering("bar=one&bar=three",
+                "");
+    }
 }


### PR DESCRIPTION
The current implementation of matches() returns superfluous matches if the query consists of multiple elements. For example, querying `foo&bar=one` returns all resources that have the `foo` attribute, instead of only those that have both `foo` and `bar=one`.

I have also added tests for these queries.