### PR TITLE
Improve ToHex String from Scandium

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -586,7 +586,9 @@ public class ClientHandshaker extends Handshaker {
 				if (key != null) {
 					rawPublicKeyBytes = key.getEncoded();
 				}
-				LOGGER.log(Level.FINE, "sending CERTIFICATE message with client RawPublicKey [{0}] to server", ByteArrayUtils.toHexString(rawPublicKeyBytes));
+				if (LOGGER.isLoggable(Level.FINE)) {
+					LOGGER.log(Level.FINE, "sending CERTIFICATE message with client RawPublicKey [{0}] to server", ByteArrayUtils.toHexString(rawPublicKeyBytes));
+				}
 				clientCertificate = new CertificateMessage(rawPublicKeyBytes, session.getPeer());
 			} else {
 				X509Certificate[] clientChain = determineClientCertificateChain(certificateRequest);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/util/ByteArrayUtils.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/util/ByteArrayUtils.java
@@ -143,27 +143,20 @@ public class ByteArrayUtils {
 	/**
 	 * Takes a byte array and returns it HEX representation.
 	 * 
-	 * @param byteArray
-	 *            the byte array.
+	 * @param bytes the byte array.
 	 * @return the HEX representation.
 	 */
-	public static String toHexString(byte[] byteArray) {
-
-		if (byteArray != null && byteArray.length != 0) {
-
-			StringBuilder builder = new StringBuilder(byteArray.length * 3);
-			for (int i = 0; i < byteArray.length; i++) {
-				builder.append(String.format("%02X", 0xFF & byteArray[i]));
-
-				if (i < byteArray.length - 1) {
-					builder.append(' ');
-				}
-			}
-			return builder.toString();
-		} else {
-			return "--";
+	public static String toHexString(byte[] bytes) {
+		char[] hexChars = new char[bytes.length * 2];
+		for (int j = 0; j < bytes.length; j++) {
+			int v = bytes[j] & 0xFF;
+			hexChars[j * 2] = hexArray[v >>> 4];
+			hexChars[j * 2 + 1] = hexArray[v & 0x0F];
 		}
+		return new String(hexChars);
 	}
+
+	private final static char[] hexArray = "0123456789ABCDEF".toCharArray();
 
 	/**
 	 * Takes a HEX stream and returns the corresponding byte array.


### PR DESCRIPTION
I'm still hunting hotspot and see that the `ByteArrayUtils.toHexString(byte[])`  is really really slow.

```
Benchmark                     Mode  Cnt        Score       Error  Units
ToHexTest.testApacheToHex    thrpt   20  2497947,633 ± 98144,759  ops/s
ToHexTest.testScandiumToHex  thrpt   20     7149,110 ±   212,437  ops/s
ToHexTest.testStackOverFlow  thrpt   20  3117261,835 ± 29545,251  ops/s
```

I was going to replace it by the apache commons codec one (same we use in Leshan) but I see that the proposed one in [stackoverflow](https://stackoverflow.com/questions/9655181/how-to-convert-a-byte-array-to-a-hex-string-in-java/9855338#9855338) is even better.

This `toHexString` method is mainly called on 
```java
DtlsCorrelationContext context = new DtlsCorrelationContext(
					session.getSessionIdentifier().toString(),
					String.valueOf(session.getReadEpoch()),
					session.getReadStateCipher());
```
in DTLSConnector (`session.getSessionIdentifier.toString()`), the others call is generally guarded by a `if LOGGER.isLoggable()`.