### PR TITLE
Add isEmptyWithDump() for more details in logs while testing. (2)

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
@@ -124,6 +124,7 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 		StringBuilder b = new StringBuilder("MessageExchangeStore contents: ");
 		b.append(exchangesByMID.size()).append(" exchanges by MID, ");
 		b.append(exchangesByToken.size()).append(" exchanges by token, ");
+		b.append(deduplicator.size()).append(" MIDs, ");
 		return b.toString();
 	}
 
@@ -163,8 +164,12 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 
 	@Override
 	public boolean isEmpty() {
-		LOGGER.finer(dumpCurrentLoadLevels());
 		return exchangesByMID.isEmpty() && exchangesByToken.isEmpty() && deduplicator.isEmpty();
+	}
+
+	@Override
+	public String toString() {
+		return dumpCurrentLoadLevels();
 	}
 
 	@Override
@@ -374,5 +379,17 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 	@Override
 	public void releaseToken(KeyToken keyToken) {
 		tokenProvider.releaseToken(keyToken);
+	}
+
+	public ConcurrentMap<KeyToken, Exchange> getExchangesByToken() {
+		return exchangesByToken;
+	}
+
+	public ConcurrentMap<KeyMID, Exchange> getExchangesByMID() {
+		return exchangesByMID;
+	}
+
+	public Deduplicator getDeduplicator() {
+		return deduplicator;
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/CropRotation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/CropRotation.java
@@ -18,6 +18,7 @@
  *    Kai Hudalla - logging
  *    Achim Kraus (Bosch Software Innovations GmbH) - make first and second
  *                                                    volatile
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add size() for test-logging
  ******************************************************************************/
 package org.eclipse.californium.core.network.deduplication;
 
@@ -127,6 +128,13 @@ public class CropRotation implements Deduplicator {
 			maps[0].clear();
 			maps[1].clear();
 			maps[2].clear();
+		}
+	}
+
+	@Override
+	public int size() {
+		synchronized (maps) {
+			return maps[0].size() + maps[1].size() + maps[2].size();
 		}
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/Deduplicator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/Deduplicator.java
@@ -16,6 +16,7 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add size() for test-logging
  ******************************************************************************/
 package org.eclipse.californium.core.network.deduplication;
 
@@ -62,6 +63,8 @@ public interface Deduplicator {
 	Exchange find(KeyMID key);
 
 	boolean isEmpty();
+
+	int size();
 
 	/**
 	 * Clears the state of this deduplicator.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/NoDeduplicator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/NoDeduplicator.java
@@ -16,6 +16,7 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add size() for test-logging
  ******************************************************************************/
 package org.eclipse.californium.core.network.deduplication;
 
@@ -52,5 +53,10 @@ public class NoDeduplicator implements Deduplicator {
 	@Override
 	public boolean isEmpty() {
 		return true;
+	}
+
+	@Override
+	public int size() {
+		return 0;
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/SweepDeduplicator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/SweepDeduplicator.java
@@ -20,7 +20,8 @@
  *                                                    explicit String concatenation
  *    Achim Kraus (Bosch Software Innovations GmbH) - use nanoTime instead of 
  *                                                    currentTimeMillis
- *    Achim Kraus (Bosch Software Innovations GmbH) - fix used milliseconds calculation 
+ *    Achim Kraus (Bosch Software Innovations GmbH) - fix used milliseconds calculation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add size() for test-logging
  *    Achim Kraus (Bosch Software Innovations GmbH) - use timestamp of add for deduplication 
  *    Achim Kraus (Bosch Software Innovations GmbH) - reduce logging for empty deduplicator.
  ******************************************************************************/
@@ -150,6 +151,11 @@ public final class SweepDeduplicator implements Deduplicator {
 	@Override
 	public boolean isEmpty() {
 		return incomingMessages.isEmpty();
+	}
+
+	@Override
+	public int size() {
+		return incomingMessages.size();
 	}
 
 	/**

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
@@ -26,9 +26,12 @@
  *                                                    preparing it for each test
  *                                                    by using setResponse() or 
  *                                                    setNotifies().
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use isEmptyWithDump() for
+ *                                                    more information on failure
  ******************************************************************************/
 package org.eclipse.californium.core.test;
 
+import static org.eclipse.californium.TestTools.isEmptyWithDump;
 import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.waitUntilDeduplicatorShouldBeEmpty;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -65,7 +68,6 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.InMemoryMessageExchangeStore;
-import org.eclipse.californium.core.network.MessageExchangeStore;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
 import org.eclipse.californium.core.server.resources.CoapExchange;
@@ -113,8 +115,8 @@ public class MemoryLeakingHashMapTest {
 	// The server endpoint that we test
 	private static CoapEndpoint serverEndpoint;
 	private static CoapEndpoint clientEndpoint;
-	private static MessageExchangeStore clientExchangeStore;
-	private static MessageExchangeStore serverExchangeStore;
+	private static InMemoryMessageExchangeStore clientExchangeStore;
+	private static InMemoryMessageExchangeStore serverExchangeStore;
 
 	private static volatile String currentRequestText;
 	private static TestResource resource;
@@ -149,8 +151,8 @@ public class MemoryLeakingHashMapTest {
 					return clientExchangeStore.isEmpty() && serverExchangeStore.isEmpty();
 				}
 			});
-			assertTrue("Client side message exchange store still contains exchanges", clientExchangeStore.isEmpty());
-			assertTrue("Server side message exchange store still contains exchanges", serverExchangeStore.isEmpty());
+			assertTrue("Client side message exchange store still contains exchanges", isEmptyWithDump(clientExchangeStore));
+			assertTrue("Server side message exchange store still contains exchanges", isEmptyWithDump(serverExchangeStore));
 		} finally {
 			clientExchangeStore.stop();
 			serverExchangeStore.stop();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
@@ -24,6 +24,8 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - split responseType in
  *                                                    type(Type... types) and
  *                                                    storeType(String var)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use isEmptyWithDump() for
+ *                                                    more information on failure
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
@@ -47,7 +49,6 @@ import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.InMemoryMessageExchangeStore;
-import org.eclipse.californium.core.network.MessageExchangeStore;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.rule.CoapNetworkRule;
@@ -87,7 +88,7 @@ public class BlockwiseServerSideTest {
 	private Integer expectedMid;
 	private byte[] expectedToken;
 	private ServerBlockwiseInterceptor serverInterceptor = new ServerBlockwiseInterceptor();
-	private MessageExchangeStore exchangeStore;
+	private InMemoryMessageExchangeStore exchangeStore;
 
 	@BeforeClass
 	public static void init() {
@@ -342,8 +343,8 @@ public class BlockwiseServerSideTest {
 			}
 		});
 		assertTrue(
-				"Incomplete ongoing blockwise exchange should have been evicted from message exchange store",
-				exchangeStore.isEmpty());
+				"Incomplete ongoing blockwise exchange should have been evicted from message exchange store: " + exchangeStore,
+				isEmptyWithDump(exchangeStore));
 	}
 
 	/**
@@ -388,8 +389,8 @@ public class BlockwiseServerSideTest {
 			}
 		});
 		assertTrue(
-				"Incomplete ongoing blockwise exchange should have been evicted from message exchange store",
-				exchangeStore.isEmpty());
+				"Incomplete ongoing blockwise exchange should have been evicted from message exchange store: " + exchangeStore,
+				isEmptyWithDump(exchangeStore));
 	}
 
 	/**

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -50,7 +50,6 @@ import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.InMemoryMessageExchangeStore;
-import org.eclipse.californium.core.network.MessageExchangeStore;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
 import org.eclipse.californium.rule.CoapNetworkRule;
@@ -76,7 +75,7 @@ public class ObserveClientSideTest {
 
 	private static NetworkConfig CONFIG;
 
-	private MessageExchangeStore clientExchangeStore;
+	private InMemoryMessageExchangeStore clientExchangeStore;
 	private LockstepEndpoint server;
 	private Endpoint client;
 	private int mid = 8000;
@@ -121,7 +120,7 @@ public class ObserveClientSideTest {
 					return clientExchangeStore.isEmpty();
 				}
 			});
-			assertTrue("Client side message exchange store still contains exchanges", clientExchangeStore.isEmpty());
+			assertTrue("Client side message exchange store still contains exchanges", isEmptyWithDump(clientExchangeStore));
 		} finally {
 			printServerLog(clientInterceptor);
 			


### PR DESCRIPTION
I try to rewrite #326 without adding the `isEmptyWithDump()` method to `MessageExchangeStore`.

The idea is to make the `InMemoryMessageExchangeStore` more monitorable by exposing internal structure.
This way tests could use it for logging but  we can also imagine users could monitor it in production. E.g. by pushing periodically the number of exchanges in something like grafana.