### PR TITLE
Rtt

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/Utils.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/Utils.java
@@ -20,11 +20,9 @@
  *                                                    (for message tracing)
  *    Achim Kraus (Bosch Software Innovations GmbH) - replace '\n' with 
  *                                                    System.lineSeparator() 
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add rtt
  ******************************************************************************/
 package org.eclipse.californium.core;
-
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.Request;
@@ -141,6 +139,9 @@ public final class Utils {
 		sb.append(String.format("Type   : %s", r.getType().toString())).append(System.lineSeparator());
 		sb.append(String.format("Status : %s", r.getCode().toString())).append(System.lineSeparator());
 		sb.append(String.format("Options: %s", r.getOptions().toString())).append(System.lineSeparator());
+		if (r.getRTT() != null) {
+			sb.append(String.format("RTT    : %d ms", r.getRTT())).append(System.lineSeparator());
+		}
 		sb.append(String.format("Payload: %d Bytes", r.getPayloadSize())).append(System.lineSeparator());
 		if (r.getPayloadSize() > 0 && MediaTypeRegistry.isPrintable(r.getOptions().getContentFormat())) {
 			sb.append("---------------------------------------------------------------").append(System.lineSeparator());

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Response.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Response.java
@@ -22,6 +22,7 @@
  *                                                    (for message tracing)
  *    Achim Kraus (Bosch Software Innovations GmbH) - introduce source and destination
  *                                                    EndpointContext
+ *    Achim Kraus (Bosch Software Innovations GmbH) - change type for rtt to Long
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
@@ -44,7 +45,7 @@ public class Response extends Message {
 	/** The response code. */
 	private final CoAP.ResponseCode code;
 
-	private long rtt;
+	private Long rtt;
 
 	private boolean last = true;
 
@@ -120,10 +121,20 @@ public class Response extends Message {
 		this.last = last;
 	}
 
-	public long getRTT() {
+	/**
+	 * Return RTT.
+	 * 
+	 * @return rtt, or {@code null}, if not set.
+	 */
+	public Long getRTT() {
 		return rtt;
 	}
 
+	/**
+	 * Set rtt.
+	 * 
+	 * @param rtt rtt of response
+	 */
 	public void setRTT(long rtt) {
 		this.rtt = rtt;
 	}


### PR DESCRIPTION
Improve RTT handling.
Use Long to detect, if its not set.
Preserve the original response in blockwise, if it's for the original request.
Add rtt to the pretty printing.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>