### PR TITLE
Fix x509 android

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
@@ -15,6 +15,10 @@
  *    Stefan Jucker - DTLS implementation
  *    Kai Hudalla (Bosch Software Innovations GmbH) - add accessor for peer address
  *    Bosch Software Innovations GmbH - migrate to SLF4J
+ *    Achim Kraus (Bosch Software Innovations GmbH) - fix matching of signature algorithm
+ *                                                    for android using characters with
+ *                                                    different case "SHA256WITHECDSA"
+ *                                                    instead of "SHA256withECDSA"
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -495,10 +499,13 @@ public final class CertificateRequest extends HandshakeMessage {
 	 */
 	boolean isSignedWithSupportedAlgorithm(X509Certificate[] chain) {
 
-		for (X509Certificate cert : chain) {
+		for (int index=0; index < chain.length; ++index) {
+			X509Certificate cert = chain[index];
 			boolean certSignatureAlgorithmSupported = false;
 			for (SignatureAndHashAlgorithm supportedAlgorithm : supportedSignatureAlgorithms) {
-				if (supportedAlgorithm.jcaName().equals(cert.getSigAlgName())) {
+				// android's certificate returns a upper case SigAlgName, e.g. "SHA256WITHECDSA"
+				// But the jcaName returns a mixed case name, e.g. "SHA256withECDSA"
+				if (supportedAlgorithm.jcaName().equalsIgnoreCase(cert.getSigAlgName())) {
 					certSignatureAlgorithmSupported = true;
 					break;
 				}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -355,6 +355,7 @@ public abstract class Handshaker {
 						return fragment;
 					} else {
 						// store message for later processing
+						LOGGER.debug("Change Cipher Spec is not expected and therefore kept for later processing!");
 						changeCipherSpec = (ChangeCipherSpecMessage) fragment;
 						return null;
 					}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/ECDHECryptography.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/ECDHECryptography.java
@@ -17,6 +17,8 @@
  *                                                    add SupportedGroup enum also holding
  *                                                    curve params, add brainpool curve params
  *    Bosch Software Innovations GmbH - migrate to SLF4J
+ *    Achim Kraus (Bosch Software Innovations GmbH) - include only usable groups into the
+ *                                                    preferred groups.
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls.cipher;
 
@@ -499,7 +501,7 @@ public final class ECDHECryptography {
 					result.add(group);
 				}
 			}
-			return result.toArray(new SupportedGroup[]{});
+			return result.toArray(new SupportedGroup[result.size()]);
 		}
 
 		/**
@@ -508,16 +510,26 @@ public final class ECDHECryptography {
 		 * @return the groups in order of preference
 		 */
 		public static List<SupportedGroup> getPreferredGroups() {
+			SupportedGroup usableGroup = null;
 			List<SupportedGroup> result = new ArrayList<>();
 			for (SupportedGroup group : SupportedGroup.values()) {
 				switch(group) {
 				case secp256r1:
 				case secp384r1:
 				case secp521r1:
-					result.add(group);
+					if (group.isUsable()) {
+						result.add(group);
+					}
+					break;
 				default:
+					if (usableGroup == null && group.isUsable()) {
+						usableGroup = group;
+					}
 					// skip
 				}
+			}
+			if (result.isEmpty() && usableGroup != null) {
+				result.add(usableGroup);
 			}
 			return result;
 		}


### PR DESCRIPTION
Fixes signature algorithm matching on android.
Include only usable groups into the preferred groups.
Add logging for postponed change cipher spec processing.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>