### PR TITLE
Fix recent cache

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageIdProviderTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageIdProviderTest.java
@@ -137,7 +137,7 @@ public class InMemoryMessageIdProviderTest {
 		InMemoryMessageIdProvider provider = new InMemoryMessageIdProvider(config);
 		addPeers(provider, MAX_PEERS);
 
-		Thread.sleep(MAX_PEER_INACTIVITY_PERIOD * 1000);
+		Thread.sleep(MAX_PEER_INACTIVITY_PERIOD * 1200);
 
 		assertThat(provider.getNextMessageId(getPeerAddress(MAX_PEERS + 1)), is(not(-1)));
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -95,7 +95,7 @@ public class ObserveClientSideTest {
 				.setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f)
 				.setInt(NetworkConfig.Keys.MARK_AND_SWEEP_INTERVAL, TEST_SWEEP_DEDUPLICATOR_INTERVAL)
 				.setLong(NetworkConfig.Keys.EXCHANGE_LIFETIME, TEST_EXCHANGE_LIFETIME)
-				.setLong(NetworkConfig.Keys.BLOCKWISE_STATUS_LIFETIME, 1500);
+				.setLong(NetworkConfig.Keys.BLOCKWISE_STATUS_LIFETIME, 2000);
 	}
 
 	@Before

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/LeastRecentlyUsedCache.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/LeastRecentlyUsedCache.java
@@ -13,6 +13,8 @@
  * Contributors:
  *    Kai Hudalla (Bosch Software Innovations GmbH) - Initial creation
  *    Achim Kraus (Bosch Software Innovations GmbH) - fix stale check in get()
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use nano time to decouple
+ *                                                    from system time changes
  ******************************************************************************/
 package org.eclipse.californium.elements.util;
 
@@ -446,7 +448,7 @@ public class LeastRecentlyUsedCache<K, V> {
 		private CacheEntry(K key, V value) {
 			this.value = value;
 			this.key = key;
-			this.lastUpdate = System.currentTimeMillis();
+			this.lastUpdate = System.nanoTime();
 		}
 
 		private K getKey() {
@@ -458,12 +460,12 @@ public class LeastRecentlyUsedCache<K, V> {
 		}
 
 		private boolean isStale(long threshold) {
-			return System.currentTimeMillis() - lastUpdate >= TimeUnit.SECONDS.toMillis(threshold);
+			return System.nanoTime() - lastUpdate >= TimeUnit.SECONDS.toNanos(threshold);
 		}
 
 		private void recordAccess(CacheEntry<K, V> header) {
 			remove();
-			lastUpdate = System.currentTimeMillis();
+			lastUpdate = System.nanoTime();
 			addBefore(header);
 		}
 

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/LeastRecentlyUsedCacheTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/LeastRecentlyUsedCacheTest.java
@@ -36,6 +36,20 @@ public class LeastRecentlyUsedCacheTest {
 	LeastRecentlyUsedCache<Integer, String> cache;
 
 	@Test
+	public void testGetFailsWhenExpired() throws InterruptedException {
+		long threshold =  1; // second
+		int capacity = 5;
+		int numberOfSessions = 1;
+
+		givenACacheWithEntries(capacity, threshold, numberOfSessions);
+		String eldest = cache.getEldest();
+		Integer key = Integer.valueOf(eldest);
+		assertNotNull(cache.get(key));
+		Thread.sleep(threshold * 1100);
+		assertNull(cache.get(key));
+	}
+
+	@Test
 	public void testStoreAddsNewValueIfCapacityNotReached() {
 		int capacity = 10;
 


### PR DESCRIPTION
The get() was broken (at least according the javadoc).
The adjust to nano time is not for increase the resolution, it's to decouple from system time changes.
Some test seem to use "odd millisecond" values. Maybe worth to change the threshold resolution for these tests also to milliseconds (but not with this PR).
Not intended to be part of 2.0.x-M6.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com> 