### PR TITLE
Add endpoint id to correlation context for matching based on that.

### DIFF
--- a/californium-core/pom.xml
+++ b/californium-core/pom.xml
@@ -135,6 +135,17 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CorrelationContextMatcherFactory.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CorrelationContextMatcherFactory.java
@@ -16,6 +16,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - create CorrelationContextMatcher
  *                                      related to connector
  *    Achim Kraus (Bosch Software Innovations GmbH) - add TCP support
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add ENDPOINT_ID_MATCHING
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -23,6 +24,7 @@ import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.CorrelationContextMatcher;
+import org.eclipse.californium.elements.EndpointCorrelationContextMatcher;
 import org.eclipse.californium.elements.RelaxedDtlsCorrelationContextMatcher;
 import org.eclipse.californium.elements.StrictDtlsCorrelationContextMatcher;
 import org.eclipse.californium.elements.TcpCorrelationContextMatcher;
@@ -60,7 +62,12 @@ public class CorrelationContextMatcherFactory {
 				return new TcpCorrelationContextMatcher();
 			}
 		}
-		return config.getBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING) ? new StrictDtlsCorrelationContextMatcher()
-				: new RelaxedDtlsCorrelationContextMatcher();
+		if (config.getBoolean(NetworkConfig.Keys.USE_ENDPOINT_ID_MATCHING)) {
+			return new EndpointCorrelationContextMatcher();
+		} else if (config.getBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING)) {
+			return new StrictDtlsCorrelationContextMatcher();
+		} else {
+			return new RelaxedDtlsCorrelationContextMatcher();
+		}
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -21,6 +21,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - add InputStream support for environments
  *                                                    without file access.
  *    Achim Kraus (Bosch Software Innovations GmbH) - add new keys for MID tracker
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add USE_ENDPOINT_ID_MATCHING
  ******************************************************************************/
 package org.eclipse.californium.core.network.config;
 
@@ -180,6 +181,7 @@ public final class NetworkConfig {
 		public static final String CROP_ROTATION_PERIOD = "CROP_ROTATION_PERIOD";
 		public static final String NO_DEDUPLICATOR = "NO_DEDUPLICATOR";
 		public static final String USE_STRICT_RESPONSE_MATCHING = "USE_STRICT_RESPONSE_MATCHING";
+		public static final String USE_ENDPOINT_ID_MATCHING = "USE_ENDPOINT_ID_MATCHING";
 
 		public static final String HTTP_PORT = "HTTP_PORT";
 		public static final String HTTP_SERVER_SOCKET_TIMEOUT = "HTTP_SERVER_SOCKET_TIMEOUT";

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
@@ -21,6 +21,7 @@
  *                                                    DEFAULT_MID_TRACKER,
  *                                                    DEFAULT_MID_TRACKER_GROUPS, and
  *                                                    DEFAULT_EXCHANGE_LIFETIME
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add USE_ENDPOINT_ID_MATCHING
  ******************************************************************************/
 package org.eclipse.californium.core.network.config;
 
@@ -142,6 +143,7 @@ public class NetworkConfigDefaults {
 		config.setLong(NetworkConfig.Keys.MARK_AND_SWEEP_INTERVAL, 10 * 1000); // 10 secs
 		config.setInt(NetworkConfig.Keys.CROP_ROTATION_PERIOD, 2000);
 		config.setBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING, false);
+		config.setBoolean(NetworkConfig.Keys.USE_ENDPOINT_ID_MATCHING, false);
 
 		config.setInt(NetworkConfig.Keys.HTTP_PORT, 8080);
 		config.setInt(NetworkConfig.Keys.HTTP_SERVER_SOCKET_TIMEOUT, 100000);

--- a/demo-apps/cf-secure/pom.xml
+++ b/demo-apps/cf-secure/pom.xml
@@ -22,9 +22,33 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>element-connector</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<classifier>tests</classifier>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>element-connector</artifactId>
+			<classifier>tests</classifier>
+		</dependency>
+		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>californium-core</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>californium-core</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<classifier>tests</classifier>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/demo-apps/cf-secure/src/test/java/org/eclipse/californium/secure/test/FixPskStore.java
+++ b/demo-apps/cf-secure/src/test/java/org/eclipse/californium/secure/test/FixPskStore.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - initial implementation.
+ *                                                    Modified variant of ManInTheMiddle
+ ******************************************************************************/
+
+package org.eclipse.californium.secure.test;
+
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+
+import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
+import org.eclipse.californium.scandium.util.ServerNames;
+
+public class FixPskStore implements PskStore {
+
+	final String identity;
+	final byte[] key;
+	
+	public FixPskStore(String identity, byte[] key) {
+		this.identity = identity;
+		this.key = Arrays.copyOf(key, key.length);
+	}
+	
+	@Override
+	public byte[] getKey(String identity) {
+		return key;
+	}
+
+	@Override
+	public byte[] getKey(ServerNames serverNames, String identity) {
+		return key;
+	}
+
+	@Override
+	public String getIdentity(InetSocketAddress inetAddress) {
+		return identity;
+	}
+
+}

--- a/demo-apps/cf-secure/src/test/java/org/eclipse/californium/secure/test/SecureObserveTest.java
+++ b/demo-apps/cf-secure/src/test/java/org/eclipse/californium/secure/test/SecureObserveTest.java
@@ -1,0 +1,309 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - initial implementation.
+ ******************************************************************************/
+package org.eclipse.californium.secure.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.californium.category.Medium;
+import org.eclipse.californium.core.CoapClient;
+import org.eclipse.californium.core.CoapHandler;
+import org.eclipse.californium.core.CoapObserveRelation;
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.CoapResponse;
+import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.EndpointManager;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.rule.CoapNetworkRule;
+import org.eclipse.californium.scandium.DTLSConnector;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Medium.class)
+public class SecureObserveTest {
+
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT,
+			CoapNetworkRule.Mode.NATIVE);
+
+	static final int REPEATS = 3;
+	static final String TARGET = "resource";
+	static final String RESPONSE = "hi";
+	static final String IDENITITY = "client1";
+	static final String KEY = "key1";
+
+	private TestNat nat;
+	private CoapServer server;
+	private DTLSConnector serverConnector;
+	private CoapEndpoint serverEndpoint;
+	private CoapEndpoint clientEndpoint;
+	private MyResource resource;
+
+	private String uri;
+
+	@Before
+	public void startupServer() {
+		System.out.println(System.lineSeparator() + "Start " + getClass().getSimpleName());
+		createSecureServer();
+	}
+
+	@After
+	public void shutdownServer() {
+		server.destroy();
+		System.out.println("End " + getClass().getSimpleName());
+	}
+
+	@Test
+	public void testSecureObserve() throws Exception {
+		CoapClient client = new CoapClient(uri);
+		CountingHandler handler = new CountingHandler();
+		CoapObserveRelation rel = client.observeAndWait(handler);
+
+		assertFalse("Observe relation not established!", rel.isCanceled());
+
+		// onLoad is called asynchronous to returning the response
+		// therefore wait for one onLoad
+		assertTrue(handler.waitForLoadCalls(1, 1000, TimeUnit.MILLISECONDS));
+
+		assertFalse("Response not received", rel.isCanceled());
+		assertNotNull("Response not received", rel.getCurrent());
+		assertEquals("\"resource says hi for the 1 time\"", rel.getCurrent().getResponseText());
+
+		for (int i = 0; i < REPEATS; ++i) {
+			resource.changed("client");
+			Thread.sleep(50);
+		}
+
+		assertTrue("Missing notifies", handler.waitForLoadCalls(REPEATS + 1, 1000, TimeUnit.MILLISECONDS));
+	}
+
+	@Test
+	public void testSecureObserveServerAddressChangedWithResume() throws Exception {
+		createNat();
+
+		CoapClient client = new CoapClient(uri);
+		CountingHandler handler = new CountingHandler();
+		CoapObserveRelation rel = client.observeAndWait(handler);
+
+		assertFalse("Observe relation not established!", rel.isCanceled());
+
+		// onLoad is called asynchronous to returning the response
+		// therefore wait for one onLoad
+		assertTrue(handler.waitForLoadCalls(1, 1000, TimeUnit.MILLISECONDS));
+
+		assertFalse("Response not received", rel.isCanceled());
+		assertNotNull("Response not received", rel.getCurrent());
+		assertEquals("\"resource says hi for the 1 time\"", rel.getCurrent().getResponseText());
+
+		for (int i = 0; i < REPEATS; ++i) {
+			resource.changed("client");
+			Thread.sleep(50);
+		}
+
+		assertTrue("Missing notifies", handler.waitForLoadCalls(REPEATS + 1, 1000, TimeUnit.MILLISECONDS));
+
+		nat.setChangeServerAddress(true);
+		serverConnector.forceResumeAllSessions();
+
+		for (int i = 0; i < REPEATS; ++i) {
+			resource.changed("client");
+			Thread.sleep(50);
+		}
+
+		assertTrue("Missing notifies after address change",
+				handler.waitForLoadCalls(REPEATS + REPEATS + 1, 1000, TimeUnit.MILLISECONDS));
+		nat.stop();
+	}
+
+	@Test
+	public void testSecureObserveServerAddressChangedWithNewHandshake() throws Exception {
+		createNat();
+
+		CoapClient client = new CoapClient(uri);
+		CountingHandler handler = new CountingHandler();
+		CoapObserveRelation rel = client.observeAndWait(handler);
+
+		assertFalse("Observe relation not established!", rel.isCanceled());
+
+		// onLoad is called asynchronous to returning the response
+		// therefore wait for one onLoad
+		assertTrue(handler.waitForLoadCalls(1, 1000, TimeUnit.MILLISECONDS));
+
+		assertFalse("Response not received", rel.isCanceled());
+		assertNotNull("Response not received", rel.getCurrent());
+		assertEquals("\"resource says hi for the 1 time\"", rel.getCurrent().getResponseText());
+
+		for (int i = 0; i < REPEATS; ++i) {
+			resource.changed("client");
+			Thread.sleep(50);
+		}
+
+		assertTrue("Missing notifies", handler.waitForLoadCalls(REPEATS + 1, 1000, TimeUnit.MILLISECONDS));
+
+		nat.setChangeServerAddress(true);
+		serverConnector.clearConnectionState();
+		resource.changed("client");
+		Thread.sleep(250);
+
+		for (int i = 0; i < REPEATS; ++i) {
+			resource.changed("client");
+			Thread.sleep(50);
+		}
+
+		assertTrue("Missing notifies after address change",
+				handler.waitForLoadCalls(REPEATS + REPEATS + 2, 1000, TimeUnit.MILLISECONDS));
+		nat.stop();
+	}
+
+	private void createSecureServer() {
+		FixPskStore pskStore = new FixPskStore(IDENITITY, KEY.getBytes());
+		DtlsConnectorConfig dtlsConfig = new DtlsConnectorConfig.Builder()
+				.setAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0)).setPskStore(pskStore).build();
+		// retransmit constantly all 200 milliseconds
+		NetworkConfig config = network.createTestConfig().setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200)
+				.setFloat(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1f).setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f)
+				.setBoolean(NetworkConfig.Keys.USE_ENDPOINT_ID_MATCHING, true);
+		serverConnector = new DTLSConnector(dtlsConfig);
+		serverEndpoint = new CoapEndpoint(serverConnector, config);
+
+		server = new CoapServer();
+		server.addEndpoint(serverEndpoint);
+		resource = new MyResource(TARGET);
+		server.add(resource);
+		server.start();
+
+		uri = serverEndpoint.getUri().toString() + "/" + TARGET;
+
+		// prepare secure client endpoint
+		DtlsConnectorConfig clientdtlsConfig = new DtlsConnectorConfig.Builder()
+				.setAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0)).setPskStore(pskStore).build();
+		clientEndpoint = new CoapEndpoint(new DTLSConnector(clientdtlsConfig), config);
+		EndpointManager.getEndpointManager().setDefaultEndpoint(clientEndpoint);
+	}
+
+	private void createNat() throws Exception {
+		nat = new TestNat(InetAddress.getLoopbackAddress(), clientEndpoint.getAddress().getPort(),
+				serverEndpoint.getAddress().getPort());
+		uri = uri.replace(Integer.toString(serverEndpoint.getAddress().getPort()), Integer.toString(nat.getPort1()));
+	}
+
+	private static class MyResource extends CoapResource {
+
+		private volatile Type type = Type.NON;
+		private volatile String currentLabel;
+		private volatile String currentResponse;
+		private AtomicInteger counter = new AtomicInteger();
+
+		public MyResource(String name) {
+			super(name);
+			prepareResponse();
+			setObservable(true);
+		}
+
+		@Override
+		public void handleGET(CoapExchange exchange) {
+			Response response = new Response(ResponseCode.CONTENT);
+			response.setPayload(currentResponse);
+			response.setType(type);
+			exchange.respond(response);
+		}
+
+		@Override
+		public void changed() {
+			prepareResponse();
+			super.changed();
+		}
+
+		public void changed(String label) {
+			currentLabel = label;
+			changed();
+		}
+
+		public void prepareResponse() {
+			int count = counter.incrementAndGet();
+			if (null == currentLabel) {
+				currentResponse = String.format("\"%s says hi for the %d time\"", getName(), count);
+			} else {
+				currentResponse = String.format("\"%s says %s for the %d time\"", getName(), currentLabel, count);
+			}
+			System.out.println("Resource " + getName() + " changed to " + currentResponse);
+		}
+
+	}
+
+	private class CountingHandler implements CoapHandler {
+
+		public AtomicInteger loadCalls = new AtomicInteger();
+		public AtomicInteger errorCalls = new AtomicInteger();
+
+		@Override
+		public void onLoad(CoapResponse response) {
+			int counter;
+			synchronized (this) {
+				counter = loadCalls.incrementAndGet();
+				notifyAll();
+			}
+			System.out.println("Received " + counter + ". Notification: " + response.advanced());
+		}
+
+		@Override
+		public void onError() {
+			int counter;
+			synchronized (this) {
+				counter = errorCalls.incrementAndGet();
+				notifyAll();
+			}
+			System.out.println(counter + " Errors!");
+		}
+
+		public boolean waitForLoadCalls(final int counter, final long timeout, final TimeUnit unit)
+				throws InterruptedException {
+			return waitForCalls(counter, timeout, unit, loadCalls);
+		}
+
+		private synchronized boolean waitForCalls(final int counter, final long timeout, final TimeUnit unit,
+				AtomicInteger calls) throws InterruptedException {
+			if (0 < timeout) {
+				long end = System.nanoTime() + unit.toNanos(timeout);
+				while (calls.get() < counter) {
+					long left = TimeUnit.NANOSECONDS.toMillis(end - System.nanoTime());
+					if (0 < left) {
+						wait(left);
+					} else {
+						break;
+					}
+				}
+			}
+			return calls.get() >= counter;
+		}
+	}
+}

--- a/demo-apps/cf-secure/src/test/java/org/eclipse/californium/secure/test/TestNat.java
+++ b/demo-apps/cf-secure/src/test/java/org/eclipse/californium/secure/test/TestNat.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - initial implementation.
+ *                                                    Modified variant of ManInTheMiddle
+ ******************************************************************************/
+
+package org.eclipse.californium.secure.test;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+
+public class TestNat {
+
+	private static final int DATAGRAM_SIZE = 2000;
+
+	private final int clientPort;
+	private final int serverPort;
+
+	private DatagramSocket socket1;
+	private DatagramSocket socket2;
+	private DatagramPacket packet1;
+	private DatagramPacket packet2;
+
+	private volatile boolean running = true;
+	private volatile boolean changeServerAddress = false;
+
+	public TestNat(final InetAddress bindAddress, final int clientPort, final int serverPort) throws Exception {
+
+		this.clientPort = clientPort;
+		this.serverPort = serverPort;
+
+		if (bindAddress == null) {
+			this.socket1 = new DatagramSocket();
+			this.socket2 = new DatagramSocket();
+		} else {
+			this.socket1 = new DatagramSocket(0, bindAddress);
+			this.socket2 = new DatagramSocket(0, bindAddress);
+		}
+		this.packet1 = new DatagramPacket(new byte[DATAGRAM_SIZE], DATAGRAM_SIZE);
+		this.packet2 = new DatagramPacket(new byte[DATAGRAM_SIZE], DATAGRAM_SIZE);
+
+		new Thread(new Runnable() {
+
+			@Override
+			public void run() {
+				runNat(packet1, socket1, socket2);
+			}
+		}).start();
+		new Thread(new Runnable() {
+
+			@Override
+			public void run() {
+				runBack(packet2, socket1, socket2);
+			}
+		}).start();
+	}
+
+	private void runNat(DatagramPacket packet, DatagramSocket socketRecv, DatagramSocket socketSec) {
+		try {
+			System.out.println("Starting test-NAT...");
+			while (running) {
+				packet.setLength(DATAGRAM_SIZE);
+				socketRecv.receive(packet);
+				DatagramSocket send = socketRecv;
+				System.out.println("Forward " + packet.getLength() + " bytes.");
+				boolean isClientPacket = packet.getPort() == clientPort;
+				if (isClientPacket) {
+					packet.setPort(serverPort);
+				} else {
+					packet.setPort(clientPort);
+					if (changeServerAddress) {
+						send = socketSec;
+					}
+				}
+				send.send(packet);
+			}
+		} catch (SocketException e) {
+			if (running) {
+				e.printStackTrace();
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	private void runBack(DatagramPacket packet, DatagramSocket socketRecv, DatagramSocket socketSec) {
+		try {
+			System.out.println("Starting test-NAT (backwards) ...");
+			while (running) {
+				packet.setLength(DATAGRAM_SIZE);
+				socketSec.receive(packet);
+				System.out.println("Backward " + packet.getLength() + " bytes.");
+				boolean isClientPacket = packet.getPort() == clientPort;
+				if (isClientPacket) {
+					packet.setPort(serverPort);
+				} else {
+					packet.setPort(clientPort);
+				}
+				socketRecv.send(packet);
+			}
+		} catch (SocketException e) {
+			if (running) {
+				e.printStackTrace();
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	public void stop() {
+		running = false;
+		socket1.close();
+		socket2.close();
+	}
+
+	public void setChangeServerAddress(boolean change) {
+		changeServerAddress = change;
+	}
+
+	public int getPort1() {
+		return socket1.getLocalPort();
+	}
+
+	public int getPort2() {
+		return socket2.getLocalPort();
+	}
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/CorrelationContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/CorrelationContext.java
@@ -14,6 +14,7 @@
  *    Bosch Software Innovations GmbH - add support for correlation context to provide
  *                                      additional information to application layer for
  *                                      matching messages (fix GitHub issue #1)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add KEY_ENDPOINT_ID.
  ******************************************************************************/
 package org.eclipse.californium.elements;
 
@@ -25,6 +26,15 @@ import java.util.Set;
  * which a message has been sent or received.
  */
 public interface CorrelationContext {
+
+	/**
+	 * Key for endpoint identity.
+	 * 
+	 * Used to access the endpoint identity, if supported by the connector.
+	 * 
+	 * @see #get(String)
+	 */
+	final String KEY_ENDPOINT_ID = "ENDPOINT";
 
 	/**
 	 * Gets a value from this context.

--- a/element-connector/src/main/java/org/eclipse/californium/elements/DtlsCorrelationContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/DtlsCorrelationContext.java
@@ -14,6 +14,7 @@
  *    Bosch Software Innovations GmbH - add support for correlation context to provide
  *                                      additional information to application layer for
  *                                      matching messages (fix GitHub issue #1)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add endpoint id.
  ******************************************************************************/
 package org.eclipse.californium.elements;
 
@@ -33,7 +34,9 @@ public class DtlsCorrelationContext extends MapBasedCorrelationContext {
 	 * @param epoch the session's current read/write epoch.
 	 * @param cipher the cipher suite of the session's current read/write state.
 	 * @throws NullPointerException if any of the params is <code>null</code>.
+	 * @deprecated
 	 */
+	@Deprecated
 	public DtlsCorrelationContext(String sessionId, String epoch, String cipher) {
 		if (sessionId == null) {
 			throw new NullPointerException("Session ID must not be null");
@@ -47,7 +50,24 @@ public class DtlsCorrelationContext extends MapBasedCorrelationContext {
 			put(KEY_CIPHER, cipher);
 		}
 	}
-
+	
+	public DtlsCorrelationContext(String endpointId, String sessionId, String epoch, String cipher) {
+		if (endpointId == null) {
+			throw new NullPointerException("Endpoint ID must not be null");
+		} else if (sessionId == null) {
+			throw new NullPointerException("Session ID must not be null");
+		} else if (epoch == null) {
+			throw new NullPointerException("Epoch must not be null");
+		} else if (cipher == null) {
+			throw new NullPointerException("Cipher must not be null");
+		} else {
+			put(KEY_ENDPOINT_ID, endpointId);
+			put(KEY_SESSION_ID, sessionId);
+			put(KEY_EPOCH, epoch);
+			put(KEY_CIPHER, cipher);
+		}
+	}
+	
 	public String getSessionId() {
 		return get(KEY_SESSION_ID);
 	}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointCorrelationContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointCorrelationContext.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - initial implementation.
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+/**
+ * A correlation context that supports endpoint identity.
+ */
+public class EndpointCorrelationContext extends MapBasedCorrelationContext {
+
+	/**
+	 * Creates a new correlation context from endpoint identity.
+	 * 
+	 * @param endpointId the endpoint identifier.
+	 * @throws NullPointerException if endpointId is <code>null</code>.
+	 */
+	public EndpointCorrelationContext(String endpointId) {
+		if (endpointId == null) {
+			throw new NullPointerException("endpoint ID must not be null");
+		} else {
+			put(KEY_ENDPOINT_ID, endpointId);
+		}
+	}
+
+	public String getEndpointId() {
+		return get(KEY_ENDPOINT_ID);
+	}
+
+	@Override
+	public String toString() {
+		return String.format("EPID(%s)", getEndpointId());
+	}
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointCorrelationContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointCorrelationContextMatcher.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+/**
+ * Endpoint correlation context matcher. Matches based on endpoint identifier.
+ */
+public class EndpointCorrelationContextMatcher extends KeySetCorrelationContextMatcher {
+
+	private static final String KEYS[] = { CorrelationContext.KEY_ENDPOINT_ID };
+
+	public EndpointCorrelationContextMatcher() {
+		super("endpoint correlation", KEYS);
+	}
+
+	@Override
+	public boolean isToBeSent(CorrelationContext messageContext, CorrelationContext connectorContext) {
+		if (null != messageContext && null == connectorContext) {
+			String id = messageContext.get(CorrelationContext.KEY_ENDPOINT_ID);
+			return null != id && !id.isEmpty();
+		}
+		return super.isToBeSent(messageContext, connectorContext);
+	}
+
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -56,6 +56,8 @@
  *                                                    handleTimeout,
  *                                                    and add error callback in
  *                                                    newDeferredMessageSender.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add peer identity name as
+ *                                                    endpoint id
  ******************************************************************************/
 package org.eclipse.californium.scandium;
 
@@ -723,6 +725,7 @@ public class DTLSConnector implements Connector {
 	private void handleApplicationMessage(ApplicationMessage message, DTLSSession session) {
 		if (messageHandler != null) {
 			DtlsCorrelationContext context = new DtlsCorrelationContext(
+					session.getPeerIdentity().getName(),
 					session.getSessionIdentifier().toString(),
 					String.valueOf(session.getReadEpoch()),
 					session.getReadStateCipher());
@@ -1360,6 +1363,7 @@ public class DTLSConnector implements Connector {
 	private void sendMessage(final RawData message, final DTLSSession session) {
 		try {
 			final CorrelationContext ctx = new DtlsCorrelationContext(
+					session.getPeerIdentity().getName(),
 					session.getSessionIdentifier().toString(),
 					String.valueOf(session.getWriteEpoch()),
 					session.getWriteStateCipher());

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -24,6 +24,8 @@
  *    Kai Hudalla (Bosch Software Innovations GmbH) - use DtlsTestTools' accessors to explicitly retrieve
  *                                                    client & server keys and certificate chains
  *    Bosch Software Innovations GmbH - add test cases for GitHub issue #1
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add server principals for
+ *                                                    endpoint id matcher tests
  ******************************************************************************/
 package org.eclipse.californium.scandium;
 
@@ -44,7 +46,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
+import org.eclipse.californium.scandium.auth.RawPublicKeyIdentity;
+import org.eclipse.californium.scandium.auth.X509CertPath;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.dtls.CertificateMessage;
 import org.eclipse.californium.scandium.dtls.Connection;
 import org.eclipse.californium.scandium.dtls.DTLSSession;
 import org.eclipse.californium.scandium.dtls.DtlsTestTools;
@@ -73,6 +78,8 @@ public class ConnectorHelper {
 	SimpleRawDataChannel serverRawDataChannel;
 	RawDataProcessor serverRawDataProcessor;
 	DTLSSession establishedServerSession;
+	Principal serverRawPrincipal;
+	Principal serverX509Principal;
 
 	private static DtlsConnectorConfig serverConfig;
 
@@ -119,6 +126,10 @@ public class ConnectorHelper {
 		server.setRawDataReceiver(serverRawDataChannel);
 		server.start();
 		serverEndpoint = server.getAddress();
+
+		serverRawPrincipal = new RawPublicKeyIdentity(serverConfig.getPublicKey());
+		CertificateMessage message = new CertificateMessage(serverConfig.getCertificateChain(), serverEndpoint);
+		serverX509Principal = new X509CertPath(message.getCertificateChain());
 	}
 
 	/**


### PR DESCRIPTION
This introduces a endpoint id to the correlation context and is intended
as "work in progress". The test in the cf-secure demo shows, how
notifies could be processed with this approach. Currently the
ObservationStore is not extended and therefore this is also based on
unique tokens. 

NOT INTENDED TO BE MERGED!

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>