### PR TITLE
Fix some transparent block2 issues.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
@@ -345,7 +345,7 @@ final class Block2BlockwiseStatus extends BlockwiseStatus {
 	 * 
 	 * @param newExchange new exchange
 	 */
-	final void completeTransfer(Exchange newExchange) {
+	final void completeOldTransfer(Exchange newExchange) {
 		Exchange exchange;
 		synchronized (this) {
 			exchange = this.exchange;
@@ -365,6 +365,20 @@ final class Block2BlockwiseStatus extends BlockwiseStatus {
 				// reset to origin request
 				exchange.setCurrentRequest(exchange.getRequest());
 			}
+		}
+	}
+	
+	/**
+	 * Complete given new exchange only if this is not the one using by this current block status
+	 */
+	final void completeNewTranfer(Exchange newExchange) {
+		Exchange exchange;
+		synchronized (this) {
+			exchange = this.exchange;
+		}
+		if (newExchange != exchange) {
+			// complete exchange
+			newExchange.setComplete();
 		}
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -217,7 +217,7 @@ public class BlockwiseLayer extends AbstractLayer {
 					// of the notify to be abandoned so that the client receives
 					// the requested response but lose the notify. 
 					clearBlock2Status(key);
-					status.completeTransfer(null);
+					status.completeOldTransfer(null);
 				}
 				
 				if (requiresBlockwise(request)) {
@@ -598,13 +598,13 @@ public class BlockwiseLayer extends AbstractLayer {
 								"discarding outdated block2 transfer {0}, current is [{1}]",
 								new Object[]{ status.getObserve(), response });
 						clearBlock2Status(key);
-						status.completeTransfer(exchange);
+						status.completeOldTransfer(exchange);
 					} else {
 						LOGGER.log(
 								Level.FINER,
 								"discarding old block2 transfer [{0}], received during ongoing block2 transfer {1}",
 								new Object[]{ response, status.getObserve() });
-						exchange.setComplete();
+						status.completeNewTranfer(exchange);
 						return;
 					}
 				}
@@ -613,7 +613,7 @@ public class BlockwiseLayer extends AbstractLayer {
 							Level.FINER,
 							"discarding outdate block2 response [{0}, {1}] received during ongoing block2 transfer {2}",
 							new Object[]{ exchange.getNotificationNumber(), response, status.getObserve() });
-					exchange.setComplete();
+					status.completeNewTranfer(exchange);
 					return;
 				}
 			}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -495,21 +495,10 @@ public class BlockwiseLayer extends AbstractLayer {
 				// included a block2 option with num = 0 (early negotiation of block size)
 
 				KeyUri key = getKey(exchange, response);
-				// There are potentially multiple blockwise transfers of the same
-				// resource representation going on with the same client.
-				// We cannot distinguish these because the status is scoped to the
-				// client's endpoint address only (which is the same in this case)
-				// thus these transfers all "share" the same status object on the
-				// server (this) side.
-				// This shared status will be cleaned up as soon as the last block
-				// is transferred for the first time. Any subsequent block2 requests
-				// with num > 0 will then be processed as "random block access" requests.
+				// We can not handle several block2 transfer for the same client/resource.
+				// So we clean previous transfer (priority to the new one)
+				clearBlock2Status(key);
 				Block2BlockwiseStatus status = getOutboundBlock2Status(key, exchange, response);
-
-				// Subsequent requests for the same resource from the same client for
-				// either block 0 or without a block2 option at all will result in
-				// the existing status being "re-used". We therefore need to make
-				// sure that we return the first block of the payload.
 				BlockOption block2 = requestBlock2 != null ? requestBlock2 : new BlockOption(preferredBlockSzx, false, 0);
 				responseToSend = status.getNextResponseBlock(block2);
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
@@ -678,6 +678,50 @@ public class BlockwiseServerSideTest {
 		client.sendRequest(CON, POST, tok, ++mid).path(RESOURCE_PATH).loadETag("tag").block2(3, false, 64).go();
 		client.expectResponse(ACK, CHANGED, tok, mid).block2(3, false, 64).payload(respPayload.substring(192, 250)).go();
 	}
+	
+	/**
+	 * Check that new request block2 transfer is well interrupted by a new one.
+	 * 
+	 * <pre>
+	 * ####### First GET with block2 response ########## 
+	 * CON [MID=7001, T=0b], GET, /test    ----->
+	 * <-----   ACK [MID=7001, T=0b], 2.05, 2:0/1/128, size2(386)
+	 * CON [MID=7002, T=0c], GET, /test, 2:1/0/128    ----->
+	 * <-----   ACK [MID=7002, T=0c], 2.05, 2:1/1/128
+	 * ####### Interrupted by new  GET with block2 response ##########
+	 * CON [MID=7003, T=0d], GET, /test    ----->
+	 * <-----   ACK [MID=7003, T=0d], 2.05, 2:0/1/128, size2(256)
+	 * CON [MID=7004, T=0e], GET, /test, 2:1/0/128    ----->
+	 * <-----   ACK [MID=7004, T=0e], 2.05, 2:1/0/128
+	 * </pre>
+	 */
+	@Test
+	public void testInterruptBlock2WithNewBlock2GET() throws Exception {
+		System.out.println("Block2 interrupted by new block2:");
+		respPayload = generateRandomPayload(386);
+		byte[] tok = generateNextToken();
+		System.out.println("Begin block2 exchange on " + RESOURCE_PATH);
+
+		// begin block2 transfer
+		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+
+		tok = generateNextToken();
+		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).block2(1, false, 128).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(1, true, 128).payload(respPayload.substring(128, 256))
+				.go();
+
+		// start a new one
+		respPayload = generateRandomPayload(256);
+		tok = generateNextToken();
+		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+
+		tok = generateNextToken();
+		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).block2(1, false, 128).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(1, false, 128).payload(respPayload.substring(128, 256))
+				.go();
+	}
 
 	/**
 	 * Verifies that a client cannot send a block with num &gt; 0 first in a blockwise PUT.


### PR DESCRIPTION
I add 2 tests and 2 fix for transparent block2 issues.

1) An older block2 notification should not stop a more recent one. (issue at client side)

2) A new block2 transfer should interrupt the previous one (issue at server side)