### PR TITLE
Clean up transparent block exchange if no response received

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
@@ -30,6 +30,7 @@ package org.eclipse.californium.core.network.config;
 
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.network.GroupedMessageIdTracker;
+import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.eclipse.californium.elements.UDPConnector;
 
 /**
@@ -63,6 +64,16 @@ public class NetworkConfigDefaults {
 	 * EXCHANGE_LIFETIME of 247s.
 	 */
 	public static final int DEFAULT_BLOCKWISE_STATUS_LIFETIME = 5 * 60 * 1000; // 5 mins
+	
+	/**
+	 * The default value for {@link Keys#PREFERRED_BLOCK_SIZE}
+	 */
+	public static final int DEFAULT_PREFERRED_BLOCK_SIZE = 512;
+	
+	/**
+	 * The default value for {@link Keys#MAX_MESSAGE_SIZE}
+	 */
+	public static final int DEFAULT_MAX_MESSAGE_SIZE = 1024;
 
 	/**
 	 * The default MID tracker.
@@ -130,8 +141,8 @@ public class NetworkConfigDefaults {
 		config.setInt(NetworkConfig.Keys.MID_TRACKER_GROUPS, DEFAULT_MID_TRACKER_GROUPS);
 		config.setInt(NetworkConfig.Keys.TOKEN_SIZE_LIMIT, 8);
 
-		config.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 512);
-		config.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 1024);
+		config.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, DEFAULT_PREFERRED_BLOCK_SIZE);
+		config.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, DEFAULT_MAX_MESSAGE_SIZE);
 		config.setInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE, DEFAULT_MAX_RESOURCE_BODY_SIZE);
 		config.setInt(NetworkConfig.Keys.BLOCKWISE_STATUS_LIFETIME, DEFAULT_BLOCKWISE_STATUS_LIFETIME); // ms
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
@@ -48,6 +48,7 @@ final class Block1BlockwiseStatus extends BlockwiseStatus {
 	static Block1BlockwiseStatus forOutboundRequest(final Exchange exchange, final Request request, final int preferredBlockSize) {
 		Block1BlockwiseStatus status = new Block1BlockwiseStatus(0, request.getOptions().getContentFormat());
 		status.request = request;
+		status.exchange = exchange;
 		status.setCurrentSzx(BlockOption.size2Szx(preferredBlockSize));
 		return status;
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
@@ -56,7 +56,6 @@ final class Block2BlockwiseStatus extends BlockwiseStatus {
 	/**
 	 * Starting exchange to stop deprecated transfers. 
 	 */
-	private Exchange exchange;
 	private Response response;
 	private byte[] etag;
 
@@ -367,7 +366,7 @@ final class Block2BlockwiseStatus extends BlockwiseStatus {
 			}
 		}
 	}
-	
+
 	/**
 	 * Complete given new exchange only if this is not the one using by this current block status
 	 */

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -272,6 +272,7 @@ public class BlockwiseLayer extends AbstractLayer {
 				}
 			});
 
+			prepareBlock1Cleanup(status, key);
 			return block;
 		}
 	}
@@ -740,6 +741,7 @@ public class BlockwiseLayer extends AbstractLayer {
 		addBlock1CleanUpObserver(nextBlock, key);
 
 		exchange.setCurrentRequest(nextBlock);
+		prepareBlock1Cleanup(status, key);
 		lower().sendRequest(exchange, nextBlock);
 	}
 
@@ -854,6 +856,7 @@ public class BlockwiseLayer extends AbstractLayer {
 
 						LOGGER.log(Level.FINER, "requesting next Block2 [num={0}]: {1}", new Object[]{ nextNum, block });
 						exchange.setCurrentRequest(block);
+						prepareBlock2Cleanup(status, key);
 						lower().sendRequest(exchange, block);
 
 					} else {
@@ -1092,6 +1095,7 @@ public class BlockwiseLayer extends AbstractLayer {
 			public void run() {
 				if (!status.isComplete()) {
 					LOGGER.log(Level.FINE, "block1 transfer timed out: {0}", key);
+					status.timeoutCurrentTranfer();
 				}
 				clearBlock1Status(key);
 			}
@@ -1150,6 +1154,7 @@ public class BlockwiseLayer extends AbstractLayer {
 			public void run() {
 				if (!status.isComplete()) {
 					LOGGER.log(Level.FINE, "block2 transfer timed out: {0}", key);
+					status.timeoutCurrentTranfer();
 				}
 				clearBlock2Status(key);
 			}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -58,6 +58,7 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.config.NetworkConfigDefaults;
 import org.eclipse.californium.elements.util.LeastRecentlyUsedCache;
 
 /**
@@ -169,12 +170,15 @@ public class BlockwiseLayer extends AbstractLayer {
 	 */
 	public BlockwiseLayer(final NetworkConfig config) {
 
-		maxMessageSize = config.getInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 4096);
-		preferredBlockSize = config.getInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 1024);
+		maxMessageSize = config.getInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, NetworkConfigDefaults.DEFAULT_MAX_MESSAGE_SIZE);
+		preferredBlockSize = config.getInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, NetworkConfigDefaults.DEFAULT_PREFERRED_BLOCK_SIZE);
 		preferredBlockSzx = BlockOption.size2Szx(preferredBlockSize);
-		blockTimeout = config.getInt(NetworkConfig.Keys.BLOCKWISE_STATUS_LIFETIME, 30 * 1000); // 30 secs
-		maxResourceBodySize = config.getInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE, 8192);
-		int maxActivePeers = config.getInt(NetworkConfig.Keys.MAX_ACTIVE_PEERS);
+		blockTimeout = config.getInt(NetworkConfig.Keys.BLOCKWISE_STATUS_LIFETIME,
+				NetworkConfigDefaults.DEFAULT_BLOCKWISE_STATUS_LIFETIME);
+		maxResourceBodySize = config.getInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE,
+				NetworkConfigDefaults.DEFAULT_MAX_RESOURCE_BODY_SIZE);
+		int maxActivePeers = config.getInt(NetworkConfig.Keys.MAX_ACTIVE_PEERS,
+				NetworkConfigDefaults.DEFAULT_MAX_ACTIVE_PEERS);
 		block1Transfers = new LeastRecentlyUsedCache<>(maxActivePeers, blockTimeout / 1000);
 		block2Transfers = new LeastRecentlyUsedCache<>(maxActivePeers, blockTimeout / 1000);
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseStatus.java
@@ -29,6 +29,7 @@ import java.util.logging.Logger;
 import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.OptionSet;
+import org.eclipse.californium.core.network.Exchange;
 
 /**
  * A tracker for the status of a blockwise transfer of a request or response body.
@@ -43,6 +44,7 @@ abstract class BlockwiseStatus {
 
 	protected boolean randomAccess;
 	protected final ByteBuffer buf;
+	protected Exchange exchange;
 
 	private ScheduledFuture<?> cleanUpTask;
 	private Message first;
@@ -287,5 +289,12 @@ abstract class BlockwiseStatus {
 			this.cleanUpTask.cancel(false);
 		}
 		this.cleanUpTask = blockCleanupHandle;
+	}
+
+	/**
+	 * Complete current transfert
+	 */
+	public void timeoutCurrentTranfer() {
+		this.exchange.setTimedOut(this.exchange.getCurrentRequest());
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -110,7 +110,8 @@ public class BlockwiseClientSideTest {
 				.setInt(NetworkConfig.Keys.ACK_TIMEOUT, ACK_TIMEOUT_IN_MS)
 				.setInt(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1)
 				.setInt(NetworkConfig.Keys.MAX_RETRANSMIT, 2)
-				.setInt(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1);
+				.setInt(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1)
+				.setInt(NetworkConfig.Keys.BLOCKWISE_STATUS_LIFETIME,300);
 	}
 
 	@Before
@@ -345,7 +346,7 @@ public class BlockwiseClientSideTest {
 		//server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 64).payload(respPayload, 64, 128).go();
 		// give client a chance to repeat
 		int timeout = config.getInt(NetworkConfig.Keys.ACK_TIMEOUT, ACK_TIMEOUT_IN_MS);
-		Thread.sleep(timeout * 2);
+		Thread.sleep((long) (timeout*1.25));
 		// repeat GET 1
 		server.expectRequest(CON, GET, path).sameBoth("B").block2(1, false, 64).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 64).payload(respPayload, 64, 128).go();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -109,7 +109,8 @@ public class BlockwiseClientSideTest {
 				.setLong(NetworkConfig.Keys.EXCHANGE_LIFETIME, TEST_EXCHANGE_LIFETIME)
 				.setInt(NetworkConfig.Keys.ACK_TIMEOUT, ACK_TIMEOUT_IN_MS)
 				.setInt(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1)
-				.setInt(NetworkConfig.Keys.MAX_RETRANSMIT, 2);
+				.setInt(NetworkConfig.Keys.MAX_RETRANSMIT, 2)
+				.setInt(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1);
 	}
 
 	@Before
@@ -933,5 +934,178 @@ public class BlockwiseClientSideTest {
 		
 		// Check the first request is canceled.
 		assertTrue(firstRequest.isCanceled());
+	}
+	
+	/**
+	 * Verifies incomplete block2 exchange (missing last piggyback response)
+	 * does not leak.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testIncompleteBlock2NoAckNoResponse() throws Exception {
+
+		System.out.println("Incomplete  block2 transfer:");
+		respPayload = generateRandomPayload(300);
+		String path = "test";
+
+		// Send GET request
+		Request request = createRequest(GET, path, server);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, GET, path).storeBoth("A").go();
+		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 128).payload(respPayload.substring(0, 128))
+				.go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 128).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 128).payload(respPayload.substring(128, 256))
+				.go();
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 128).go();
+		// we don't answer to the last request, @after should check is there is
+		// no leak.
+
+		printServerLog(clientInterceptor);
+	}
+
+	/**
+	 * Verifies incomplete block1 exchange (missing piggyback response) does not
+	 * leak.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testIncompleteBlock1NoAckNoResponse() throws Exception {
+
+		System.out.println("Incomplete  block1 transfer:");
+		reqtPayload = generateRandomPayload(300);
+		String path = "test";
+
+		// Send PUT request
+		Request request = createRequest(PUT, path, server);
+		request.setPayload(reqtPayload);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, PUT, path).storeBoth("A").block1(0, true, 128).payload(reqtPayload, 0, 128).go();
+		server.sendResponse(ACK, CONTINUE).loadBoth("A").block1(1, false, 128).go();
+		server.expectRequest(CON, PUT, path).storeBoth("B").block1(1, true, 128).payload(reqtPayload, 128, 256).go();
+		// we don't answer to the last request, @after should check is there is
+		// no leak.
+
+		printServerLog(clientInterceptor);
+	}
+
+	/**
+	 * Verifies cancelled block2 exchange does not leak.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testCancelledBlock2() throws Exception {
+
+		System.out.println("cancelled block2 transfer:");
+		respPayload = generateRandomPayload(300);
+		String path = "test";
+
+		// Send GET request
+		Request request = createRequest(GET, path, server);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, GET, path).storeBoth("A").go();
+		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 128).payload(respPayload.substring(0, 128))
+				.go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 128).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 128).payload(respPayload.substring(128, 256))
+				.go();
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 128).go();
+		printServerLog(clientInterceptor);
+
+		System.out.println("Cancel request " + request);
+		request.cancel();
+		assertTrue("ExchangeStore must be empty", clientExchangeStore.isEmpty());
+
+	}
+
+	/**
+	 * Verifies cancelled block1 exchange does not leak.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testCancelledBlock1() throws Exception {
+
+		System.out.println("Cancelled  block1 transfer:");
+		reqtPayload = generateRandomPayload(300);
+		String path = "test";
+
+		// Send PUT request
+		Request request = createRequest(PUT, path, server);
+		request.setPayload(reqtPayload);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, PUT, path).storeBoth("A").block1(0, true, 128).payload(reqtPayload, 0, 128).go();
+		server.sendResponse(ACK, CONTINUE).loadBoth("A").block1(1, false, 128).go();
+		server.expectRequest(CON, PUT, path).storeBoth("B").block1(1, true, 128).payload(reqtPayload, 128, 256).go();
+		printServerLog(clientInterceptor);
+
+		System.out.println("Cancel request " + request);
+		request.cancel();
+		assertTrue("ExchangeStore must be empty", clientExchangeStore.isEmpty());
+
+	}
+
+	/**
+	 * Verifies acknowledged incomplete block 2 exchange does not leak.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testIncompleteBlock2AckNoResponse() throws Exception {
+
+		System.out.println("Incomplete Acknowledged block2 transfer:");
+		respPayload = generateRandomPayload(300);
+		String path = "test";
+
+		// Send GET request
+		Request request = createRequest(GET, path, server);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, GET, path).storeBoth("A").go();
+		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 128).payload(respPayload.substring(0, 128))
+				.go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 128).go();
+		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 128).payload(respPayload.substring(128, 256))
+				.go();
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 128).go();
+		server.sendEmpty(ACK).loadMID("C").go();
+		// we acknowledge but never send the response, @after should check is
+		// there is no leak.
+
+		printServerLog(clientInterceptor);
+	}
+
+	/**
+	 * Verifies acknowledged incomplete block 2 exchange does not leak.
+	 * 
+	 * @throws Exception if the test fails.
+	 */
+	@Test
+	public void testIncompleteBlock1AckNoResponse() throws Exception {
+
+		System.out.println("Incomplete Acknowledged block1 transfer:");
+		reqtPayload = generateRandomPayload(300);
+		String path = "test";
+
+		// Send PUT request
+		Request request = createRequest(PUT, path, server);
+		request.setPayload(reqtPayload);
+		client.sendRequest(request);
+
+		server.expectRequest(CON, PUT, path).storeBoth("A").block1(0, true, 128).payload(reqtPayload, 0, 128).go();
+		server.sendResponse(ACK, CONTINUE).loadBoth("A").block1(1, false, 128).go();
+		server.expectRequest(CON, PUT, path).storeBoth("B").block1(1, true, 128).payload(reqtPayload, 128, 256).go();
+		server.sendEmpty(ACK).loadMID("B").go();
+		// we acknowledge but never send the response, @after should check is
+		// there is no leak.
+
+		printServerLog(clientInterceptor);
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -70,8 +70,8 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Large.class)
 public class ObserveClientSideTest {
-	private static final int TEST_EXCHANGE_LIFETIME = 247; // milliseconds
-	private static final int TEST_SWEEP_DEDUPLICATOR_INTERVAL = 100; // milliseconds
+	private static final int TEST_EXCHANGE_LIFETIME = 2470; // milliseconds
+	private static final int TEST_SWEEP_DEDUPLICATOR_INTERVAL = 1000; // milliseconds
 	
 	@ClassRule
 	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
@@ -97,7 +97,8 @@ public class ObserveClientSideTest {
 				.setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f)
 				.setFloat(NetworkConfig.Keys.MAX_RETRANSMIT, 2)
 				.setInt(NetworkConfig.Keys.MARK_AND_SWEEP_INTERVAL, TEST_SWEEP_DEDUPLICATOR_INTERVAL)
-				.setLong(NetworkConfig.Keys.EXCHANGE_LIFETIME, TEST_EXCHANGE_LIFETIME);
+				.setLong(NetworkConfig.Keys.EXCHANGE_LIFETIME, TEST_EXCHANGE_LIFETIME)
+				.setLong(NetworkConfig.Keys.BLOCKWISE_STATUS_LIFETIME, 1500);
 	}
 
 	@Before
@@ -406,7 +407,7 @@ public class ObserveClientSideTest {
 		server.sendResponse(ACK, CONTENT).loadBoth("SECOND_BLOCK").block2(1, true, 16)
 				.payload(respPayload.substring(16, 32)).go();
 		// ensure client don't ask for block anymore
-		Message message = server.receiveNextMessage(1, TimeUnit.SECONDS);
+		Message message = server.receiveNextMessage(1000, TimeUnit.MILLISECONDS);
 		assertNull("No block2 message expected anymore", message);
 		// TODO ensure that blockdata buffer is cleared in blockwiselayer...
 


### PR DESCRIPTION
This aims to fix #429 (at least partially)
tests of #418 are also rebased on this branch. They could be used for more "checking". (#418 is not intended to be merged)

See #437 for more details about this choice of implementation.


 