### PR TITLE
Use endpoint context for in- and outcoming messages.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
@@ -43,6 +43,7 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.observe.ObserveNotificationOrderer;
+import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.util.DaemonThreadFactory;
 
 /**
@@ -125,8 +126,9 @@ public class CoapObserveRelation {
 		}
 		if (registrationPending.compareAndSet(false, true)) {
 			Request refresh = Request.newGet();
-			refresh.setDestination(request.getDestination());
-			refresh.setDestinationPort(request.getDestinationPort());
+			EndpointContext destinationContext = response != null ? response.advanced().getSourceContext()
+					: request.getDestinationContext();
+			refresh.setDestinationContext(destinationContext);
 			// use same Token
 			refresh.setToken(request.getToken());
 			// copy options, but set Observe to zero
@@ -155,10 +157,13 @@ public class CoapObserveRelation {
 	 * Send request with option "cancel observe" (GET with Observe=1).
 	 */
 	private void sendCancelObserve() {
+		CoapResponse response = current;
 		Request request = this.request;
+		EndpointContext destinationContext = response != null ? response.advanced().getSourceContext()
+				: request.getDestinationContext();
+		
 		Request cancel = Request.newGet();
-		cancel.setDestination(request.getDestination());
-		cancel.setDestinationPort(request.getDestinationPort());
+		cancel.setDestinationContext(destinationContext);
 		// use same Token
 		cancel.setToken(request.getToken());
 		// copy options

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/EmptyMessage.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/EmptyMessage.java
@@ -16,6 +16,8 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use source and destination
+ *                                                    EndpointContext
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
@@ -76,8 +78,7 @@ public class EmptyMessage extends Message {
 	 */
 	public static EmptyMessage newACK(Message message) {
 		EmptyMessage ack = new EmptyMessage(Type.ACK);
-		ack.setDestination(message.getSource());
-		ack.setDestinationPort(message.getSourcePort());
+		ack.setDestinationContext(message.getSourceContext());
 		ack.setMID(message.getMID());
 		return ack;
 	}
@@ -90,8 +91,7 @@ public class EmptyMessage extends Message {
 	 */
 	public static EmptyMessage newRST(Message message) {
 		EmptyMessage rst = new EmptyMessage(Type.RST);
-		rst.setDestination(message.getSource());
-		rst.setDestinationPort(message.getSourcePort());
+		rst.setDestinationContext(message.getSourceContext());
 		rst.setMID(message.getMID());
 		return rst;
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Response.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Response.java
@@ -17,9 +17,11 @@
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
  *    Achim Kraus (Bosch Software Innovations GmbH) - move payload string conversion
- *    												  from toString() to
+ *                                                    from toString() to
  *                                                    Message.getPayloadTracingString(). 
  *                                                    (for message tracing)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - introduce source and destination
+ *                                                    EndpointContext
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
@@ -47,22 +49,24 @@ public class Response extends Message {
 	private boolean last = true;
 
 	/**
-	 * Creates a response to the specified request with the specified response
-	 * code. The destination address of the response is the source address of
-	 * the request.
-	 * Type and MID are usually set automatically by the {@link ReliabilityLayer}.
-	 * The token is set automatically by the {@link Matcher}.
+	 * Creates a response to the provided received request with the specified
+	 * response code. The destination endpoint context of the response will be
+	 * the source endpoint context of the request. Type and MID are usually set
+	 * automatically by the {@link ReliabilityLayer}. The token is set
+	 * automatically by the {@link Matcher}.
 	 *
-	 * @param request
-	 *            the request
-	 * @param code
-	 *            the code
+	 * @param receivedRequest the request
+	 * @param code the code
 	 * @return the response
+	 * @throws IllegalArgumentException if request has no source endpoint
+	 *             context.
 	 */
-	public static Response createResponse(Request request, ResponseCode code) {
+	public static Response createResponse(Request receivedRequest, ResponseCode code) {
+		if (receivedRequest.getSourceContext() == null) {
+			throw new IllegalArgumentException("received request must contain a source context.");
+		}
 		Response response = new Response(code);
-		response.setDestination(request.getSource());
-		response.setDestinationPort(request.getSourcePort());
+		response.setDestinationContext(receivedRequest.getSourceContext());
 		return response;
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
@@ -38,6 +38,8 @@
  *                                                    would terminate the observation
  *                                                    and therefore doesn't contain a
  *                                                    observe option.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace parameter EndpointContext 
+ *                                                    by EndpointContext of response.
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -54,7 +56,6 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.observe.Observation;
 import org.eclipse.californium.core.observe.ObservationStore;
-import org.eclipse.californium.elements.EndpointContext;
 
 /**
  * A base class for implementing Matchers that provides support for using a
@@ -166,11 +167,10 @@ public abstract class BaseMatcher implements Matcher {
 	 * {@link #observationStore} and if found, recreate a exchange.
 	 * 
 	 * @param response notify response
-	 * @param responseContext endpoint context of response
 	 * @return exchange, if a new one is create of the stored observe
 	 *         informations, null, otherwise.
 	 */
-	protected final Exchange matchNotifyResponse(final Response response, final EndpointContext responseContext) {
+	protected final Exchange matchNotifyResponse(final Response response) {
 
 		Exchange exchange = null;
 		if (!CoAP.ResponseCode.isSuccess(response.getCode()) || response.getOptions().hasObserve()) {
@@ -184,8 +184,6 @@ public abstract class BaseMatcher implements Matcher {
 				// notification
 				// response
 				final Request request = obs.getRequest();
-				request.setDestination(response.getSource());
-				request.setDestinationPort(response.getSourcePort());
 				exchange = new Exchange(request, Origin.LOCAL, obs.getContext());
 				exchange.setRequest(request);
 				LOG.log(Level.FINER, "re-created exchange from original observe request: {0}", request);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -30,9 +30,12 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - stop retransmission on complete.
  *    Achim Kraus (Bosch Software Innovations GmbH) - adjust javadoc for 
  *                                                    completeCurrentRequest.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - rename CorrelationContext to
+ *                                                    EndpointContext.
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
+import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -239,8 +242,7 @@ public class Exchange {
 	 * @param response the response
 	 */
 	public void sendResponse(Response response) {
-		response.setDestination(request.getSource());
-		response.setDestinationPort(request.getSourcePort());
+		response.setDestinationContext(request.getSourceContext());
 		setResponse(response);
 		endpoint.sendResponse(this, response);
 	}
@@ -720,7 +722,8 @@ public class Exchange {
 		 *         scoped to the message's source address and port.
 		 */
 		public static KeyMID fromInboundMessage(Message message) {
-			return new KeyMID(message.getMID(), message.getSource().getAddress(), message.getSourcePort());
+			InetSocketAddress address = message.getSourceContext().getPeerAddress();
+			return new KeyMID(message.getMID(), address.getAddress().getAddress(), address.getPort());
 		}
 
 		/**
@@ -731,7 +734,8 @@ public class Exchange {
 		 *         scoped to the message's destination address and port.
 		 */
 		public static KeyMID fromOutboundMessage(Message message) {
-			return new KeyMID(message.getMID(), message.getDestination().getAddress(), message.getDestinationPort());
+			InetSocketAddress address = message.getDestinationContext().getPeerAddress();
+			return new KeyMID(message.getMID(), address.getAddress().getAddress(), address.getPort());
 		}
 	}
 
@@ -768,11 +772,12 @@ public class Exchange {
 		 * <p>
 		 * The key will be scoped to the message's source endpoint.
 		 * 
-		 * @param msg the message.
+		 * @param message the message.
 		 * @return the key.
 		 */
-		public static KeyToken fromInboundMessage(final Message msg) {
-			return new KeyToken(msg.getToken(), msg.getSource().getAddress(), msg.getSourcePort());
+		public static KeyToken fromInboundMessage(final Message message) {
+			InetSocketAddress address = message.getSourceContext().getPeerAddress();
+			return new KeyToken(message.getToken(), address.getAddress().getAddress(), address.getPort());
 		}
 
 		/**
@@ -780,11 +785,12 @@ public class Exchange {
 		 * <p>
 		 * The key will be scoped to the message's destination endpoint.
 		 * 
-		 * @param msg the message.
+		 * @param message the message.
 		 * @return the key.
 		 */
-		public static KeyToken fromOutboundMessage(final Message msg) {
-			return new KeyToken(msg.getToken(), msg.getDestination().getAddress(), msg.getDestinationPort());
+		public static KeyToken fromOutboundMessage(final Message message) {
+			InetSocketAddress address = message.getDestinationContext().getPeerAddress();
+			return new KeyToken(message.getToken(), address.getAddress().getAddress(), address.getPort());
 		}
 
 		/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
@@ -171,7 +171,7 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 	public int assignMessageId(final Message message) {
 		int mid = message.getMID();
 		if (Message.NONE == mid) {
-			InetSocketAddress dest = new InetSocketAddress(message.getDestination(), message.getDestinationPort());
+			InetSocketAddress dest = message.getDestinationContext().getPeerAddress();
 			mid = messageIdProvider.getNextMessageId(dest);
 			if (Message.NONE == mid) {
 				LOGGER.log(Level.WARNING, "Cannot send message to {0}, all MIDs are in use", dest);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryRandomTokenProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryRandomTokenProvider.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package org.eclipse.californium.core.network;
 
+import java.net.InetSocketAddress;
 import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.Set;
@@ -76,13 +77,14 @@ public class InMemoryRandomTokenProvider implements TokenProvider {
 	}
 
 	private KeyToken createUnusedToken(final Message message) {
-		byte[] address = message.getDestination().getAddress();
+		InetSocketAddress socketAddress = message.getDestinationContext().getPeerAddress();
+		byte[] address = socketAddress.getAddress().getAddress();
 		byte[] token = new byte[tokenSizeLimit];
 		KeyToken result;
 		// TODO what to do when there are no more unused tokens left?
 		do {
 			rng.nextBytes(token);
-			result =  KeyToken.fromValues(token, address, message.getDestinationPort());
+			result =  KeyToken.fromValues(token, address, socketAddress.getPort());
 		} while (!usedTokens.add(result));
 		return result;
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
@@ -15,13 +15,14 @@
  *    (a lot of changes from different authors, please refer to gitlog).
  *    Achim Kraus (Bosch Software Innovations GmbH) - make exchangeStore final
  *                                                    remove setMessageExchangeStore
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace parameter EndpointContext 
+ *                                                    by EndpointContext of response.
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
-import org.eclipse.californium.elements.EndpointContext;
 
 /**
  * The Matcher is the component at the bottom of the CoAP stack.
@@ -122,12 +123,10 @@ public interface Matcher {
 	 * accordingly ({@link Response#setDuplicate(boolean)}.
 	 * 
 	 * @param response the response message received from the peer.
-	 * @param responseContext contains additional information from the transport layer
-	 *        which can be used to correlate the message with a request.
 	 * @return the message exchange that the response is a part of or {@code null}
 	 *         if the response cannot be matched to an ongoing exchange.
 	 */
-	Exchange receiveResponse(Response response, EndpointContext responseContext);
+	Exchange receiveResponse(Response response);
 
 	/**
 	 * Determines the message exchange that an empty message received from a peer

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -33,6 +33,8 @@
  *                                                 starting observe requests
  * Achim Kraus (Bosch Software Innovations GmbH) - optimize correlation context
  *                                                 processing. issue #311
+ * Achim Kraus (Bosch Software Innovations GmbH) - replace parameter EndpointContext 
+ *                                                 by EndpointContext of response.
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -46,7 +48,6 @@ import org.eclipse.californium.core.network.Exchange.KeyToken;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.observe.ObservationStore;
-import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.EndpointContextMatcher;
 
 /**
@@ -122,7 +123,7 @@ public final class TcpMatcher extends BaseMatcher {
 	}
 
 	@Override
-	public Exchange receiveResponse(final Response response, final EndpointContext responseContext) {
+	public Exchange receiveResponse(final Response response) {
 
 		final Exchange.KeyToken idByToken = Exchange.KeyToken.fromInboundMessage(response);
 		Exchange exchange = exchangeStore.get(idByToken);
@@ -135,13 +136,13 @@ public final class TcpMatcher extends BaseMatcher {
 			// because we do not check that the notification's sender is
 			// the same as the receiver of the original observe request
 			// TODO: assert that notification's source endpoint is correct
-			exchange = matchNotifyResponse(response, responseContext);
+			exchange = matchNotifyResponse(response);
 		}
 
 		if (exchange == null) {
 			// There is no exchange with the given token - ignore response
 			return null;
-		} else if (endpointContextMatcher.isResponseRelatedToRequest(exchange.getEndpointContext(), responseContext)) {
+		} else if (endpointContextMatcher.isResponseRelatedToRequest(exchange.getEndpointContext(), response.getSourceContext())) {
 			return exchange;
 		} else {
 			LOGGER.log(Level.INFO,

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -37,6 +37,8 @@
  *                                                    Proactive observe cancellation may cause
  *                                                    errors, if they cancel not completely 
  *                                                    created notifies (before the MID is assigned).
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace parameter EndpointContext 
+ *                                                    by EndpointContext of response.
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -56,7 +58,6 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.observe.ObservationStore;
 import org.eclipse.californium.core.observe.ObserveRelation;
-import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.EndpointContextMatcher;
 
 /**
@@ -196,7 +197,7 @@ public final class UdpMatcher extends BaseMatcher {
 	}
 
 	@Override
-	public Exchange receiveResponse(final Response response, final EndpointContext responseContext) {
+	public Exchange receiveResponse(final Response response) {
 
 		/*
 		 * This response could be
@@ -220,7 +221,7 @@ public final class UdpMatcher extends BaseMatcher {
 			// the same as the receiver of the original observe request
 			// TODO: assert that notification's source endpoint is correct
 			isNotify = true;
-			exchange = matchNotifyResponse(response, responseContext);
+			exchange = matchNotifyResponse(response);
 		}
 
 		if (exchange == null) {
@@ -236,12 +237,12 @@ public final class UdpMatcher extends BaseMatcher {
 					return prev;
 				}
 			} else {
-				LOGGER.log(Level.FINER, "Discarding unmatchable piggy-backed response from [{0}:{1}]: {2}",
-						new Object[]{response.getSource(), response.getSourcePort(), response});
+				LOGGER.log(Level.FINER, "Discarding unmatchable piggy-backed response from [{0}]: {1}",
+						new Object[]{response.getSourceContext(), response});
 			}
 			// ignore response
 			return null;
-		} else if (endpointContextMatcher.isResponseRelatedToRequest(exchange.getEndpointContext(), responseContext)) {
+		} else if (endpointContextMatcher.isResponseRelatedToRequest(exchange.getEndpointContext(), response.getSourceContext())) {
 
 			if (response.getType() == Type.ACK && exchange.getCurrentRequest().getMID() != response.getMID()) {
 				// The token matches but not the MID.
@@ -295,8 +296,8 @@ public final class UdpMatcher extends BaseMatcher {
 			LOGGER.log(Level.FINE, "Received expected reply for message exchange {0}", idByMID);
 		} else {
 			LOGGER.log(Level.FINE,
-					"Ignoring unmatchable empty message from {0}:{1}: {2}",
-					new Object[]{message.getSource(), message.getSourcePort(), message});
+					"Ignoring unmatchable empty message from {0}: {1}",
+					new Object[]{message.getSourceContext(), message});
 		}
 		return exchange;
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -21,6 +21,8 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - add InputStream support for environments
  *                                                    without file access.
  *    Achim Kraus (Bosch Software Innovations GmbH) - add new keys for MID tracker
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace USE_STRICT_RESPONSE_MATCHING
+ *                                                    by DTLS_RESPONSE_MATCHING
  ******************************************************************************/
 package org.eclipse.californium.core.network.config;
 
@@ -179,7 +181,7 @@ public final class NetworkConfig {
 		public static final String DEDUPLICATOR_CROP_ROTATION = "DEDUPLICATOR_CROP_ROTATION";
 		public static final String CROP_ROTATION_PERIOD = "CROP_ROTATION_PERIOD";
 		public static final String NO_DEDUPLICATOR = "NO_DEDUPLICATOR";
-		public static final String USE_STRICT_RESPONSE_MATCHING = "USE_STRICT_RESPONSE_MATCHING";
+		public static final String DTLS_RESPONSE_MATCHING = "DTLS_RESPONSE_MATCHING";
 
 		public static final String HTTP_PORT = "HTTP_PORT";
 		public static final String HTTP_SERVER_SOCKET_TIMEOUT = "HTTP_SERVER_SOCKET_TIMEOUT";

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
@@ -23,6 +23,8 @@
  *                                                    DEFAULT_EXCHANGE_LIFETIME
  *    Achim Kraus (Bosch Software Innovations GmbH) - increase DEFAULT_MAX_RESOURCE_BODY_SIZE
  *                                                    to 8192.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace USE_STRICT_RESPONSE_MATCHING
+ *                                                    by DTLS_RESPONSE_MATCHING
  ******************************************************************************/
 package org.eclipse.californium.core.network.config;
 
@@ -85,6 +87,15 @@ public class NetworkConfigDefaults {
 	 */
 	public static final long DEFAULT_EXCHANGE_LIFETIME = 247 * 1000;
 
+	/**
+	 * The default DTLS response matcher.
+	 * 
+	 * Supported values are {@code STRICT}, {@code RELAXED}, or {@code PRINCIPAL}.
+	 * <p>
+	 * The default value is {@code STRICT}.
+	 */
+	public static final String DEFAULT_DTLS_RESPONSE_MATCHING = "STRICT";
+
 	/*
 	 * Accept other message versions than 1
 	 * Refuse unknown options
@@ -143,7 +154,7 @@ public class NetworkConfigDefaults {
 		config.setString(NetworkConfig.Keys.DEDUPLICATOR, NetworkConfig.Keys.DEDUPLICATOR_MARK_AND_SWEEP);
 		config.setLong(NetworkConfig.Keys.MARK_AND_SWEEP_INTERVAL, 10 * 1000); // 10 secs
 		config.setInt(NetworkConfig.Keys.CROP_ROTATION_PERIOD, 2000);
-		config.setBoolean(NetworkConfig.Keys.USE_STRICT_RESPONSE_MATCHING, false);
+		config.setString(NetworkConfig.Keys.DTLS_RESPONSE_MATCHING, DEFAULT_DTLS_RESPONSE_MATCHING);
 
 		config.setInt(NetworkConfig.Keys.HTTP_PORT, 8080);
 		config.setInt(NetworkConfig.Keys.HTTP_SERVER_SOCKET_TIMEOUT, 100000);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/MessageTracer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/MessageTracer.java
@@ -39,31 +39,31 @@ public class MessageTracer implements MessageInterceptor {
 	
 	@Override
 	public void sendRequest(Request request) {
-		LOGGER.log(Level.INFO, "{0}:{1} <== req {2}", new Object[]{request.getDestination(), request.getDestinationPort(), request});
+		LOGGER.log(Level.INFO, "{0} <== req {1}", new Object[]{request.getDestinationContext(), request});
 	}
 	
 	@Override
 	public void sendResponse(Response response) {
-		LOGGER.log(Level.INFO, "{0}:{1} <== res {2}", new Object[]{response.getDestination(), response.getDestinationPort(), response});
+		LOGGER.log(Level.INFO, "{0} <== res {1}", new Object[]{response.getDestinationContext(), response});
 	}
 	
 	@Override
 	public void sendEmptyMessage(EmptyMessage message) {
-		LOGGER.log(Level.INFO, "{0}:{1} <== emp {2}", new Object[]{message.getDestination(), message.getDestinationPort(), message});
+		LOGGER.log(Level.INFO, "{0} <== emp {1}", new Object[]{message.getDestinationContext(), message});
 	}
 	
 	@Override
 	public void receiveRequest(Request request) {
-		LOGGER.log(Level.INFO, "{0}:{1} ==> req {2}", new Object[]{request.getSource(), request.getSourcePort(), request});
+		LOGGER.log(Level.INFO, "{0} ==> req {1}", new Object[]{request.getSourceContext(), request});
 	}
 	
 	@Override
 	public void receiveResponse(Response response) {
-		LOGGER.log(Level.INFO, "{0}:{1} ==> res {2}", new Object[]{response.getSource(), response.getSourcePort(), response});
+		LOGGER.log(Level.INFO, "{0} ==> res {1}", new Object[]{response.getSourceContext(), response});
 	}	
 
 	@Override
 	public void receiveEmptyMessage(EmptyMessage message) {
-		LOGGER.log(Level.INFO, "{0}:{1} ==> emp {2}", new Object[]{message.getSource(), message.getSourcePort(), message});
+		LOGGER.log(Level.INFO, "{0} ==> emp {1}", new Object[]{message.getSourceContext(), message});
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/OriginTracer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/OriginTracer.java
@@ -18,6 +18,7 @@
  *    Kai Hudalla - logging
  *    Kai Hudalla (Bosch Software Innovations GmbH) - use Logger's message formatting instead of
  *                                                    explicit String concatenation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use EndpointContext
  ******************************************************************************/
 package org.eclipse.californium.core.network.interceptors;
 
@@ -73,7 +74,7 @@ public class OriginTracer implements MessageInterceptor {
 
 	@Override
 	public void receiveRequest(Request request) {
-		LOGGER.log(Level.INFO, "{0}", request.getSource());
+		LOGGER.log(Level.INFO, "{0}", request.getSourceContext());
 	}
 
 	@Override
@@ -100,6 +101,6 @@ public class OriginTracer implements MessageInterceptor {
 	public void receiveEmptyMessage(EmptyMessage message) {
 		// only log pings
 		if (message.getType() == Type.CON)
-			LOGGER.log(Level.INFO, "{0}", message.getSource());
+			LOGGER.log(Level.INFO, "{0}", message.getSourceContext());
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataParser.java
@@ -20,6 +20,8 @@
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
  * Achim Kraus (Bosch Software Innovations GmbH) - add CoAP detail information 
  *                                                 to MessageFormatException
+ * Achim Kraus (Bosch Software Innovations GmbH) - add EndpointContext when parsing
+ *                                                 RawData. 
  ******************************************************************************/
 package org.eclipse.californium.core.network.serialization;
 
@@ -42,8 +44,9 @@ public abstract class DataParser {
 	 * @throws MessageFormatException if the array cannot be parsed into a message.
 	 */
 	public final Message parseMessage(final RawData raw) {
-
-		return parseMessage(raw.getBytes());
+		Message message = parseMessage(raw.getBytes());
+		message.setSourceContext(raw.getEndpointContext());
+		return message;
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
@@ -22,12 +22,12 @@
  *                                                 (fix GitHub issue #104)
  * Achim Kraus (Bosch Software Innovations GmbH) - add outboundCallback for responses
  *                                                 and empty messages. issue #305
+ * Achim Kraus (Bosch Software Innovations GmbH) - use Destination EndpointContext 
+ *                                                 for RawData
  ******************************************************************************/
 package org.eclipse.californium.core.network.serialization;
 
 import org.eclipse.californium.core.coap.*;
-import org.eclipse.californium.elements.AddressEndpointContext;
-import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.MessageCallback;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.util.DatagramWriter;
@@ -76,7 +76,7 @@ public abstract class DataSerializer {
 		}
 		return RawData.outbound(
 						request.getBytes(),
-						new AddressEndpointContext(request.getDestination(), request.getDestinationPort()),
+						request.getDestinationContext(),
 						outboundCallback,
 						false);
 	}
@@ -110,18 +110,17 @@ public abstract class DataSerializer {
 	 * @return The object containing the serialized response.
 	 */
 	public final RawData serializeResponse(final Response response) {
-		return serializeResponse(response, null, null);
+		return serializeResponse(response, null);
 	}
 	
 	/**
 	 * Serializes response and caches bytes on the request object to skip future serializations.
 	 * 
 	 * @param response The response to serialize.
-	 * @param context endpoint context for response. Maybe null.
 	 * @param outboundCallback The callback to invoke once the message is sent. 
 	 * @return The object containing the serialized response.
 	 */
-	public final RawData serializeResponse(final Response response, EndpointContext context, final MessageCallback outboundCallback) {
+	public final RawData serializeResponse(final Response response, final MessageCallback outboundCallback) {
 		if (response.getBytes() == null) {
 			DatagramWriter writer = new DatagramWriter();
 			byte[] body = serializeOptionsAndPayload(response);
@@ -134,12 +133,9 @@ public abstract class DataSerializer {
 			byte[] bytes = writer.toByteArray();
 			response.setBytes(bytes);
 		}
-		if (context == null) {
-			context = new AddressEndpointContext(response.getDestination(), response.getDestinationPort());
-		}
 		return RawData.outbound(
 				response.getBytes(),
-				context,
+				response.getDestinationContext(),
 				outboundCallback,
 				false);
 	}
@@ -151,17 +147,16 @@ public abstract class DataSerializer {
 	 * @return The object containing the serialized message.
 	 */
 	public final RawData serializeEmptyMessage(final EmptyMessage emptyMessage) {
-		return serializeEmptyMessage(emptyMessage, null, null);
+		return serializeEmptyMessage(emptyMessage, null);
 	}
 	/**
 	 * Serializes empty messages and caches bytes on the emptyMessage object to skip future serializations.
 	 * 
 	 * @param emptyMessage The message to serialize.
-	 * @param context endpoint context for response. Maybe null.
 	 * @param outboundCallback The callback to invoke once the message is sent. 
 	 * @return The object containing the serialized message.
 	 */
-	public final RawData serializeEmptyMessage(final EmptyMessage emptyMessage, EndpointContext context, final MessageCallback outboundCallback) {
+	public final RawData serializeEmptyMessage(final EmptyMessage emptyMessage, final MessageCallback outboundCallback) {
 		if (emptyMessage.getBytes() == null) {
 			DatagramWriter writer = new DatagramWriter();
 			byte[] body = serializeOptionsAndPayload(emptyMessage);
@@ -174,12 +169,9 @@ public abstract class DataSerializer {
 			byte[] bytes = writer.toByteArray();
 			emptyMessage.setBytes(bytes);
 		}
-		if (context == null) {
-			context = new AddressEndpointContext(emptyMessage.getDestination(), emptyMessage.getDestinationPort());
-		}
 		return RawData.outbound(
 				emptyMessage.getBytes(),
-				context,
+				emptyMessage.getDestinationContext(),
 				outboundCallback,
 				false);
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *    Bosch Software Innovations - initial creation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use EndpointContext
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -115,8 +116,7 @@ final class Block1BlockwiseStatus extends BlockwiseStatus {
 		Request block = new Request(request.getCode());
 		// do not enforce CON, since NON could make sense over SMS or similar transports
 		block.setType(request.getType());
-		block.setDestination(request.getDestination());
-		block.setDestinationPort(request.getDestinationPort());
+		block.setDestinationContext(request.getDestinationContext());
 		// copy options
 		block.setOptions(new OptionSet(request.getOptions()));
 		// copy message observers so that a failing blockwise request also notifies observers registered with

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
@@ -19,6 +19,7 @@
  *                                                    Add isNew and matchTransfer.
  *                                                    Move isNotification and getObserve
  *                                                    from BlockwiseStatus
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use EndpointContext
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -289,8 +290,7 @@ final class Block2BlockwiseStatus extends BlockwiseStatus {
 		} else {
 
 			block = new Response(response.getCode());
-			block.setDestination(response.getDestination());
-			block.setDestinationPort(response.getDestinationPort());
+			block.setDestinationContext(response.getDestinationContext());
 			block.setOptions(new OptionSet(response.getOptions()));
 			// observe option must only be included in first block
 			block.getOptions().removeObserve();

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -36,6 +36,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - introduce stop transfer on
  *                                                    received responses generally.
  *                                                    cleanup stale functions.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use EndpointContext
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -381,8 +382,7 @@ public class BlockwiseLayer extends AbstractLayer {
 
 					// Assemble and deliver
 					Request assembled = new Request(request.getCode());
-					assembled.setSenderIdentity(request.getSenderIdentity());
-					status.assembleMessage(assembled);
+					status.assembleReceivedMessage(assembled);
 
 					// make sure we deliver the request using the MID and token of the latest request
 					// so that the response created by the application layer can reply to his token and
@@ -565,8 +565,7 @@ public class BlockwiseLayer extends AbstractLayer {
 				} else {
 					resp.setType(Type.NON);
 				}
-				resp.setSource(response.getSource());
-				resp.setSourcePort(response.getSourcePort());
+				resp.setSourceContext(response.getSourceContext());
 				resp.setPayload(response.getPayload());
 				resp.setOptions(response.getOptions());
 				exchange.setResponse(resp);
@@ -820,8 +819,7 @@ public class BlockwiseLayer extends AbstractLayer {
 						Request block = new Request(request.getCode());
 						// do not enforce CON, since NON could make sense over SMS or similar transports
 						block.setType(request.getType());
-						block.setDestination(request.getDestination());
-						block.setDestinationPort(request.getDestinationPort());
+						block.setDestinationContext(response.getSourceContext());
 
 						/*
 						 * WARNING:
@@ -867,7 +865,7 @@ public class BlockwiseLayer extends AbstractLayer {
 								"all {0} blocks have been retrieved, assembling response and delivering to application layer",
 								status.getBlockCount());
 						Response assembled = new Response(response.getCode());
-						status.assembleMessage(assembled);
+						status.assembleReceivedMessage(assembled);
 
 						// set overall transfer RTT
 						assembled.setRTT(exchange.calculateRTT());

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseStatus.java
@@ -84,7 +84,7 @@ abstract class BlockwiseStatus {
 	 * containing the re-assembled body.
 	 * 
 	 * @param first The message.
-	 * @see #assembleMessage(Message)
+	 * @see #assembleReceivedMessage(Message)
 	 */
 	final synchronized void setFirst(final Message first) {
 		this.first = first;
@@ -248,17 +248,22 @@ abstract class BlockwiseStatus {
 	 * 
 	 * @param message The message.
 	 * @throws NullPointerException if the message is {@code null}.
+	 * @throws IllegalStateException if the first message is {@code null} or the
+	 *             source is not defined.
 	 */
-	final synchronized void assembleMessage(final Message message) {
+	final synchronized void assembleReceivedMessage(final Message message) {
 
 		if (message == null) {
 			throw new NullPointerException("message must not be null");
 		} else if (first == null) {
 			throw new IllegalStateException("first message is not set");
+		} else if (first.getSourceContext() == null) {
+			throw new IllegalStateException("first message has no peer context");
+		} else if (first.getSourceContext().getPeerAddress() == null) {
+			throw new IllegalStateException("first message has no peer address");
 		}
 		// The assembled request will contain the options of the first block
-		message.setSource(first.getSource());
-		message.setSourcePort(first.getSourcePort());
+		message.setSourceContext(first.getSourceContext());
 		message.setType(first.getType());
 		message.setMID(first.getMID());
 		message.setToken(first.getToken());

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/KeyUri.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/KeyUri.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
+import java.net.InetSocketAddress;
 import java.util.Arrays;
 
 import org.eclipse.californium.core.Utils;
@@ -129,7 +130,8 @@ public final class KeyUri {
 		} else if (requestUri == null) {
 			throw new NullPointerException("URI must not be null");
 		} else {
-			return new KeyUri(requestUri, response.getOptions(), response.getSource().getAddress(), response.getSourcePort());
+			InetSocketAddress address = response.getSourceContext().getPeerAddress();
+			return new KeyUri(requestUri, response.getOptions(), address.getAddress().getAddress(), address.getPort());
 		}
 	}
 
@@ -147,7 +149,8 @@ public final class KeyUri {
 		} else if (requestUri == null) {
 			throw new NullPointerException("URI must not be null");
 		} else {
-			return new KeyUri(requestUri, response.getOptions(), response.getDestination().getAddress(), response.getDestinationPort());
+			InetSocketAddress address = response.getDestinationContext().getPeerAddress();
+			return new KeyUri(requestUri, response.getOptions(), address.getAddress().getAddress(), address.getPort());
 		}
 	}
 
@@ -162,7 +165,8 @@ public final class KeyUri {
 		if (request == null) {
 			throw new NullPointerException("request must not be null");
 		} else {
-			return new KeyUri(request.getURI(), request.getOptions(), request.getSource().getAddress(), request.getSourcePort());
+			InetSocketAddress address = request.getSourceContext().getPeerAddress();
+			return new KeyUri(request.getURI(), request.getOptions(), address.getAddress().getAddress(), address.getPort());
 		}
 	}
 
@@ -177,7 +181,8 @@ public final class KeyUri {
 		if (request == null) {
 			throw new NullPointerException("request must not be null");
 		} else {
-			return new KeyUri(request.getURI(), request.getOptions(), request.getDestination().getAddress(), request.getDestinationPort());
+			InetSocketAddress address = request.getDestinationContext().getPeerAddress();
+			return new KeyUri(request.getURI(), request.getOptions(), address.getAddress().getAddress(), address.getPort());
 		}
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/Observation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/Observation.java
@@ -22,7 +22,13 @@ import org.eclipse.californium.elements.EndpointContext;
  */
 public final class Observation {
 
+	/**
+	 * Initiate request for observation. 
+	 */
 	private final Request request;
+	/**
+	 * Endpoint context the request was sent in.
+	 */
 	private final EndpointContext context;
 
 	/**
@@ -52,6 +58,8 @@ public final class Observation {
 	}
 
 	/**
+	 * Gets the endpoint context the requeste was sent in.
+	 * 
 	 * @return the endpoint context for this observation
 	 */
 	public EndpointContext getContext() {

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationUtil.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationUtil.java
@@ -12,6 +12,8 @@
  * 
  * Contributors:
  *    Bosch Software Innovations GmbH - initial implementation. 
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add endpoint context 
+ *                                                    to shallow clone.
  ******************************************************************************/
 package org.eclipse.californium.core.observe;
 
@@ -39,6 +41,7 @@ public final class ObservationUtil {
 			throw new IllegalArgumentException("missing request for observation!");
 		}
 		Request clonedRequest = new Request(request.getCode());
+		clonedRequest.setDestinationContext(request.getDestinationContext());
 		clonedRequest.setType(request.getType());
 		clonedRequest.setMID(request.getMID());
 		clonedRequest.setToken(request.getToken());

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
@@ -69,11 +69,11 @@ public class CoapEndpointTest {
 	List<Request> receivedRequests;
 	CountDownLatch latch;
 	CountDownLatch sentLatch;
-	EndpointContext context;
+	EndpointContext establishedContext;
 
 	@Before
 	public void setUp() throws Exception {
-		context = new MapBasedEndpointContext(CONNECTOR_ADDRESS, null);
+		establishedContext = new MapBasedEndpointContext(CONNECTOR_ADDRESS, null);
 		receivedRequests = new ArrayList<Request>();
 		connector = new SimpleConnector();
 		endpoint = new CoapEndpoint(connector, CONFIG);
@@ -111,8 +111,7 @@ public class CoapEndpointTest {
 
 		// GIVEN an outbound request
 		Request request = Request.newGet();
-		request.setDestination(InetAddress.getLoopbackAddress());
-		request.setDestinationPort(CoAP.DEFAULT_COAP_PORT);
+		request.setDestinationContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
 		request.addMessageObserver(new MessageObserverAdapter() {
 			@Override
 			public void onSent() {
@@ -142,7 +141,7 @@ public class CoapEndpointTest {
 		RawData inboundRequest = RawData.inbound(getSerializedRequest(), new AddressEndpointContext(SOURCE_ADDRESS, clientId), false);
 		connector.receiveMessage(inboundRequest);
 		assertTrue(latch.await(2, TimeUnit.SECONDS));
-		assertThat(receivedRequests.get(0).getSenderIdentity(), is(clientId));
+		assertThat(receivedRequests.get(0).getSourceContext().getPeerIdentity(), is(clientId));
 	}
 
 	@Test
@@ -216,7 +215,7 @@ public class CoapEndpointTest {
 
 		@Override
 		public void send(RawData msg) {
-			msg.onContextEstablished(context);
+			msg.onContextEstablished(establishedContext);
 			msg.onSent();
 			sentLatch.countDown();
 		}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
@@ -138,7 +138,8 @@ public class InMemoryMessageExchangeStoreTest {
 
 	private Exchange newOutboundRequest() {
 		Request request = Request.newGet();
-		request.setURI("coap://127.0.0.1:12000/test");
+		request.setURI("coap://127.0.0.1:" + PEER_PORT + "/test");
+		request.prepareDestinationContext();
 		Exchange exchange = new Exchange(request, Origin.LOCAL);
 		return exchange;
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTestUtils.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTestUtils.java
@@ -29,6 +29,7 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.InMemoryObservationStore;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.observe.ObservationStore;
+import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.EndpointContextMatcher;
 
@@ -67,8 +68,7 @@ public final class MatcherTestUtils {
 
 	static Exchange sendRequest(InetSocketAddress dest, Matcher matcher, EndpointContext exchangeContext) {
 		Request request = Request.newGet();
-		request.setDestination(dest.getAddress());
-		request.setDestinationPort(dest.getPort());
+		request.setDestinationContext(new AddressEndpointContext(dest));
 		Exchange exchange = new Exchange(request, Origin.LOCAL);
 		exchange.setRequest(request);
 		matcher.sendRequest(exchange, request);
@@ -78,8 +78,7 @@ public final class MatcherTestUtils {
 
 	static Exchange sendObserveRequest(InetSocketAddress dest, Matcher matcher, EndpointContext exchangeContext) {
 		Request request = Request.newGet();
-		request.setDestination(dest.getAddress());
-		request.setDestinationPort(dest.getPort());
+		request.setDestinationContext(new AddressEndpointContext(dest));
 		request.setObserve();
 		Exchange exchange = new Exchange(request, Origin.LOCAL);
 		exchange.setRequest(request);
@@ -88,13 +87,16 @@ public final class MatcherTestUtils {
 		return exchange;
 	}
 
-	static Response receiveResponseFor(final Request request) {
+	public static Response receiveResponseFor(final Request request) {
+		return receiveResponseFor(request, request.getDestinationContext());
+	}
+
+	public static Response receiveResponseFor(final Request request, final EndpointContext sourceContext) {
 		Response response = new Response(ResponseCode.CONTENT);
 		response.setMID(request.getMID());
 		response.setToken(request.getToken());
 		response.setBytes(new byte[]{});
-		response.setSource(request.getDestination());
-		response.setSourcePort(request.getDestinationPort());
+		response.setSourceContext(sourceContext);
 		return response;
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/TcpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/TcpMatcherTest.java
@@ -70,8 +70,7 @@ public class TcpMatcherTest {
 		TcpMatcher matcher = newTcpMatcher(endpointContextMatcher);
 		Exchange exchange = sendRequest(dest, matcher, exchangeEndpointContext);
 
-		Exchange matched = matcher.receiveResponse(receiveResponseFor(exchange.getCurrentRequest()),
-				responseEndpointContext);
+		Exchange matched = matcher.receiveResponse(receiveResponseFor(exchange.getCurrentRequest(), responseEndpointContext));
 		
 		verify(endpointContextMatcher, times(1)).isResponseRelatedToRequest(exchangeEndpointContext,
 				responseEndpointContext);
@@ -87,8 +86,7 @@ public class TcpMatcherTest {
 		TcpMatcher matcher = newTcpMatcher(endpointContextMatcher);
 		Exchange exchange = sendRequest(dest, matcher, exchangeEndpointContext);
 
-		Exchange matchedExchange = matcher.receiveResponse(receiveResponseFor(exchange.getCurrentRequest()),
-				responseEndpointContext);
+		Exchange matchedExchange = matcher.receiveResponse(receiveResponseFor(exchange.getCurrentRequest(), responseEndpointContext));
 		
 		verify(endpointContextMatcher, times(1)).isResponseRelatedToRequest(exchangeEndpointContext,
 				responseEndpointContext);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -35,6 +35,7 @@ import org.eclipse.californium.core.network.Exchange.KeyToken;
 import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.InMemoryObservationStore;
+import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.EndpointContextMatcher;
 import org.junit.Before;
@@ -80,8 +81,8 @@ public class UdpMatcherTest {
 		Exchange exchange = sendRequest(dest, matcher, exchangeEndpointContext);
 
 		// WHEN a response arrives with arbitrary additional endpoint information
-		Response response = receiveResponseFor(exchange.getCurrentRequest());
-		Exchange matchedExchange = matcher.receiveResponse(response, responseEndpointContext);
+		Response response = receiveResponseFor(exchange.getCurrentRequest(), responseEndpointContext);
+		Exchange matchedExchange = matcher.receiveResponse(response);
 
 		verify(endpointContextMatcher, times(1)).isResponseRelatedToRequest(exchangeEndpointContext, responseEndpointContext);
 		
@@ -99,8 +100,8 @@ public class UdpMatcherTest {
 		Exchange exchange = sendRequest(dest, matcher, exchangeEndpointContext);
 
 		// WHEN a response arrives with arbitrary additional endpoint information
-		Response response = receiveResponseFor(exchange.getCurrentRequest());
-		Exchange matchedExchange = matcher.receiveResponse(response, responseEndpointContext);
+		Response response = receiveResponseFor(exchange.getCurrentRequest(), responseEndpointContext);
+		Exchange matchedExchange = matcher.receiveResponse(response);
 
 		verify(endpointContextMatcher, times(1)).isResponseRelatedToRequest(exchangeEndpointContext, responseEndpointContext);
 		
@@ -159,8 +160,7 @@ public class UdpMatcherTest {
 
 		// GIVEN a request that has not been sent yet
 		Request request = Request.newGet();
-		request.setDestination(dest.getAddress());
-		request.setDestinationPort(dest.getPort());
+		request.setDestinationContext(new AddressEndpointContext(dest));
 		Exchange exchange = new Exchange(request, Origin.LOCAL);
 		exchange.setRequest(request);
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataParserTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataParserTest.java
@@ -40,6 +40,8 @@ import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.Option;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.RawData;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -52,6 +54,7 @@ import org.junit.runners.Parameterized;
  */
 @Category(Small.class) @RunWith(Parameterized.class) public class DataParserTest {
 
+	private static final EndpointContext ENDPOINT_CONTEXT = new AddressEndpointContext(InetAddress.getLoopbackAddress(), 1000);
 	private final DataSerializer serializer;
 	private final DataParser parser;
 	private final int expectedMid;
@@ -71,8 +74,7 @@ import org.junit.runners.Parameterized;
 
 	@Test public void testRequestParsing() {
 		Request request = new Request(Code.POST);
-		request.setDestination(InetAddress.getLoopbackAddress());
-		request.setDestinationPort(1000);
+		request.setDestinationContext(ENDPOINT_CONTEXT);
 		request.setType(Type.NON);
 		request.setMID(expectedMid);
 		request.setToken(new byte[] { 11, 82, -91, 77, 3 });
@@ -171,8 +173,7 @@ import org.junit.runners.Parameterized;
 
 	@Test public void testResponseParsing() {
 		Response response = new Response(ResponseCode.CONTENT);
-		response.setDestination(InetAddress.getLoopbackAddress());
-		response.setDestinationPort(1000);
+		response.setDestinationContext(ENDPOINT_CONTEXT);
 		response.setType(Type.NON);
 		response.setMID(expectedMid);
 		response.setToken(new byte[] { 22, -1, 0, 78, 100, 22 });
@@ -191,8 +192,7 @@ import org.junit.runners.Parameterized;
 
 	@Test public void testUTF8Encoding() {
 		Response response = new Response(ResponseCode.CONTENT);
-		response.setDestination(InetAddress.getLoopbackAddress());
-		response.setDestinationPort(1000);
+		response.setDestinationContext(ENDPOINT_CONTEXT);
 		response.setType(Type.NON);
 		response.setMID(expectedMid);
 		response.setToken(new byte[] {});

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/BlockwiseLayerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/BlockwiseLayerTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.californium.core.network.stack;
 
 import static org.eclipse.californium.TestTools.generateRandomPayload;
+import static org.eclipse.californium.core.network.MatcherTestUtils.receiveResponseFor;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
@@ -26,7 +27,6 @@ import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
-import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.MessageObserver;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
@@ -34,6 +34,7 @@ import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
+import org.eclipse.californium.elements.AddressEndpointContext;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.ArgumentCaptor;
@@ -62,7 +63,7 @@ public class BlockwiseLayerTest {
 		BlockwiseLayer blockwiseLayer = new BlockwiseLayer(config);
 		blockwiseLayer.setUpperLayer(appLayer);
 
-		Request request = newBlockwiseRequest(256, 64);
+		Request request = newReceivedBlockwiseRequest(256, 64);
 		Exchange exchange = new Exchange(request, Origin.REMOTE);
 
 		blockwiseLayer.receiveRequest(exchange, request);
@@ -85,7 +86,7 @@ public class BlockwiseLayerTest {
 		BlockwiseLayer blockwiseLayer = new BlockwiseLayer(config);
 		blockwiseLayer.setLowerLayer(outbox);
 
-		Request request = newBlockwiseRequest(256, 64);
+		Request request = newReceivedBlockwiseRequest(256, 64);
 		Exchange exchange = new Exchange(request, Origin.REMOTE);
 
 		blockwiseLayer.receiveRequest(exchange, request);
@@ -109,11 +110,10 @@ public class BlockwiseLayerTest {
 
 		Request req = Request.newGet();
 		req.setURI("coap://127.0.0.1/bigResource");
+		req.prepareDestinationContext();
 		req.addMessageObserver(requestObserver);
 
-		Response response = Response.createResponse(req, ResponseCode.CONTENT);
-		response.setSource(InetAddress.getLoopbackAddress());
-		response.setSourcePort(CoAP.DEFAULT_COAP_PORT);
+		Response response = receiveResponseFor(req);
 		response.getOptions().setSize2(256).setBlock2(BlockOption.size2Szx(64), true, 0);
 
 		Exchange exchange = new Exchange(null, Origin.LOCAL);
@@ -139,15 +139,14 @@ public class BlockwiseLayerTest {
 		// GIVEN an established observation of a resource with a body requiring blockwise transfer
 		Request req = Request.newGet();
 		req.setURI("coap://127.0.0.1/bigResource");
+		req.prepareDestinationContext();
 		Exchange exchange = new Exchange(null, Origin.LOCAL);
 		exchange.setRequest(req);
 
 		// WHEN the request used to establish the observe relation has been canceled
 		// and a notification arrives
 		req.cancel();
-		Response response = Response.createResponse(req, ResponseCode.CONTENT);
-		response.setSource(InetAddress.getLoopbackAddress());
-		response.setSourcePort(CoAP.DEFAULT_COAP_PORT);
+		Response response = receiveResponseFor(req);
 		response.getOptions().setSize2(100).setBlock2(BlockOption.size2Szx(64), true, 0).setObserve(12);
 		blockwiseLayer.receiveResponse(exchange, response);
 
@@ -156,10 +155,11 @@ public class BlockwiseLayerTest {
 		verify(upperLayer).receiveResponse(exchange, response);
 	}
 
-	private static Request newBlockwiseRequest(final int bodySize, final int blockSize) {
+	private static Request newReceivedBlockwiseRequest(final int bodySize, final int blockSize) {
 		Request request = Request.newPut();
 		request.getOptions().setBlock1(BlockOption.size2Szx(blockSize), true, 0).setSize1(bodySize);
 		request.setPayload(generateRandomPayload(blockSize));
+		request.setSourceContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
 		return request;
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapStackTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapStackTest.java
@@ -6,6 +6,7 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.Outbox;
 import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.AddressEndpointContext;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -49,8 +50,7 @@ public class CoapStackTest {
 
 	@Test public void cancelledMessageExpectExchangeComplete() {
 		Request request = new Request(CoAP.Code.GET);
-		request.setDestination(InetAddress.getLoopbackAddress());
-		request.setDestinationPort(CoAP.DEFAULT_COAP_PORT);
+		request.setDestinationContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
 
 		ArgumentCaptor<Exchange> exchangeCaptor = ArgumentCaptor.forClass(Exchange.class);
 		doNothing().when(outbox).sendRequest(exchangeCaptor.capture(), eq(request));

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapTcpStackTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapTcpStackTest.java
@@ -9,6 +9,7 @@ import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.Outbox;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.MessageDeliverer;
+import org.eclipse.californium.elements.AddressEndpointContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -60,8 +61,7 @@ public class CoapTcpStackTest {
 
 	@Test public void sendRequestExpectSent() {
 		Request message = new Request(CoAP.Code.GET);
-		message.setDestination(InetAddress.getLoopbackAddress());
-		message.setDestinationPort(CoAP.DEFAULT_COAP_PORT);
+		message.setDestinationContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
 		stack.sendRequest(message);
 
 		verify(outbox).sendRequest(any(Exchange.class), eq(message));

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapUdpStackTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapUdpStackTest.java
@@ -9,6 +9,7 @@ import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.Outbox;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.MessageDeliverer;
+import org.eclipse.californium.elements.AddressEndpointContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -51,8 +52,7 @@ public class CoapUdpStackTest {
 
 	@Test public void sendRequestExpectSent() {
 		Request message = new Request(CoAP.Code.GET);
-		message.setDestination(InetAddress.getLoopbackAddress());
-		message.setDestinationPort(CoAP.DEFAULT_COAP_PORT);
+		message.setDestinationContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
 		stack.sendRequest(message);
 
 		verify(outbox).sendRequest(any(Exchange.class), eq(message));

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/SmallServerClientTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/SmallServerClientTest.java
@@ -38,6 +38,7 @@ import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.EndpointManager;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.server.MessageDeliverer;
+import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.Before;
@@ -81,8 +82,7 @@ public class SmallServerClientTest {
 		// send request
 		Request request = new Request(CoAP.Code.POST);
 		request.setConfirmable(false);
-		request.setDestination(InetAddress.getLoopbackAddress());
-		request.setDestinationPort(serverPort);
+		request.setDestinationContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), serverPort));
 		request.setPayload("client says hi");
 		request.send();
 		System.out.println("client sent request");

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
@@ -76,6 +76,8 @@ import org.eclipse.californium.core.network.serialization.DataParser;
 import org.eclipse.californium.core.network.serialization.DataSerializer;
 import org.eclipse.californium.core.network.serialization.UdpDataParser;
 import org.eclipse.californium.core.network.serialization.UdpDataSerializer;
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
 import org.eclipse.californium.elements.UDPConnector;
@@ -289,7 +291,8 @@ public class LockstepEndpoint {
 	}
 
 	public void send(RawData raw) {
-		if (raw.getAddress() == null || raw.getPort() == 0) {
+		InetSocketAddress address = raw.getEndpointContext().getPeerAddress();
+		if (address.getAddress() == null || address.getPort() == 0) {
 			throw new RuntimeException("Message has no destination address/port");
 		}
 		connector.send(raw);
@@ -355,10 +358,7 @@ public class LockstepEndpoint {
 	public Message receiveNextMessage(int timeout, TimeUnit unit) throws InterruptedException {
 		RawData raw = incoming.poll(timeout, unit); // or take()?
 		if (raw != null) {
-			Message message = parser.parseMessage(raw);
-			message.setSource(raw.getAddress());
-			message.setSourcePort(raw.getPort());
-			return message;
+			return parser.parseMessage(raw);
 		}
 		return null;
 	}
@@ -1462,13 +1462,10 @@ public class LockstepEndpoint {
 		@Override
 		public void go() {
 			EmptyMessage message = new EmptyMessage(null);
-			if (destination != null) {
-				message.setDestination(destination.getAddress());
-				message.setDestinationPort(destination.getPort());
-			}
 			setProperties(message);
-
-			RawData raw = serializer.serializeEmptyMessage(message);
+			EndpointContext context = new AddressEndpointContext(destination);
+			message.setDestinationContext(context);
+			RawData raw = serializer.serializeEmptyMessage(message, null);
 			send(raw);
 		}
 	}
@@ -1569,12 +1566,9 @@ public class LockstepEndpoint {
 		@Override
 		public void go() {
 			Request request = new Request(code);
-			if (destination != null) {
-				request.setDestination(destination.getAddress());
-				request.setDestinationPort(destination.getPort());
-			}
 			setProperties(request);
-
+			EndpointContext context = new AddressEndpointContext(destination);
+			request.setDestinationContext(context);
 			RawData raw = serializer.serializeRequest(request);
 			send(raw);
 		}
@@ -1697,13 +1691,10 @@ public class LockstepEndpoint {
 		@Override
 		public void go() {
 			Response response = new Response(code);
-			if (destination != null) {
-				response.setDestination(destination.getAddress());
-				response.setDestinationPort(destination.getPort());
-			}
 			setProperties(response);
-
-			RawData raw = serializer.serializeResponse(response);
+			EndpointContext context = new AddressEndpointContext(destination);
+			response.setDestinationContext(context);
+			RawData raw = serializer.serializeResponse(response, null);
 			send(raw);
 		}
 	}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/PrincipalEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/PrincipalEndpointContextMatcher.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+import java.security.Principal;
+
+/**
+ * Principal based endpoint context matcher.
+ * 
+ * Matches DTLS based on the used principal. Requires unique and stable credentials.
+ */
+public class PrincipalEndpointContextMatcher implements EndpointContextMatcher {
+
+	public PrincipalEndpointContextMatcher() {
+	}
+
+	@Override
+	public String getName() {
+		return "principal correlation";
+	}
+
+	@Override
+	public boolean isResponseRelatedToRequest(EndpointContext requestContext, EndpointContext responseContext) {
+		return internalMatch(requestContext, responseContext);
+	}
+
+	@Override
+	public boolean isToBeSent(EndpointContext messageContext, EndpointContext connectorContext) {
+		if (null == connectorContext) {
+			return true;
+		}
+		return internalMatch(messageContext, connectorContext);
+	}
+
+	private final boolean internalMatch(EndpointContext requestedContext, EndpointContext availableContext) {
+		if (requestedContext.getPeerIdentity() != null) {
+			if (availableContext.getPeerIdentity() == null) {
+				return false;
+			}
+			if (!matchPrincipals(requestedContext.getPeerIdentity(), availableContext.getPeerIdentity())) {
+				return false;
+			}
+		}
+		String cipher = requestedContext.get(DtlsEndpointContext.KEY_CIPHER);
+		if (cipher != null) {
+			if (!cipher.equals(availableContext.get(DtlsEndpointContext.KEY_CIPHER))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Match principals.
+	 * 
+	 * Intended to be overwritten, when asymmetric principal implementations are
+	 * used, and {@link #equals(Object)} doesn't work.
+	 * 
+	 * @param requestedPrincipal requested principal from requested endpoint
+	 *            context.
+	 * @param availablePrincipal available principal from available endpoint
+	 *            context
+	 * @return {@code true}, if the principals are matching, {@code false},
+	 *         otherwise.
+	 */
+	protected boolean matchPrincipals(Principal requestedPrincipal, Principal availablePrincipal) {
+		return requestedPrincipal.equals(availablePrincipal);
+	}
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/PrincipalEndpointContextMatcherTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/PrincipalEndpointContextMatcherTest.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.InetSocketAddress;
+import java.security.Principal;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class PrincipalEndpointContextMatcherTest {
+
+	private static final InetSocketAddress ADDRESS = new InetSocketAddress(0);
+	
+	private Principal principal1;
+	private Principal principal2;
+	private Principal principal3;
+	private EndpointContext connectionContext;
+	private EndpointContext messageContext;
+	private EndpointContext differentMessageContext;
+	private EndpointContext unsecureMessageContext;
+	private EndpointContextMatcher matcher;
+
+	@Before
+	public void setup() {
+		principal1 = new TestPrincipal("P1");
+		principal2 = new TestPrincipal("P1"); // intended to have the same name as principal1
+		principal3 = new TestPrincipal("P3");
+		
+		connectionContext = new DtlsEndpointContext(ADDRESS, principal1, "session", "1", "CIPHER");
+		messageContext = new AddressEndpointContext(ADDRESS, principal2);
+		differentMessageContext = new AddressEndpointContext(ADDRESS, principal3);
+		unsecureMessageContext = new AddressEndpointContext(ADDRESS, null);
+		matcher = new PrincipalEndpointContextMatcher();
+	}
+
+	@Test
+	public void testWithConnectionEndpointContext() {
+		assertThat(matcher.isToBeSent(messageContext, connectionContext), is(true));
+		assertThat(matcher.isToBeSent(differentMessageContext, connectionContext), is(false));
+		assertThat(matcher.isToBeSent(unsecureMessageContext, connectionContext), is(true));
+	}
+
+	@Test
+	public void testWithoutConnectionEndpointContext() {
+		assertThat(matcher.isToBeSent(messageContext, null), is(true));
+		assertThat(matcher.isToBeSent(differentMessageContext, null), is(true));
+		assertThat(matcher.isToBeSent(unsecureMessageContext, null), is(true));
+	}
+
+	private static class TestPrincipal implements Principal {
+		private final String name;
+		public TestPrincipal(String name) {
+			this.name = name;
+		}
+		@Override
+		public String getName() {
+			return name;
+		}
+		
+		@Override
+		public int hashCode() {
+			return name.hashCode();
+		}
+		
+		@Override
+		public boolean equals(Object other) {
+			if (this == other) {
+				return true;
+			} else if (other == null || !(other instanceof Principal)) {
+				return false;
+			}
+			return name.equals(((Principal)other).getName());
+		}
+		
+	}
+
+}


### PR DESCRIPTION
Add destination and source endpoint context to Message.
Remove setter for source from Message and move setter for destination
from Message to Request. Introduce new principal base endpoint context
matcher and change network configuration for this.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>