### PR TITLE
Use isSendRawKey generally to priorize raw public certificates.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -26,6 +26,8 @@
  *    Kai Hudalla (Bosch Software Innovations GmbH) - derive max fragment length from network MTU
  *    Kai Hudalla (Bosch Software Innovations GmbH) - use SessionListener to trigger sending of pending
  *                                                    APPLICATION messages
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use isSendRawKey also for 
+ *                                                    supportedServerCertificateTypes
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -151,10 +153,11 @@ public class ClientHandshaker extends Handshaker {
 		this.preferredCipherSuites = config.getSupportedCipherSuites();
 		this.maxFragmentLengthCode = config.getMaxFragmentLengthCode();
 		this.supportedServerCertificateTypes = new ArrayList<>();
-		if (rootCertificates != null && rootCertificates.length > 0) {
-			this.supportedServerCertificateTypes.add(CertificateType.X_509);
-		}
 		this.supportedServerCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
+		if (rootCertificates != null && rootCertificates.length > 0) {
+			int index = config.isSendRawKey() ? 1 : 0;
+			this.supportedServerCertificateTypes.add(index, CertificateType.X_509);
+		}
 
 		this.supportedClientCertificateTypes = new ArrayList<>();
 		if (privateKey != null && publicKey != null) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -31,6 +31,8 @@
  *    Kai Hudalla (Bosch Software Innovations GmbH) - derive max fragment length from network MTU
  *    Kai Hudalla (Bosch Software Innovations GmbH) - support MaxFragmentLength Hello extension sent by client
  *    Achim Kraus (Bosch Software Innovations GmbH) - don't ignore retransmission of last flight
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use isSendRawKey also for 
+ *                                                    supportedClientCertificateTypes
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -194,7 +196,8 @@ public class ServerHandshaker extends Handshaker {
 		this.supportedClientCertificateTypes = new ArrayList<>();
 		this.supportedClientCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
 		if (rootCertificates != null && rootCertificates.length > 0) {
-			this.supportedClientCertificateTypes.add(CertificateType.X_509);
+			int index = config.isSendRawKey() ? 1 : 0;
+			this.supportedClientCertificateTypes.add(index, CertificateType.X_509);
 		}
 
 		this.supportedServerCertificateTypes = new ArrayList<>();


### PR DESCRIPTION
Currently isSendRawKey is only used to indicate, that the own priority
would be a raw public certificate, but doesn't use that to priorize the
requested certificate type.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>