### PR TITLE
 Add a way to define response timeout on request. 

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -137,6 +137,9 @@ public class Request extends Message {
 	/** Contextual information about this request */
 	private Map<String, String> userContext;
 
+	/** maximum time to wait for a response to this request */
+	private long responseTimeout;
+
 	/**
 	 * Creates a request of type {@code CON} for a CoAP code.
 	 * 
@@ -729,6 +732,36 @@ public class Request extends Message {
 				notifyAll();
 			}
 		}
+	}
+
+	/**
+	 * <p>
+	 * Define a timeout value to wait the response. Zero or negative value means
+	 * no timeout.
+	 * </p>
+	 * <p>
+	 * By default no timeout is used, which means user should cancel request
+	 * manually when it will not expect response anymore. (not doing this may
+	 * cause memory leak)
+	 * </p>
+	 * <p>
+	 * The time is measured before the request is sent. So you should set a time
+	 * large enough to allow DTLS handshake or CoAP retransmission or
+	 * transparent block-wise transfer.
+	 * </p>
+	 * 
+	 * @param time maximum time to wait in milliseconds (zero or negative value
+	 *            means no timeout)
+	 */
+	public void setResponseTimeout(long time) {
+		responseTimeout = Math.max(0, time);
+	}
+	
+	/**
+	 * The maximum time to wait for a response in milliseconds (Zero means no timeout)
+	 */
+	public long getResponseTimeout() {
+		return responseTimeout;
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -248,6 +248,7 @@ public class BlockwiseLayer extends AbstractLayer {
 			status = getOutboundBlock1Status(key, exchange, request);
 
 			final Request block = status.getNextRequestBlock();
+			block.setResponseTimeout(blockTimeout);
 
 			block.addMessageObserver(new MessageObserverAdapter() {
 
@@ -735,6 +736,7 @@ public class BlockwiseLayer extends AbstractLayer {
 		int nextNum = status.getCurrentNum() + currentSize / newSize;
 		LOGGER.log(Level.FINE, "sending next Block1 num={0}", nextNum);
 		Request nextBlock = status.getNextRequestBlock(nextNum, newSzx);
+		nextBlock.setResponseTimeout(blockTimeout);
 		// we use the same token to ease traceability
 		nextBlock.setToken(response.getToken());
 		addBlock1CleanUpObserver(nextBlock, key);
@@ -817,6 +819,7 @@ public class BlockwiseLayer extends AbstractLayer {
 						Request request = exchange.getRequest();
 
 						Request block = new Request(request.getCode());
+						block.setResponseTimeout(blockTimeout);
 						// do not enforce CON, since NON could make sense over SMS or similar transports
 						block.setType(request.getType());
 						block.setDestinationContext(response.getSourceContext());

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapUdpStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapUdpStack.java
@@ -99,6 +99,7 @@ public class CoapUdpStack extends BaseCoapStack {
 				new ExchangeCleanupLayer(),
 				new ObserveLayer(config),
 				new BlockwiseLayer(config),
+				new ResponseTimeoutLayer(),
 				reliabilityLayer };
 
 		setLayers(layers);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ResponseTimeoutLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ResponseTimeoutLayer.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ */
+package org.eclipse.californium.core.network.stack;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+
+/**
+ * Handle response timeout for request. It Should mark request as timeout if responseTimeout expired.
+ * 
+ * @see Request#getResponseTimeout()
+ */
+public class ResponseTimeoutLayer extends AbstractLayer {
+	
+	@Override
+	public void sendRequest(final Exchange exchange,final Request request) {
+		if (request.getResponseTimeout() > 0) {
+			
+			// Schedule task at timeout
+			final ScheduledFuture<?> task = executor.schedule(new Runnable() {
+				@Override
+				public void run() {
+					exchange.setTimedOut(request);
+				}
+			}, request.getResponseTimeout(), TimeUnit.MILLISECONDS);
+
+			// Cancel task if response received or request failed before.
+			request.addMessageObserver(new MessageObserverAdapter() {
+
+				@Override
+				public void onResponse(Response response) {
+					task.cancel(false);
+				}
+				
+				@Override
+				protected void failed() {
+					task.cancel(false);
+				}
+			});
+		}
+		
+		lower().sendRequest(exchange, request);
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -110,7 +110,8 @@ public class BlockwiseClientSideTest {
 				.setInt(NetworkConfig.Keys.ACK_TIMEOUT, ACK_TIMEOUT_IN_MS)
 				.setInt(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1)
 				.setInt(NetworkConfig.Keys.MAX_RETRANSMIT, 2)
-				.setInt(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1);
+				.setInt(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1)
+				.setInt(NetworkConfig.Keys.BLOCKWISE_STATUS_LIFETIME,300);
 	}
 
 	@Before
@@ -345,7 +346,7 @@ public class BlockwiseClientSideTest {
 		//server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 64).payload(respPayload, 64, 128).go();
 		// give client a chance to repeat
 		int timeout = config.getInt(NetworkConfig.Keys.ACK_TIMEOUT, ACK_TIMEOUT_IN_MS);
-		Thread.sleep(timeout * 2);
+		Thread.sleep((long) (timeout*1.25));
 		// repeat GET 1
 		server.expectRequest(CON, GET, path).sameBoth("B").block2(1, false, 64).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 64).payload(respPayload, 64, 128).go();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -84,9 +84,9 @@ public class BlockwiseClientSideTest {
 	private static final int MAX_RESOURCE_BODY_SIZE = 1024;
 	private static final int RESPONSE_TIMEOUT_IN_MS = 1000;
 	private static final int ERROR_TIMEOUT_IN_MS = 500;
-	// client retransmits after 200 ms
+	// client retransmits after 100 ms
 	private static final int ACK_TIMEOUT_IN_MS = 200;
-
+	
 	private static NetworkConfig config;
 
 	private LockstepEndpoint server;
@@ -109,7 +109,8 @@ public class BlockwiseClientSideTest {
 				.setLong(NetworkConfig.Keys.EXCHANGE_LIFETIME, TEST_EXCHANGE_LIFETIME)
 				.setInt(NetworkConfig.Keys.ACK_TIMEOUT, ACK_TIMEOUT_IN_MS)
 				.setInt(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1)
-				.setInt(NetworkConfig.Keys.MAX_RETRANSMIT, 2);
+				.setInt(NetworkConfig.Keys.MAX_RETRANSMIT, 2)
+				.setInt(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1);
 	}
 
 	@Before
@@ -933,5 +934,178 @@ public class BlockwiseClientSideTest {
 		
 		// Check the first request is canceled.
 		assertTrue(firstRequest.isCanceled());
+	}
+	
+	/**
+	 * Verifies incomplete block2 exchange (missing last piggyback response)
+	 * does not leak.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testIncompleteBlock2NoAckNoResponse() throws Exception {
+
+		System.out.println("Incomplete  block2 transfer:");
+		respPayload = generateRandomPayload(300);
+		String path = "test";
+
+		// Send GET request
+		Request request = createRequest(GET, path, server);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, GET, path).storeBoth("A").go();
+		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 128).payload(respPayload.substring(0, 128))
+				.go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 128).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 128).payload(respPayload.substring(128, 256))
+				.go();
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 128).go();
+		// we don't answer to the last request, @after should check is there is
+		// no leak.
+
+		printServerLog(clientInterceptor);
+	}
+
+	/**
+	 * Verifies incomplete block1 exchange (missing piggyback response) does not
+	 * leak.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testIncompleteBlock1NoAckNoResponse() throws Exception {
+
+		System.out.println("Incomplete  block1 transfer:");
+		reqtPayload = generateRandomPayload(300);
+		String path = "test";
+
+		// Send PUT request
+		Request request = createRequest(PUT, path, server);
+		request.setPayload(reqtPayload);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, PUT, path).storeBoth("A").block1(0, true, 128).payload(reqtPayload, 0, 128).go();
+		server.sendResponse(ACK, CONTINUE).loadBoth("A").block1(1, false, 128).go();
+		server.expectRequest(CON, PUT, path).storeBoth("B").block1(1, true, 128).payload(reqtPayload, 128, 256).go();
+		// we don't answer to the last request, @after should check is there is
+		// no leak.
+
+		printServerLog(clientInterceptor);
+	}
+
+	/**
+	 * Verifies cancelled block2 exchange does not leak.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testCancelledBlock2() throws Exception {
+
+		System.out.println("cancelled block2 transfer:");
+		respPayload = generateRandomPayload(300);
+		String path = "test";
+
+		// Send GET request
+		Request request = createRequest(GET, path, server);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, GET, path).storeBoth("A").go();
+		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 128).payload(respPayload.substring(0, 128))
+				.go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 128).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 128).payload(respPayload.substring(128, 256))
+				.go();
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 128).go();
+		printServerLog(clientInterceptor);
+
+		System.out.println("Cancel request " + request);
+		request.cancel();
+		assertTrue("ExchangeStore must be empty", clientExchangeStore.isEmpty());
+
+	}
+
+	/**
+	 * Verifies cancelled block1 exchange does not leak.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testCancelledBlock1() throws Exception {
+
+		System.out.println("Cancelled  block1 transfer:");
+		reqtPayload = generateRandomPayload(300);
+		String path = "test";
+
+		// Send PUT request
+		Request request = createRequest(PUT, path, server);
+		request.setPayload(reqtPayload);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, PUT, path).storeBoth("A").block1(0, true, 128).payload(reqtPayload, 0, 128).go();
+		server.sendResponse(ACK, CONTINUE).loadBoth("A").block1(1, false, 128).go();
+		server.expectRequest(CON, PUT, path).storeBoth("B").block1(1, true, 128).payload(reqtPayload, 128, 256).go();
+		printServerLog(clientInterceptor);
+
+		System.out.println("Cancel request " + request);
+		request.cancel();
+		assertTrue("ExchangeStore must be empty", clientExchangeStore.isEmpty());
+
+	}
+
+	/**
+	 * Verifies acknowledged incomplete block 2 exchange does not leak.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testIncompleteBlock2AckNoResponse() throws Exception {
+
+		System.out.println("Incomplete Acknowledged block2 transfer:");
+		respPayload = generateRandomPayload(300);
+		String path = "test";
+
+		// Send GET request
+		Request request = createRequest(GET, path, server);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, GET, path).storeBoth("A").go();
+		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 128).payload(respPayload.substring(0, 128))
+				.go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 128).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 128).payload(respPayload.substring(128, 256))
+				.go();
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 128).go();
+		server.sendEmpty(ACK).loadMID("C").go();
+		// we acknowledge but never send the response, @after should check is
+		// there is no leak.
+
+		printServerLog(clientInterceptor);
+	}
+
+	/**
+	 * Verifies acknowledged incomplete block 2 exchange does not leak.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testIncompleteBlock1AckNoResponse() throws Exception {
+
+		System.out.println("Incomplete Acknowledged block1 transfer:");
+		reqtPayload = generateRandomPayload(300);
+		String path = "test";
+
+		// Send PUT request
+		Request request = createRequest(PUT, path, server);
+		request.setPayload(reqtPayload);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, PUT, path).storeBoth("A").block1(0, true, 128).payload(reqtPayload, 0, 128).go();
+		server.sendResponse(ACK, CONTINUE).loadBoth("A").block1(1, false, 128).go();
+		server.expectRequest(CON, PUT, path).storeBoth("B").block1(1, true, 128).payload(reqtPayload, 128, 256).go();
+		server.sendEmpty(ACK).loadMID("B").go();
+		// we acknowledge but never send the response, @after should check is
+		// there is no leak.
+
+		printServerLog(clientInterceptor);
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -97,7 +97,8 @@ public class ObserveClientSideTest {
 				.setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f)
 				.setFloat(NetworkConfig.Keys.MAX_RETRANSMIT, 2)
 				.setInt(NetworkConfig.Keys.MARK_AND_SWEEP_INTERVAL, TEST_SWEEP_DEDUPLICATOR_INTERVAL)
-				.setLong(NetworkConfig.Keys.EXCHANGE_LIFETIME, TEST_EXCHANGE_LIFETIME);
+				.setLong(NetworkConfig.Keys.EXCHANGE_LIFETIME, TEST_EXCHANGE_LIFETIME)
+				.setLong(NetworkConfig.Keys.BLOCKWISE_STATUS_LIFETIME, 300);
 	}
 
 	@Before
@@ -406,7 +407,7 @@ public class ObserveClientSideTest {
 		server.sendResponse(ACK, CONTENT).loadBoth("SECOND_BLOCK").block2(1, true, 16)
 				.payload(respPayload.substring(16, 32)).go();
 		// ensure client don't ask for block anymore
-		Message message = server.receiveNextMessage(1, TimeUnit.SECONDS);
+		Message message = server.receiveNextMessage(150, TimeUnit.MILLISECONDS);
 		assertNull("No block2 message expected anymore", message);
 		// TODO ensure that blockdata buffer is cleared in blockwiselayer...
 
@@ -493,7 +494,7 @@ public class ObserveClientSideTest {
 		server.sendResponse(CON, CONTENT).loadToken("OBS").observe(0).mid(++mid).payload(notifyPayload).go();
 		server.expectEmpty(ACK, mid).go();
 		// Check this one is discard.
-		Response response = request.waitForResponse(1000);
+		Response response = request.waitForResponse(150);
 		assertNull("Older notification must be discard", response);
 
 		// Send next block


### PR DESCRIPTION
The idea is to add timeout for response on request.
I reject this idea by the past https://github.com/eclipse/californium/pull/74 to keep the coapstack as simple as possible,  but finally using it to resolve memory blockwise issue (#418) seems an elegant way.


Here is how this behave :
>Define a timeout value to wait the response. Zero or negative value means no timeout. 
By default no timeout is used, which means user should cancel request manually when it will not expect response anymore. (not doing this may cause memory leak) 
The time is measured before the request is sent. So you should set a time large enough to allow DTLS handshake or CoAP retransmission or transparent block-wise transfer. 

For transparent blockwise, `BLOCKWISE_STATUS_LIFETIME` is used

>The maximum amount of time (in milliseconds) allowed between transfers of individual blocks in a blockwise transfer before the blockwise transfer state is discarded. 



I had to modify some timing in tests, I hope this will not increase hudson/jenkins tests instability...

ResponseTimeoutLayer implementation is really simple. If this causes performance issue, we will be able to change the implementation easily. 
(Not directly linked but it is so bad that we cannot change layer implementation more easily, this could help to check if blockwiselayer leaks in tests)
