### PR TITLE
Use socket's reuseAddress only, if bindAddress determines a port.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -57,6 +57,8 @@
  *                                                    and add error callback in
  *                                                    newDeferredMessageSender.
  *    Achim Kraus (Bosch Software Innovations GmbH) - reuse receive buffer and packet. 
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use socket's reuseAddress only
+ *                                                    if bindAddress determines a port
  ******************************************************************************/
 package org.eclipse.californium.scandium;
 
@@ -349,8 +351,8 @@ public class DTLSConnector implements Connector {
 			this.hasInternalExecutor = true;
 		}
 		socket = new DatagramSocket(null);
-		// make it easier to stop/start a server consecutively without delays
-		if (config.isAddressReuseEnabled()) {
+		if (bindAddress.getPort() != 0 && config.isAddressReuseEnabled()) {
+			// make it easier to stop/start a server consecutively without delays
 			LOGGER.config("Enable address reuse for socket!");
 			socket.setReuseAddress(true);
 			if (!socket.getReuseAddress()) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -834,7 +834,7 @@ public final class DtlsConnectorConfig {
 				config.address = new InetSocketAddress(0);
 			}
 			if (config.enableReuseAddress == null) {
-				config.enableReuseAddress = true;
+				config.enableReuseAddress = false;
 			}
 			if (config.trustStore == null) {
 				config.trustStore = new X509Certificate[0];


### PR DESCRIPTION
Running the scandium tests repeatedly shows on my build systems, that "reuseAddress" even causes failures with the client and server on the **same** port. This reduces that failure.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>