### PR TITLE
Add get on incomplete DTLS configuration for DTLSconfiguration.Builder

### DIFF
--- a/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/SecureClient.java
+++ b/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/SecureClient.java
@@ -69,7 +69,7 @@ public class SecureClient {
 			Certificate[] trustedCertificates = new Certificate[1];
 			trustedCertificates[0] = trustStore.getCertificate("root");
 
-			DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder(new InetSocketAddress(0));
+			DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();
 			builder.setPskStore(new StaticPskStore("Client_identity", "secretPSK".getBytes()));
 			builder.setIdentity((PrivateKey)keyStore.getKey("client", KEY_STORE_PASSWORD.toCharArray()),
 					keyStore.getCertificateChain("client"), true);

--- a/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/SecureServer.java
+++ b/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/SecureServer.java
@@ -91,7 +91,8 @@ public class SecureServer {
 			InputStream in = SecureServer.class.getClassLoader().getResourceAsStream(KEY_STORE_LOCATION);
 			keyStore.load(in, KEY_STORE_PASSWORD.toCharArray());
 
-			DtlsConnectorConfig.Builder config = new DtlsConnectorConfig.Builder(new InetSocketAddress(DTLS_PORT));
+			DtlsConnectorConfig.Builder config = new DtlsConnectorConfig.Builder();
+			config.setAddress(new InetSocketAddress(DTLS_PORT));
 			config.setSupportedCipherSuites(new CipherSuite[]{CipherSuite.TLS_PSK_WITH_AES_128_CCM_8,
 					CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8});
 			config.setPskStore(pskStore);

--- a/demo-apps/sc-dtls-example-client/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSClient.java
+++ b/demo-apps/sc-dtls-example-client/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSClient.java
@@ -70,7 +70,7 @@ public class ExampleDTLSClient {
 			Certificate[] trustedCertificates = new Certificate[1];
 			trustedCertificates[0] = trustStore.getCertificate("root");
 
-			DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder(new InetSocketAddress(0));
+			DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();
 			builder.setPskStore(new StaticPskStore("Client_identity", "secretPSK".getBytes()));
 			builder.setIdentity((PrivateKey)keyStore.getKey("client", KEY_STORE_PASSWORD.toCharArray()),
 					keyStore.getCertificateChain("client"), true);

--- a/demo-apps/sc-dtls-example-server/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSServer.java
+++ b/demo-apps/sc-dtls-example-server/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSServer.java
@@ -71,7 +71,8 @@ public class ExampleDTLSServer {
 			Certificate[] trustedCertificates = new Certificate[1];
 			trustedCertificates[0] = trustStore.getCertificate("root");
 
-			DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder(new InetSocketAddress(DEFAULT_PORT));
+			DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();
+			builder.setAddress(new InetSocketAddress(DEFAULT_PORT));
 			builder.setPskStore(pskStore);
 			builder.setIdentity((PrivateKey)keyStore.getKey("server", KEY_STORE_PASSWORD.toCharArray()),
 					keyStore.getCertificateChain("server"), true);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -343,6 +343,8 @@ public final class DtlsConnectorConfig {
 		 * 
 		 * The builder is initialized to the following default values
 		 * <ul>
+		 * <li><em>address</em>: a wildcard address with a system chosen ephemeral port
+		 *  see {@link InetSocketAddress#InetSocketAddress(int)}</li>
 		 * <li><em>maxFragmentLength</em>: 4096 bytes</li>
 		 * <li><em>maxPayloadSize</em>: 4096 + 25 bytes (max fragment size + 25 bytes for headers)</li>
 		 * <li><em>maxRetransmissions</em>: 4</li>
@@ -362,17 +364,25 @@ public final class DtlsConnectorConfig {
 		 * only if the server does not require clients to authenticate, i.e. this only
 		 * works with the ECDH based cipher suites. If you want to create such a <em>client-only</em>
 		 * configuration, you need to use the {@link #setClientOnly()} method on the builder.
+		 */
+		public Builder() {
+			config = new DtlsConnectorConfig();
+		}
+
+		/**
+		 * Sets the IP address and port the connector should bind to
 		 * 
 		 * @param address the IP address and port the connector should bind to
 		 * @throws IllegalArgumentException if the given addess is unresolved
 		 */
-		public Builder(InetSocketAddress address) {
+		public Builder setAddress(InetSocketAddress address) {
 			if (address.isUnresolved()) {
 				throw new IllegalArgumentException("Bind address must not be unresolved");
 			}
-			config = new DtlsConnectorConfig();
 			config.address = address;
+			return this;
 		}
+
 
 		/**
 		 * Indicates that the <em>DTLSConnector</em> will only be used as a
@@ -772,6 +782,9 @@ public final class DtlsConnectorConfig {
 		 */
 		public DtlsConnectorConfig build() {
 			// set default values
+			if (config.address == null) {
+				config.address = new InetSocketAddress(0);
+			}
 			if (config.trustStore == null) {
 				config.trustStore = new X509Certificate[0];
 			}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -63,42 +63,43 @@ public final class DtlsConnectorConfig {
 	 */
 	public static final long DEFAULT_STALE_CONNECTION_TRESHOLD = 30 * 60; // 30 minutes
 	private static final String EC_ALGORITHM_NAME = "EC";
+
 	private InetSocketAddress address;
-	private X509Certificate[] trustStore = new X509Certificate[0];
+	private X509Certificate[] trustStore;
 
 	/**
 	 * Experimental feature : Stop retransmission at message receipt
 	 */
-	private boolean earlyStopRetransmission = true;
+	private Boolean earlyStopRetransmission;
 
 	/**
 	 * The maximum fragment length this connector can process at once.
 	 */
-	private Integer maxFragmentLengthCode = null;
+	private Integer maxFragmentLengthCode;
 
 	/** The initial timer value for retransmission; rfc6347, section: 4.2.4.1 */
-	private int retransmissionTimeout = 1000;
+	private Integer retransmissionTimeout;
 
 	/**
 	 * Maximal number of retransmissions before the attempt to transmit a
 	 * message is canceled
 	 */
-	private int maxRetransmissions = 4;
+	private Integer maxRetransmissions;
 
 	/** does the server require the client to authenticate */
-	private boolean clientAuthenticationRequired = true;
+	private Boolean clientAuthenticationRequired;
 
 	/** do we send only the raw key (RPK) and not the full certificate (X509) */
-	private boolean sendRawKey = true;
+	private Boolean sendRawKey;
 
 	/** store of the PSK */
-	private PskStore pskStore = null;
+	private PskStore pskStore;
 
 	/** the private key for RPK and X509 mode */
-	private PrivateKey privateKey = null;
+	private PrivateKey privateKey;
 
 	/** the public key for both RPK and X.509 mode */
-	private PublicKey publicKey = null;
+	private PublicKey publicKey;
 
 	/** the certificate for RPK and X509 mode */
 	private X509Certificate[] certChain;
@@ -106,10 +107,10 @@ public final class DtlsConnectorConfig {
 	/** the supported cipher suites in order of preference */
 	private CipherSuite[] supportedCipherSuites;
 
-	private int outboundMessageBufferSize = 100000;
+	private Integer outboundMessageBufferSize;
 
-	private int maxConnections = DEFAULT_MAX_CONNECTIONS;
-	private long staleConnectionThreshold = DEFAULT_STALE_CONNECTION_TRESHOLD;
+	private Integer maxConnections = DEFAULT_MAX_CONNECTIONS;
+	private Long staleConnectionThreshold = DEFAULT_STALE_CONNECTION_TRESHOLD;
 
 	private ServerNameResolver serverNameResolver;
 
@@ -144,7 +145,7 @@ public final class DtlsConnectorConfig {
 	 * 
 	 * @return the (initial) time to wait in milliseconds
 	 */
-	public int getRetransmissionTimeout() {
+	public Integer getRetransmissionTimeout() {
 		return retransmissionTimeout;
 	}
 
@@ -154,7 +155,7 @@ public final class DtlsConnectorConfig {
 	 * 
 	 * @return the maximum number of re-transmissions
 	 */
-	public int getMaxRetransmissions() {
+	public Integer getMaxRetransmissions() {
 		return maxRetransmissions;
 	}
 
@@ -162,7 +163,7 @@ public final class DtlsConnectorConfig {
 	 * @return true if retransmissions should be stopped as soon as we receive
 	 *         handshake message
 	 */
-	public boolean isEarlyStopRetransmission() {
+	public Boolean isEarlyStopRetransmission() {
 		return earlyStopRetransmission;
 	}
 
@@ -172,7 +173,7 @@ public final class DtlsConnectorConfig {
 	 * 
 	 * @return the number of messages
 	 */
-	public int getOutboundMessageBufferSize() {
+	public Integer getOutboundMessageBufferSize() {
 		return outboundMessageBufferSize;
 	}
 
@@ -276,7 +277,7 @@ public final class DtlsConnectorConfig {
 	 * 
 	 * @return <code>true</code> if clients need to authenticate
 	 */
-	public boolean isClientAuthenticationRequired() {
+	public Boolean isClientAuthenticationRequired() {
 		return clientAuthenticationRequired;
 	}
 
@@ -290,7 +291,7 @@ public final class DtlsConnectorConfig {
 	 * 
 	 * @return <code>true</code> if <em>RawPublicKey</em> is used by the connector
 	 */
-	public boolean isSendRawKey() {
+	public Boolean isSendRawKey() {
 		return sendRawKey;
 	}
 
@@ -304,7 +305,7 @@ public final class DtlsConnectorConfig {
 	 * @return The maximum number of active connections supported.
 	 * @see #getStaleConnectionThreshold()
 	 */
-	public int getMaxConnections() {
+	public Integer getMaxConnections() {
 		return maxConnections;
 	}
 
@@ -317,7 +318,7 @@ public final class DtlsConnectorConfig {
 	 * @return The number of seconds.
 	 * @see #getMaxConnections()
 	 */
-	public long getStaleConnectionThreshold() {
+	public Long getStaleConnectionThreshold() {
 		return staleConnectionThreshold;
 	}
 
@@ -738,6 +739,18 @@ public final class DtlsConnectorConfig {
 		}
 
 		/**
+		 * Returns a potentially incomplete configuration. Only fields set by
+		 * users are affected, there is no default value, no consistency check.
+		 * To get a full usable {@link DtlsConnectorConfig} use {@link #build()}
+		 * instead.
+		 * 
+		 * @return the incomplete Configuration
+		 */
+		public DtlsConnectorConfig getIncompleteConfig() {
+			return config;
+		}
+
+		/**
 		 * Creates an instance of <code>DtlsConnectorConfig</code> based on the properties
 		 * set on this builder.
 		 * <p>
@@ -758,15 +771,43 @@ public final class DtlsConnectorConfig {
 		 * @throws IllegalStateException if the configuration is inconsistent
 		 */
 		public DtlsConnectorConfig build() {
+			// set default values
+			if (config.trustStore == null) {
+				config.trustStore = new X509Certificate[0];
+			}
+			if (config.earlyStopRetransmission == null) {
+				config.earlyStopRetransmission = true;
+			}
+			if (config.retransmissionTimeout == null) {
+				config.retransmissionTimeout = 1000;
+			}
+			if (config.maxRetransmissions == null) {
+				config.maxRetransmissions = 4;
+			}
+			if (config.clientAuthenticationRequired == null) {
+				config.clientAuthenticationRequired = true;
+			}
+			if (config.sendRawKey == null) {
+				config.sendRawKey = true;
+			}
+			if (config.outboundMessageBufferSize == null) {
+				config.outboundMessageBufferSize = 100000;
+			}
+			if (config.maxConnections == null){
+				config.maxConnections = DEFAULT_MAX_CONNECTIONS;
+			}
+			if (config.staleConnectionThreshold == null) {
+				config.staleConnectionThreshold = DEFAULT_STALE_CONNECTION_TRESHOLD;
+			}
 			if (config.getSupportedCipherSuites().length == 0) {
 				determineCipherSuitesFromConfig();
 			}
 
+			// check cipher consistency
 			if (config.getSupportedCipherSuites().length == 0) {
 				throw new IllegalStateException("Supported cipher suites must be set either " +
 						"explicitly or implicitly by means of setting the identity or PSK store");
 			}
-
 			for (CipherSuite suite : config.getSupportedCipherSuites()) {
 				switch (suite) {
 				case TLS_PSK_WITH_AES_128_CCM_8:

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -27,8 +27,7 @@
  ******************************************************************************/
 package org.eclipse.californium.scandium;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -103,9 +102,9 @@ public class ConnectorHelper {
 
 		InMemoryPskStore pskStore = new InMemoryPskStore();
 		pskStore.setKey(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes());
-		serverConfig = new DtlsConnectorConfig.Builder(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0))
-			.setSupportedCipherSuites(
-				new CipherSuite[]{
+		serverConfig = new DtlsConnectorConfig.Builder()
+			.setAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0))
+			.setSupportedCipherSuites(new CipherSuite[] {
 						CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
 						CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
 						CipherSuite.TLS_PSK_WITH_AES_128_CCM_8,
@@ -150,7 +149,8 @@ public class ConnectorHelper {
 	}
 
 	static DtlsConnectorConfig.Builder newStandardClientConfigBuilder(final InetSocketAddress bindAddress) throws IOException, GeneralSecurityException {
-		return new DtlsConnectorConfig.Builder(bindAddress)
+		return new DtlsConnectorConfig.Builder()
+				.setAddress(bindAddress)
 				.setIdentity(DtlsTestTools.getClientPrivateKey(), DtlsTestTools.getClientCertificateChain(), true)
 				.setTrustStore(DtlsTestTools.getTrustedCertificates());
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -173,7 +173,8 @@ public class DTLSConnectorTest {
 			}
 		};
 		pskStore.setKey(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes());
-		serverConfig = new DtlsConnectorConfig.Builder(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0))
+		serverConfig = new DtlsConnectorConfig.Builder()
+			.setAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0))
 			.setSupportedCipherSuites(
 				new CipherSuite[]{
 						CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
@@ -228,7 +229,8 @@ public class DTLSConnectorTest {
 	}
 
 	private static DtlsConnectorConfig.Builder newStandardConfigBuilder(InetSocketAddress bindAddress)  throws Exception {
-		return new DtlsConnectorConfig.Builder(bindAddress)
+		return new DtlsConnectorConfig.Builder()
+				.setAddress(bindAddress)
 				.setIdentity(DtlsTestTools.getClientPrivateKey(), DtlsTestTools.getClientCertificateChain(), true)
 				.setTrustStore(DtlsTestTools.getTrustedCertificates());
 	}
@@ -1493,7 +1495,8 @@ public class DTLSConnectorTest {
 	public void testConnectorAbortsHandshakeOnUnknownPskIdentity() throws Exception {
 
 		final CountDownLatch latch = new CountDownLatch(1);
-		clientConfig = new DtlsConnectorConfig.Builder(clientEndpoint)
+		clientConfig = new DtlsConnectorConfig.Builder()
+			.setAddress(clientEndpoint)
 			.setPskStore(new StaticPskStore("unknownIdentity", CLIENT_IDENTITY_SECRET.getBytes()))
 			.build();
 		client = new DTLSConnector(clientConfig);
@@ -1517,7 +1520,8 @@ public class DTLSConnectorTest {
 	 */
 	@Test
 	public void testConnectorEstablishesSecureSessionUsingCbcBlockCipher() throws Exception {
-		clientConfig =  new DtlsConnectorConfig.Builder(clientEndpoint)
+		clientConfig =  new DtlsConnectorConfig.Builder()
+			.setAddress(clientEndpoint)
 			.setSupportedCipherSuites(new CipherSuite[]{CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256})
 			.setIdentity(DtlsTestTools.getClientPrivateKey(), DtlsTestTools.getClientCertificateChain(), false)
 			.setTrustStore(DtlsTestTools.getTrustedCertificates())
@@ -1548,7 +1552,8 @@ public class DTLSConnectorTest {
 	public void testProcessApplicationMessageAddsPreSharedKeyIdentity() throws Exception {
 
 		// given an established session with a client using PSK authentication
-		clientConfig = new DtlsConnectorConfig.Builder(clientEndpoint)
+		clientConfig = new DtlsConnectorConfig.Builder()
+			.setAddress(clientEndpoint)
 			.setPskStore(new StaticPskStore(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()))
 			.build();
 		client = new DTLSConnector(clientConfig, clientConnectionStore);
@@ -1566,7 +1571,8 @@ public class DTLSConnectorTest {
 	public void testProcessApplicationMessageAddsX509CertPath() throws Exception {
 
 		// given an established session with a client using X.509 based authentication
-		clientConfig = new DtlsConnectorConfig.Builder(clientEndpoint)
+		clientConfig = new DtlsConnectorConfig.Builder()
+			.setAddress(clientEndpoint)
 			.setIdentity(DtlsTestTools.getClientPrivateKey(), DtlsTestTools.getClientCertificateChain(), false)
 			.setTrustStore(DtlsTestTools.getTrustedCertificates())
 			.build();
@@ -1588,7 +1594,8 @@ public class DTLSConnectorTest {
 
 		// given an established session with a server that doesn't require
 		// clients to authenticate
-		serverConfig = new DtlsConnectorConfig.Builder(serverEndpoint)
+		serverConfig = new DtlsConnectorConfig.Builder()
+				.setAddress(clientEndpoint)
 				.setIdentity(DtlsTestTools.getPrivateKey(), DtlsTestTools.getServerCertificateChain(), true)
 				.setClientAuthenticationRequired(false)
 				.build();

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/config/DtlsConnectorConfigTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/config/DtlsConnectorConfigTest.java
@@ -47,7 +47,7 @@ public class DtlsConnectorConfigTest {
 	@Before
 	public void setUp() throws Exception {
 		endpoint =  new InetSocketAddress(InetAddress.getLocalHost(), 10000);
-		builder = new DtlsConnectorConfig.Builder(endpoint);
+		builder = new DtlsConnectorConfig.Builder().setAddress(endpoint);
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
@@ -20,8 +20,7 @@
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import java.net.InetAddress;
@@ -133,7 +132,8 @@ public class ClientHandshakerTest {
 
 	private void givenAClientHandshaker(final InetSocketAddress peer, final boolean configureTrustStore) throws Exception {
 		DtlsConnectorConfig.Builder builder = 
-				new DtlsConnectorConfig.Builder(new InetSocketAddress(InetAddress.getLocalHost(), 0))
+				new DtlsConnectorConfig.Builder()
+					.setAddress(new InetSocketAddress(InetAddress.getLocalHost(), 0))
 					.setIdentity(
 						DtlsTestTools.getClientPrivateKey(),
 						DtlsTestTools.getClientCertificateChain(),

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
@@ -24,9 +24,7 @@
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
@@ -34,7 +32,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
-import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.LinkedList;
@@ -47,8 +44,8 @@ import org.eclipse.californium.scandium.dtls.CertificateTypeExtension.Certificat
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedGroup;
 import org.eclipse.californium.scandium.dtls.pskstore.StaticPskStore;
-import org.eclipse.californium.scandium.util.ServerNames;
 import org.eclipse.californium.scandium.util.ServerName.NameType;
+import org.eclipse.californium.scandium.util.ServerNames;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -86,7 +83,8 @@ public class ServerHandshakerTest {
 		endpoint = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 		session = new DTLSSession(endpoint, false);
 		recordLayer = new SimpleRecordLayer();
-		config = new DtlsConnectorConfig.Builder(endpoint)
+		config = new DtlsConnectorConfig.Builder()
+				.setAddress(endpoint)
 				.setIdentity(privateKey, certificateChain, false)
 				.setTrustStore(trustedCertificates)
 				.setSupportedCipherSuites(new CipherSuite[]{SERVER_CIPHER_SUITE})
@@ -211,7 +209,8 @@ public class ServerHandshakerTest {
 
 		// GIVEN a server handshaker that supports a public key based cipher using RawPublicKeys
 		// only as well as a pre-shared key based cipher
-		config = new DtlsConnectorConfig.Builder(endpoint)
+		config = new DtlsConnectorConfig.Builder()
+				.setAddress(endpoint)
 				.setIdentity(privateKey, DtlsTestTools.getPublicKey())
 				.setSupportedCipherSuites(new CipherSuite[]{
 						CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,


### PR DESCRIPTION
The idea was to allow to external lib to complete a user configuration.

I'm sure this is not so clear, so you can have a look at Leshan issues (https://github.com/eclipse/leshan/pull/350, https://github.com/eclipse/leshan/pull/356) to better understand the needs.