### PR TITLE
Cleanup notify exchange when replaced by newer notify.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -28,6 +28,8 @@
  *                                                    issue #311
  *    Achim Kraus (Bosch Software Innovations GmbH) - forward setTimedOut to messages.
  *    Achim Kraus (Bosch Software Innovations GmbH) - stop retransmission on complete.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - adjust javadoc for 
+ *                                                    completeCurrentRequest.
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -519,11 +521,15 @@ public class Exchange {
 	}
 
 	/**
+	 * Complete exchange using the current request and response.
+	 * 
 	 * This method is only needed when the same {@link Exchange} instance uses
-	 * different tokens during its lifetime, e.g., when using a different token
-	 * for retrieving the rest of a blockwise notification (when not altered,
-	 * Californium reuses the same token for this). See {@link BlockwiseLayer}
-	 * for an example use case.
+	 * different tokens or MIDs during its lifetime, e.g., when using a different
+	 * token for retrieving the rest of a blockwise notification (when not altered,
+	 * Californium reuses the same token for this). Or when different CON notifies
+	 * are sent with different MIDs. 
+	 * <p>
+	 * See {@link BlockwiseLayer} or {@link ObserveLayer} for an example use case.
 	 */
 	public void completeCurrentRequest() {
 		setRetransmissionHandle(null);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
@@ -25,6 +25,8 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - fix copy & paste error
  *                                                    replace "response" with "next" in
  *                                                    onAcknowledgement()
+ *    Achim Kraus (Bosch Software Innovations GmbH) - complete old notification
+ *                                                    exchange
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -227,6 +229,8 @@ public class ObserveLayer extends AbstractLayer {
 					// Cancel the original retransmission and send the fresh
 					// notification here
 					response.cancel();
+					// Using new MIDs requires to cleanup the current exchange with old MID.
+					exchange.completeCurrentRequest();
 					// Convert all notification retransmissions to CON
 					if (next.getType() != Type.CON) {
 						next.setType(Type.CON);


### PR DESCRIPTION
Complete old notification exchange.

We may also rename `Exchange.completeCurrentRequest()`, but this would trigger some other files to change. So, if we have a conclusion for a better name, I would rename then once.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>