### PR TITLE
remove deduplication of ACK messages

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
@@ -353,10 +353,12 @@ public class Matcher {
 				// See issue #275
 				return null;
 			}
-			
-			// There is an exchange with the given token
-			Exchange prev = deduplicator.findPrevious(idByMID, exchange);
-			if (prev != null) { // (and thus it holds: prev == exchange)
+
+			// we have received a Response matching the token of an ongoing Exchange's Request
+			// according to the CoAP spec (https://tools.ietf.org/html/rfc7252#section-4.5),
+			// message deduplication is relevant for CON and NON messages only
+			if ((response.getType() == CoAP.Type.CON || response.getType() == CoAP.Type.NON) &&
+					deduplicator.findPrevious(idByMID, exchange) != null) {
 				LOGGER.info("Duplicate response for open exchange: "+response);
 				response.setDuplicate(true);
 			} else {


### PR DESCRIPTION
as it is not relevant according to the [CoAP spec](https://tools.ietf.org/html/rfc7252#section-4.5)

This change is already implemented in Californium 2: https://github.com/eclipse/californium/commit/45897ef294a7874d0fcc5b9cff7f957c6ca18141#diff-942dc0e01246d1b1fb4a246c3a09a888R282