### PR TITLE
InMemoryMessageIdProvider does not remove stale entry

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageIdProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageIdProvider.java
@@ -114,7 +114,7 @@ public class InMemoryMessageIdProvider implements MessageIdProvider {
 
 	private synchronized MessageIdTracker getTracker(final InetSocketAddress destination) {
 		MessageIdTracker tracker = trackers.get(destination);
-		if (tracker == null && 0 < trackers.remainingCapacity()) {
+		if (tracker == null) {
 			// create new tracker for destination lazily
 			int mid = null == random ? 0 : random.nextInt(MessageIdTracker.TOTAL_NO_OF_MIDS);
 			switch (mode) {
@@ -129,7 +129,11 @@ public class InMemoryMessageIdProvider implements MessageIdProvider {
 				tracker = new GroupedMessageIdTracker(mid, config);
 				break;
 			}
-			trackers.put(destination, tracker);
+			if (trackers.put(destination, tracker)) {
+				return tracker;
+			} else {
+				return null;
+			}
 		}
 		return tracker;
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageIdProviderTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageIdProviderTest.java
@@ -127,6 +127,21 @@ public class InMemoryMessageIdProviderTest {
 				is(-1));
 	}
 
+	@Test
+	public void testGetNextMessageIdIfMaxPeersIsReachedWithStaleEntry() throws InterruptedException {
+
+		int MAX_PEERS = 2;
+		int MAX_PEER_INACTIVITY_PERIOD = 1; // seconds
+		config.setLong(NetworkConfig.Keys.MAX_ACTIVE_PEERS, MAX_PEERS);
+		config.setLong(NetworkConfig.Keys.MAX_PEER_INACTIVITY_PERIOD, MAX_PEER_INACTIVITY_PERIOD);
+		InMemoryMessageIdProvider provider = new InMemoryMessageIdProvider(config);
+		addPeers(provider, MAX_PEERS);
+
+		Thread.sleep(MAX_PEER_INACTIVITY_PERIOD * 1000);
+
+		assertThat(provider.getNextMessageId(getPeerAddress(MAX_PEERS + 1)), is(not(-1)));
+	}
+
 	private static void addPeers(final MessageIdProvider provider, final int peerCount) {
 		for (int i = 0; i < peerCount; i++) {
 			provider.getNextMessageId(getPeerAddress(i));


### PR DESCRIPTION
if `InMemoryMessageIdProvider` is full but contains stale entries, adding new entry is not allowed.

This bug comes from a miss-understanding of `remainingCapacity`.

```java
/**
 * Gets the number of entries that can be added to this cache without
 * the need for removing stale entries.
 * 
 * @return The number of entries.
*/
public final int remainingCapacity() {
```