### PR TITLE
Add hooks for customizing ServerMessageDeliverer by extension

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/server/MessageDeliverer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/MessageDeliverer.java
@@ -38,6 +38,7 @@ public interface MessageDeliverer {
 	 * 
 	 * @param exchange
 	 *            the exchange containing the inbound {@code Request}
+	 * @throws NullPointerException if exchange is {@code null}.
 	 */
 	void deliverRequest(Exchange exchange);
 
@@ -48,6 +49,8 @@ public interface MessageDeliverer {
 	 *            the exchange containing the originating CoAP request
 	 * @param response
 	 *            the inbound CoAP response message
+	 * @throws NullPointerException if exchange or response are {@code null}.
+	 * @throws IllegalArgumentException if the exchange does not contain a request.
 	 */
 	void deliverResponse(Exchange exchange, Response response);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
@@ -22,6 +22,7 @@
 package org.eclipse.californium.core.server;
 
 import java.net.InetSocketAddress;
+import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -42,7 +43,7 @@ import org.eclipse.californium.core.server.resources.Resource;
  * The ServerMessageDeliverer delivers requests to corresponding resources and
  * responses to corresponding requests.
  */
-public final class ServerMessageDeliverer implements MessageDeliverer {
+public class ServerMessageDeliverer implements MessageDeliverer {
 
 	private static final Logger LOGGER = Logger.getLogger(ServerMessageDeliverer.class.getCanonicalName());
 
@@ -62,37 +63,74 @@ public final class ServerMessageDeliverer implements MessageDeliverer {
 		this.root = root;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.californium.MessageDeliverer#deliverRequest(org.eclipse.californium.network.Exchange)
+	/**
+	 * Delivers an inbound CoAP request to an appropriate resource.
+	 * <p>
+	 * This method first invokes {@link #preDeliverRequest(Exchange)}.
+	 * The request is considered <em>processed</em> if the
+	 * <em>preDeliverRequest</em> method returned {@code true}.
+	 * <p>
+	 * Otherwise, this method
+	 * <ol>
+	 * <li>tries to {@linkplain #findResource(List) find a matching resource},</li>
+	 * <li>handle a GET request's observe option and </li>
+	 * <li>deliver the request to the resource for processing.</li>
+	 * </ol>
+	 * 
+	 * @param exchange The exchange containing the inbound request.
+	 * @throws NullPointerException if exchange is {@code null}.
 	 */
 	@Override
-	public void deliverRequest(final Exchange exchange) {
-		Request request = exchange.getRequest();
-		List<String> path = request.getOptions().getUriPath();
-		final Resource resource = findResource(path);
-		if (resource != null) {
-			checkForObserveOption(exchange, resource);
-			
-			// Get the executor and let it process the request
-			Executor executor = resource.getExecutor();
-			if (executor != null) {
-				exchange.setCustomExecutor();
-				executor.execute(new Runnable() {
-					public void run() {
-						resource.handleRequest(exchange);
-					} });
+	public final void deliverRequest(final Exchange exchange) {
+		if (exchange == null) {
+			throw new NullPointerException("exchange must not be null");
+		}
+		boolean processed = preDeliverRequest(exchange);
+		if (!processed) {
+			Request request = exchange.getRequest();
+			List<String> path = request.getOptions().getUriPath();
+			final Resource resource = findResource(path);
+			if (resource != null) {
+				checkForObserveOption(exchange, resource);
+
+				// Get the executor and let it process the request
+				Executor executor = resource.getExecutor();
+				if (executor != null) {
+					exchange.setCustomExecutor();
+					executor.execute(new Runnable() {
+						public void run() {
+							resource.handleRequest(exchange);
+						} });
+				} else {
+					resource.handleRequest(exchange);
+				}
 			} else {
-				resource.handleRequest(exchange);
+				LOGGER.log(Level.INFO, "Did not find resource {0} requested by {1}:{2}",
+						new Object[]{path, request.getSource(), request.getSourcePort()});
+				exchange.sendResponse(new Response(ResponseCode.NOT_FOUND));
 			}
-		} else {
-			LOGGER.log(Level.INFO, "Did not find resource {0} requested by {1}:{2}",
-					new Object[]{path, request.getSource(), request.getSourcePort()});
-			exchange.sendResponse(new Response(ResponseCode.NOT_FOUND));
 		}
 	}
 
 	/**
+	 * Invoked by the <em>deliverRequest</em> before the request gets processed.
+	 * <p>
+	 * Subclasses may override this method in order to replace the default request handling logic
+	 * or to modify or add headers etc before the request gets processed.
+	 * <p>
+	 * This default implementation returns {@code false}.
+	 * 
+	 * @param exchange The exchange for the incoming request.
+	 * @return {@code true} if the request has already been processed by this method and thus
+	 *         should not be delivered to a matching resource anymore.
+	 */
+	protected boolean preDeliverRequest(final Exchange exchange) {
+		return false;
+	}
+
+	/**
 	 * Checks whether an observe relationship has to be established or canceled.
+	 * <p>
 	 * This is done here to have a server-global observeManager that holds the
 	 * set of remote endpoints for all resources. This global knowledge is required
 	 * for efficient orphan handling.
@@ -104,17 +142,14 @@ public final class ServerMessageDeliverer implements MessageDeliverer {
 	 * @param path
 	 *            the path to the resource
 	 */
-	private void checkForObserveOption(final Exchange exchange, final Resource resource) {
+	protected final void checkForObserveOption(final Exchange exchange, final Resource resource) {
+
 		Request request = exchange.getRequest();
-		if (request.getCode() != Code.GET) {
-			return;
-		}
+		if (request.getCode() == Code.GET && request.getOptions().hasObserve() && resource.isObservable()) {
 
-		InetSocketAddress source = new InetSocketAddress(request.getSource(), request.getSourcePort());
+			InetSocketAddress source = new InetSocketAddress(request.getSource(), request.getSourcePort());
 
-		if (request.getOptions().hasObserve() && resource.isObservable()) {
-			
-			if (request.getOptions().getObserve()==0) {
+			if (request.getOptions().getObserve() == 0) {
 				// Requests wants to observe and resource allows it :-)
 				LOGGER.log(Level.FINER,
 						"Initiate an observe relation between {0}:{1} and resource {2}",
@@ -125,7 +160,7 @@ public final class ServerMessageDeliverer implements MessageDeliverer {
 				exchange.setRelation(relation);
 				// all that's left is to add the relation to the resource which
 				// the resource must do itself if the response is successful
-				
+
 			} else if (request.getOptions().getObserve() == 1) {
 				// Observe defines 1 for canceling
 				ObserveRelation relation = observeManager.getRelation(source, request.getToken());
@@ -144,8 +179,8 @@ public final class ServerMessageDeliverer implements MessageDeliverer {
 	 * @param list the path as list of resource names
 	 * @return the resource or null if not found
 	 */
-	private Resource findResource(final List<String> list) {
-		LinkedList<String> path = new LinkedList<String>(list);
+	protected final Resource findResource(final List<String> list) {
+		Deque<String> path = new LinkedList<String>(list);
 		Resource current = root;
 		while (!path.isEmpty() && current != null) {
 			String name = path.removeFirst();
@@ -154,11 +189,24 @@ public final class ServerMessageDeliverer implements MessageDeliverer {
 		return current;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.californium.MessageDeliverer#deliverResponse(org.eclipse.californium.network.Exchange, org.eclipse.californium.coap.Response)
+	/**
+	 * Delivers an inbound CoAP response message to its corresponding request.
+	 * <p>
+	 * This method first invokes {@link #preDeliverResponse(Exchange, Response)}.
+	 * The response is considered <em>processed</em> if the
+	 * <em>preDeliverResponse</em> method returned {@code true}.
+	 * <p>
+* 	 * Otherwise, this method delivers the response to the corresponding request.
+	 * 
+	 * @param exchange
+	 *            The exchange containing the originating CoAP request.
+	 * @param response
+	 *            The inbound CoAP response message.
+	 * @throws NullPointerException if exchange or response are {@code null}.
+	 * @throws IllegalArgumentException if the exchange does not contain a request.
 	 */
 	@Override
-	public void deliverResponse(Exchange exchange, Response response) {
+	public final void deliverResponse(final Exchange exchange, final Response response) {
 		if (response == null) {
 			throw new NullPointerException("Response must not be null");
 		} else if (exchange == null) {
@@ -166,7 +214,31 @@ public final class ServerMessageDeliverer implements MessageDeliverer {
 		} else if (exchange.getRequest() == null) {
 			throw new IllegalArgumentException("Exchange does not contain request");
 		} else {
-			exchange.getRequest().setResponse(response);
+			boolean processed = preDeliverResponse(exchange, response);
+			if (!processed) {
+				exchange.getRequest().setResponse(response);
+			}
 		}
+	}
+
+	/**
+	 * Invoked by the <em>deliverResponse</em> method before the response is delivered to the
+	 * corresponding request.
+	 * <p>
+	 * Subclasses may override this method in order to replace the default response handling logic
+	 * or to modify or add headers etc before the response is delivered to the request.
+	 * <p>
+	 * The response is delivered to the request if and only if the exchange's request does not
+	 * contain a <em>response</em> when this method returns.
+	 * <p>
+	 * This default implementation returns {@code false}.
+	 * 
+	 * @param exchange The exchange containing the request that the incoming response belongs to.
+	 * @param response The incoming response.
+	 * @return {@code true} if the response has been processed by this method and thus should
+	 *         not be delivered to the corresponding request anymore.
+	 */
+	protected boolean preDeliverResponse(final Exchange exchange, final Response response) {
+		return false;
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/server/ServerMessageDelivererTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/server/ServerMessageDelivererTest.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.server;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.Option;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.Exchange.Origin;
+import org.eclipse.californium.core.server.resources.Resource;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+
+/**
+ * Verifies behavior of {@link ServerMessageDeliverer}.
+ *
+ */
+public class ServerMessageDelivererTest {
+
+	private Resource rootResource;
+	private Exchange incomingRequest;
+	private Response incomingResponse;
+	private Exchange outboundRequest;
+
+	/**
+	 * Sets up the fixture.
+	 */
+	@Before
+	public void setUp() {
+		rootResource = mock(Resource.class);
+		when(rootResource.getChild(anyString())).thenReturn(rootResource);
+		when(rootResource.getExecutor()).thenReturn(null);
+		incomingRequest = new Exchange(new Request(Code.POST), Exchange.Origin.REMOTE);
+		incomingRequest.setRequest(incomingRequest.getCurrentRequest());
+		incomingResponse = new Response(ResponseCode.CONTENT);
+		outboundRequest = new Exchange(new Request(Code.GET), Origin.LOCAL);
+		outboundRequest.setRequest(outboundRequest.getCurrentRequest());
+	}
+
+	/**
+	 * Verifies that the message deliverer does not deliver incoming
+	 * requests to resources if a subclass has already processed the
+	 * request.
+	 */
+	@Test
+	public void testDeliverRequestYieldsToSubclass() {
+
+		// GIVEN a message deliverer subclass which processes all incoming requests
+		// in its preDeliverRequest method
+		ServerMessageDeliverer deliverer = new ServerMessageDeliverer(rootResource) {
+			@Override
+			protected boolean preDeliverRequest(Exchange exchange) {
+				Response response = new Response(ResponseCode.CREATED);
+				exchange.setResponse(response);
+				return true;
+			}
+		};
+
+		// WHEN a request is received
+		deliverer.deliverRequest(incomingRequest);
+
+		// THEN the request is not delivered to the match-all root resource
+		verify(rootResource, never()).handleRequest(incomingRequest);
+		verify(rootResource, never()).getChild(anyString());
+	}
+
+	/**
+	 * Verifies that the message deliverer delivers incoming
+	 * requests to resources if a subclass has not yet processed the response.
+	 */
+	@Test
+	public void testDeliverRequestProcessesRequestAfterPreDeliverRequest() {
+
+		// GIVEN a message deliverer subclass that adds a custom option to incoming
+		// requests
+		final Option customOption = new Option(200);
+		ServerMessageDeliverer deliverer = new ServerMessageDeliverer(rootResource) {
+			@Override
+			protected boolean preDeliverRequest(Exchange exchange) {
+				exchange.getRequest().getOptions().addOption(customOption);
+				return false;
+			}
+		};
+
+		// WHEN a request is received
+		deliverer.deliverRequest(incomingRequest);
+
+		// THEN the request is delivered to the match-all root resource
+		ArgumentCaptor<Exchange> exchangeCaptor = ArgumentCaptor.forClass(Exchange.class);
+		verify(rootResource).handleRequest(exchangeCaptor.capture());
+		// and the request contains the custom option
+		assertTrue(exchangeCaptor.getValue().getRequest().getOptions().hasOption(200));
+	}
+
+	/**
+	 * Verifies that incoming responses are not delivered to their originating requests
+	 * if a subclass has already processed the response.
+	 */
+	@Test
+	public void testDeliverResponseYieldsToSubclass() {
+
+		// GIVEN a message deliverer subclass that processes all incoming responses
+		ServerMessageDeliverer deliverer = new ServerMessageDeliverer(rootResource) {
+
+			@Override
+			protected boolean preDeliverResponse(Exchange exchange, Response response) {
+				return true;
+			}
+		};
+
+		// WHEN a response is received
+		deliverer.deliverResponse(outboundRequest, incomingResponse);
+
+		// THEN the response is not delivered to the request
+		assertNull(outboundRequest.getRequest().getResponse());
+	}
+
+	/**
+	 * Verifies that incoming responses are delivered to their originating requests
+	 * if a subclass has not already processed the response.
+	 */
+	@Test
+	public void testDeliverResponseProcessesResponseAfterPreDeliverResponse() {
+
+		// GIVEN a message deliverer subclass that adds a custom option to incoming
+		// responses
+		ServerMessageDeliverer deliverer = new ServerMessageDeliverer(rootResource) {
+
+			@Override
+			protected boolean preDeliverResponse(Exchange exchange, Response response) {
+				response.getOptions().addOption(new Option(200));
+				return false;
+			}
+		};
+
+		// WHEN a response is received
+		deliverer.deliverResponse(outboundRequest, incomingResponse);
+
+		// THEN the response is delivered to the request
+		assertNotNull(outboundRequest.getRequest().getResponse());
+		// and the response contains the custom option
+		assertTrue(outboundRequest.getRequest().getResponse().getOptions().hasOption(200));
+	}
+}

--- a/demo-apps/cf-secure/src/main/resources/Scandium-logging.properties
+++ b/demo-apps/cf-secure/src/main/resources/Scandium-logging.properties
@@ -1,0 +1,71 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.  
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+#handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overridden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+java.util.logging.FileHandler.pattern = %h/java%u.log
+java.util.logging.FileHandler.limit = 50000
+java.util.logging.FileHandler.count = 1
+java.util.logging.FileHandler.formatter = org.eclipse.californium.scandium.ScandiumFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = FINEST
+java.util.logging.ConsoleHandler.formatter = org.eclipse.californium.scandium.ScandiumFormatter
+
+# Example to customize the SimpleFormatter output format 
+# to print one-line log message like this:
+#     <level>: <log message> [<date/time>]
+#
+# java.util.logging.SimpleFormatter.format=%4$s: %5$s [%1$tc]%n
+
+californium.LogPolicy.showClass=true
+californium.LogPolicy.showLevel=true
+californium.LogPolicy.showMethod=true
+californium.LogPolicy.showMessage=true
+californium.LogPolicy.showSource=true
+californium.LogPolicy.showThread=true
+californium.LogPolicy.showThreadID=true
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+# For example, set the com.xyz.foo logger to only log SEVERE
+# messages:
+org.eclipse.californium.scandium.handlers = java.util.logging.ConsoleHandler
+org.eclipse.californium.scandium.useParentHandlers = false
+org.eclipse.californium.scandium.level = INFO
+org.eclipse.californium.scandium.DTLSConnector.level = FINER
+org.eclipse.californium.scandium.dtls.level = FINEST
+org.eclipse.californium.scandium.dtls.Connection.level = INFO


### PR DESCRIPTION
Provide methods that subclasses can override to safely customize message
deliverer behavior.

fixes #318 