### PR TITLE
Extend endpoint context with inet socket address and principal.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
@@ -26,12 +26,12 @@
 package org.eclipse.californium.core.network.serialization;
 
 import org.eclipse.californium.core.coap.*;
+import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.MessageCallback;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.util.DatagramWriter;
 
-import java.net.InetSocketAddress;
 import java.util.List;
 
 import static org.eclipse.californium.core.coap.CoAP.MessageFormat.*;
@@ -76,9 +76,7 @@ public abstract class DataSerializer {
 		}
 		return RawData.outbound(
 						request.getBytes(),
-						new InetSocketAddress(request.getDestination(),
-						request.getDestinationPort()),
-						null,
+						new AddressEndpointContext(request.getDestination(), request.getDestinationPort()),
 						outboundCallback,
 						false);
 	}
@@ -123,7 +121,7 @@ public abstract class DataSerializer {
 	 * @param outboundCallback The callback to invoke once the message is sent. 
 	 * @return The object containing the serialized response.
 	 */
-	public final RawData serializeResponse(final Response response, final EndpointContext context, final MessageCallback outboundCallback) {
+	public final RawData serializeResponse(final Response response, EndpointContext context, final MessageCallback outboundCallback) {
 		if (response.getBytes() == null) {
 			DatagramWriter writer = new DatagramWriter();
 			byte[] body = serializeOptionsAndPayload(response);
@@ -136,10 +134,11 @@ public abstract class DataSerializer {
 			byte[] bytes = writer.toByteArray();
 			response.setBytes(bytes);
 		}
+		if (context == null) {
+			context = new AddressEndpointContext(response.getDestination(), response.getDestinationPort());
+		}
 		return RawData.outbound(
 				response.getBytes(),
-				new InetSocketAddress(response.getDestination(),
-						response.getDestinationPort()),
 				context,
 				outboundCallback,
 				false);
@@ -162,7 +161,7 @@ public abstract class DataSerializer {
 	 * @param outboundCallback The callback to invoke once the message is sent. 
 	 * @return The object containing the serialized message.
 	 */
-	public final RawData serializeEmptyMessage(final EmptyMessage emptyMessage, final EndpointContext context, final MessageCallback outboundCallback) {
+	public final RawData serializeEmptyMessage(final EmptyMessage emptyMessage, EndpointContext context, final MessageCallback outboundCallback) {
 		if (emptyMessage.getBytes() == null) {
 			DatagramWriter writer = new DatagramWriter();
 			byte[] body = serializeOptionsAndPayload(emptyMessage);
@@ -175,10 +174,11 @@ public abstract class DataSerializer {
 			byte[] bytes = writer.toByteArray();
 			emptyMessage.setBytes(bytes);
 		}
+		if (context == null) {
+			context = new AddressEndpointContext(emptyMessage.getDestination(), emptyMessage.getDestinationPort());
+		}
 		return RawData.outbound(
 				emptyMessage.getBytes(),
-				new InetSocketAddress(emptyMessage.getDestination(),
-						emptyMessage.getDestinationPort()),
 				context,
 				outboundCallback,
 				false);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTestUtils.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTestUtils.java
@@ -14,6 +14,8 @@
  *    Bosch Software Innovations - initial creation
  *    Achim Kraus (Bosch Software Innovations GmbH) - make exchangeStore in 
  *                                                    BaseMatcher final
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use provided EndpointContextMatcher
+ *                                                    instead of factory
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -28,6 +30,7 @@ import org.eclipse.californium.core.observe.InMemoryObservationStore;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.observe.ObservationStore;
 import org.eclipse.californium.elements.EndpointContext;
+import org.eclipse.californium.elements.EndpointContextMatcher;
 
 /**
  * Helper methods for testing {@code Matcher}s.
@@ -38,49 +41,42 @@ public final class MatcherTestUtils {
 	private MatcherTestUtils() {
 	}
 
-	static TcpMatcher newTcpMatcher(boolean useStrictMatching) {
-		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
-		config.setBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING, useStrictMatching);
-		NotificationListener notificationListener = new NotificationListener() {
+	private static NotificationListener notificationListener = new NotificationListener() {
 
-			@Override
-			public void onNotification(Request request, Response response) {
-			}
-			
-		};
-		TcpMatcher matcher = new TcpMatcher(config, notificationListener, new InMemoryObservationStore(), new InMemoryMessageExchangeStore(config), EndpointContextMatcherFactory.create(null, config));
+		@Override
+		public void onNotification(Request request, Response response) {
+		}
+		
+	};
+
+	
+	static TcpMatcher newTcpMatcher(EndpointContextMatcher correlationContextMatcher) {
+		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
+		TcpMatcher matcher = new TcpMatcher(config, notificationListener, new InMemoryObservationStore(), new InMemoryMessageExchangeStore(config), correlationContextMatcher);
 		matcher.start();
 		return matcher;
 	}
 
-	static UdpMatcher newUdpMatcher(boolean useStrictMatching, MessageExchangeStore exchangeStore, ObservationStore observationStore) {
+	static UdpMatcher newUdpMatcher(MessageExchangeStore exchangeStore, ObservationStore observationStore, EndpointContextMatcher correlationContextMatcher) {
 		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
-		config.setBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING, useStrictMatching);
-		NotificationListener notificationListener = new NotificationListener() {
-
-			@Override
-			public void onNotification(Request request, Response response) {
-			}
-			
-		};
-		UdpMatcher matcher = new UdpMatcher(config, notificationListener, observationStore, exchangeStore, EndpointContextMatcherFactory.create(null, config));
+		UdpMatcher matcher = new UdpMatcher(config, notificationListener, observationStore, exchangeStore, correlationContextMatcher);
 
 		matcher.start();
 		return matcher;
 	}
 
-	static Exchange sendRequest(InetSocketAddress dest, Matcher matcher, EndpointContext ctx) {
+	static Exchange sendRequest(InetSocketAddress dest, Matcher matcher, EndpointContext exchangeContext) {
 		Request request = Request.newGet();
 		request.setDestination(dest.getAddress());
 		request.setDestinationPort(dest.getPort());
 		Exchange exchange = new Exchange(request, Origin.LOCAL);
 		exchange.setRequest(request);
 		matcher.sendRequest(exchange, request);
-		exchange.setEndpointContext(ctx);
+		exchange.setEndpointContext(exchangeContext);
 		return exchange;
 	}
 
-	static Exchange sendObserveRequest(InetSocketAddress dest, Matcher matcher) {
+	static Exchange sendObserveRequest(InetSocketAddress dest, Matcher matcher, EndpointContext exchangeContext) {
 		Request request = Request.newGet();
 		request.setDestination(dest.getAddress());
 		request.setDestinationPort(dest.getPort());
@@ -88,18 +84,17 @@ public final class MatcherTestUtils {
 		Exchange exchange = new Exchange(request, Origin.LOCAL);
 		exchange.setRequest(request);
 		matcher.sendRequest(exchange, request);
+		exchange.setEndpointContext(exchangeContext);
 		return exchange;
 	}
 
-	static Response responseFor(final Request request) {
+	static Response receiveResponseFor(final Request request) {
 		Response response = new Response(ResponseCode.CONTENT);
 		response.setMID(request.getMID());
 		response.setToken(request.getToken());
 		response.setBytes(new byte[]{});
 		response.setSource(request.getDestination());
 		response.setSourcePort(request.getDestinationPort());
-		response.setDestination(request.getSource());
-		response.setDestinationPort(request.getSourcePort());
 		return response;
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -14,6 +14,8 @@
  *    Bosch Software Innovations GmbH - initial creation
  *    Achim Kraus (Bosch Software Innovations GmbH) - add CorrelationContextMatcher
  *                                                    (fix GitHub issue #104)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use EndpointContext and
+ *                                                    EndpointContextMatcher mocks
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -28,12 +30,13 @@ import java.net.InetSocketAddress;
 
 import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange.KeyToken;
 import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.InMemoryObservationStore;
-import org.eclipse.californium.elements.DtlsEndpointContext;
-import org.eclipse.californium.elements.MapBasedEndpointContext;
+import org.eclipse.californium.elements.EndpointContext;
+import org.eclipse.californium.elements.EndpointContextMatcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -45,172 +48,70 @@ import org.junit.experimental.categories.Category;
 @Category(Small.class)
 public class UdpMatcherTest {
 
-	static final String SESSION_ID = "010203";
-	static final String OTHER_SESSION_ID = "567322";
-	static final String EPOCH = "1";
-	static final String OTHER_EPOCH = "2";
-	static final String CIPHER = "TLS_PSK";
-	static final String OTHER_CIPHER = "TLS_NULL";
 	static final InetSocketAddress dest = new InetSocketAddress(InetAddress.getLoopbackAddress(), 5684);
 
 	private InMemoryObservationStore observationStore;
 	private InMemoryRandomTokenProvider tokenProvider; 
 	private InMemoryMessageExchangeStore messageExchangeStore;
-
+	private EndpointContext exchangeEndpointContext;
+	private EndpointContext responseEndpointContext;
+	private EndpointContextMatcher endpointContextMatcher;
+	
 	@Before
 	public void before(){
 		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
 		tokenProvider = new InMemoryRandomTokenProvider(config);
 		messageExchangeStore = new InMemoryMessageExchangeStore(config, tokenProvider);
 		observationStore =  new InMemoryObservationStore();
+		exchangeEndpointContext = mock(EndpointContext.class);
+		responseEndpointContext = mock(EndpointContext.class);
+		endpointContextMatcher = mock(EndpointContextMatcher.class);
+		when(exchangeEndpointContext.getPeerAddress()).thenReturn(dest);
+		when(responseEndpointContext.getPeerAddress()).thenReturn(dest);
 	}
 
 	@Test
-	public void testReceiveResponseAcceptsResponseWithoutEndpointInformation() {
+	public void testReceiveResponseAcceptsWithEndpointContext() {
 		// GIVEN a request sent without any additional endpoint information
-		//  using a matcher set to lax matching
-		UdpMatcher matcher = newUdpMatcher(false);
-		Exchange exchange = sendRequest(dest, matcher, null);
+		when(endpointContextMatcher.isResponseRelatedToRequest(exchangeEndpointContext, responseEndpointContext)).thenReturn(true);
+
+		UdpMatcher matcher = newUdpMatcher();
+
+		Exchange exchange = sendRequest(dest, matcher, exchangeEndpointContext);
 
 		// WHEN a response arrives with arbitrary additional endpoint information
-		Exchange matchedExchange = matcher.receiveResponse(
-												responseFor(exchange.getCurrentRequest()),
-												new MapBasedEndpointContext());
+		Response response = receiveResponseFor(exchange.getCurrentRequest());
+		Exchange matchedExchange = matcher.receiveResponse(response, responseEndpointContext);
 
+		verify(endpointContextMatcher, times(1)).isResponseRelatedToRequest(exchangeEndpointContext, responseEndpointContext);
+		
 		// THEN assert that the response is successfully matched against the request
 		assertThat(matchedExchange, is(exchange));
 	}
 
 	@Test
-	public void testReceiveResponseRejectsResponseWithArbitraryEndpointInformation() {
-		// GIVEN a request sent with some additional endpoint information
-		//  using a matcher set to lax matching
-		UdpMatcher matcher = newUdpMatcher(false);
-		MapBasedEndpointContext ctx = new MapBasedEndpointContext();
-		ctx.put("key", "value");
-		Exchange exchange = sendRequest(dest, matcher, ctx);
+	public void testReceiveResponseRejectsWithEndpointContext() {
+		// GIVEN a request sent without any additional endpoint information
+		when(endpointContextMatcher.isResponseRelatedToRequest(exchangeEndpointContext, responseEndpointContext)).thenReturn(false);
 
-		// WHEN a response arrives without any endpoint information
-		Exchange matchedExchange = matcher.receiveResponse(responseFor(exchange.getCurrentRequest()), null);
+		UdpMatcher matcher = newUdpMatcher();
 
-		// THEN assert that the response is not matched
+		Exchange exchange = sendRequest(dest, matcher, exchangeEndpointContext);
+
+		// WHEN a response arrives with arbitrary additional endpoint information
+		Response response = receiveResponseFor(exchange.getCurrentRequest());
+		Exchange matchedExchange = matcher.receiveResponse(response, responseEndpointContext);
+
+		verify(endpointContextMatcher, times(1)).isResponseRelatedToRequest(exchangeEndpointContext, responseEndpointContext);
+		
+		// THEN assert that the response is successfully matched against the request
 		assertThat(matchedExchange, is(nullValue()));
 	}
 
-	// tests verifying lax response matching based on SESSION ID and CIPHER only
-
-	@Test
-	public void testReceiveResponseAcceptsResponseFromDifferentEpochUsingLaxMatching() {
-		// GIVEN a request sent via a DTLS transport using a matcher set to lax matching
-		UdpMatcher matcher = newUdpMatcher(false);
-		Exchange exchange = sendRequest(dest, matcher, new DtlsEndpointContext(SESSION_ID, EPOCH, CIPHER));
-
-		// WHEN a response arrives with the same message ID within the same DTLS session, using
-		// the same cipher but from a different epoch
-		Exchange matchedExchange = matcher.receiveResponse(
-												responseFor(exchange.getCurrentRequest()),
-												new DtlsEndpointContext(SESSION_ID, OTHER_EPOCH, CIPHER));
-
-		// THEN assert that the response is matched successfully
-		assertThat(matchedExchange, is(exchange));
-	}
-
-	@Test
-	public void testReceiveResponseRejectsResponseFromDifferentSessionUsingLaxMatching() {
-		// GIVEN a request sent via a DTLS transport using a matcher set to lax matching
-		UdpMatcher matcher = newUdpMatcher(false);
-		Exchange exchange = sendRequest(dest, matcher, new DtlsEndpointContext(SESSION_ID, EPOCH, CIPHER));
-
-		// WHEN a response arrives with the same message ID but a different DTLS session
-		Exchange matchedExchange = matcher.receiveResponse(
-												responseFor(exchange.getCurrentRequest()),
-												new DtlsEndpointContext(OTHER_SESSION_ID, EPOCH, CIPHER));
-
-		// THEN assert that the response is not matched
-		assertThat(matchedExchange, is(nullValue()));
-	}
-
-	@Test
-	public void testReceiveResponseRejectsResponseUsingDifferentCipherUsingLaxMatching() {
-		// GIVEN a request sent via a DTLS transport using a matcher set to lax matching
-		UdpMatcher matcher = newUdpMatcher(false);
-		Exchange exchange = sendRequest(dest, matcher, new DtlsEndpointContext(SESSION_ID, EPOCH, CIPHER));
-
-		// WHEN a response arrives with the same message ID within the same DTLS session but using another cipher
-		Exchange matchedExchange = matcher.receiveResponse(
-												responseFor(exchange.getCurrentRequest()),
-												new DtlsEndpointContext(SESSION_ID, EPOCH, OTHER_CIPHER));
-
-		// THEN assert that the response is not matched
-		assertThat(matchedExchange, is(nullValue()));
-	}
-
-	// tests verifying strict response matching
-
-	@Test
-	public void testReceiveResponseAcceptsResponseFromSameSessionEpochAndCipherUsingStrictMatching() {
-		// GIVEN a request sent via a DTLS transport
-		UdpMatcher matcher = newUdpMatcher(true);
-		Exchange exchange = sendRequest(dest, matcher, new DtlsEndpointContext(SESSION_ID, EPOCH, CIPHER));
-
-		// WHEN a response arrives with the same message ID, session ID, epoch and cipher
-		Exchange matchedExchange = matcher.receiveResponse(
-												responseFor(exchange.getCurrentRequest()),
-												new DtlsEndpointContext(SESSION_ID, EPOCH, CIPHER));
-
-		// THEN assert that the response is matched successfully
-		assertThat(matchedExchange, is(exchange));
-	}
-
-	@Test
-	public void testReceiveResponseRejectsResponseFromDifferentEpochUsingStrictMatching() {
-		// GIVEN a request sent via a DTLS transport using a matcher set to strict matching
-		UdpMatcher matcher = newUdpMatcher(true);
-		Exchange exchange = sendRequest(dest, matcher, new DtlsEndpointContext(SESSION_ID, EPOCH, CIPHER));
-
-		// WHEN a response arrives with the same message ID, session ID and cipher but from a different epoch
-		Exchange matchedExchange = matcher.receiveResponse(
-												responseFor(exchange.getCurrentRequest()),
-												new DtlsEndpointContext(SESSION_ID, OTHER_EPOCH, CIPHER));
-
-		// THEN assert that the response is not matched
-		assertThat(matchedExchange, is(nullValue()));
-	}
-
-	@Test
-	public void testReceiveResponseRejectsResponseFromDifferentSessionUsingStrictMatching() {
-		// GIVEN a request sent via a DTLS transport using a matcher set to strict matching
-		UdpMatcher matcher = newUdpMatcher(true);
-		Exchange exchange = sendRequest(dest, matcher, new DtlsEndpointContext(SESSION_ID, EPOCH, CIPHER));
-
-		// WHEN a response arrives with the same message ID, epoch and cipher but a different session ID
-		Exchange matchedExchange = matcher.receiveResponse(
-												responseFor(exchange.getCurrentRequest()),
-												new DtlsEndpointContext(OTHER_SESSION_ID, EPOCH, CIPHER));
-
-		// THEN assert that the response is not matched
-		assertThat(matchedExchange, is(nullValue()));
-	}
-
-	@Test
-	public void testReceiveResponseRejectsResponseUsingDifferentCipherUsingStrictMatching() {
-		// GIVEN a request sent via a DTLS transport using a matcher set to strict matching
-		UdpMatcher matcher = newUdpMatcher(true);
-		Exchange exchange = sendRequest(dest, matcher, new DtlsEndpointContext(SESSION_ID, EPOCH, CIPHER));
-
-		// WHEN a response arrives with the same message ID, session ID and epoch but using a different cipher
-		Exchange matchedExchange = matcher.receiveResponse(
-												responseFor(exchange.getCurrentRequest()),
-												new DtlsEndpointContext(SESSION_ID, EPOCH, OTHER_CIPHER));
-
-		// THEN assert that the response is not matched
-		assertThat(matchedExchange, is(nullValue()));
-	}
-	
 	@Test
 	public void testReceiveResponseReleasesToken() {
 		// GIVEN a request without token sent
-		UdpMatcher matcher = newUdpMatcher(false);
+		UdpMatcher matcher = newUdpMatcher();
 		Exchange exchange = sendRequest(dest, matcher, null);
 				// WHEN request gets completed
 		exchange.completeCurrentRequest();
@@ -219,12 +120,12 @@ public class UdpMatcherTest {
 		KeyToken keyToken = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
 		assertThat(tokenProvider.isTokenInUse(keyToken), is(false));
 	}
-	
+
 	@Test
 	public void testReceiveResponseForObserveDoesNotReleaseToken() {
 		// GIVEN a request without token sent
-		UdpMatcher matcher = newUdpMatcher(false);
-		Exchange exchange = sendObserveRequest(dest, matcher);
+		UdpMatcher matcher = newUdpMatcher();
+		Exchange exchange = sendObserveRequest(dest, matcher, exchangeEndpointContext);
 
 		// WHEN observe request gets completed
 		exchange.completeCurrentRequest();
@@ -238,8 +139,8 @@ public class UdpMatcherTest {
 	public void testCancelObserveReleasesToken() {
 
 		// GIVEN an exchange for an outbound request
-		UdpMatcher matcher = newUdpMatcher(false);
-		Exchange exchange = sendObserveRequest(dest, matcher);
+		UdpMatcher matcher = newUdpMatcher();
+		Exchange exchange = sendObserveRequest(dest, matcher, exchangeEndpointContext);
 
 		// WHEN canceling any observe relations for the exchange's token
 		matcher.cancelObserve(exchange.getCurrentRequest().getToken());
@@ -265,7 +166,8 @@ public class UdpMatcherTest {
 
 		MessageExchangeStore exchangeStore = mock(MessageExchangeStore.class);
 		when(exchangeStore.registerOutboundRequest(exchange)).thenReturn(false);
-		UdpMatcher matcher = MatcherTestUtils.newUdpMatcher(false, exchangeStore, observationStore);
+		verify(endpointContextMatcher, never()).isResponseRelatedToRequest(null, null);
+		UdpMatcher matcher = MatcherTestUtils.newUdpMatcher(exchangeStore, observationStore, endpointContextMatcher);
 
 		// WHEN the request is being sent
 		matcher.sendRequest(exchange, request);
@@ -276,7 +178,7 @@ public class UdpMatcherTest {
 		assertFalse(exchange.hasObserver());
 	}
 
-	private UdpMatcher newUdpMatcher(boolean useStrictMatching) {
-		return MatcherTestUtils.newUdpMatcher(useStrictMatching, messageExchangeStore, observationStore);
+	private UdpMatcher newUdpMatcher() {
+		return MatcherTestUtils.newUdpMatcher(messageExchangeStore, observationStore, endpointContextMatcher);
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataParserTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataParserTest.java
@@ -19,6 +19,7 @@
  * Bosch Software Innovations GmbH - add test cases
  * Achim Kraus (Bosch Software Innovations GmbH) - add test for CoAP specific 
  *                                                 exception information
+ * Achim Kraus (Bosch Software Innovations GmbH) - parse byte[] instead of RawData
  ******************************************************************************/
 package org.eclipse.californium.core.network.serialization;
 
@@ -26,7 +27,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import java.net.InetSocketAddress;
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,7 +37,6 @@ import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.CoAPMessageFormatException;
 import org.eclipse.californium.core.coap.Message;
-import org.eclipse.californium.core.coap.MessageFormatException;
 import org.eclipse.californium.core.coap.Option;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
@@ -71,6 +71,8 @@ import org.junit.runners.Parameterized;
 
 	@Test public void testRequestParsing() {
 		Request request = new Request(Code.POST);
+		request.setDestination(InetAddress.getLoopbackAddress());
+		request.setDestinationPort(1000);
 		request.setType(Type.NON);
 		request.setMID(expectedMid);
 		request.setToken(new byte[] { 11, 82, -91, 77, 3 });
@@ -90,16 +92,15 @@ import org.junit.runners.Parameterized;
 
 	@Test public void testParseMessageDetectsIllegalCodeClass() {
 		// GIVEN a message with a class code of 1, i.e. not a request
-		byte[] malformedRequest = new byte[] { 0b01000000, // ver 1, CON, token length: 0
+		byte[] malformedRequest = new byte[] { 
+				0b01000000, // ver 1, CON, token length: 0
 				0b00100001, // code: 1.01 -> class 1 is reserved
 				0x00, 0x10 // message ID
 		};
 
-		RawData rawData = new RawData(malformedRequest, new InetSocketAddress(0));
-
 		// WHEN parsing the request
 		try {
-			parser.parseMessage(rawData);
+			parser.parseMessage(malformedRequest);
 			fail("Parser should have detected that message is not a request");
 		} catch (CoAPMessageFormatException e) {
 			assertEquals(0b00100001, e.getCode());
@@ -110,16 +111,15 @@ import org.junit.runners.Parameterized;
 
 	@Test public void testParseMessageDetectsIllegalCode() {
 		// GIVEN a message with a class code of 0.07, i.e. not a request
-		byte[] malformedRequest = new byte[] { 0b01000000, // ver 1, CON, token length: 0
+		byte[] malformedRequest = new byte[] { 
+				0b01000000, // ver 1, CON, token length: 0
 				0b00000111, // code: 0.07 -> class 1 is reserved
 				0x00, 0x10 // message ID
 		};
 
-		RawData rawData = new RawData(malformedRequest, new InetSocketAddress(0));
-
 		// WHEN parsing the request
 		try {
-			parser.parseMessage(rawData);
+			parser.parseMessage(malformedRequest);
 			fail("Parser should have detected that message is not a request");
 		} catch (CoAPMessageFormatException e) {
 			assertEquals(0b00000111, e.getCode());
@@ -130,18 +130,17 @@ import org.junit.runners.Parameterized;
 
 	@Test public void testParseMessageDetectsMalformedOption() {
 		// GIVEN a request with an option value shorter than specified
-		byte[] malformedGetRequest = new byte[] { 0b01000000, // ver 1, CON, token length: 0
+		byte[] malformedGetRequest = new byte[] { 
+				0b01000000, // ver 1, CON, token length: 0
 				0b00000001, // code: 0.01 (GET request)
 				0x00, 0x10, // message ID
 				0x24, // option number 2, length: 4
 				0x01, 0x02, 0x03 // token value is one byte short
 		};
 
-		RawData rawData = new RawData(malformedGetRequest, new InetSocketAddress(0));
-
 		// WHEN parsing the request
 		try {
-			parser.parseMessage(rawData);
+			parser.parseMessage(malformedGetRequest);
 			fail("Parser should have detected malformed options");
 		} catch (CoAPMessageFormatException e) {
 			// THEN an exception is thrown by the parser
@@ -152,16 +151,16 @@ import org.junit.runners.Parameterized;
 
 	@Test public void testParseMessageDetectsMissingPayload() {
 		// GIVEN a request with a payload delimiter but empty payload
-		byte[] malformedGetRequest = new byte[] { 0b01000000, // ver 1, CON, token length: 0
+		byte[] malformedGetRequest = new byte[] { 
+				0b01000000, // ver 1, CON, token length: 0
 				0b00000001, // code: 0.01 (GET request)
 				0x00, 0x10, // message ID
 				(byte) 0xFF // payload marker
 		};
-		RawData rawData = new RawData(malformedGetRequest, new InetSocketAddress(0));
 
 		// WHEN parsing the request
 		try {
-			parser.parseMessage(rawData);
+			parser.parseMessage(malformedGetRequest);
 			fail("Parser should have detected missing payload");
 		} catch (CoAPMessageFormatException e) {
 			// THEN an exception is thrown by the parser
@@ -172,6 +171,8 @@ import org.junit.runners.Parameterized;
 
 	@Test public void testResponseParsing() {
 		Response response = new Response(ResponseCode.CONTENT);
+		response.setDestination(InetAddress.getLoopbackAddress());
+		response.setDestinationPort(1000);
 		response.setType(Type.NON);
 		response.setMID(expectedMid);
 		response.setToken(new byte[] { 22, -1, 0, 78, 100, 22 });
@@ -190,6 +191,8 @@ import org.junit.runners.Parameterized;
 
 	@Test public void testUTF8Encoding() {
 		Response response = new Response(ResponseCode.CONTENT);
+		response.setDestination(InetAddress.getLoopbackAddress());
+		response.setDestinationPort(1000);
 		response.setType(Type.NON);
 		response.setMID(expectedMid);
 		response.setToken(new byte[] {});

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataSerializerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataSerializerTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 
 import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
@@ -48,6 +49,8 @@ import org.junit.runners.Parameterized.Parameters;
 @Category(Small.class)
 @RunWith(Parameterized.class)
 public class DataSerializerTest {
+
+	private static final InetSocketAddress ADDRESS = new InetSocketAddress(0);
 
 	/**
 	 * The concrete serializer to run the test cases with.
@@ -110,8 +113,10 @@ public class DataSerializerTest {
 	 */
 	@Test
 	public void testSerializeResponseWithEndpointContext() {
-		EndpointContext context = new DtlsEndpointContext("session", "1", "CIPHER");
+		EndpointContext context = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
 		Request request = Request.newGet();
+		request.setSource(ADDRESS.getAddress());
+		request.setSourcePort(ADDRESS.getPort());
 		request.setToken(new byte[] { 0x00 });
 		request.setMID(1);
 		Response response = Response.createResponse(request, ResponseCode.CONTENT);
@@ -129,8 +134,10 @@ public class DataSerializerTest {
 	 */
 	@Test
 	public void testSerializeEmptyMessageWithEndpointContext() {
-		EndpointContext context = new DtlsEndpointContext("session", "1", "CIPHER");
+		EndpointContext context = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
 		Request request = Request.newGet();
+		request.setSource(ADDRESS.getAddress());
+		request.setSourcePort(ADDRESS.getPort());
 		request.setMID(1);
 
 		EmptyMessage ack = EmptyMessage.newACK(request);

--- a/demo-apps/sc-dtls-example-client/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSClient.java
+++ b/demo-apps/sc-dtls-example-client/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSClient.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
 import org.eclipse.californium.elements.util.DaemonThreadFactory;
@@ -130,7 +131,8 @@ public class ExampleDTLSClient {
 		if (0 < c) {
 			clientMessageCounter.incrementAndGet();
 			try {
-				dtlsConnector.send(new RawData(("HELLO WORLD " + c + ".").getBytes(), raw.getInetSocketAddress()));
+				RawData data = RawData.outbound(("HELLO WORLD " + c + ".").getBytes(), raw.getEndpointContext(), null, false);
+				dtlsConnector.send(data);
 			} catch (IllegalStateException e) {
 				LOG.log(Level.FINER, "send failed after " + (c - 1) + " messages!", e);
 			}
@@ -149,7 +151,8 @@ public class ExampleDTLSClient {
 	}
 
 	private void startTest(InetSocketAddress peer) {
-		dtlsConnector.send(new RawData("HELLO WORLD".getBytes(), peer));
+		RawData data = RawData.outbound("HELLO WORLD".getBytes(), new AddressEndpointContext(peer), null, false);
+		dtlsConnector.send(data);
 	}
 
 	private int stop() {

--- a/demo-apps/sc-dtls-example-server/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSServer.java
+++ b/demo-apps/sc-dtls-example-server/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSServer.java
@@ -114,7 +114,8 @@ public class ExampleDTLSServer {
 		@Override
 		public void receiveData(final RawData raw) {
 			LOG.log(Level.INFO, "Received request: {0}", new String(raw.getBytes()));
-			connector.send(new RawData("ACK".getBytes(), raw.getAddress(), raw.getPort()));
+			RawData response = RawData.outbound("ACK".getBytes(), raw.getEndpointContext(), null, false);
+			connector.send(response);
 		}
 	}
 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/AddressEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/AddressEndpointContext.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A endpoint context providing the inet socket address and a optional principal.
+ */
+public class AddressEndpointContext implements EndpointContext {
+
+	private final InetSocketAddress peerAddress;
+
+	private final Principal peerIdentity;
+
+	/**
+	 * Create endpoint context without principal.
+	 * 
+	 * @param peerAddress socket address of peer's service
+	 * @throws NullPointerException if provided peer address is {@code null}.
+	 */
+	public AddressEndpointContext(InetSocketAddress peerAddress) {
+		if (peerAddress == null) {
+			throw new NullPointerException("missing peer socket address!");
+		}
+		this.peerAddress = peerAddress;
+		this.peerIdentity = null;
+	}
+
+	/**
+	 * Create endpoint context without principal.
+	 * 
+	 * @param address inet address of peer
+	 * @param port port of peer
+	 * @throws NullPointerException if provided address is {@code null}.
+	 */
+	public AddressEndpointContext(InetAddress address, int port) {
+		if (address == null) {
+			throw new NullPointerException("missing peer inet address!");
+		}
+		this.peerAddress = new InetSocketAddress(address, port);
+		this.peerIdentity = null;
+	}
+
+	/**
+	 * Create endpoint context with principal.
+	 * 
+	 * @param peerAddress socket address of peer's service
+	 * @param peerIdentity peer's principal
+	 * @throws NullPointerException if provided peer address is {@code null}.
+	 */
+	public AddressEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity) {
+		if (peerAddress == null) {
+			throw new NullPointerException("missing peer socket address!");
+		}
+		this.peerAddress = peerAddress;
+		this.peerIdentity = peerIdentity;
+	}
+
+	@Override
+	public String get(String key) {
+		return null;
+	}
+
+	@Override
+	public Set<Map.Entry<String, String>> entrySet() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public boolean inhibitNewConnection() {
+		return false;
+	}
+
+	@Override
+	public Principal getPeerIdentity() {
+		return peerIdentity;
+	}
+
+	@Override
+	public InetSocketAddress getPeerAddress() {
+		return peerAddress;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = peerAddress.hashCode();
+		if (peerIdentity != null) {
+			result = peerIdentity.hashCode();
+		}
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (!(obj instanceof AddressEndpointContext)) {
+			return false;
+		}
+		AddressEndpointContext other = (AddressEndpointContext) obj;
+		if (!peerAddress.equals(other.getPeerAddress())) {
+			return false;
+		}
+		if (peerIdentity != null) {
+			if (!peerIdentity.equals(other.getPeerIdentity())) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("IP(%s:%d)", peerAddress.getHostString(), peerAddress.getPort());
+	}
+
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
@@ -14,8 +14,13 @@
  *    Bosch Software Innovations GmbH - add support for correlation context to provide
  *                                      additional information to application layer for
  *                                      matching messages (fix GitHub issue #1)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - extend endpoint context with
+ *                                                    inet socket address and principal
  ******************************************************************************/
 package org.eclipse.californium.elements;
+
+import java.net.InetSocketAddress;
+import java.security.Principal;
 
 /**
  * A endpoint context that explicitly supports DTLS specific properties.
@@ -29,12 +34,17 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 	/**
 	 * Creates a new endpoint context from DTLS session parameters.
 	 * 
+	 * @param peerAddress peer address of endpoint context
+	 * @param peerIdentity peer identity of endpoint context
 	 * @param sessionId the session's ID.
 	 * @param epoch the session's current read/write epoch.
 	 * @param cipher the cipher suite of the session's current read/write state.
-	 * @throws NullPointerException if any of the params is <code>null</code>.
+	 * @throws NullPointerException if any of the params (except peerIdentity)
+	 *             is {@code null}.
 	 */
-	public DtlsEndpointContext(String sessionId, String epoch, String cipher) {
+	public DtlsEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity, String sessionId, String epoch,
+			String cipher) {
+		super(peerAddress, peerIdentity);
 		if (sessionId == null) {
 			throw new NullPointerException("Session ID must not be null");
 		} else if (epoch == null) {
@@ -58,5 +68,11 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 
 	public String getCipher() {
 		return get(KEY_CIPHER);
+	}
+
+	@Override
+	public String toString() {
+		return String.format("DTLS(%s:%d,ID:%s)", getPeerAddress().getHostString(), getPeerAddress().getPort(),
+				getSessionId());
 	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContext.java
@@ -14,15 +14,44 @@
  *    Bosch Software Innovations GmbH - add support for correlation context to provide
  *                                      additional information to application layer for
  *                                      matching messages (fix GitHub issue #1)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - extend and rename 
+ *                                      CorrelationContext into EndpointContext.
  ******************************************************************************/
 package org.eclipse.californium.elements;
 
+import java.net.InetSocketAddress;
+import java.security.Principal;
 import java.util.Map;
 import java.util.Set;
 
 /**
  * A container for storing transport specific information about the context in
  * which a message has been sent or received.
+ * 
+ * Contains several endpoint identity candidates:
+ * 
+ * <table summary="Endpoint Identity Candidates">
+ * <tr>
+ * <th>Candidate</th>
+ * <th>Description</th>
+ * <th>Long-Term-Stable</th>
+ * </tr>
+ * <tr>
+ * <td>InetSocketAddress</td>
+ * <td>identity for plain coap according RFC7252</td>
+ * <td>With IPv4 and NATs too frequently not long-term-stable</td>
+ * </tr>
+ * <tr>
+ * <td>Principal</td>
+ * <td>identity for secure endpoint, requires unique credentials per client</td>
+ * <td>As stable as the credentials</td>
+ * </tr>
+ * <tr>
+ * <td>DTLS Session, cipher suite, epoch</td>
+ * <td>identity for secure coaps according RFC7252</td>
+ * <td>With new or resumed DTLS session not long-term-stable</td>
+ * </tr>
+ * </table>
  */
 public interface EndpointContext {
 
@@ -30,15 +59,42 @@ public interface EndpointContext {
 	 * Gets a value from this context.
 	 * 
 	 * @param key the key to retrieve the value for.
-	 * @return the value or <code>null</code> if this context does not contain a
+	 * @return the value or {@code null} if this context does not contain a
 	 *         value for the given key.
 	 */
 	String get(String key);
 
 	/**
-	 * Gets a Set of a Map.Entry which contains the key-value pair of the EndpointContext.
+	 * Gets a Set of a Map.Entry which contains the key-value pair of the
+	 * CorrelationContext.
+	 * 
+	 * The Set is intended to be "unmodifiable".
 	 *
 	 * @return A set of a map entry containing the key value pair.
 	 */
 	Set<Map.Entry<String, String>> entrySet();
+
+	/**
+	 * Check, if the correlation information contained, will inhibit a new
+	 * connection.
+	 * 
+	 * @return {@code true}, if no new connection could match the correlation
+	 *         context provided in this instance. {@code false}, if a new
+	 *         connection may match this correlation context.
+	 */
+	boolean inhibitNewConnection();
+
+	/**
+	 * Get identity of peer the message is for or from.
+	 * 
+	 * @return identity of peer. {@code null}, if not available.
+	 */
+	Principal getPeerIdentity();
+
+	/**
+	 * Get inet address of peer the message is for or from.
+	 * 
+	 * @return address of peer
+	 */
+	InetSocketAddress getPeerAddress();
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContextMatcher.java
@@ -48,10 +48,10 @@ public interface EndpointContextMatcher {
 	 * context of the connector.
 	 * 
 	 * @param messageContext endpoint context of message
-	 * @param connectorContext endpoint context of connector
+	 * @param connectionContext endpoint context of connection
 	 * @return true, if message should be sent, false, if message should not be
 	 *         sent.
 	 */
-	boolean isToBeSent(EndpointContext messageContext, EndpointContext connectorContext);
+	boolean isToBeSent(EndpointContext messageContext, EndpointContext connectionContext);
 
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/KeySetEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/KeySetEndpointContextMatcher.java
@@ -16,6 +16,8 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - add isToBeSent to control
  *                                                    outgoing messages
  *                                                    (fix GitHub issue #104)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use inhibitNewConnection 
+ *                                                    for isToBeSent.
  ******************************************************************************/
 package org.eclipse.californium.elements;
 
@@ -63,15 +65,16 @@ public class KeySetEndpointContextMatcher implements EndpointContextMatcher {
 	}
 
 	@Override
-	public boolean isToBeSent(EndpointContext messageContext, EndpointContext connectorContext) {
-		return internalMatch(messageContext, connectorContext);
+	public boolean isToBeSent(EndpointContext messageContext, EndpointContext connectionContext) {
+		if (null == connectionContext) {
+			return !messageContext.inhibitNewConnection();
+		}
+		return internalMatch(messageContext, connectionContext);
 	}
 
 	private final boolean internalMatch(EndpointContext requestedContext, EndpointContext availableContext) {
-		if (null == requestedContext) {
+		if (!requestedContext.inhibitNewConnection()) {
 			return true;
-		} else if (null == availableContext) {
-			return false;
 		}
 		return EndpointContextUtil.match(getName(), keys, requestedContext, availableContext);
 	}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/RawData.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/RawData.java
@@ -22,6 +22,9 @@
  *                                                    (fix GitHub issue #104)
  *    Achim Kraus (Bosch Software Innovations GmbH) - add onSent and onError.
  *                                                    issue #305
+ *    Achim Kraus (Bosch Software Innovations GmbH) - move address and principal to
+ *                                                    EndpointContext and cleanup
+ *                                                    constructors.
  ******************************************************************************/
 package org.eclipse.californium.elements;
 
@@ -31,216 +34,112 @@ import java.security.Principal;
 import java.util.Arrays;
 
 /**
- * A container object for the data received or sent via a <code>Connector</code>.
+ * A container object for the data received or sent via a {@link Connector}.
  * 
  * The following meta-data is included:
  * <ul>
- * <li>the source/destination IP address</li>
- * <li>the source/destination port</li>
+ * <li>the peer's endpoint context, containing it's address, optional principal,
+ * and optional correlation information</li>
  * <li>a flag indicating whether the message is a multicast message (default is
- * <code>false</code>)</li>
+ * {@code false})</li>
  * </ul>
  * 
- * A message received from a client via the network may also optionally contain the
- * authenticated sender's identity as a <code>java.security.Principal</code> object.
+ * A message received from a client via the network may also optionally contain
+ * the authenticated sender's identity as a {@link java.security.Principal}
+ * object.
  */
 public final class RawData {
 
 	/** The raw message. */
 	public final byte[] bytes;
 
-	/** The source/destination address. */
-	private InetSocketAddress address;
-
 	/** Indicates if this message is a multicast message */
 	private boolean multicast;
 
-	private Principal senderIdentity;
+	/**
+	 * Endpoint context of the remote peer.
+	 */
+	private EndpointContext peerEndpointContext;
 
-	private EndpointContext endpointContext;
-
+	/**
+	 * Message callback to receive the actual endpoint context the message is
+	 * sent in.
+	 */
 	private MessageCallback callback;
 
 	/**
 	 * Instantiates a new raw data.
+	 * 
+	 * Use {@link #inbound(byte[], EndpointContext, boolean)} or
+	 * {@link #outbound(byte[], EndpointContext, MessageCallback, boolean)}.
 	 *
 	 * @param data the data that is to be sent or has been received
-	 * @param address the IP address and port the data is to be sent to or has been received from
-	 * @throws NullPointerException if any of the given parameters is <code>null</code>
+	 * @param endpointContext remote peers endpoint context.
+	 * @param multicast indicates whether the data represents a multicast
+	 *            message
+	 * @throws NullPointerException if data or address is {@code null}
 	 */
-	public RawData(byte[] data, InetSocketAddress address) {
-		this(data, address, null, false);
-	}
-
-	/**
-	 * Instantiates a new raw data.
-	 *
-	 * @param data the data that is to be sent or has been received
-	 * @param address the IP address and port the data is to be sent to or has been received from
-	 * @param clientIdentity the identity of the authenticated sender of the message
-	 *     (or <code>null</code> if sender is not authenticated)
-	 * @throws NullPointerException if any of the given parameters is <code>null</code>
-	 */
-	public RawData(byte[] data, InetSocketAddress address, Principal clientIdentity) {
-		this(data, address, clientIdentity, false);
-	}
-
-	/**
-	 * Instantiates a new raw data.
-	 *
-	 * @param data the data that is to be sent or has been received
-	 * @param address the IP address the data is to be sent to or has been received from
-	 * @param port the port the data is to be sent to or has been received from
-	 * @throws NullPointerException if data is <code>null</code>
-	 */
-	public RawData(byte[] data, InetAddress address, int port) {
-		this(data, address, port, null, false);
-	}
-
-	/**
-	 * Instantiates a new raw data.
-	 *
-	 * @param data the data that is to be sent or has been received
-	 * @param address the IP address the data is to be sent to or has been received from
-	 * @param port the port the data is to be sent to or has been received from
-	 * @param clientIdentity the identity of the authenticated sender of the message
-	 *     (or <code>null</code> if sender is not authenticated)
-	 * @throws NullPointerException if data is <code>null</code>
-	 */
-	public RawData(byte[] data, InetAddress address, int port, Principal clientIdentity) {
-		this(data, address, port, clientIdentity, false);
-	}
-
-	/**
-	 * Instantiates a new raw data.
-	 *
-	 * @param data the data that is to be sent or has been received
-	 * @param address the IP address and port the data is to be sent to or has been received from
-	 * @param multicast indicates whether the data represents a multicast message
-	 * @throws NullPointerException if data or address is <code>null</code>
-	 */
-	public RawData(byte[] data, InetSocketAddress address, boolean multicast) {
-		this(data, address, null, multicast);
-	}
-
-	/**
-	 * Instantiates a new raw data.
-	 *
-	 * @param data the data that is to be sent or has been received
-	 * @param address the IP address and port the data is to be sent to or has been received from
-	 * @param clientIdentity the identity of the authenticated sender of the message
-	 *     (or <code>null</code> if sender is not authenticated)
-	 * @param multicast indicates whether the data represents a multicast message
-	 * @throws NullPointerException if data or address is <code>null</code>
-	 */
-	public RawData(byte[] data, InetSocketAddress address, Principal clientIdentity, boolean multicast) {
-		this(data, address, clientIdentity, null, multicast);
-	}
-
-	/**
-	 * Instantiates a new raw data.
-	 *
-	 * @param data the data that is to be sent or has been received
-	 * @param address the IP address and port the data is to be sent to or has been received from
-	 * @param clientIdentity the identity of the authenticated sender of the message
-	 *     (or <code>null</code> if sender is not authenticated)
-	 * @param endpointContext additional information regarding the context the message has been
-	 *      received in. The information contained will usually come from the transport layer, e.g.
-	 *      the ID of the DTLS session the message has been received in, and can be used to correlate
-	 *      this message with another (previously send) message.
-	 * @param multicast indicates whether the data represents a multicast message
-	 * @throws NullPointerException if data or address is <code>null</code>
-	 */
-	private RawData(byte[] data, InetSocketAddress address, Principal clientIdentity, EndpointContext endpointContext, boolean multicast) {
+	private RawData(byte[] data, EndpointContext peerEndpointContext, MessageCallback callback, boolean multicast) {
 		if (data == null) {
 			throw new NullPointerException("Data must not be null");
-		} else if (address == null) {
-			throw new NullPointerException("Address must not be null");
+		} else if (peerEndpointContext == null) {
+			throw new NullPointerException("Peer's EndpointContext must not be null");
 		} else {
 			this.bytes = data;
-			this.address = address;
-			this.senderIdentity = clientIdentity;
-			this.endpointContext = endpointContext;
+			this.peerEndpointContext = peerEndpointContext;
+			this.callback = callback;
 			this.multicast = multicast;
 		}
-	}
-
-	/**
-	 * Instantiates a new raw data.
-	 *
-	 * @param data the data that is to be sent or has been received
-	 * @param address the IP address the data is to be sent to or has been received from
-	 * @param port the port the data is to be sent to or has been received from
-	 * @param multicast indicates whether the data represents a multicast message
-	 * @throws NullPointerException if data is <code>null</code>
-	 */
-	public RawData(byte[] data, InetAddress address, int port, boolean multicast) {
-		this(data, address, port, null, multicast);
-	}
-
-	/**
-	 * Instantiates a new raw data.
-	 *
-	 * @param data the data that is to be sent or has been received
-	 * @param address the IP address the data is to be sent to or has been received from
-	 * @param port the port the data is to be sent to or has been received from
-	 * @param clientIdentity the identity of the authenticated sender of the message
-	 *     (or <code>null</code> if sender is not authenticated)
-	 * @param multicast indicates whether the data represents a multicast message
-	 * @throws NullPointerException if data is <code>null</code>
-	 */
-	public RawData(byte[] data, InetAddress address, int port, Principal clientIdentity, boolean multicast) {
-		this(data, new InetSocketAddress(address, port), clientIdentity, multicast);
 	}
 
 	/**
 	 * Instantiates a new raw data for a message received from a peer.
 	 *
 	 * @param data the data that is to be sent or has been received.
-	 * @param address the IP address and port the data has been received from.
-	 * @param clientIdentity the identity of the authenticated sender of the message
-	 *     (or <code>null</code> if sender is not authenticated).
-	 * @param endpointContext additional information regarding the context the message has been
-	 *      received in. The information contained will usually come from the transport layer, e.g.
-	 *      the ID of the DTLS session the message has been received in, and can be used to correlate
-	 *      this message with another (previously sent) message.
-	 * @param isMulticast indicates whether the data has been received as a multicast message.
+	 * @param peerEndpointContext information regarding the context the message
+	 *            has been received in. The information contained will usually
+	 *            come from the transport layer, e.g. the ID of the DTLS session
+	 *            the message has been received in, and can be used to correlate
+	 *            this message with another (previously sent) message.
+	 * @param isMulticast indicates whether the data has been received as a
+	 *            multicast message.
 	 * @return the raw data object containing the inbound message.
-	 * @throws NullPointerException if data or address is <code>null</code>.
+	 * @throws NullPointerException if data or address is {@code null}.
 	 */
-	public static RawData inbound(byte[] data, InetSocketAddress address, Principal clientIdentity,
-			EndpointContext endpointContext, boolean isMulticast) {
-		return new RawData(data, address, clientIdentity, endpointContext, isMulticast);
+	public static RawData inbound(byte[] data, EndpointContext peerEndpointContext, boolean isMulticast) {
+		return new RawData(data, peerEndpointContext, null, isMulticast);
 	}
 
 	/**
 	 * Instantiates a new raw data for a message to be sent to a peer.
 	 * <p>
-	 * The given callback handler is notified when the message has been sent by a <code>Connector</code>.
-	 * The information contained in the <code>MessageContext</code> object that is passed in to the
-	 * handler may be relevant for matching a response received via a <code>RawDataChannel</code> to a request
-	 * sent using this method, e.g. when using a DTLS based connector the context may contain the DTLS session
-	 * ID and epoch number which is required to match a response to a request as defined in the CoAP specification.
+	 * The given callback handler is notified when the message has been sent by
+	 * a <code>Connector</code>. The information contained in the
+	 * <code>MessageContext</code> object that is passed in to the handler may
+	 * be relevant for matching a response received via a
+	 * <code>RawDataChannel</code> to a request sent using this method, e.g.
+	 * when using a DTLS based connector the context may contain the DTLS
+	 * session ID and epoch number which is required to match a response to a
+	 * request as defined in the CoAP specification.
 	 * </p>
 	 * <p>
-	 * The message context is set via a callback in order to allow <code>Connector</code> implementations to
-	 * process (send) messages asynchronously.
+	 * The message context is set via a callback in order to allow
+	 * <code>Connector</code> implementations to process (send) messages
+	 * asynchronously.
 	 * </p>
 	 * 
 	 * @param data the data to send.
-	 * @param address the IP address and port the data is to be sent to.
-	 * @param endpointContext endpoint context for sending data (may be <code>null</code>).
-	 * @param callback the handler to call when this message has been sent (may be <code>null</code>).
-	 * @param useMulticast indicates whether the data should be sent using a multicast message.
+	 * @param peerEndpointContext remote peer's endpoint context to send data.
+	 * @param callback the handler to call when this message has been sent (may
+	 *            be {@code null}).
+	 * @param useMulticast indicates whether the data should be sent using a
+	 *            multicast message.
 	 * @return the raw data object containing the outbound message.
-	 * @throws NullPointerException if data or address is <code>null</code>.
+	 * @throws NullPointerException if data or peerContext is {@code null}.
 	 */
-	public static RawData outbound(byte[] data, InetSocketAddress address, EndpointContext endpointContext, MessageCallback callback, boolean useMulticast) {
-		RawData result = new RawData(data, address);
-		result.endpointContext = endpointContext;
-		result.callback = callback;
-		result.multicast = useMulticast;
-		return result;
+	public static RawData outbound(byte[] data, EndpointContext peerEndpointContext, MessageCallback callback,
+			boolean useMulticast) {
+		return new RawData(data, peerEndpointContext, callback, useMulticast);
 	}
 
 	/**
@@ -267,7 +166,7 @@ public final class RawData {
 	 * @return the address
 	 */
 	public InetAddress getAddress() {
-		return address.getAddress();
+		return peerEndpointContext.getPeerAddress().getAddress();
 	}
 
 	/**
@@ -276,7 +175,7 @@ public final class RawData {
 	 * @return the port
 	 */
 	public int getPort() {
-		return address.getPort();
+		return peerEndpointContext.getPeerAddress().getPort();
 	}
 
 	/**
@@ -294,7 +193,7 @@ public final class RawData {
 	 * @return the address
 	 */
 	public InetSocketAddress getInetSocketAddress() {
-		return address;
+		return peerEndpointContext.getPeerAddress();
 	}
 
 	/**
@@ -302,22 +201,22 @@ public final class RawData {
 	 * 
 	 * This property is only meaningful for messages received from a client.
 	 * 
-	 * @return the identity or <code>null</code> if the
-	 *      sender has not been authenticated
+	 * @return the identity or <code>null</code> if the sender has not been
+	 *         authenticated
 	 */
 	public Principal getSenderIdentity() {
-		return senderIdentity;
+		return peerEndpointContext.getPeerIdentity();
 	}
 
 	/**
 	 * Gets additional information regarding the context this message has been
 	 * received in or should be sent in.
 	 * 
-	 * @return the messageContext the endpoint information or <code>null</code> if
-	 *           no additional endpoint information is available
+	 * @return the messageContext the endpoint information or <code>null</code>
+	 *         if no additional endpoint information is available
 	 */
 	public EndpointContext getEndpointContext() {
-		return endpointContext;
+		return peerEndpointContext;
 	}
 
 	/**
@@ -327,7 +226,7 @@ public final class RawData {
 	 *         otherwise
 	 */
 	public boolean isSecure() {
-		return (endpointContext != null && endpointContext.get(DtlsEndpointContext.KEY_SESSION_ID) != null);
+		return (peerEndpointContext != null && peerEndpointContext.get(DtlsEndpointContext.KEY_SESSION_ID) != null);
 	}
 
 	/**

--- a/element-connector/src/main/java/org/eclipse/californium/elements/TcpEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/TcpEndpointContext.java
@@ -14,8 +14,13 @@
  *    Bosch Software Innovations GmbH - initial support for correlation context to provide
  *                                      additional information to application layer for
  *                                      matching messages using TCP.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - extend endpoint context with
+ *                                                    inet socket address and principal
  ******************************************************************************/
 package org.eclipse.californium.elements;
+
+import java.net.InetSocketAddress;
+import java.security.Principal;
 
 /**
  * A endpoint context that explicitly supports TCP specific properties.
@@ -31,10 +36,26 @@ public class TcpEndpointContext extends MapBasedEndpointContext {
 	/**
 	 * Creates a new endpoint context from TCP connection ID.
 	 * 
+	 * @param peerAddress peer address of endpoint context
 	 * @param connectionId the connectionn's ID.
-	 * @throws NullPointerException if connectionId is <code>null</code>.
+	 * @throws NullPointerException if connectionId or peer address is
+	 *             <code>null</code>.
 	 */
-	public TcpEndpointContext(String connectionId) {
+	public TcpEndpointContext(InetSocketAddress peerAddress, String connectionId) {
+		this(peerAddress, null, connectionId);
+	}
+
+	/**
+	 * Creates a new endpoint context from TCP connection ID.
+	 * 
+	 * @param peerAddress peer address of endpoint context
+	 * @param peerIdentity peer identity of endpoint context
+	 * @param connectionId the connectionn's ID.
+	 * @throws NullPointerException if connectionId or peer address is
+	 *             <code>null</code>.
+	 */
+	public TcpEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity, String connectionId) {
+		super(peerAddress, peerIdentity);
 		if (connectionId == null) {
 			throw new NullPointerException("Connection ID must not be null");
 		} else {
@@ -48,7 +69,8 @@ public class TcpEndpointContext extends MapBasedEndpointContext {
 
 	@Override
 	public String toString() {
-		return String.format("TCP(%s)", getConnectionId());
+		return String.format("TCP(%s:%d,ID:%s)", getPeerAddress().getHostString(), getPeerAddress().getPort(),
+				getConnectionId());
 	}
 
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
@@ -304,7 +304,7 @@ public class UDPConnector implements Connector {
 							datagram.getAddress(), datagram.getPort()});
 			}
 			byte[] bytes = Arrays.copyOfRange(datagram.getData(), datagram.getOffset(), datagram.getLength());
-			RawData msg = new RawData(bytes, datagram.getAddress(), datagram.getPort());
+			RawData msg = RawData.inbound(bytes, new AddressEndpointContext(datagram.getAddress(), datagram.getPort()), false);
 
 			receiver.receiveData(msg);
 		}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UdpEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UdpEndpointContextMatcher.java
@@ -16,6 +16,9 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - add isToBeSent to control
  *                                                    outgoing messages
  *                                                    (fix GitHub issue #104)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use inhibitNewConnection
+ *                                                    to distinguish from 
+ *                                                    none plain UDP contexts.
  ******************************************************************************/
 package org.eclipse.californium.elements;
 
@@ -46,7 +49,7 @@ public class UdpEndpointContextMatcher implements EndpointContextMatcher {
 	}
 
 	private final boolean internalMatch(EndpointContext requestedContext, EndpointContext availableContext) {
-		return (null == requestedContext) || (null != availableContext);
+		return (null == requestedContext) || !requestedContext.inhibitNewConnection() || (null != availableContext);
 	}
 
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/DatagramFramer.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/DatagramFramer.java
@@ -25,7 +25,6 @@ import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.RawData;
 
 import java.math.BigInteger;
-import java.net.InetSocketAddress;
 import java.util.List;
 
 /**
@@ -72,9 +71,8 @@ public class DatagramFramer extends ByteToMessageDecoder {
 			in.readBytes(data);
 			// This is TCP connector, so we know remote address is InetSocketAddress.
 			Channel channel = ctx.channel();
-			InetSocketAddress socketAddress = (InetSocketAddress) channel.remoteAddress();
 			EndpointContext endpointContext = NettyContextUtils.buildEndpointContext(channel);
-			RawData rawData = RawData.inbound(data, socketAddress, null, endpointContext, false);
+			RawData rawData = RawData.inbound(data, endpointContext, false);
 			out.add(rawData);
 		}
 	}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/NettyContextUtils.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/NettyContextUtils.java
@@ -18,6 +18,7 @@ package org.eclipse.californium.elements.tcp;
 
 import io.netty.channel.Channel;
 
+import java.net.InetSocketAddress;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -40,8 +41,9 @@ public class NettyContextUtils {
 	 * @return endpoint context
 	 */
 	public static EndpointContext buildEndpointContext(Channel channel) {
+		InetSocketAddress address = (InetSocketAddress) channel.remoteAddress();
 		String id = channel.id().asShortText();
 		LOGGER.log(LEVEL, "TCP({0})", id);
-		return new TcpEndpointContext(id);
+		return new TcpEndpointContext(address, null, id);
 	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpClientConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/tcp/TcpClientConnector.java
@@ -130,10 +130,10 @@ public class TcpClientConnector implements Connector {
 		if (null != endpointMatcher && !poolMap.contains(addressKey)
 				&& !endpointMatcher.isToBeSent(msg.getEndpointContext(), null)) {
 			if (LOGGER.isLoggable(Level.WARNING)) {
-				LOGGER.log(Level.WARNING, "TcpConnector (drops {0} bytes to {1}:{2}",
+				LOGGER.log(Level.WARNING, "TcpConnector (drops {0} bytes to new {1}:{2}",
 						new Object[] { msg.getSize(), msg.getAddress(), msg.getPort() });
 			}
-			msg.onError(new EndpointMismatchException());
+			msg.onError(new EndpointMismatchException("no connection"));
 			return;
 		}
 		final ChannelPool channelPool = poolMap.get(addressKey);

--- a/element-connector/src/test/java/org/eclipse/californium/elements/DtlsEndpointContextMatcherTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/DtlsEndpointContextMatcherTest.java
@@ -18,11 +18,15 @@ package org.eclipse.californium.elements;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.net.InetSocketAddress;
+
 import org.junit.Before;
 import org.junit.Test;
 
 public class DtlsEndpointContextMatcherTest {
 
+	private static final InetSocketAddress ADDRESS = new InetSocketAddress(0);
+	
 	private EndpointContext connectorContext;
 	private EndpointContext relaxedMessageContext;
 	private EndpointContext strictMessageContext;
@@ -33,11 +37,11 @@ public class DtlsEndpointContextMatcherTest {
 
 	@Before
 	public void setup() {
-		connectorContext = new DtlsEndpointContext("session", "1", "CIPHER");
-		relaxedMessageContext = new DtlsEndpointContext("session", "2", "CIPHER");
-		strictMessageContext = new DtlsEndpointContext("session", "1", "CIPHER");
-		differentMessageContext = new DtlsEndpointContext("new session", "1", "CIPHER");
-		MapBasedEndpointContext mapBasedContext = new MapBasedEndpointContext();
+		connectorContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
+		relaxedMessageContext = new DtlsEndpointContext(ADDRESS, null,"session", "2", "CIPHER");
+		strictMessageContext = new DtlsEndpointContext(ADDRESS, null,"session", "1", "CIPHER");
+		differentMessageContext = new DtlsEndpointContext(ADDRESS, null,"new session", "1", "CIPHER");
+		MapBasedEndpointContext mapBasedContext = new MapBasedEndpointContext(ADDRESS, null);
 		mapBasedContext.put("ID", "session");
 		unsecureMessageContext = mapBasedContext;
 		relaxedMatcher = new RelaxedDtlsEndpointContextMatcher();
@@ -45,32 +49,28 @@ public class DtlsEndpointContextMatcherTest {
 	}
 
 	@Test
-	public void testRelaxedWithConnectorEndpointContext() {
-		assertThat(relaxedMatcher.isToBeSent(null, connectorContext), is(true));
+	public void testRelaxedWithConnectionEndpointContext() {
 		assertThat(relaxedMatcher.isToBeSent(relaxedMessageContext, connectorContext), is(true));
 		assertThat(relaxedMatcher.isToBeSent(differentMessageContext, connectorContext), is(false));
 		assertThat(relaxedMatcher.isToBeSent(unsecureMessageContext, connectorContext), is(false));
 	}
 
 	@Test
-	public void testStrictWithConnectorEndpointContext() {
-		assertThat(strictMatcher.isToBeSent(null, connectorContext), is(true));
+	public void testStrictWithConnectionEndpointContext() {
 		assertThat(strictMatcher.isToBeSent(strictMessageContext, connectorContext), is(true));
 		assertThat(strictMatcher.isToBeSent(relaxedMessageContext, connectorContext), is(false));
 		assertThat(strictMatcher.isToBeSent(unsecureMessageContext, connectorContext), is(false));
 	}
 
 	@Test
-	public void testRelaxedWithoutConnectorEndpointContext() {
-		assertThat(relaxedMatcher.isToBeSent(null, null), is(true));
+	public void testRelaxedWithoutConnectionEndpointContext() {
 		assertThat(relaxedMatcher.isToBeSent(relaxedMessageContext, null), is(false));
 		assertThat(relaxedMatcher.isToBeSent(differentMessageContext, null), is(false));
 		assertThat(relaxedMatcher.isToBeSent(unsecureMessageContext, null), is(false));
 	}
 
 	@Test
-	public void testStrictWithoutConnectorEndpointContext() {
-		assertThat(strictMatcher.isToBeSent(null, null), is(true));
+	public void testStrictWithoutConnectionEndpointContext() {
 		assertThat(strictMatcher.isToBeSent(strictMessageContext, null), is(false));
 		assertThat(strictMatcher.isToBeSent(relaxedMessageContext, null), is(false));
 		assertThat(strictMatcher.isToBeSent(unsecureMessageContext, null), is(false));

--- a/element-connector/src/test/java/org/eclipse/californium/elements/EndpointContextUtilTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/EndpointContextUtilTest.java
@@ -18,12 +18,15 @@ package org.eclipse.californium.elements;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.net.InetSocketAddress;
 import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
 
 public class EndpointContextUtilTest {
+
+	private static final InetSocketAddress ADDRESS = new InetSocketAddress(0);
 
 	private EndpointContext connectorContext;
 	private EndpointContext relaxedMessageContext;
@@ -34,15 +37,15 @@ public class EndpointContextUtilTest {
 
 	@Before
 	public void setup() {
-		connectorContext = new DtlsEndpointContext("session", "1", "CIPHER");
-		relaxedMessageContext = new DtlsEndpointContext("session", "2", "CIPHER");
-		strictMessageContext = new DtlsEndpointContext("session", "1", "CIPHER");
-		differentMessageContext = new DtlsEndpointContext("new session", "1", "CIPHER");
-		MapBasedEndpointContext mapBasedContext = new MapBasedEndpointContext();
+		connectorContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
+		relaxedMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "2", "CIPHER");
+		strictMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
+		differentMessageContext = new DtlsEndpointContext(ADDRESS, null, "new session", "1", "CIPHER");
+		MapBasedEndpointContext mapBasedContext = new MapBasedEndpointContext(ADDRESS, null);
 		mapBasedContext.put("ID", "session");
 		mapBasedContext.put("UNKNOWN", "secret");
 		unsecureMessageContext = mapBasedContext;
-		mapBasedContext = new MapBasedEndpointContext();
+		mapBasedContext = new MapBasedEndpointContext(ADDRESS, null);
 		mapBasedContext.put("ID", "session");
 		mapBasedContext.put("UNKNOWN", "topsecret");
 		unsecureMessageContext2 = mapBasedContext;

--- a/element-connector/src/test/java/org/eclipse/californium/elements/RawDataTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/RawDataTest.java
@@ -38,22 +38,19 @@ public class RawDataTest {
 	@Test
 	public void testIsSecure() {
 
-		RawData rawData = RawData.inbound(new byte[]{0x01, 0x02}, SOURCE, null, getSecureEndpointContext(), false);
+		RawData rawData = RawData.inbound(new byte[]{0x01, 0x02}, getSecureEndpointContext(), false);
 		assertTrue(rawData.isSecure());
 
-		rawData = RawData.inbound(new byte[]{0x01, 0x02}, SOURCE, null, getNonSecureEndpointContext(), false);
-		assertFalse(rawData.isSecure());
-
-		rawData = RawData.inbound(new byte[]{0x01, 0x02}, SOURCE, null, null, false);
+		rawData = RawData.inbound(new byte[]{0x01, 0x02}, getNonSecureEndpointContext(), false);
 		assertFalse(rawData.isSecure());
 	}
 
 	private EndpointContext getSecureEndpointContext() {
-		return new DtlsEndpointContext("12345", "2", "PSK");
+		return new DtlsEndpointContext(SOURCE, null, "12345", "2", "PSK");
 	}
 
 	private EndpointContext getNonSecureEndpointContext() {
-		MapBasedEndpointContext ctx = new MapBasedEndpointContext();
+		MapBasedEndpointContext ctx = new MapBasedEndpointContext(SOURCE, null);
 		ctx.put("someKey", "someValue");
 		return ctx;
 	}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/TcpEndpointContextMatcherTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/TcpEndpointContextMatcherTest.java
@@ -18,10 +18,13 @@ package org.eclipse.californium.elements;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.net.InetSocketAddress;
+
 import org.junit.Before;
 import org.junit.Test;
 
 public class TcpEndpointContextMatcherTest {
+	private static final InetSocketAddress ADDRESS = new InetSocketAddress(0);
 
 	private EndpointContext connectorContext;
 	private EndpointContext messageContext;
@@ -30,22 +33,20 @@ public class TcpEndpointContextMatcherTest {
 
 	@Before
 	public void setup() {
-		connectorContext = new TcpEndpointContext("ID1");
-		messageContext = new TcpEndpointContext("ID1");
-		differentMessageContext = new TcpEndpointContext("ID2");
+		connectorContext = new TcpEndpointContext(ADDRESS, "ID1");
+		messageContext = new TcpEndpointContext(ADDRESS, "ID1");
+		differentMessageContext = new TcpEndpointContext(ADDRESS, "ID2");
 		matcher = new TcpEndpointContextMatcher();
 	}
 
 	@Test
 	public void testWithConnectorEndpointContext() {
-		assertThat(matcher.isToBeSent(null, connectorContext), is(true));
 		assertThat(matcher.isToBeSent(messageContext, connectorContext), is(true));
 		assertThat(matcher.isToBeSent(differentMessageContext, connectorContext), is(false));
 	}
 
 	@Test
 	public void testWithoutConnectorEndpointContext() {
-		assertThat(matcher.isToBeSent(null, null), is(true));
 		assertThat(matcher.isToBeSent(messageContext, null), is(false));
 		assertThat(matcher.isToBeSent(differentMessageContext, null), is(false));
 	}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/UDPConnectorTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/UDPConnectorTest.java
@@ -59,9 +59,9 @@ public class UDPConnectorTest {
 	public void testSendMessageWithEndpointContext() throws InterruptedException {
 		byte[] data = { 0, 1, 2 };
 		InetSocketAddress dest = new InetSocketAddress(0);
-		EndpointContext context = new DtlsEndpointContext("session", "1", "CIPHER");
+		EndpointContext context = new DtlsEndpointContext(dest, null, "session", "1", "CIPHER");
 		
-		RawData message = RawData.outbound(data, dest, context, null, false);
+		RawData message = RawData.outbound(data, context, null, false);
 		connector.setEndpointContextMatcher(matcher);
 		connector.send(message);
 		

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/ConnectorTestUtil.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/ConnectorTestUtil.java
@@ -29,6 +29,7 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Random;
 
+import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.MessageCallback;
 import org.eclipse.californium.elements.RawData;
@@ -58,8 +59,8 @@ public class ConnectorTestUtil {
 		return server;
 	}
 
-	public static RawData createMessage(InetSocketAddress address, int messageSize, EndpointContext contextToSent,
-			MessageCallback callback) throws Exception {
+	public static RawData createMessage(int messageSize, EndpointContext contextToSent, MessageCallback callback)
+			throws Exception {
 		byte[] data = new byte[messageSize];
 		random.nextBytes(data);
 
@@ -87,7 +88,12 @@ public class ConnectorTestUtil {
 			stream.write(data);
 			stream.flush();
 
-			return RawData.outbound(stream.toByteArray(), getDestination(address), contextToSent, callback, false);
+			return RawData.outbound(stream.toByteArray(), contextToSent, callback, false);
 		}
+	}
+
+	public static RawData createMessage(InetSocketAddress address, int messageSize, MessageCallback callback)
+			throws Exception {
+		return createMessage(messageSize, new AddressEndpointContext(getDestination(address)), callback);
 	}
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TcpConnectorTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TcpConnectorTest.java
@@ -95,7 +95,7 @@ public class TcpConnectorTest {
 		server.start();
 		client.start();
 
-		RawData msg = createMessage(server.getAddress(), messageSize, null, null);
+		RawData msg = createMessage(server.getAddress(), messageSize, null);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(1);
@@ -103,7 +103,7 @@ public class TcpConnectorTest {
 
 		// Response message must go over the same connection client already
 		// opened
-		msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress(), messageSize, null, null);
+		msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress(), messageSize, null);
 		server.send(msg);
 		clientCatcher.blockUntilSize(1);
 		assertArrayEquals(msg.getBytes(), clientCatcher.getMessage(0).getBytes());
@@ -128,7 +128,7 @@ public class TcpConnectorTest {
 			client.setRawDataReceiver(clientCatcher);
 			client.start();
 
-			RawData msg = createMessage(server.getAddress(), messageSize, null, null);
+			RawData msg = createMessage(server.getAddress(), messageSize, null);
 			messages.add(msg);
 			client.send(msg);
 		}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TcpEndpointContextTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TcpEndpointContextTest.java
@@ -90,7 +90,7 @@ public class TcpEndpointContextTest {
 		client.start();
 
 		SimpleMessageCallback clientCallback = new SimpleMessageCallback();
-		RawData msg = createMessage(server.getAddress(), 100, null, clientCallback);
+		RawData msg = createMessage(server.getAddress(), 100, clientCallback);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(1);
@@ -106,7 +106,7 @@ public class TcpEndpointContextTest {
 		// Response message must go over the same connection client already
 		// opened
 		SimpleMessageCallback serverCallback = new SimpleMessageCallback();
-		msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress(), 100, null,
+		msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress(), 100, 
 				serverCallback);
 		server.send(msg);
 		clientCatcher.blockUntilSize(1);
@@ -126,7 +126,7 @@ public class TcpEndpointContextTest {
 
 		// send next message
 		clientCallback = new SimpleMessageCallback();
-		msg = createMessage(server.getAddress(), 100, null, clientCallback);
+		msg = createMessage(server.getAddress(), 100, clientCallback);
 
 		client.send(msg);
 
@@ -167,7 +167,7 @@ public class TcpEndpointContextTest {
 		client.start();
 
 		SimpleMessageCallback clientCallback = new SimpleMessageCallback();
-		RawData msg = createMessage(server.getAddress(), 100, null, clientCallback);
+		RawData msg = createMessage(server.getAddress(), 100, clientCallback);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(1);
@@ -179,7 +179,7 @@ public class TcpEndpointContextTest {
 		Thread.sleep(TimeUnit.MILLISECONDS.convert(ConnectorTestUtil.IDLE_TIMEOUT_RECONNECT_IN_S * 2, TimeUnit.SECONDS));
 
 		clientCallback = new SimpleMessageCallback();
-		msg = createMessage(server.getAddress(), 100, null, clientCallback);
+		msg = createMessage(server.getAddress(), 100, clientCallback);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(2);
@@ -233,7 +233,7 @@ public class TcpEndpointContextTest {
 		client.start();
 
 		SimpleMessageCallback clientCallback = new SimpleMessageCallback();
-		RawData msg = createMessage(server.getAddress(), 100, null, clientCallback);
+		RawData msg = createMessage(server.getAddress(), 100, clientCallback);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(1);
@@ -246,7 +246,7 @@ public class TcpEndpointContextTest {
 		server.start();
 
 		clientCallback = new SimpleMessageCallback();
-		msg = createMessage(server.getAddress(), 100, null, clientCallback);
+		msg = createMessage(server.getAddress(), 100, clientCallback);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(2);
@@ -288,7 +288,6 @@ public class TcpEndpointContextTest {
 	@Test
 	public void testClientSendingEndpointContext() throws Exception {
 		TcpEndpointContextMatcher matcher = new TcpEndpointContextMatcher();
-		TcpEndpointContext context = new TcpEndpointContext("n.a.");
 		TcpServerConnector server = new TcpServerConnector(createServerAddress(0),
 				ConnectorTestUtil.NUMBER_OF_THREADS, ConnectorTestUtil.IDLE_TIMEOUT_IN_S);
 		TcpClientConnector client = new TcpClientConnector(ConnectorTestUtil.NUMBER_OF_THREADS,
@@ -306,14 +305,15 @@ public class TcpEndpointContextTest {
 		client.start();
 
 		SimpleMessageCallback clientCallback = new SimpleMessageCallback();
-		RawData msg = createMessage(server.getAddress(), 100, context, clientCallback);
+		TcpEndpointContext context = new TcpEndpointContext(getDestination(server.getAddress()), "n.a.");
+		RawData msg = createMessage(100, context, clientCallback);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(1, 2000);
 		assertThat("Serverside received unexpected message", !serverCatcher.hasMessage(0));
 
 		clientCallback = new SimpleMessageCallback();
-		msg = createMessage(server.getAddress(), 100, null, clientCallback);
+		msg = createMessage(server.getAddress(), 100, clientCallback);
 		client.send(msg);
 		serverCatcher.blockUntilSize(1);
 
@@ -322,12 +322,12 @@ public class TcpEndpointContextTest {
 				is(instanceOf(TcpEndpointContext.class)));
 		assertThat(clientContext.get(TcpEndpointContext.KEY_CONNECTION_ID), is(not(isEmptyOrNullString())));
 
-		msg = createMessage(server.getAddress(), 100, clientContext, clientCallback);
+		msg = createMessage(100, clientContext, clientCallback);
 		client.send(msg);
 		serverCatcher.blockUntilSize(2);
 
 		clientCallback = new SimpleMessageCallback();
-		msg = createMessage(server.getAddress(), 100, context, clientCallback);
+		msg = createMessage(100, context, clientCallback);
 		client.send(msg);
 
 		serverCatcher.blockUntilSize(3, 2000);
@@ -352,7 +352,6 @@ public class TcpEndpointContextTest {
 	@Test
 	public void testServerSendingEndpointContext() throws Exception {
 		TcpEndpointContextMatcher matcher = new TcpEndpointContextMatcher();
-		TcpEndpointContext context = new TcpEndpointContext("n.a.");
 		TcpServerConnector server = new TcpServerConnector(createServerAddress(0),
 				ConnectorTestUtil.NUMBER_OF_THREADS, ConnectorTestUtil.IDLE_TIMEOUT_IN_S);
 		TcpClientConnector client = new TcpClientConnector(ConnectorTestUtil.NUMBER_OF_THREADS,
@@ -370,7 +369,7 @@ public class TcpEndpointContextTest {
 		client.start();
 
 		SimpleMessageCallback clientCallback = new SimpleMessageCallback();
-		RawData msg = createMessage(server.getAddress(), 100, null, clientCallback);
+		RawData msg = createMessage(server.getAddress(), 100, clientCallback);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(1);
@@ -382,19 +381,20 @@ public class TcpEndpointContextTest {
 		assertThat(serverContext.get(TcpEndpointContext.KEY_CONNECTION_ID), is(not(isEmptyOrNullString())));
 
 		SimpleMessageCallback serverCallback = new SimpleMessageCallback();
-		msg = createMessage(receivedMsg.getInetSocketAddress(), 100, serverContext, serverCallback);
+		msg = createMessage(100, serverContext, serverCallback);
 		server.send(msg);
 
 		clientCatcher.blockUntilSize(1);
 
 		serverCallback = new SimpleMessageCallback();
-		msg = createMessage(receivedMsg.getInetSocketAddress(), 100, null, serverCallback);
+		msg = createMessage(receivedMsg.getInetSocketAddress(), 100, serverCallback);
 		server.send(msg);
 
 		clientCatcher.blockUntilSize(2);
 
 		serverCallback = new SimpleMessageCallback();
-		msg = createMessage(receivedMsg.getInetSocketAddress(), 100, context, serverCallback);
+		TcpEndpointContext context = new TcpEndpointContext(receivedMsg.getInetSocketAddress(), "n.a.");
+		msg = createMessage(100, context, serverCallback);
 		server.send(msg);
 
 		clientCatcher.blockUntilSize(3, 2000);
@@ -442,7 +442,7 @@ public class TcpEndpointContextTest {
 		List<SimpleMessageCallback> callbacks = new ArrayList<>();
 		for (InetSocketAddress address : serverAddresses) {
 			SimpleMessageCallback callback = new SimpleMessageCallback();
-			RawData message = createMessage(address, 100, null, callback);
+			RawData message = createMessage(address, 100, callback);
 			callbacks.add(callback);
 			messages.add(message);
 			client.send(message);
@@ -460,7 +460,7 @@ public class TcpEndpointContextTest {
 		List<SimpleMessageCallback> followupCallbacks = new ArrayList<>();
 		for (InetSocketAddress address : serverAddresses) {
 			SimpleMessageCallback callback = new SimpleMessageCallback();
-			RawData message = createMessage(address, 100, null, callback);
+			RawData message = createMessage(address, 100, callback);
 			followupCallbacks.add(callback);
 			followupMessages.add(message);
 			client.send(message);

--- a/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TlsConnectorTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/tcp/TlsConnectorTest.java
@@ -124,7 +124,7 @@ public class TlsConnectorTest {
 		server.start();
 		client.start();
 
-		RawData msg = createMessage(server.getAddress(), 100, null, null);
+		RawData msg = createMessage(server.getAddress(), 100, null);
 
 		client.send(msg);
 		serverCatcher.blockUntilSize(1);
@@ -132,7 +132,7 @@ public class TlsConnectorTest {
 
 		// Response message must go over the same connection client already
 		// opened
-		msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress(), 10000, null, null);
+		msg = createMessage(serverCatcher.getMessage(0).getInetSocketAddress(), 10000, null);
 		server.send(msg);
 		clientCatcher.blockUntilSize(1);
 		assertArrayEquals(msg.getBytes(), clientCatcher.getMessage(0).getBytes());
@@ -157,7 +157,7 @@ public class TlsConnectorTest {
 			client.setRawDataReceiver(clientCatcher);
 			client.start();
 
-			RawData msg = createMessage(server.getAddress(), 100, null, null);
+			RawData msg = createMessage(server.getAddress(), 100, null);
 			messages.add(msg);
 			client.send(msg);
 		}
@@ -201,7 +201,7 @@ public class TlsConnectorTest {
 
 		List<RawData> messages = new ArrayList<>();
 		for (InetSocketAddress address : servers.keySet()) {
-			RawData message = createMessage(address, 100, null, null);
+			RawData message = createMessage(address, 100, null);
 			messages.add(message);
 			client.send(message);
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -735,10 +735,12 @@ public class DTLSConnector implements Connector {
 	private void handleApplicationMessage(ApplicationMessage message, DTLSSession session) {
 		if (messageHandler != null) {
 			DtlsEndpointContext context = new DtlsEndpointContext(
+					message.getPeer(),
+					session.getPeerIdentity(),
 					session.getSessionIdentifier().toString(),
 					String.valueOf(session.getReadEpoch()),
 					session.getReadStateCipher());
-			messageHandler.receiveData(RawData.inbound(message.getData(), message.getPeer(), session.getPeerIdentity(), context, false));
+			messageHandler.receiveData(RawData.inbound(message.getData(), context, false));
 		}
 	}
 
@@ -1323,6 +1325,8 @@ public class DTLSConnector implements Connector {
 	private void sendMessage(final RawData message, final DTLSSession session) {
 		try {
 			final EndpointContext ctx = new DtlsEndpointContext(
+					message.getInetSocketAddress(),
+					session.getPeerIdentity(),
 					session.getSessionIdentifier().toString(),
 					String.valueOf(session.getWriteEpoch()),
 					session.getWriteStateCipher());

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
@@ -160,7 +161,8 @@ public class ConnectorHelper {
 	}
 
 	void givenAnEstablishedSession(final DTLSConnector client, boolean releaseSocket) throws Exception {
-		givenAnEstablishedSession(client, new RawData("Hello World".getBytes(), serverEndpoint), releaseSocket);
+		RawData raw = RawData.outbound("Hello World".getBytes(), new AddressEndpointContext(serverEndpoint), null, false);
+		givenAnEstablishedSession(client, raw, releaseSocket);
 	}
 
 	void givenAnEstablishedSession(final DTLSConnector client, RawData msgToSend, boolean releaseSocket) throws Exception {
@@ -245,7 +247,7 @@ public class ConnectorHelper {
 		@Override
 		public RawData process(RawData request) {
 			inboundMessage.set(request);
-			return new RawData("ACK".getBytes(), request.getInetSocketAddress());
+			return RawData.outbound("ACK".getBytes(), request.getEndpointContext(), null, false);
 		}
 
 		@Override

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -63,6 +63,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
 import org.eclipse.californium.elements.tcp.SimpleMessageCallback;
@@ -253,8 +254,7 @@ public class DTLSConnectorTest {
 		SimpleMessageCallback callback = new SimpleMessageCallback();
 		RawData outboundMessage = RawData.outbound(
 				new byte[]{0x01},
-				serverEndpoint,
-				null, 
+				new AddressEndpointContext(serverEndpoint),
 				callback,
 				false);
 
@@ -528,7 +528,8 @@ public class DTLSConnectorTest {
 		assertNotNull(con.getEstablishedSession());
 		assertThat(con.getEstablishedSession().getSessionIdentifier(), is(establishedServerSession.getSessionIdentifier()));
 
-		client.send(new RawData("Hello World".getBytes(), serverEndpoint));
+		RawData data = RawData.outbound("Hello World".getBytes(), new AddressEndpointContext(serverEndpoint), null, false);
+		client.send(data);
 
 		con = serverConnectionStore.get(client.getAddress());
 		assertNotNull(con);
@@ -800,7 +801,8 @@ public class DTLSConnectorTest {
 			client.setRawDataReceiver(clientRawDataChannel);
 			client.start();
 			clientEndpoint = client.getAddress();
-			client.send(new RawData("Hello World".getBytes(), rawServerEndpoint));
+			RawData data = RawData.outbound("Hello World".getBytes(), new AddressEndpointContext(rawServerEndpoint), null, false);
+			client.send(data);
 
 			// Create server handshaker
 			DTLSSession serverSession = new DTLSSession(clientEndpoint, false, 1);
@@ -840,7 +842,8 @@ public class DTLSConnectorTest {
 
 			// force resuming handshake
 			client.forceResumeSessionFor(rawServerEndpoint);
-			client.send(new RawData("Hello Again".getBytes(), rawServerEndpoint));
+			data = RawData.outbound("Hello Again".getBytes(), new AddressEndpointContext(rawServerEndpoint), null, false);
+			client.send(data);
 
 			// Wait to receive response (should be CLIENT HELLO, flight 1)
 			rs = collector.waitForFlight(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS);
@@ -905,7 +908,8 @@ public class DTLSConnectorTest {
 			client.setRawDataReceiver(clientRawDataChannel);
 			client.start();
 			clientEndpoint = client.getAddress();
-			client.send(new RawData("Hello World".getBytes(), rawServerEndpoint));
+			RawData data = RawData.outbound("Hello World".getBytes(), new AddressEndpointContext(rawServerEndpoint), null, false);
+			client.send(data);
 
 			// Create server handshaker
 			ServerHandshaker serverHandshaker = new ServerHandshaker(new DTLSSession(clientEndpoint, false, 1),
@@ -1069,7 +1073,8 @@ public class DTLSConnectorTest {
 		client.setRawDataReceiver(clientRawDataChannel);
 		client.start();
 
-		client.send(new RawData("Hello World".getBytes(), serverEndpoint));
+		RawData data = RawData.outbound("Hello World".getBytes(), new AddressEndpointContext(serverEndpoint), null, false);
+		client.send(data);
 
 		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
 		Connection con = serverConnectionStore.get(clientEndpoint);
@@ -1106,7 +1111,8 @@ public class DTLSConnectorTest {
 		clientRawDataChannel.setLatch(latch);
 
 		// send message
-		client.send(new RawData(msg.getBytes(), serverEndpoint));
+		RawData data = RawData.outbound(msg.getBytes(), new AddressEndpointContext(serverEndpoint), null, false);
+		client.send(data);
 		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
 
 		// check we use the same session id
@@ -1137,7 +1143,8 @@ public class DTLSConnectorTest {
 		clientRawDataChannel.setLatch(latch);
 
 		// send message
-		client.send(new RawData(msg.getBytes(), serverEndpoint));
+		RawData data = RawData.outbound(msg.getBytes(), new AddressEndpointContext(serverEndpoint), null, false);
+		client.send(data);
 		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
 
 		// check we use the same session id
@@ -1168,7 +1175,8 @@ public class DTLSConnectorTest {
 		clientRawDataChannel.setLatch(latch);
 
 		// send message
-		client.send(new RawData(msg.getBytes(), serverEndpoint));
+		RawData data = RawData.outbound(msg.getBytes(), new AddressEndpointContext(serverEndpoint), null, false);
+		client.send(data);
 		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
 
 		// check we use the same session id
@@ -1201,7 +1209,8 @@ public class DTLSConnectorTest {
 		clientRawDataChannel.setLatch(latch);
 
 		// send message
-		client.send(new RawData(msg.getBytes(), serverEndpoint));
+		RawData data = RawData.outbound(msg.getBytes(), new AddressEndpointContext(serverEndpoint), null, false);
+		client.send(data);
 		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
 
 		// check we use the same session id
@@ -1234,7 +1243,8 @@ public class DTLSConnectorTest {
 		clientRawDataChannel.setLatch(latch);
 
 		// send message
-		client.send(new RawData(msg.getBytes(), serverEndpoint));
+		RawData data = RawData.outbound(msg.getBytes(), new AddressEndpointContext(serverEndpoint), null, false);
+		client.send(data);
 		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
 
 		// check we use the same session id
@@ -1261,7 +1271,8 @@ public class DTLSConnectorTest {
 		clientRawDataChannel.setLatch(latch);
 
 		// send message
-		client.send(new RawData(msg.getBytes(), serverEndpoint));
+		RawData data = RawData.outbound(msg.getBytes(), new AddressEndpointContext(serverEndpoint), null, false);
+		client.send(data);
 		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
 
 		// check we use the same session id
@@ -1291,7 +1302,8 @@ public class DTLSConnectorTest {
 		serverConnectionStore.remove(clientEndpoint);
 
 		// send message
-		client.send(new RawData(msg.getBytes(), serverEndpoint));
+		RawData data = RawData.outbound(msg.getBytes(), new AddressEndpointContext(serverEndpoint), null, false);
+		client.send(data);
 		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
 
 		// check session id was not equals
@@ -1365,7 +1377,8 @@ public class DTLSConnectorTest {
 		client.setRawDataReceiver(clientRawDataChannel);
 		client.start();
 		clientEndpoint = client.getAddress();
-		client.send(new RawData("Hello World".getBytes(), serverEndpoint));
+		RawData data = RawData.outbound("Hello World".getBytes(), new AddressEndpointContext(serverEndpoint), null, false);
+		client.send(data);
 
 		assertFalse(latch.await(500, TimeUnit.MILLISECONDS));
 		assertNull("Server should not have established a session with client", serverConnectionStore.get(clientEndpoint));
@@ -1391,7 +1404,7 @@ public class DTLSConnectorTest {
 		});
 		client.start();
 		SimpleMessageCallback callback = new SimpleMessageCallback();
-		RawData data = RawData.outbound("Hello".getBytes(), serverEndpoint, null, callback, false);
+		RawData data = RawData.outbound("Hello".getBytes(), new AddressEndpointContext(serverEndpoint), callback, false);
 		client.send(data);
 
 		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
@@ -1572,8 +1585,10 @@ public class DTLSConnectorTest {
 	private void givenAnEstablishedSession() throws Exception {
 		givenAnEstablishedSession(true);
 	}
+	
 	private void givenAnEstablishedSession(boolean releaseSocket) throws Exception {
-		givenAnEstablishedSession(new RawData("Hello World".getBytes(), serverEndpoint), releaseSocket);
+		RawData raw = RawData.outbound("Hello World".getBytes(), new AddressEndpointContext(serverEndpoint), null, false);
+		givenAnEstablishedSession(raw, releaseSocket);
 	}
 
 	private void givenAnEstablishedSession(RawData msgToSend, boolean releaseSocket) throws Exception {
@@ -1859,7 +1874,7 @@ public class DTLSConnectorTest {
 		@Override
 		public RawData process(RawData request) {
 			inboundMessage.set(request);
-			return new RawData("ACK".getBytes(), request.getInetSocketAddress());
+			return RawData.outbound("ACK".getBytes(), request.getEndpointContext(), null, false);
 		}
 
 		@Override

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.EndpointContextMatcher;
+import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.DtlsEndpointContext;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.tcp.SimpleMessageCallback;
@@ -116,7 +117,7 @@ public class DTLSEndpointContextTest {
 		TestEndpointContextMatcher endpointContextMatcher = new TestEndpointContextMatcher(1);
 		client.setEndpointContextMatcher(endpointContextMatcher);
 		// GIVEN a message to send
-		RawData outboundMessage = RawData.outbound(new byte[] { 0x01 }, serverHelper.serverEndpoint, null, callback,
+		RawData outboundMessage = RawData.outbound(new byte[] { 0x01 }, new AddressEndpointContext(serverHelper.serverEndpoint), callback,
 				false);
 
 		// WHEN sending the initial message, but being blocked by EndpointContextMatcher
@@ -168,7 +169,7 @@ public class DTLSEndpointContextTest {
 		EndpointContext endpointContext = endpointMatcher.getConnectionEndpointContext(1);
 
 		// GIVEN a message with endpoint context
-		RawData outboundMessage = RawData.outbound(new byte[] { 0x01 }, serverHelper.serverEndpoint, endpointContext,
+		RawData outboundMessage = RawData.outbound(new byte[] { 0x01 }, endpointContext,
 				null, false);
 
 		// WHEN sending a message
@@ -196,7 +197,7 @@ public class DTLSEndpointContextTest {
 		client.forceResumeAllSessions();
 
 		// GIVEN a message with endpoint context
-		RawData outboundMessage = RawData.outbound(new byte[] { 0x01 }, serverHelper.serverEndpoint, null, null, false);
+		RawData outboundMessage = RawData.outbound(new byte[] { 0x01 }, new AddressEndpointContext(serverHelper.serverEndpoint), null, false);
 
 		// WHEN sending a message
 		client.send(outboundMessage);
@@ -209,7 +210,7 @@ public class DTLSEndpointContextTest {
 	@Test
 	public void testConnectorAddsEndpointContextToReceivedApplicationMessage() throws Exception {
 		// GIVEN a message to be sent to the server
-		RawData outboundMessage = RawData.outbound(new byte[] { 0x01 }, serverHelper.serverEndpoint, null, null, false);
+		RawData outboundMessage = RawData.outbound(new byte[] { 0x01 }, new AddressEndpointContext(serverHelper.serverEndpoint), null, false);
 
 		// WHEN a session has been established and the message has been sent to
 		// the server


### PR DESCRIPTION
Cleanup RawData constructors.
Use EndpointContext and EndpointContextMatcher mocks for Matcher tests
in core.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>