### PR TITLE
Use direct socket implementation for scandium.

### DIFF
--- a/scandium-core/pom.xml
+++ b/scandium-core/pom.xml
@@ -19,12 +19,14 @@
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>element-connector</artifactId>
+			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>element-connector</artifactId>
 			<classifier>tests</classifier>
 			<type>jar</type>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -53,6 +55,7 @@
 						   by means of the Scandium-logging.properties file
 						-->
 						<java.util.logging.config.file>${project.build.testOutputDirectory}/Scandium-logging.properties</java.util.logging.config.file>
+						<org.eclipse.californium.junit.socketmode>DIRECT</org.eclipse.californium.junit.socketmode>
 					</systemPropertyVariables>
 					<excludes>
 						<exclude>**/*$*</exclude>
@@ -61,8 +64,8 @@
 						Running the tests in parallel may cause problems with rebinding to a an address within a test,
 						e.g. if another test running in parallel binds to that address in between.
 					-->
-					<parallel>classes</parallel>
-					<threadCount>8</threadCount>
+					<!-- parallel>classes</parallel>
+					<threadCount>8</threadCount-->
 					<groups>org.eclipse.californium.scandium.category.Small</groups>
 					<excludedGroups>org.eclipse.californium.scandium.category.Medium,org.eclipse.californium.scandium.category.Large</excludedGroups>
 				</configuration>
@@ -78,8 +81,8 @@
 								Running the tests in parallel may cause problems with rebinding to a an address within a test,
 								e.g. if another test running in parallel binds to that address in between.
 							-->
-							<parallel>classes</parallel>
-							<threadCount>1</threadCount>
+							<!--parallel>classes</parallel>
+							<threadCount>1</threadCount-->
 							<groups>org.eclipse.californium.scandium.category.Medium</groups>
 							<excludedGroups>org.eclipse.californium.scandium.category.Small,org.eclipse.californium.scandium.category.Large</excludedGroups>
 						</configuration>
@@ -95,8 +98,8 @@
 								Running the tests in parallel may cause problems with rebinding to a an address within a test,
 								e.g. if another test running in parallel binds to that address in between.
 							-->
-							<parallel>classes</parallel>
-							<threadCount>1</threadCount>
+							<!-- parallel>classes</parallel>
+							<threadCount>1</threadCount-->
 							<groups>org.eclipse.californium.scandium.category.Large</groups>
 							<excludedGroups>org.eclipse.californium.scandium.category.Small,org.eclipse.californium.scandium.category.Medium</excludedGroups>
 						</configuration>

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Record.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Record.java
@@ -789,6 +789,15 @@ public class Record {
 	}
 
 	/**
+	 * Get fragment payload as byte array.
+	 * 
+	 * @return fragments byte array.
+	 */
+	public byte[] getFragmentBytes() {
+		return fragmentBytes;
+	}
+
+	/**
 	 * Gets the object representation of this record's <em>DTLSPlaintext.fragment</em>.
 	 *  
 	 * If this record only contains the fragment's ciphertext representation, it is

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -104,11 +104,13 @@ import org.eclipse.californium.scandium.dtls.SessionId;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.InMemoryPskStore;
 import org.eclipse.californium.scandium.dtls.pskstore.StaticPskStore;
+import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -122,6 +124,8 @@ import eu.javaspecialists.tjsn.concurrency.stripedexecutor.StripedExecutorServic
  */
 @Category(Medium.class)
 public class DTLSConnectorTest {
+	@ClassRule
+	public static DtlsNetworkRule network = new DtlsNetworkRule(DtlsNetworkRule.Mode.DIRECT, DtlsNetworkRule.Mode.NATIVE);
 
 	private static final int CLIENT_CONNECTION_STORE_CAPACITY = 5;
 	private static final int SERVER_CONNECTION_STORE_CAPACITY = 2;

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
@@ -43,10 +43,12 @@ import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.Connection;
 import org.eclipse.californium.scandium.dtls.DTLSSession;
 import org.eclipse.californium.scandium.dtls.InMemoryConnectionStore;
+import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -58,6 +60,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Medium.class)
 public class DTLSEndpointContextTest {
+	@ClassRule
+	public static DtlsNetworkRule network = new DtlsNetworkRule(DtlsNetworkRule.Mode.DIRECT, DtlsNetworkRule.Mode.NATIVE);
 
 	private static final int CLIENT_CONNECTION_STORE_CAPACITY = 5;
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/HelloExtensionNegotiationTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/HelloExtensionNegotiationTest.java
@@ -40,10 +40,12 @@ import org.eclipse.californium.scandium.category.Medium;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.DTLSSession;
 import org.eclipse.californium.scandium.dtls.InMemoryConnectionStore;
+import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -53,6 +55,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Medium.class)
 public class HelloExtensionNegotiationTest {
+	@ClassRule
+	public static DtlsNetworkRule network = new DtlsNetworkRule(DtlsNetworkRule.Mode.DIRECT, DtlsNetworkRule.Mode.NATIVE);
 
 	private static final int CLIENT_CONNECTION_STORE_CAPACITY = 5;
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/rule/DtlsNetworkRule.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/rule/DtlsNetworkRule.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.rule;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.eclipse.californium.elements.rule.NetworkRule;
+import org.eclipse.californium.elements.util.DatagramFormatter;
+import org.eclipse.californium.scandium.dtls.ContentType;
+import org.eclipse.californium.scandium.dtls.HandshakeType;
+import org.eclipse.californium.scandium.dtls.Record;
+
+/**
+ * DTLS network rules for junit test using datagram sockets.
+ *
+ * The rule is intended to be mainly used as <code>&#64;ClassRule<code>
+ * 
+ * <pre>
+ * public class AbcNetworkTest {
+ *    &#64;ClassRule
+ *    public static DtlsNetworkRule network = new DtlsNetworkRule(Mode.DIRECT, Mode.NATIVE);
+ *    ...
+ * </pre>
+ * 
+ * For the DIRECT mode there is an additional parameters available
+ * {@link #setDelay(int)}.
+ */
+public class DtlsNetworkRule extends NetworkRule {
+
+	public static final Logger LOGGER = Logger.getLogger(DtlsNetworkRule.class.getName());
+
+	private static final InetSocketAddress ADDRESS = new InetSocketAddress(0) {
+
+		private static final long serialVersionUID = 3463123750760014012L;
+
+		@Override
+		public String toString() {
+			return "";
+		}
+	};
+
+	/**
+	 * CoAP datagram formatter. Used for logging.
+	 */
+	private static final DatagramFormatter FORMATTER = new DatagramFormatter() {
+	
+		@Override
+		public String format(byte[] data) {
+			if (null == data) {
+				return "<null>";
+			} else if (0 == data.length) {
+				return "[] (empty)";
+			}
+			try {
+				List<Record> records = Record.fromByteArray(data, ADDRESS);
+				int max = records.size();
+				StringBuilder builder = new StringBuilder();
+				for (int index = 0; index < max;) {
+					Record record = records.get(index);
+					if (max == 1) {
+						builder.append("rec(");
+					} else {
+						builder.append("rec(#").append(index).append(", ");
+					}
+					builder.append(record.getLength()).append(" bytes, ");
+					if (record.isNewClientHello()) {
+						builder.append("NEW CLIENT_HELLO");
+					} else {
+						builder.append(record.getType());
+						builder.append(", Epoch=").append(record.getEpoch());
+						builder.append(", RSeqNo=").append(record.getSequenceNumber());
+						if (record.getType() == ContentType.HANDSHAKE && record.getEpoch() == 0) {
+							byte[] fragment = record.getFragmentBytes();
+							if (fragment != null && fragment.length > 6) {
+								HandshakeType type = HandshakeType.getTypeByCode(fragment[0] & 0xff);
+								int seqn = (fragment[4] & 0xff) << 8 | (fragment[5]  & 0xff);
+								builder.append(", ").append(type).append(", HSeqNo=").append(seqn);
+							}
+						}
+					}
+					builder.append(")");
+					if (++index < max) {
+						builder.append(",");
+					}
+				}
+				return builder.toString();
+			} catch (RuntimeException ex) {
+				return "decode " + data.length + " received bytes with " + ex.getMessage();
+			}
+		}
+	
+	};
+
+	/**
+	 * Create rule supporting provided modes.
+	 * 
+	 * @param modes supported datagram socket implementation modes.
+	 */
+	public DtlsNetworkRule(Mode... modes) {
+		super(FORMATTER, modes);
+	}
+
+	@Override
+	public DtlsNetworkRule setDelay(int delayInMillis) {
+		return (DtlsNetworkRule) super.setDelay(delayInMillis);
+	}
+
+}

--- a/scandium-core/src/test/resources/Scandium-logging.properties
+++ b/scandium-core/src/test/resources/Scandium-logging.properties
@@ -69,3 +69,8 @@ org.eclipse.californium.scandium.useParentHandlers = false
 org.eclipse.californium.scandium.level = INFO
 org.eclipse.californium.scandium.dtls.level = CONFIG
 org.eclipse.californium.scandium.dtls.Connection.level = INFO
+
+org.eclipse.californium.elements.handlers = java.util.logging.ConsoleHandler
+org.eclipse.californium.elements.useParentHandlers = false
+org.eclipse.californium.elements.level = INFO
+org.eclipse.californium.elements.util.DirectDatagramSocketImpl.level = FINE


### PR DESCRIPTION
Support very fast reopen and didn't (rarely) drop packages.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>