### PR TITLE
Performance improvements to Californium-proxy

### DIFF
--- a/californium-proxy/pom.xml
+++ b/californium-proxy/pom.xml
@@ -17,9 +17,7 @@
 	<description>Cross-proxy module</description>
 
 	<properties>
-		<httpcomponents.version>4.2.5</httpcomponents.version>
-		<httpcomponents.version.lowerbound>4.2</httpcomponents.version.lowerbound>
-		<httpcomponents.version.upperbound>5</httpcomponents.version.upperbound>
+		<httpasyncclient.version>4.1.2</httpasyncclient.version>
 	</properties>
 
 	<dependencies>
@@ -35,14 +33,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpcore-nio</artifactId>
-			<version>${httpcomponents.version}</version>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>${httpcomponents.version}</version>
+			<artifactId>httpasyncclient</artifactId>
+			<version>${httpasyncclient.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
@@ -73,7 +65,6 @@
 							org.eclipse.californium.proxy.resources
 						</Export-Package>
 						<Import-Package>
-							org.apache.http*; version="[${httpcomponents.version.lowerbound},${httpcomponents.version.upperbound})",
 							*
 						</Import-Package>
 						<Bundle-SymbolicName>${project.groupId}.proxy</Bundle-SymbolicName>

--- a/californium-proxy/src/main/java/org/eclipse/californium/compat/CompletableFuture.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/compat/CompletableFuture.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2017 NTNU Gjøvik and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Martin Storø Nyfløtt (NTNU Gjøvik) - performance improvements to HTTP cross-proxy
+ ******************************************************************************/
+
+package org.eclipse.californium.compat;
+
+/**
+ * Backport of the class introduced in Java java.util.concurrent.CompletableFuture<T>.
+ * @param <T> Type of the result the future shall complete with.
+ */
+public class CompletableFuture<T> {
+    private T result;
+    private Consumer<T> consumer;
+
+    /**
+     * Sets the result of the action completed with the future.
+     * The result will be executed on the consumer registered on this future.
+     * @param result Result of the future.
+     */
+    public void complete(T result) {
+        synchronized (this) {
+            this.result = result;
+
+            if (consumer != null) {
+                consumer.accept(result);
+            }
+        }
+    }
+
+    /**
+     * Sets the consumer of the future.
+     * @param consumer Will receive a notification one the result of the
+     *                 future has been set.
+     */
+    public void thenAccept(Consumer<T> consumer) {
+        synchronized (this) {
+            this.consumer = consumer;
+
+            if (result != null) {
+                consumer.accept(result);
+            }
+        }
+    }
+}

--- a/californium-proxy/src/main/java/org/eclipse/californium/compat/Consumer.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/compat/Consumer.java
@@ -1,27 +1,29 @@
 /*******************************************************************************
- * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
- * 
+ * Copyright (c) 2017 NTNU Gjøvik and others.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v1.0 which accompany this distribution.
- * 
+ *
  * The Eclipse Public License is available at
  *    http://www.eclipse.org/legal/epl-v10.html
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
- * 
+ *
  * Contributors:
- *    Matthias Kovatsch - creator and main architect
- *    Martin Lanter - architect and re-implementation
- *    Francesco Corazza - HTTP cross-proxy
+ *    Martin Storø Nyfløtt (NTNU Gjøvik) - performance improvements to HTTP cross-proxy
  ******************************************************************************/
-package org.eclipse.californium.proxy;
 
-import org.eclipse.californium.core.coap.Request;
+package org.eclipse.californium.compat;
 
-
-public interface RequestHandler {
-
-	public void handleRequest(Request request, HttpRequestContext context);
-	
+/**
+ * Backport of the class java.util.function.Consumer<T>
+ * @param <T> Type that the consumer will receives.
+ */
+public interface Consumer<T> {
+    /**
+     * Executed when a said action is sent to the consumer.
+     * @param result Result of some action.
+     */
+    public void accept(T result);
 }

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapTranslator.java
@@ -99,10 +99,10 @@ public final class CoapTranslator {
 					incomingRequest.getOptions().getProxyUri(), "UTF-8");
 			serverUri = new URI(proxyUriString);
 		} catch (UnsupportedEncodingException e) {
-			LOGGER.warn("UTF-8 do not support this encoding: " + e);
+			LOGGER.warn("UTF-8 do not support this encoding", e);
 			throw new TranslationException("UTF-8 do not support this encoding", e);
 		} catch (URISyntaxException e) {
-			LOGGER.warn("Cannot translate the server uri" + e);
+			LOGGER.warn("Cannot translate the server uri", e);
 			throw new TranslationException("Cannot translate the server uri", e);
 		}
 

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/EndPointManagerPool.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/EndPointManagerPool.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2017 NTNU Gjøvik and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Martin Storø Nyfløtt (NTNU Gjøvik) - performance improvements to HTTP cross-proxy
+ ******************************************************************************/
+package org.eclipse.californium.proxy;
+
+import org.eclipse.californium.core.network.EndpointManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+/**
+ * A pool of EndpointManagers to avoid concurrency issues across concurrent requests.
+ */
+public class EndPointManagerPool {
+	private static final int INIT_SIZE = 10;
+	private static final Queue<EndpointManager> managers = initManagerPool(INIT_SIZE);
+
+	 private static final Logger LOGGER = LoggerFactory.getLogger(EndPointManagerPool.class);
+
+	private static Queue<EndpointManager> initManagerPool(final int size) {
+		final Queue<EndpointManager> clients = new ArrayDeque<>(size);
+
+		for (int i = 0; i < size; i++) {
+			clients.add(createManager());
+		}
+
+		return clients;
+	}
+
+    /**
+     * @return An EndpointManager that is not in use.
+     */
+	public static EndpointManager getManager() {
+		synchronized (managers) {
+			if (managers.size() > 0) {
+				return managers.remove();
+			}
+		}
+
+		LOGGER.warn("Out of endpoint managers, creating more");
+
+		return createManager();
+	}
+
+	private static EndpointManager createManager() {
+		return new EndpointManager();
+	}
+
+    /**
+     * Puts back and EndpointManager so that other clients can use it.
+     * @param manager Manager to free.
+     */
+	public static void putClient(final EndpointManager manager) {
+		if (manager == null) return;
+		synchronized (managers) {
+			if (managers.size() >= INIT_SIZE) {
+				manager.getDefaultEndpoint().destroy();
+			} else {
+				managers.add(manager);
+			}
+		}
+	}
+}

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpClientFactory.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpClientFactory.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2017 NTNU Gjøvik and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Martin Storø Nyfløtt (NTNU Gjøvik) - performance improvements to HTTP cross-proxy
+ ******************************************************************************/
+package org.eclipse.californium.proxy;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.protocol.RequestAcceptEncoding;
+import org.apache.http.client.protocol.ResponseContentEncoding;
+import org.apache.http.impl.client.DefaultConnectionKeepAliveStrategy;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
+import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
+import org.apache.http.nio.reactor.ConnectingIOReactor;
+import org.apache.http.nio.reactor.IOReactorException;
+import org.apache.http.protocol.*;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class HttpClientFactory {
+	private static final int KEEP_ALIVE = 5000;
+	private static final Logger LOGGER = Logger.getLogger(HttpClientFactory.class.getName());
+
+	private HttpClientFactory() {
+	}
+
+	public static CloseableHttpAsyncClient createClient() {
+		try {
+			final CloseableHttpAsyncClient client = HttpAsyncClientBuilder.create()
+					.disableCookieManagement()
+					.setDefaultRequestConfig(createCustomRequestConfig())
+					.setConnectionManager(createPoolingConnManager())
+					.addInterceptorFirst(new RequestAcceptEncoding())
+					.addInterceptorFirst(new RequestConnControl())
+					// .addInterceptorFirst(new RequestContent())
+					.addInterceptorFirst(new RequestDate())
+					.addInterceptorFirst(new RequestExpectContinue())
+					.addInterceptorFirst(new RequestTargetHost())
+					.addInterceptorFirst(new RequestUserAgent())
+					.addInterceptorFirst(new ResponseContentEncoding())
+					.setKeepAliveStrategy(new DefaultConnectionKeepAliveStrategy() {
+						@Override
+						public long getKeepAliveDuration(HttpResponse response, HttpContext context) {
+							long keepAlive = super.getKeepAliveDuration(response, context);
+							if (keepAlive == -1) {
+								// Keep connections alive if a keep-alive value
+								// has not be explicitly set by the server
+								keepAlive = KEEP_ALIVE;
+							}
+							return keepAlive;
+						}
+
+					})
+					.build();
+			client.start();
+			return client;
+		} catch (IOReactorException e) {
+			LOGGER.log(Level.SEVERE, e.getMessage(), e);
+			return null;
+		}
+	}
+
+	private static RequestConfig createCustomRequestConfig() {
+		return RequestConfig.custom()
+				.setConnectionRequestTimeout(5000)
+				.setConnectTimeout(1000)
+				.setSocketTimeout(500).build();
+	}
+
+	private static PoolingNHttpClientConnectionManager createPoolingConnManager() throws IOReactorException {
+		ConnectingIOReactor ioReactor = new DefaultConnectingIOReactor();
+
+		PoolingNHttpClientConnectionManager cm = new PoolingNHttpClientConnectionManager(ioReactor);
+		cm.setMaxTotal(50);
+		cm.setDefaultMaxPerRoute(50);
+
+		return cm;
+	}
+}

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpRequestContext.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpRequestContext.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2017 NTNU Gjøvik and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Martin Storø Nyfløtt (NTNU Gjøvik) - performance improvements to HTTP cross-proxy
+ ******************************************************************************/
+package org.eclipse.californium.proxy;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.impl.EnglishReasonPhraseCatalog;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.nio.protocol.HttpAsyncExchange;
+import org.eclipse.californium.core.coap.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Locale;
+
+/**
+ * This class deals encapsulates members related to a HTTP request in order to
+ * send a response to the original HTTP request.
+ */
+public final class HttpRequestContext {
+	private final HttpAsyncExchange httpExchange;
+	private final HttpRequest httpRequest;
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(HttpRequestContext.class);
+
+	/**
+	 * Instantiates a new coap response worker.
+	 *
+	 * @param httpExchange   the http exchange
+	 * @param httpRequest    the http request
+	 */
+	public HttpRequestContext(HttpAsyncExchange httpExchange, HttpRequest httpRequest) {
+		// super(name);
+		this.httpExchange = httpExchange;
+		this.httpRequest = httpRequest;
+	}
+
+	public void handleRequestForwarding(final Response coapResponse) {
+		if (coapResponse == null) {
+			LOGGER.warn("No coap response");
+			sendSimpleHttpResponse(HttpTranslator.STATUS_NOT_FOUND);
+			return;
+		}
+
+		// get the sample http response
+		HttpResponse httpResponse = httpExchange.getResponse();
+
+		try {
+			// translate the coap response in an http response
+			new HttpTranslator().getHttpResponse(httpRequest, coapResponse, httpResponse);
+
+			LOGGER.debug("Outgoing http response: {}", httpResponse.getStatusLine());
+		} catch (TranslationException e) {
+			LOGGER.warn("Failed to translate coap response to http response: {}", e.getMessage());
+			sendSimpleHttpResponse(HttpTranslator.STATUS_TRANSLATION_ERROR);
+			return;
+		}
+
+		// send the response
+		httpExchange.submitResponse();
+	}
+
+	/**
+	 * Send simple http response.
+	 *
+	 * @param httpCode     the http code
+	 */
+	public void sendSimpleHttpResponse(int httpCode) {
+		// get the empty response from the exchange
+		HttpResponse httpResponse = httpExchange.getResponse();
+
+		// create and set the status line
+		StatusLine statusLine = new BasicStatusLine(HttpVersion.HTTP_1_1, httpCode, EnglishReasonPhraseCatalog.INSTANCE.getReason(httpCode, Locale.ENGLISH));
+		httpResponse.setStatusLine(statusLine);
+
+		// send the error response
+		httpExchange.submitResponse();
+	}
+}

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
@@ -233,7 +233,7 @@ public final class HttpTranslator {
 				try {
 					optionNumber = Integer.parseInt(optionCodeString.trim());
 				} catch (Exception e) {
-					LOGGER.warn("Problems in the parsing: " + e.getMessage());
+					LOGGER.warn("Problems in the parsing", e);
 					// ignore the option if not recognized
 					continue;
 				}
@@ -283,7 +283,7 @@ public final class HttpTranslator {
 							try {
 								maxAge = Integer.parseInt(headerValue.substring(index + 1).trim());
 							} catch (NumberFormatException e) {
-								LOGGER.warn("Cannot convert cache control in max-age option");
+								LOGGER.warn("Cannot convert cache control in max-age option", e);
 								continue;
 							}
 						}
@@ -317,7 +317,7 @@ public final class HttpTranslator {
 				// Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
 				// This cannot be parsed into a single CoAP Option and yields a
 				// NumberFormatException
-				LOGGER.warn("Could not parse header line "+header);
+				LOGGER.warn("Could not parse header line {}", header);
 			}
 		} // while (headerIterator.hasNext())
 
@@ -422,7 +422,7 @@ public final class HttpTranslator {
 		try {
 			coapMethod = Integer.parseInt(coapMethodString.trim());
 		} catch (NumberFormatException e) {
-			LOGGER.warn("Cannot convert the http method in coap method: " + e);
+			LOGGER.warn("Cannot convert the http method in coap method", e);
 			throw new TranslationException("Cannot convert the http method in coap method", e);
 		}
 
@@ -439,10 +439,10 @@ public final class HttpTranslator {
 		try {
 			uriString = URLDecoder.decode(uriString, "UTF-8");
 		} catch (UnsupportedEncodingException e) {
-			LOGGER.warn("Failed to decode the uri: " + e.getMessage());
+			LOGGER.warn("Failed to decode the uri", e);
 			throw new TranslationException("Failed decoding the uri: " + e.getMessage());
 		} catch (Throwable e) {
-			LOGGER.warn("Malformed uri: " + e.getMessage());
+			LOGGER.warn("Malformed uri", e);
 			throw new InvalidFieldException("Malformed uri: " + e.getMessage());
 		}
 
@@ -481,7 +481,7 @@ public final class HttpTranslator {
 				coapRequest.setDestination(localHostAddress);
 				// TODO: setDestinationPort???
 			} catch (UnknownHostException e) {
-				LOGGER.warn("Cannot get the localhost address: " + e.getMessage());
+				LOGGER.warn("Cannot get the localhost address", e);
 				throw new TranslationException("Cannot get the localhost address: " + e.getMessage());
 			}
 		} else {
@@ -566,7 +566,7 @@ public final class HttpTranslator {
 			try {
 				coapCode = ResponseCode.valueOf(Integer.parseInt(coapCodeString.trim()));
 			} catch (NumberFormatException e) {
-				LOGGER.warn("Cannot convert the status code in number: " + e.getMessage());
+				LOGGER.warn("Cannot convert the status code in number", e);
 				throw new TranslationException("Cannot convert the status code in number", e);
 			}
 		}
@@ -664,7 +664,7 @@ public final class HttpTranslator {
 				try {
 					contentType = ContentType.parse(coapContentTypeString);
 				} catch (UnsupportedCharsetException e) {
-					LOGGER.debug("Cannot convert string to ContentType: {}", e.getMessage());
+					LOGGER.debug("Cannot convert string to ContentType", e);
 					contentType = ContentType.APPLICATION_OCTET_STREAM;
 				}
 			}
@@ -815,10 +815,10 @@ public final class HttpTranslator {
 					coapRequest.getOptions().getProxyUri(), "UTF-8");
 			proxyUri = new URI(proxyUriString);
 		} catch (UnsupportedEncodingException e) {
-			LOGGER.warn("UTF-8 do not support this encoding: " + e);
+			LOGGER.warn("UTF-8 do not support this encoding", e);
 			throw new TranslationException("UTF-8 do not support this encoding", e);
 		} catch (URISyntaxException e) {
-			LOGGER.warn("Cannot translate the server uri" + e);
+			LOGGER.warn("Cannot translate the server uri", e);
 			throw new InvalidFieldException("Cannot get the proxy-uri from the coap message", e);
 		}
 
@@ -893,7 +893,7 @@ public final class HttpTranslator {
 		try {
 			httpCode = Integer.parseInt(httpCodeString.trim());
 		} catch (NumberFormatException e) {
-			LOGGER.warn("Cannot convert the coap code in http status code" + e);
+			LOGGER.warn("Cannot convert the coap code in http status code", e);
 			throw new TranslationException("Cannot convert the coap code in http status code", e);
 		}
 
@@ -971,10 +971,10 @@ public final class HttpTranslator {
 			// If the character sequence starting at the input buffer's current
 			// position cannot be mapped to an equivalent byte sequence and the
 			// current unmappable-character
-			LOGGER.debug("Charset translation: cannot mapped to an output char byte: {}", e.getMessage());
+			LOGGER.debug("Charset translation: cannot mapped to an output char byte", e);
 			return null;
 		} catch (CharacterCodingException e) {
-			LOGGER.warn("Problem in the decoding/encoding charset: " + e.getMessage());
+			LOGGER.warn("Problem in the decoding/encoding charset", e);
 			throw new TranslationException("Problem in the decoding/encoding charset", e);
 		}
 

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ForwardingResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ForwardingResource.java
@@ -17,6 +17,8 @@
  ******************************************************************************/
 package org.eclipse.californium.proxy.resources;
 
+import org.eclipse.californium.compat.CompletableFuture;
+import org.eclipse.californium.compat.Consumer;
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
@@ -34,11 +36,15 @@ public abstract class ForwardingResource extends CoapResource {
 	}
 
 	@Override
-	public void handleRequest(Exchange exchange) {
+	public void handleRequest(final Exchange exchange) {
 		exchange.sendAccept();
-		Response response = forwardRequest(exchange.getRequest());
-		exchange.sendResponse(response);
+		forwardRequest(exchange.getRequest()).thenAccept(new Consumer<Response>() {
+			@Override
+			public void accept(Response response) {
+				exchange.sendResponse(response);
+			}
+		});
 	}
 
-	public abstract Response forwardRequest(Request request);
+	public abstract CompletableFuture<Response> forwardRequest(Request request);
 }

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCacheResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCacheResource.java
@@ -195,7 +195,7 @@ public class ProxyCacheResource extends CoapResource implements CacheResource {
 				}
 			} else {
 				// this code should not be reached
-				LOGGER.error("Code not recognized: " + code);
+				LOGGER.error("Code not recognized: {}", code);
 			}
 		}
 	}
@@ -376,7 +376,7 @@ public class ProxyCacheResource extends CoapResource implements CacheResource {
 				// TODO why not UTF-8?
 				proxyUri = URLEncoder.encode(proxyUri, "ISO-8859-1");
 			} catch (UnsupportedEncodingException e) {
-				LOGGER.error("ISO-8859-1 encoding not supported: " + e.getMessage());
+				LOGGER.error("ISO-8859-1 encoding not supported: {}", e.getMessage());
 			}
 			byte[] payload = request.getPayload();
 

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyHttpClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyHttpClientResource.java
@@ -18,7 +18,6 @@
  ******************************************************************************/
 package org.eclipse.californium.proxy.resources;
 
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -27,26 +26,14 @@ import java.net.URLDecoder;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.ResponseHandler;
-import org.apache.http.client.protocol.RequestAcceptEncoding;
-import org.apache.http.client.protocol.ResponseContentEncoding;
-import org.apache.http.impl.client.AbstractHttpClient;
-import org.apache.http.impl.client.DefaultConnectionKeepAliveStrategy;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.protocol.HttpContext;
-import org.apache.http.protocol.RequestConnControl;
-import org.apache.http.protocol.RequestDate;
-import org.apache.http.protocol.RequestExpectContinue;
-import org.apache.http.protocol.RequestTargetHost;
-import org.apache.http.protocol.RequestUserAgent;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.protocol.*;
+import org.eclipse.californium.compat.CompletableFuture;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
-import org.eclipse.californium.proxy.CoapTranslator;
-import org.eclipse.californium.proxy.HttpTranslator;
-import org.eclipse.californium.proxy.InvalidFieldException;
-import org.eclipse.californium.proxy.TranslationException;
+import org.eclipse.californium.proxy.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,36 +49,7 @@ public class ProxyHttpClientResource extends ForwardingResource {
 	 * DefaultHttpClient is thread safe. It is recommended that the same
 	 * instance of this class is reused for multiple request executions.
 	 */
-	private static final AbstractHttpClient HTTP_CLIENT = new DefaultHttpClient();
-
-	// http client static configuration
-	static {
-		// request interceptors
-		HTTP_CLIENT.addRequestInterceptor(new RequestAcceptEncoding());
-		HTTP_CLIENT.addRequestInterceptor(new RequestConnControl());
-		// HTTP_CLIENT.addRequestInterceptor(new RequestContent());
-		HTTP_CLIENT.addRequestInterceptor(new RequestDate());
-		HTTP_CLIENT.addRequestInterceptor(new RequestExpectContinue());
-		HTTP_CLIENT.addRequestInterceptor(new RequestTargetHost());
-		HTTP_CLIENT.addRequestInterceptor(new RequestUserAgent());
-
-		// response intercptors
-		HTTP_CLIENT.addResponseInterceptor(new ResponseContentEncoding());
-
-		HTTP_CLIENT.setKeepAliveStrategy(new DefaultConnectionKeepAliveStrategy() {
-			@Override
-			public long getKeepAliveDuration(HttpResponse response, HttpContext context) {
-				long keepAlive = super.getKeepAliveDuration(response, context);
-				if (keepAlive == -1) {
-					// Keep connections alive if a keep-alive value
-					// has not be explicitly set by the server
-					keepAlive = KEEP_ALIVE;
-				}
-				return keepAlive;
-			}
-
-		});
-	}
+	private static final CloseableHttpAsyncClient asyncClient = HttpClientFactory.createClient();
 
 	public ProxyHttpClientResource() {
 		// set the resource hidden
@@ -106,13 +64,15 @@ public class ProxyHttpClientResource extends ForwardingResource {
 	}
 
 	@Override
-	public Response forwardRequest(Request request) {
+	public CompletableFuture<Response> forwardRequest(Request request) {
+		final CompletableFuture<Response> future = new CompletableFuture<>();
 		final Request incomingCoapRequest = request;
 		
 		// check the invariant: the request must have the proxy-uri set
 		if (!incomingCoapRequest.getOptions().hasProxyUri()) {
 			LOGGER.warn("Proxy-uri option not set.");
-			return new Response(ResponseCode.BAD_OPTION);
+			future.complete(new Response(ResponseCode.BAD_OPTION));
+			return future;
 		}
 
 		// remove the fake uri-path // TODO: why? still necessary in new Cf?
@@ -126,10 +86,12 @@ public class ProxyHttpClientResource extends ForwardingResource {
 			proxyUri = new URI(proxyUriString);
 		} catch (UnsupportedEncodingException e) {
 			LOGGER.warn("Proxy-uri option malformed: {}", e.getMessage());
-			return new Response(CoapTranslator.STATUS_FIELD_MALFORMED);
+			future.complete(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
+			return future;
 		} catch (URISyntaxException e) {
 			LOGGER.warn("Proxy-uri option malformed: {}", e.getMessage());
-			return new Response(CoapTranslator.STATUS_FIELD_MALFORMED);
+			future.complete(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
+			return future;
 		}
 
 		// get the requested host, if the port is not specified, the constructor
@@ -143,49 +105,51 @@ public class ProxyHttpClientResource extends ForwardingResource {
 			LOGGER.debug("Outgoing http request: {}", httpRequest.getRequestLine());
 		} catch (InvalidFieldException e) {
 			LOGGER.warn("Problems during the http/coap translation: {}", e.getMessage());
-			return new Response(CoapTranslator.STATUS_FIELD_MALFORMED);
+			future.complete(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
+			return future;
 		} catch (TranslationException e) {
 			LOGGER.warn("Problems during the http/coap translation: {}", e.getMessage());
-			return new Response(CoapTranslator.STATUS_TRANSLATION_ERROR);
+			future.complete(new Response(CoapTranslator.STATUS_TRANSLATION_ERROR));
+			return future;
 		}
 
-		ResponseHandler<Response> httpResponseHandler = new ResponseHandler<Response>() {
+		asyncClient.execute(httpHost, httpRequest, new BasicHttpContext(), new FutureCallback<HttpResponse>() {
 			@Override
-			public Response handleResponse(HttpResponse httpResponse) throws ClientProtocolException, IOException {
+			public void completed(HttpResponse result) {
 				long timestamp = System.nanoTime();
-				LOGGER.debug("Incoming http response: {}", httpResponse.getStatusLine());
+				LOGGER.debug("Incoming http response: {}", result.getStatusLine());
 				// the entity of the response, if non repeatable, could be
 				// consumed only one time, so do not debug it!
 				// System.out.println(EntityUtils.toString(httpResponse.getEntity()));
 
 				// translate the received http response in a coap response
 				try {
-					Response coapResponse = new HttpTranslator().getCoapResponse(httpResponse, incomingCoapRequest);
+					Response coapResponse = new HttpTranslator().getCoapResponse(result, incomingCoapRequest);
 					coapResponse.setTimestamp(timestamp);
-					return coapResponse;
+
+					future.complete(coapResponse);
 				} catch (InvalidFieldException e) {
 					LOGGER.warn("Problems during the http/coap translation: {}", e.getMessage());
-					return new Response(CoapTranslator.STATUS_FIELD_MALFORMED);
+					future.complete(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
 				} catch (TranslationException e) {
 					LOGGER.warn("Problems during the http/coap translation: {}", e.getMessage());
-					return new Response(CoapTranslator.STATUS_TRANSLATION_ERROR);
+					future.complete(new Response(CoapTranslator.STATUS_TRANSLATION_ERROR));
 				}
 			}
-		};
 
-		// accept the request sending a separate response to avoid the timeout
-		// in the requesting client
-		LOGGER.debug("Acknowledge message sent");
+			@Override
+			public void failed(Exception ex) {
+				LOGGER.warn("Failed to get the http response: {}", ex.getMessage());
+				future.complete(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
+			}
 
-		Response coapResponse = null;
-		try {
-			// execute the request
-			coapResponse = HTTP_CLIENT.execute(httpHost, httpRequest, httpResponseHandler, null);
-		} catch (IOException e) {
-			LOGGER.warn("Failed to get the http response: {}", e.getMessage());
-			return new Response(ResponseCode.INTERNAL_SERVER_ERROR);
-		}
+			@Override
+			public void cancelled() {
+				LOGGER.warn("Request canceled");
+				future.complete(new Response(ResponseCode.SERVICE_UNAVAILABLE));
+			}
+		});
 
-		return coapResponse;
+		return future;
 	}
 }


### PR DESCRIPTION
This is another submission of PR #474 which targets the 2.0.x branch instead of the master branch in addition to support Java versions prior to Java 8. I will paste the original text from #474 here:

With this PR, the stability and throughput of the californium-proxy gets significantly improved: 

- Proper use of log formatting to avoid the performance problem I have discussed in issue https://github.com/eclipse/californium/issues/436.
- For some strange reason, for each request that goes through the proxy (towards a CoAP server) creates two threads: One worker thread that will perform the CoAP request, and one that will send the HTTP response back to the original requester. The second one will wait for the first one to complete. On top of it all, these two threads are created for each time there is a request. Californium has an async/nonblocking API where there is also a heavy worker thread model already in place, which renders this way of creating threads (for what I assume is either before they got the async support with the message handler in place, or before the threading model was introduce) for each incoming request useless. 
- Outgoing HTTP requests are now using the Apache HttpAsyncClient.
- Prevent race conditions where concurrent HTTP requests may use the same Endpoint for CoAP requests where the message body might get inter-mixed with other concurrent messages. This is solved by using a pool of EndpointManagers across requests.

To benchmark the impact of these performance optimizations, I send as many requests through a http/coap/http pipeline for 5 minutes towards a local nginx server:
```
HTTP requestster -- <HTTP> -- Californium -- <CoAP> -- Californium -- <HTTP> -- nginx
```

With the current master, I get an average request throughput of 2.7ms (std.dev 2.5ms), with the changes propsed in this PR: 2.1ms (std.dev 1.01ms). This can be further improved by scaling down the threading model in Californium. Currently, each request is captured in a networking thread, which is then queued to a "protocol stage thread" which will do the actual packet processing. Messages sent back are also running on their own thread. This leads to each message being passed through 4 different threads (2 additional in the current master) which introduce delays where a message is picked up by the next thread, and limits cache-hit rate for threads. Some of these threads could have been taken care of at a lower level, both simplifying application design and performance. However, this goes beyond the scope of this PR.
