### PR TITLE
Configurable sslcontextutil

### DIFF
--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/SslContextUtilConfigurationTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/SslContextUtilConfigurationTest.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.security.GeneralSecurityException;
+
+import org.eclipse.californium.elements.util.SslContextUtil.Credentials;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SslContextUtilConfigurationTest {
+
+	public static final char[] KEY_STORE_PASSWORD = "endPass".toCharArray();
+	public static final String KEY_STORE_PASSWORD_HEX = "656E6450617373";
+	public static final String KEY_STORE_LOCATION = SslContextUtil.CLASSPATH_SCHEME + "certs/keyStore.jks";
+	public static final String ALIAS_SERVER = "server";
+	public static final String CUSTOM_SCHEME = "test://";
+	public static final String CUSTOM_SCHEME_KEY_STORE_LOCATION = CUSTOM_SCHEME + "keyStore.jks";
+
+	public static final String CUSTOM_ENDING = ".cks";
+	public static final String CUSTOM_TYPE = "CKS";
+
+	private TestInputStreamFactory testFactory;
+
+	@Before
+	public void init() {
+		SslContextUtil.configureDefaults();
+		testFactory = new TestInputStreamFactory();
+		testFactory.stream = SslContextUtil.class.getClassLoader().getResourceAsStream("certs/keyStore.jks");
+	}
+
+	@After
+	public void close() {
+		try {
+			testFactory.close();
+		} catch (IOException e) {
+		}
+	}
+
+	@Test
+	public void testLoadKeyStoreFromClasspath() throws IOException, GeneralSecurityException {
+		Credentials credentials = SslContextUtil.loadCredentials(KEY_STORE_LOCATION, ALIAS_SERVER, KEY_STORE_PASSWORD,
+				KEY_STORE_PASSWORD);
+		assertThat(credentials, is(notNullValue()));
+	}
+
+	@Test(expected = MalformedURLException.class)
+	public void testNotConfiguredScheme() throws IOException, GeneralSecurityException {
+		SslContextUtil.loadCredentials(CUSTOM_SCHEME_KEY_STORE_LOCATION, ALIAS_SERVER, KEY_STORE_PASSWORD,
+				KEY_STORE_PASSWORD);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testConfigureInputStreamFactoryWithoutScheme() throws IOException, GeneralSecurityException {
+		SslContextUtil.configure(null, testFactory);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testConfigureInputStreamFactoryWithInvalidScheme() throws IOException, GeneralSecurityException {
+		SslContextUtil.configure("test:", testFactory);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testConfigureInputStreamFactoryWithoutFactory() throws IOException, GeneralSecurityException {
+		SslContextUtil.configure(CUSTOM_SCHEME, (SslContextUtil.InputStreamFactory) null);
+	}
+
+	@Test
+	public void testConfigureInputStreamFactory() throws IOException, GeneralSecurityException {
+		SslContextUtil.configure(CUSTOM_SCHEME, testFactory);
+		Credentials credentials = SslContextUtil.loadCredentials(CUSTOM_SCHEME_KEY_STORE_LOCATION, ALIAS_SERVER,
+				KEY_STORE_PASSWORD, KEY_STORE_PASSWORD);
+		assertThat(credentials, is(notNullValue()));
+		assertThat(testFactory.uri, is(CUSTOM_SCHEME_KEY_STORE_LOCATION));
+	}
+
+	@Test
+	public void testLoadKeyStoreFromClasspathWithCustomConfiguration() throws IOException, GeneralSecurityException {
+		testFactory.close();
+		SslContextUtil.configure(CUSTOM_SCHEME, testFactory);
+		Credentials credentials = SslContextUtil.loadCredentials(KEY_STORE_LOCATION, ALIAS_SERVER, KEY_STORE_PASSWORD,
+				KEY_STORE_PASSWORD);
+		assertThat(credentials, is(notNullValue()));
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testConfigureKeyStoreTypeWithoutEnding() throws IOException, GeneralSecurityException {
+		SslContextUtil.configure(null, CUSTOM_TYPE);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testConfigureKeyStoreTypeWithoutType() throws IOException, GeneralSecurityException {
+		SslContextUtil.configure(CUSTOM_ENDING, (String) null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testConfigureKeyStoreTypeWithInvalidEnding() throws IOException, GeneralSecurityException {
+		SslContextUtil.configure(CUSTOM_TYPE, CUSTOM_TYPE);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testConfigureKeyStoreTypeWithInvalidType() throws IOException, GeneralSecurityException {
+		SslContextUtil.configure(CUSTOM_ENDING, "");
+	}
+
+	@Test
+	public void testConfigureKeyStoreType() throws IOException, GeneralSecurityException {
+		try {
+			SslContextUtil.configure(SslContextUtil.JKS_ENDING, CUSTOM_TYPE);
+			SslContextUtil.loadCredentials(KEY_STORE_LOCATION, ALIAS_SERVER, KEY_STORE_PASSWORD, KEY_STORE_PASSWORD);
+			fail("custom key store type \"" + CUSTOM_TYPE + "\" is not intended to be supported!");
+		} catch (GeneralSecurityException ex) {
+			assertThat(ex.getMessage(), containsString(CUSTOM_TYPE));
+		}
+	}
+
+	private class TestInputStreamFactory implements SslContextUtil.InputStreamFactory {
+
+		public String uri;
+		public InputStream stream;
+
+		public void close() throws IOException {
+			if (stream != null) {
+				stream.close();
+				stream = null;
+			}
+		}
+
+		@Override
+		public InputStream create(String uri) throws IOException {
+			this.uri = uri;
+			InputStream result = stream;
+			stream = null;
+			return result;
+		}
+
+	}
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/SslContextUtilCredentialsTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/SslContextUtilCredentialsTest.java
@@ -35,7 +35,7 @@ public class SslContextUtilCredentialsTest {
 
 	public static final char[] KEY_STORE_PASSWORD = "endPass".toCharArray();
 	public static final String KEY_STORE_PASSWORD_HEX = "656E6450617373";
-	public static final String KEY_STORE_LOCATION = SslContextUtil.CLASSPATH_PROTOCOL + "certs/keyStore.jks";
+	public static final String KEY_STORE_LOCATION = SslContextUtil.CLASSPATH_SCHEME + "certs/keyStore.jks";
 
 	public static final String ALIAS_SERVER = "server";
 	public static final String ALIAS_CLIENT = "client";

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/SslContextUtilTrustTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/SslContextUtilTrustTest.java
@@ -35,7 +35,7 @@ public class SslContextUtilTrustTest {
 
 	public static final char[] TRUST_STORE_PASSWORD = "rootPass".toCharArray();
 	public static final String TRUST_STORE_PASSWORD_HEX = "726F6F7450617373";
-	public static final String TRUST_STORE_LOCATION = SslContextUtil.CLASSPATH_PROTOCOL + "certs/trustStore.jks";
+	public static final String TRUST_STORE_LOCATION = SslContextUtil.CLASSPATH_SCHEME + "certs/trustStore.jks";
 
 	public static final char[] TRUST_STORE_WRONG_PASSWORD = "wrongPass".toCharArray();
 


### PR DESCRIPTION
Improve support for android.
Note: old android doesn't support ecc cipher suites and therefore fail using californium demo certs!

Signed-off-by: Achim Kraus achim.kraus@bosch-si.com