### PR TITLE
Use only one byte[] buffer for receiving message.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -180,6 +180,8 @@ public class DTLSConnector implements Connector {
 
 	/** The thread that receives messages */
 	private Worker receiver;
+	private byte[] receiverBuffer;
+	
 
 	/** The thread that sends messages */
 	private Worker sender;
@@ -392,6 +394,7 @@ public class DTLSConnector implements Connector {
 				}
 			};
 
+		receiverBuffer = new byte[inboundDatagramBufferSize];
 		receiver = new Worker("DTLS-Receiver-" + lastBindAddress) {
 				@Override
 				public void doWork() throws Exception {
@@ -491,8 +494,8 @@ public class DTLSConnector implements Connector {
 
 	private void receiveNextDatagramFromNetwork() throws IOException {
 
-		byte[] buffer = new byte[inboundDatagramBufferSize];
-		DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+		
+		DatagramPacket packet = new DatagramPacket(receiverBuffer, receiverBuffer.length);
 		DatagramSocket socket = getSocket();
 		if (socket == null) {
 			// very unlikely race condition.


### PR DESCRIPTION
Still playing with profiler.

Profiling ExampleDTLSServer againt ExampleDTLSClient (with 1000 clients/1000 message).
I see that DTLS-receiver Thread allocate 8,5 GB.
With this PR it goes down to 0,5GB.

In practice, I don't notice any performance improvement.