### PR TITLE
Fix skip test builds.

### DIFF
--- a/californium-core/pom.xml
+++ b/californium-core/pom.xml
@@ -28,15 +28,31 @@
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>element-connector</artifactId>
-			<classifier>tests</classifier>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>element-connector</artifactId>
-			<type>jar</type>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<!-- maven compile would try to resolve test dependencies, 
+				even if tests are skipped. Therefore include this 
+				test dependency only, if tests are enabled -->
+			<id>tests</id>
+			<activation>
+				<property>
+					<name>maven.test.skip</name>
+					<value>!true</value>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>element-connector</artifactId>
+					<classifier>tests</classifier>
+					<type>test-jar</type>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 
 	<build>
 		<plugins>
@@ -136,10 +152,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<goals>
+							<!-- export CoapNetworkRule for tests -->
 							<goal>test-jar</goal>
 						</goals>
 					</execution>

--- a/demo-apps/cf-secure/pom.xml
+++ b/demo-apps/cf-secure/pom.xml
@@ -28,47 +28,60 @@
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>element-connector</artifactId>
-			<classifier>tests</classifier>
-            <type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>element-connector</artifactId>
-            <type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>californium-core</artifactId>
 			<version>${project.version}</version>
-            <type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>californium-core</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-			<classifier>tests</classifier>
-            <type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>scandium</artifactId>
 			<version>${project.version}</version>
-			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>demo-certs</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>cf-nat</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-            <type>jar</type>
-		</dependency>
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<!-- maven compile would try to resolve test dependencies, 
+				even if tests are skipped. Therefore include this 
+				test dependency only, if tests are enabled -->
+			<id>tests</id>
+			<activation>
+				<property>
+					<name>maven.test.skip</name>
+					<value>!true</value>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>element-connector</artifactId>
+					<classifier>tests</classifier>
+					<type>test-jar</type>
+				</dependency>
+				<dependency>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>californium-core</artifactId>
+					<version>${project.version}</version>
+					<classifier>tests</classifier>
+					<scope>test</scope>
+					<type>test-jar</type>
+				</dependency>
+				<dependency>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>cf-nat</artifactId>
+					<version>${project.version}</version>
+					<scope>test</scope>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 
 	<build>
 		<plugins>

--- a/element-connector/pom.xml
+++ b/element-connector/pom.xml
@@ -65,10 +65,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<goals>
+							<!-- export NetworkRule and RepeatingTestRunner for tests -->
 							<goal>test-jar</goal>
 						</goals>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -153,8 +153,9 @@
 				<groupId>${project.groupId}</groupId>
 				<artifactId>element-connector</artifactId>
 				<version>${project.version}</version>
-				<scope>test</scope>
 				<classifier>tests</classifier>
+				<scope>test</scope>
+				<type>test-jar</type>
 			</dependency>
 			<dependency>
 				<groupId>${project.groupId}</groupId>
@@ -257,6 +258,11 @@
 							</goals>
 						</execution>
 					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>3.0.2</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/scandium-core/pom.xml
+++ b/scandium-core/pom.xml
@@ -19,14 +19,6 @@
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>element-connector</artifactId>
-			<type>jar</type>
-		</dependency>
-		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>element-connector</artifactId>
-			<classifier>tests</classifier>
-			<type>jar</type>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -41,6 +33,29 @@
 			<artifactId>hamcrest-library</artifactId>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<!-- maven compile would try to resolve test dependencies, 
+				even if tests are skipped. Therefore include this 
+				test dependency only, if tests are enabled -->
+			<id>tests</id>
+			<activation>
+				<property>
+					<name>maven.test.skip</name>
+					<value>!true</value>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>element-connector</artifactId>
+					<classifier>tests</classifier>
+					<type>test-jar</type>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
Builds with -Dmaven.test.skip=true failed. Therefore introduce profile
as proposed workaround in
https://issues.apache.org/jira/browse/MJAR-138.
Change to use type "test-jar" instead of "jar" for test only libraries.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>