### PR TITLE
Do not wait client sequentially in ExampleDTLSClient

### DIFF
--- a/demo-apps/sc-dtls-example-client/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSClient.java
+++ b/demo-apps/sc-dtls-example-client/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSClient.java
@@ -29,13 +29,15 @@ import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
+import org.eclipse.californium.elements.util.DaemonThreadFactory;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.ScandiumLogger;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
@@ -45,20 +47,21 @@ public class ExampleDTLSClient {
 
 	static {
 		ScandiumLogger.initialize();
-		ScandiumLogger.setLevel(Level.FINE);
+		ScandiumLogger.setLevel(Level.WARNING);
 	}
 
 	private static final int DEFAULT_PORT = 5684;
+	private static final long DEFAULT_TIMEOUT_NANOS = TimeUnit.MILLISECONDS.toNanos(10000);
 	private static final Logger LOG = Logger.getLogger(ExampleDTLSClient.class.getName());
 	private static final String TRUST_STORE_PASSWORD = "rootPass";
 	private static final String KEY_STORE_PASSWORD = "endPass";
 	private static final String KEY_STORE_LOCATION = "certs/keyStore.jks";
 	private static final String TRUST_STORE_LOCATION = "certs/trustStore.jks";
-	private static final int NB_MESSAGE = 1000;
 
-	private static CountDownLatch latch;
+	private static int maxMessages = 0;
+	private static CountDownLatch messageCounter;
+
 	private DTLSConnector dtlsConnector;
-	private final AtomicLong count = new AtomicLong();
 
 	public ExampleDTLSClient() {
 		InputStream inTrust = null;
@@ -85,20 +88,14 @@ public class ExampleDTLSClient {
 					keyStore.getCertificateChain("client"), true);
 			builder.setTrustStore(trustedCertificates);
 			builder.setEnableAddressReuse(false);
-			builder.setConnectionThreadCount(2);
+			builder.setConnectionThreadCount(1);
 			dtlsConnector = new DTLSConnector(builder.build());
 			dtlsConnector.setRawDataReceiver(new RawDataChannel() {
 
 				@Override
 				public void receiveData(RawData raw) {
-					long c = count.incrementAndGet();
-					LOG.log(Level.INFO, "Received response: {0} {1}", new Object[] { new String(raw.getBytes()), c });
-					if (c < NB_MESSAGE) {
-						dtlsConnector
-								.send(new RawData(("HELLO WORLD " + c + ".").getBytes(), raw.getInetSocketAddress()));
-					} else {
-						latch.countDown();
-						dtlsConnector.destroy();
+					if (dtlsConnector.isRunning()) {
+						receive(raw);
 					}
 				}
 			});
@@ -119,8 +116,23 @@ public class ExampleDTLSClient {
 		}
 	}
 
-	public long nbMessageReceived() {
-		return count.get();
+	private void receive(RawData raw) {
+
+		messageCounter.countDown();
+		long c = messageCounter.getCount();
+		if (LOG.isLoggable(Level.INFO)) {
+			LOG.log(Level.INFO, "Received response: {0} {1}", new Object[] { new String(raw.getBytes()), c });
+		}
+		if (0 < c) {
+			try {
+				dtlsConnector.send(new RawData(("HELLO WORLD " + c + ".").getBytes(), raw.getInetSocketAddress()));
+			} catch (IllegalStateException e) {
+				LOG.log(Level.FINER, "send failed after " + (c - 1) + " messages!", e);
+			}
+		} else {
+			dtlsConnector.destroy();
+		}
+
 	}
 
 	private void start() {
@@ -136,55 +148,87 @@ public class ExampleDTLSClient {
 	}
 
 	private void stop() {
-		if (dtlsConnector.isRunning())
+		if (dtlsConnector.isRunning()) {
 			dtlsConnector.destroy();
+		}
 	}
 
 	public static void main(String[] args) throws InterruptedException {
-		int max = 1;
+		int clients = 1;
+		int messages = 100;
 		if (0 < args.length) {
-			max = Integer.parseInt(args[0]);
+			clients = Integer.parseInt(args[0]);
+			if (1 < args.length) {
+				messages = Integer.parseInt(args[1]);
+			}
 		}
-		latch = new CountDownLatch(max);
-		List<ExampleDTLSClient> clients = new ArrayList<>(max);
+		maxMessages = (messages * clients);
+		messageCounter = new CountDownLatch(maxMessages);
+		List<ExampleDTLSClient> clientList = new ArrayList<>(clients);
+		ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors(),
+				new DaemonThreadFactory("Aux#"));
+
+		System.out.println("Create " + clients + " DTLS example clients, expect to send " + maxMessages +" messages overall.");
+
+		final CountDownLatch start = new CountDownLatch(clients);
 
 		// Create & start clients
-		for (int index = 0; index < max; ++index) {
-			ExampleDTLSClient client = new ExampleDTLSClient();
-			client.start();
-			clients.add(client);
+		for (int index = 0; index < clients; ++index) {
+			final ExampleDTLSClient client = new ExampleDTLSClient();
+			clientList.add(client);
+			executor.execute(new Runnable() {
+
+				@Override
+				public void run() {
+					client.start();
+					start.countDown();
+				}
+			});
 		}
+		start.await();
+		System.out.println(clients + " DTLS example clients started.");
 
 		// Get peer address
 		InetSocketAddress peer;
-		if (args.length == 3) {
-			peer = new InetSocketAddress(args[1], Integer.parseInt(args[2]));
+		if (args.length == 4) {
+			peer = new InetSocketAddress(args[2], Integer.parseInt(args[3]));
 		} else {
 			peer = new InetSocketAddress(InetAddress.getLoopbackAddress(), DEFAULT_PORT);
 		}
 
 		// Start Test
 		long nanos = System.nanoTime();
-		for (ExampleDTLSClient client : clients) {
+		long lastMessageCountDown = messageCounter.getCount();
+
+		for (ExampleDTLSClient client : clientList) {
 			client.startTest(peer);
 		}
 
-		// Wait for it
-		latch.await(max * 50, TimeUnit.MILLISECONDS);
+		// Wait with timeout or all messages send.
+		while (!messageCounter.await(DEFAULT_TIMEOUT_NANOS, TimeUnit.NANOSECONDS)) {
+			long current = messageCounter.getCount();
+			if (lastMessageCountDown == current && current < maxMessages) {
+				// no new messages, clients are stale
+				// adjust start time with timeout
+				nanos += DEFAULT_TIMEOUT_NANOS; 
+				break;
+			}
+			lastMessageCountDown = current;
+		}
+		long count = maxMessages - messageCounter.getCount();
 		nanos = System.nanoTime() - nanos;
 
-		// Count messages
-		long count = 0;
-		for (ExampleDTLSClient client : clients) {
-			count += client.nbMessageReceived();
+		System.out.println(clients + " DTLS example clients finished.");
+
+		for (ExampleDTLSClient client : clientList) {
+			client.stop();
 		}
 
-		System.out.println(count + " messages received, " + (max * NB_MESSAGE) + " expected");
+		System.out.println(count + " messages received, " + (maxMessages) + " expected");
 		System.out.println(count + " messages in " + TimeUnit.NANOSECONDS.toMillis(nanos) + " ms");
 		System.out.println((count * 1000) / TimeUnit.NANOSECONDS.toMillis(nanos) + " messages per s");
-
-		for (ExampleDTLSClient client : clients) {
-			client.stop();
+		if (count < maxMessages) {
+			System.out.println("Stale at " + lastMessageCountDown + " messages");
 		}
 	}
 }

--- a/demo-apps/sc-dtls-example-server/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSServer.java
+++ b/demo-apps/sc-dtls-example-server/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSServer.java
@@ -38,10 +38,10 @@ public class ExampleDTLSServer {
 
 	static {
 		ScandiumLogger.initialize();
-		ScandiumLogger.setLevel(Level.FINE);
+		ScandiumLogger.setLevel(Level.WARNING);
 	}
 
-	private static final int DEFAULT_PORT = 5684; 
+	private static final int DEFAULT_PORT = 5684;
 	private static final Logger LOG = Logger.getLogger(ExampleDTLSServer.class.getName());
 	private static final String TRUST_STORE_PASSWORD = "rootPass";
 	private static final String KEY_STORE_PASSWORD = "endPass";
@@ -74,7 +74,7 @@ public class ExampleDTLSServer {
 			DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();
 			builder.setAddress(new InetSocketAddress(DEFAULT_PORT));
 			builder.setPskStore(pskStore);
-			builder.setIdentity((PrivateKey)keyStore.getKey("server", KEY_STORE_PASSWORD.toCharArray()),
+			builder.setIdentity((PrivateKey) keyStore.getKey("server", KEY_STORE_PASSWORD.toCharArray()),
 					keyStore.getCertificateChain("server"), true);
 			builder.setTrustStore(trustedCertificates);
 			dtlsConnector = new DTLSConnector(builder.build());
@@ -97,8 +97,9 @@ public class ExampleDTLSServer {
 	public void start() {
 		try {
 			dtlsConnector.start();
+			System.out.println("DTLS example server started");
 		} catch (IOException e) {
-			throw new IllegalStateException("Unexpected error starting the DTLS UDP server",e);
+			throw new IllegalStateException("Unexpected error starting the DTLS UDP server", e);
 		}
 	}
 
@@ -119,6 +120,11 @@ public class ExampleDTLSServer {
 
 	public static void main(String[] args) {
 
+		if (0 < args.length) {
+			if (args[0].equals("-v")) {
+				ScandiumLogger.setLevel(Level.INFO);
+			}
+		}
 		ExampleDTLSServer server = new ExampleDTLSServer();
 		server.start();
 	}


### PR DESCRIPTION
When I use ExampleDTLSClient with more than 300 client, it does not finished.
 I didn't find why, like if I face a packet lost even if  I'm on localhost.

Anyway I changed the code a little to make it stop on timeout. (not 1 timeout by client)