### PR TITLE
Add javadoc about thread-safe requirement to SessionCache.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -14,6 +14,7 @@
  *    Kai Hudalla (Bosch Software Innovations GmbH) - Initial creation
  *    Achim Kraus (Bosch Software Innovations GmbH) - add empty implementation 
  *                                                    for handshakeFailed.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use final for collections
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -64,8 +65,8 @@ public final class InMemoryConnectionStore implements ResumptionSupportingConnec
 	private static final Logger LOG = Logger.getLogger(InMemoryConnectionStore.class.getName());
 	private static final int DEFAULT_CACHE_SIZE = 150000;
 	private static final long DEFAULT_EXPIRATION_THRESHOLD = 36 * 60 * 60; // 36h
-	private LeastRecentlyUsedCache<InetSocketAddress, Connection> connections;
-	private SessionCache sessionCache;
+	private final LeastRecentlyUsedCache<InetSocketAddress, Connection> connections;
+	private final SessionCache sessionCache;
 
 	/**
 	 * Creates a store with a capacity of 500000 connections and

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SessionCache.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SessionCache.java
@@ -12,14 +12,17 @@
  * 
  * Contributors:
  *    Bosch Software Innovations GmbH - Initial creation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add javadoc about required
+ *                                                    thread-safe implementation
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
 /**
  * A second level cache for current connection state of DTLS sessions.
  * <p>
- * Connection state can be put to the cache and later retrieved by the
- * DTLS session's ID.
+ * Connection state can be put to the cache and later retrieved by the DTLS
+ * session's ID. The provided cache is required to be thread-safe because it
+ * will be accessed concurrently.
  * </p>
  */
 public interface SessionCache {

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemorySessionCache.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemorySessionCache.java
@@ -12,11 +12,13 @@
  * 
  * Contributors:
  *    Bosch Software Innovations - initial creation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use ConcurrentHashMap for
+ *                                                    thread-safe implementation
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
@@ -27,7 +29,7 @@ import org.eclipse.californium.elements.util.DatagramWriter;
  */
 public class InMemorySessionCache implements SessionCache {
 
-	private final Map<SessionId, byte[]> cache = new HashMap<>();
+	private final Map<SessionId, byte[]> cache = new ConcurrentHashMap<>();
 
 	/**
 	 * Puts a ticket to the cache.


### PR DESCRIPTION
Implementation test InMemorySessionCache thread-safe.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>