### PR TITLE
Make entries map unmodifiable.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
@@ -44,18 +44,7 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 	 */
 	public DtlsEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity, String sessionId, String epoch,
 			String cipher) {
-		super(peerAddress, peerIdentity);
-		if (sessionId == null) {
-			throw new NullPointerException("Session ID must not be null");
-		} else if (epoch == null) {
-			throw new NullPointerException("Epoch must not be null");
-		} else if (cipher == null) {
-			throw new NullPointerException("Cipher must not be null");
-		} else {
-			put(KEY_SESSION_ID, sessionId);
-			put(KEY_EPOCH, epoch);
-			put(KEY_CIPHER, cipher);
-		}
+		super(peerAddress, peerIdentity, KEY_SESSION_ID, sessionId, KEY_CIPHER, cipher, KEY_EPOCH, epoch);
 	}
 
 	public String getSessionId() {

--- a/element-connector/src/main/java/org/eclipse/californium/elements/TcpEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/TcpEndpointContext.java
@@ -55,12 +55,7 @@ public class TcpEndpointContext extends MapBasedEndpointContext {
 	 *             <code>null</code>.
 	 */
 	public TcpEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity, String connectionId) {
-		super(peerAddress, peerIdentity);
-		if (connectionId == null) {
-			throw new NullPointerException("Connection ID must not be null");
-		} else {
-			put(KEY_CONNECTION_ID, connectionId);
-		}
+		super(peerAddress, peerIdentity, KEY_CONNECTION_ID, connectionId);
 	}
 
 	public String getConnectionId() {

--- a/element-connector/src/test/java/org/eclipse/californium/elements/DtlsEndpointContextMatcherTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/DtlsEndpointContextMatcherTest.java
@@ -41,8 +41,7 @@ public class DtlsEndpointContextMatcherTest {
 		relaxedMessageContext = new DtlsEndpointContext(ADDRESS, null,"session", "2", "CIPHER");
 		strictMessageContext = new DtlsEndpointContext(ADDRESS, null,"session", "1", "CIPHER");
 		differentMessageContext = new DtlsEndpointContext(ADDRESS, null,"new session", "1", "CIPHER");
-		MapBasedEndpointContext mapBasedContext = new MapBasedEndpointContext(ADDRESS, null);
-		mapBasedContext.put("ID", "session");
+		MapBasedEndpointContext mapBasedContext = new MapBasedEndpointContext(ADDRESS, null,"ID", "session");
 		unsecureMessageContext = mapBasedContext;
 		relaxedMatcher = new RelaxedDtlsEndpointContextMatcher();
 		strictMatcher = new StrictDtlsEndpointContextMatcher();

--- a/element-connector/src/test/java/org/eclipse/californium/elements/EndpointContextUtilTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/EndpointContextUtilTest.java
@@ -41,13 +41,9 @@ public class EndpointContextUtilTest {
 		relaxedMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "2", "CIPHER");
 		strictMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
 		differentMessageContext = new DtlsEndpointContext(ADDRESS, null, "new session", "1", "CIPHER");
-		MapBasedEndpointContext mapBasedContext = new MapBasedEndpointContext(ADDRESS, null);
-		mapBasedContext.put("ID", "session");
-		mapBasedContext.put("UNKNOWN", "secret");
+		MapBasedEndpointContext mapBasedContext = new MapBasedEndpointContext(ADDRESS, null, "ID", "session", "UNKNOWN", "secret");
 		unsecureMessageContext = mapBasedContext;
-		mapBasedContext = new MapBasedEndpointContext(ADDRESS, null);
-		mapBasedContext.put("ID", "session");
-		mapBasedContext.put("UNKNOWN", "topsecret");
+		mapBasedContext = new MapBasedEndpointContext(ADDRESS, null, "ID", "session", "UNKNOWN", "topsecret");
 		unsecureMessageContext2 = mapBasedContext;
 	}
 


### PR DESCRIPTION
See issue #425.
Use still sub-classes but optionally provide attributes as pair-list to
the constructor.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>