### PR TITLE
Introduce CoapEndpointBuilder and deprecate the constructors.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
@@ -167,7 +167,10 @@ public class CoapServer implements ServerInterface {
 				new NamedThreadFactory("CoapServer#")); //$NON-NLS-1$
 		// create endpoint for each port
 		for (int port : ports) {
-			addEndpoint(new CoapEndpoint(port, this.config));
+			CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+			builder.setPort(port);
+			builder.setNetworkConfig(config);
+			addEndpoint(builder.build());
 		}
 	}
 
@@ -207,7 +210,10 @@ public class CoapServer implements ServerInterface {
 			// servers should bind to the configured port (while clients should use an ephemeral port through the default endpoint)
 			int port = config.getInt(NetworkConfig.Keys.COAP_PORT);
 			LOGGER.info("no endpoints have been defined for server, setting up server endpoint on default port {}", port);
-			addEndpoint(new CoapEndpoint(port, this.config));
+			CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+			builder.setPort(port);
+			builder.setNetworkConfig(config);
+			addEndpoint(builder.build());
 		}
 
 		int started = 0;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/EndpointManager.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/EndpointManager.java
@@ -133,7 +133,7 @@ public class EndpointManager {
 			} else if (CoAP.COAP_SECURE_TCP_URI_SCHEME.equalsIgnoreCase(uriScheme)) {
 				throw new IllegalStateException("URI scheme " + uriScheme + " requires a previous set connector!");
 			} else {
-				endpoint = new CoapEndpoint();
+				endpoint = new CoapEndpoint.CoapEndpointBuilder().build();
 			}
 			try {
 				endpoint.start();

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
@@ -77,7 +77,11 @@ public class CoapEndpointTest {
 		establishedContext = new MapBasedEndpointContext(CONNECTOR_ADDRESS, null);
 		receivedRequests = new ArrayList<Request>();
 		connector = new SimpleConnector();
-		endpoint = new CoapEndpoint(connector, CONFIG);
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setConnector(connector);
+		builder.setNetworkConfig(CONFIG);
+
+		endpoint = builder.build();
 		sentLatch = new CountDownLatch(1);
 		latch = new CountDownLatch(1);
 		MessageDeliverer deliverer = new MessageDeliverer() {
@@ -157,7 +161,10 @@ public class CoapEndpointTest {
 	@Test
 	public void testSecureSchemeIsSetOnIncomingRequest() throws Exception {
 		SimpleConnector connector = new SimpleSecureConnector();
-		Endpoint endpoint = new CoapEndpoint(connector, CONFIG);
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setConnector(connector);
+		builder.setNetworkConfig(CONFIG);
+		Endpoint endpoint = builder.build();
 		MessageDeliverer deliverer = new MessageDeliverer() {
 
 			@Override

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/EndpointManagerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/EndpointManagerTest.java
@@ -72,7 +72,7 @@ public class EndpointManagerTest {
 	public void testSetDefaultEndpoint() throws Exception {
 		// GIVEN a old and a new endpoint
 		Endpoint oldEndpoint = EndpointManager.getEndpointManager().getDefaultEndpoint();
-		Endpoint endpoint = new CoapEndpoint();
+		Endpoint endpoint = new CoapEndpoint.CoapEndpointBuilder().build();
 
 		// WHEN set the new default endpoint
 		EndpointManager.getEndpointManager().setDefaultEndpoint(endpoint);
@@ -149,7 +149,10 @@ public class EndpointManagerTest {
 	}
 
 	private static Endpoint createEndpoint(String protocol) {
-		return new CoapEndpoint(new DummyConnector(protocol), network.getStandardTestConfig());
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setConnector(new DummyConnector(protocol));
+		builder.setNetworkConfig(network.getStandardTestConfig());
+		return builder.build();
 	}
 
 	private static class DummyConnector implements Connector {

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/BlockwiseTransferTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/BlockwiseTransferTest.java
@@ -98,8 +98,9 @@ public class BlockwiseTransferTest {
 
 	@Before
 	public void createClient() throws IOException {
-
-		clientEndpoint = new CoapEndpoint(config);
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setNetworkConfig(config);
+		clientEndpoint = builder.build();
 		clientEndpoint.start();
 	}
 
@@ -263,7 +264,11 @@ public class BlockwiseTransferTest {
 
 		CoapServer result = new CoapServer();
 
-		serverEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		builder.setNetworkConfig(config);
+
+		serverEndpoint = builder.build();
 		serverEndpoint.addInterceptor(interceptor);
 		result.addEndpoint(serverEndpoint);
 		result.add(new CoapResource(RESOURCE_TEST) {

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ClientAsynchronousTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ClientAsynchronousTest.java
@@ -239,7 +239,9 @@ public class ClientAsynchronousTest {
 	}
 
 	private static void createServer() {
-		CoapEndpoint endpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		CoapEndpoint endpoint = builder.build();
 
 		resource = new StorageResource(TARGET, CONTENT_1);
 		server = new CoapServer();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ClientSynchronousTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ClientSynchronousTest.java
@@ -175,7 +175,9 @@ public class ClientSynchronousTest {
 	@Test
 	public void testSynchronousPing() throws Exception {
 		final AtomicBoolean sent = new AtomicBoolean();
-		CoapEndpoint clientEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		CoapEndpoint clientEndpoint = builder.build();
 		clientEndpoint.addInterceptor(new MessageInterceptorAdapter() {
 			
 			@Override
@@ -228,8 +230,9 @@ public class ClientSynchronousTest {
 	}
 
 	private static void createServer() {
-
-		serverEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		serverEndpoint = builder.build();
 
 		resource = new StorageResource(TARGET, CONTENT_1);
 		server = new CoapServer();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
@@ -376,11 +376,19 @@ public class MemoryLeakingHashMapTest {
 
 		// Create the endpoint for the server and create surveillant
 		serverExchangeStore = new InMemoryMessageExchangeStore(config);	
-		serverEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config, serverExchangeStore);
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		builder.setNetworkConfig(config);
+		builder.setMessageExchangeStore(serverExchangeStore);
+		serverEndpoint = builder.build();
 		serverEndpoint.addInterceptor(new MessageTracer());
 
 		clientExchangeStore = new InMemoryMessageExchangeStore(config);
-		clientEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config,  clientExchangeStore);
+		builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		builder.setNetworkConfig(config);
+		builder.setMessageExchangeStore(clientExchangeStore);
+		clientEndpoint = builder.build();
 		clientEndpoint.start();
 
 		// Create a server with two resources: one that sends piggy-backed

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MessageExchangeStoreTool.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MessageExchangeStoreTool.java
@@ -39,6 +39,8 @@ import org.eclipse.californium.core.network.stack.CoapStack;
 import org.eclipse.californium.core.network.stack.CoapUdpStack;
 import org.eclipse.californium.core.network.stack.Layer;
 import org.eclipse.californium.core.observe.InMemoryObservationStore;
+import org.eclipse.californium.elements.UDPConnector;
+import org.eclipse.californium.elements.UdpEndpointContextMatcher;
 
 /**
  * Test tools for MessageExchangeStore.
@@ -155,7 +157,7 @@ public class MessageExchangeStoreTool {
 
 		private CoapTestEndpoint(InetSocketAddress bind, NetworkConfig config,
 				InMemoryObservationStore observationStore, MessageExchangeStore exchangeStore) {
-			super(CoapEndpoint.createUDPConnector(bind, config), config, observationStore, exchangeStore);
+			super(new UDPConnector(bind), true, config, observationStore, exchangeStore, new UdpEndpointContextMatcher());
 			this.exchangeStore = exchangeStore;
 			this.observationStore = observationStore;
 			this.requestChecker = new RequestEventChecker();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MessageTypeTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MessageTypeTest.java
@@ -65,7 +65,9 @@ public class MessageTypeTest {
 		System.out.println(System.lineSeparator() + "Start " + MessageTypeTest.class.getSimpleName());
 		EndpointManager.clear();
 
-		CoapEndpoint endpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		CoapEndpoint endpoint = builder.build();
 
 		server = new CoapServer();
 		server.addEndpoint(endpoint);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ObserveTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ObserveTest.java
@@ -376,7 +376,10 @@ public class ObserveTest {
 		NetworkConfig config = network.createTestConfig().setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200)
 				.setFloat(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1f).setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f);
 
-		CoapEndpoint endpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		builder.setNetworkConfig(config);
+		CoapEndpoint endpoint = builder.build();
 
 		server = new CoapServer();
 		server.addEndpoint(endpoint);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/RandomAccessBlockTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/RandomAccessBlockTest.java
@@ -81,13 +81,23 @@ public class RandomAccessBlockTest {
 		System.out.println(System.lineSeparator() + "Start " + RandomAccessBlockTest.class.getName());
 		NetworkConfig config = network.getStandardTestConfig()
 			.setInt(Keys.MAX_RESOURCE_BODY_SIZE, maxBodySize);
-		CoapEndpoint endpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
+
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		builder.setNetworkConfig(config);
+
+		CoapEndpoint endpoint = builder.build();
 		server = new CoapServer();
 		server.addEndpoint(endpoint);
 		server.add(new BlockwiseResource(TARGET, RESP_PAYLOAD));
 		server.start();
 		serverAddress = endpoint.getAddress();
-		clientEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
+
+		builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		builder.setNetworkConfig(config);
+		
+		clientEndpoint = builder.build();
 	}
 
 	@After

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceTreeTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceTreeTest.java
@@ -108,7 +108,9 @@ public class ResourceTreeTest {
 	}
 	
 	private void createServer() {
-		CoapEndpoint endpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		CoapEndpoint endpoint = builder.build();
 		
 		resource = new TestResource(NAME_1, PAYLOAD);
 		server = new CoapServer();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/SmallServerClientTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/SmallServerClientTest.java
@@ -95,7 +95,9 @@ public class SmallServerClientTest {
 	}
 
 	private void createSimpleServer() {
-		CoapEndpoint endpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		CoapEndpoint endpoint = builder.build();
 		server = new CoapServer();
 		server.addEndpoint(endpoint);
 		server.setMessageDeliverer(new MessageDeliverer() {

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
@@ -86,7 +86,11 @@ public class ClusteringTest {
 		store = new InMemoryObservationStore();
 
 		notificationListener1 = new SynchronousNotificationListener();
-		client1 = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config, store);
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		builder.setNetworkConfig(config);
+		builder.setObservationStore(store);
+		client1 = builder.build();
 		client1.addNotificationListener(notificationListener1);
 		client1.addInterceptor(clientInterceptor);
 		client1.addInterceptor(new MessageTracer());
@@ -95,7 +99,11 @@ public class ClusteringTest {
 		System.out.println("Client 1 binds to port " + clientPort1);
 
 		notificationListener2 = new SynchronousNotificationListener();
-		client2 = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config, store);
+		builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		builder.setNetworkConfig(config);
+		builder.setObservationStore(store);
+		client2 = builder.build();
 		client2.addNotificationListener(notificationListener2);
 		client2.addInterceptor(clientInterceptor);
 		client2.addInterceptor(new MessageTracer());

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/DeduplicationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/DeduplicationTest.java
@@ -69,7 +69,10 @@ public class DeduplicationTest {
 			.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 128)
 			.setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200) // client retransmits after 200 ms
 			.setInt(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1);
-		client = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		builder.setNetworkConfig(config);
+		client = builder.build();
 		client.addInterceptor(new MessageTracer());
 		client.start();
 		clientPort = client.getAddress().getPort();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ServerDeduplicationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ServerDeduplicationTest.java
@@ -70,7 +70,10 @@ public class ServerDeduplicationTest {
 		NetworkConfig config = network.getStandardTestConfig();
 		config.setString(NetworkConfig.Keys.DEDUPLICATOR, NetworkConfig.Keys.DEDUPLICATOR_MARK_AND_SWEEP);
 		config.setInt(NetworkConfig.Keys.MARK_AND_SWEEP_INTERVAL, DEDUPLICATOR_SWEEP_INTERVAL);
-		Endpoint ep = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		builder.setNetworkConfig(config);
+		Endpoint ep = builder.build();
 		ep.addInterceptor(new MessageTracer());
 		server = new CoapServer();
 		server.addEndpoint(ep);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/maninmiddle/LossyBlockwiseTransferTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/maninmiddle/LossyBlockwiseTransferTest.java
@@ -82,10 +82,18 @@ public class LossyBlockwiseTransferTest {
 			.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 32)
 			.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 32);
 
-		clientEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		builder.setNetworkConfig(config);
+
+		clientEndpoint = builder.build();
 		clientEndpoint.start();
 
-		Endpoint serverEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), config);
+		builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		builder.setNetworkConfig(config);
+
+		Endpoint serverEndpoint = builder.build();
 		server = new CoapServer();
 		server.addEndpoint(serverEndpoint);
 		server.add(new CoapResource("test") {

--- a/californium-osgi/src/main/java/org/eclipse/californium/osgi/SimpleServerEndpointFactory.java
+++ b/californium-osgi/src/main/java/org/eclipse/californium/osgi/SimpleServerEndpointFactory.java
@@ -53,9 +53,10 @@ public class SimpleServerEndpointFactory implements EndpointFactory {
 
 	@Override
 	public final Endpoint getEndpoint(NetworkConfig config, InetSocketAddress address) {
-		
-		CoapEndpoint endpoint = new CoapEndpoint(address, config);
-		return endpoint;
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setNetworkConfig(config);
+		builder.setInetSocketAddress(address);
+		return builder.build();
 	}
 
 	@Override
@@ -63,9 +64,11 @@ public class SimpleServerEndpointFactory implements EndpointFactory {
 
 		Endpoint endpoint = null;
 		if (secureConnectorFactory != null) {
-			endpoint = new CoapEndpoint(
-					secureConnectorFactory.newConnector(address),
-					config);
+			Connector connector = secureConnectorFactory.newConnector(address);
+			CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+			builder.setNetworkConfig(config);
+			builder.setConnector(connector);
+			endpoint = builder.build();
 		} else {
 			log.debug("A secure ConnectorFactory is required to create secure Endpoints.");
 		}

--- a/demo-apps/cf-benchmark-observe/src/main/java/org/eclipse/californium/benchmark/observe/ObserveBenchmarkClient.java
+++ b/demo-apps/cf-benchmark-observe/src/main/java/org/eclipse/californium/benchmark/observe/ObserveBenchmarkClient.java
@@ -101,7 +101,9 @@ public class ObserveBenchmarkClient {
 			
 		server.add(new AnnounceResource("announce"));
 		
-		server.addEndpoint(new CoapEndpoint(sockAddr));
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(sockAddr);
+		server.addEndpoint(builder.build());
 		server.start();
 
 		System.out.println("Observe benchmark announcement server listening on " + sockAddr);

--- a/demo-apps/cf-benchmark/src/main/java/org/eclipse/californium/benchmark/BenchmarkServer.java
+++ b/demo-apps/cf-benchmark/src/main/java/org/eclipse/californium/benchmark/BenchmarkServer.java
@@ -109,8 +109,10 @@ public class BenchmarkServer {
 		server.add(new BenchmarkResource("benchmark"));
 		server.add(new FibonacciResource("fibonacci"));
 		server.add(new ShutDownResource("shutdown"));
-		
-		server.addEndpoint(new CoapEndpoint(sockAddr));
+
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setInetSocketAddress(sockAddr);
+		server.addEndpoint(builder.build());
 		server.start();
 
 		System.out.println("Benchmark server listening on " + sockAddr);

--- a/demo-apps/cf-benchmark/src/main/java/org/eclipse/californium/benchmark/TcpThroughputServer.java
+++ b/demo-apps/cf-benchmark/src/main/java/org/eclipse/californium/benchmark/TcpThroughputServer.java
@@ -20,7 +20,10 @@ public class TcpThroughputServer {
 				.setLong(NetworkConfig.Keys.EXCHANGE_LIFETIME, 10000);
 
 		Connector serverConnector = new TcpServerConnector(new InetSocketAddress(CoAP.DEFAULT_COAP_PORT), 1, 100);
-		CoapEndpoint endpoint = new CoapEndpoint(serverConnector, net);
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setConnector(serverConnector);
+		builder.setNetworkConfig(net);
+		CoapEndpoint endpoint = builder.build();
 
 		CoapServer server = new CoapServer(net);
 		server.addEndpoint(endpoint);

--- a/demo-apps/cf-cocoa/src/main/java/org/eclipse/californium/examples/CocoaClient.java
+++ b/demo-apps/cf-cocoa/src/main/java/org/eclipse/californium/examples/CocoaClient.java
@@ -56,7 +56,9 @@ public class CocoaClient {
 				.setInt(NetworkConfig.Keys.NSTART, 4);
 
 		// create an endpoint with this configuration
-		CoapEndpoint cocoaEndpoint = new CoapEndpoint(config);
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setNetworkConfig(config);
+		CoapEndpoint cocoaEndpoint = builder.build();
 		// all CoapClients will use the default endpoint (unless
 		// CoapClient#setEndpoint() is used)
 		EndpointManager.getEndpointManager().setDefaultEndpoint(cocoaEndpoint);

--- a/demo-apps/cf-helloworld-server/src/main/java/org/eclipse/californium/examples/HelloWorldServer.java
+++ b/demo-apps/cf-helloworld-server/src/main/java/org/eclipse/californium/examples/HelloWorldServer.java
@@ -31,84 +31,90 @@ import org.eclipse.californium.elements.tcp.TcpServerConnector;
 
 public class HelloWorldServer extends CoapServer {
 
-    private static final int COAP_PORT = NetworkConfig.getStandard().getInt(NetworkConfig.Keys.COAP_PORT);
-    private static final int TCP_THREADS = NetworkConfig.getStandard().getInt(NetworkConfig.Keys.TCP_WORKER_THREADS);
-    private static final int TCP_IDLE_TIMEOUT = NetworkConfig.getStandard()
-            .getInt(NetworkConfig.Keys.TCP_CONNECTION_IDLE_TIMEOUT);
+	private static final int COAP_PORT = NetworkConfig.getStandard().getInt(NetworkConfig.Keys.COAP_PORT);
+	private static final int TCP_THREADS = NetworkConfig.getStandard().getInt(NetworkConfig.Keys.TCP_WORKER_THREADS);
+	private static final int TCP_IDLE_TIMEOUT = NetworkConfig.getStandard()
+			.getInt(NetworkConfig.Keys.TCP_CONNECTION_IDLE_TIMEOUT);
 
-    /*
-     * Application entry point.
-     */
-    public static void main(String[] args) {
+	/*
+	 * Application entry point.
+	 */
+	public static void main(String[] args) {
 
-        try {
-            // create server
-            boolean udp = true;
-            boolean tcp = false;
-            if (0 < args.length) {
-                tcp = args[0].equalsIgnoreCase("coap+tcp:");
-                if (tcp) {
-                    System.out.println("Please Note: the TCP support is currently experimental!");
-                }
-            }
-            HelloWorldServer server = new HelloWorldServer();
-            // add endpoints on all IP addresses
-            server.addEndpoints(udp, tcp);
-            server.start();
+		try {
+			// create server
+			boolean udp = true;
+			boolean tcp = false;
+			if (0 < args.length) {
+				tcp = args[0].equalsIgnoreCase("coap+tcp:");
+				if (tcp) {
+					System.out.println("Please Note: the TCP support is currently experimental!");
+				}
+			}
+			HelloWorldServer server = new HelloWorldServer();
+			// add endpoints on all IP addresses
+			server.addEndpoints(udp, tcp);
+			server.start();
 
-        } catch (SocketException e) {
-            System.err.println("Failed to initialize server: " + e.getMessage());
-        }
-    }
+		} catch (SocketException e) {
+			System.err.println("Failed to initialize server: " + e.getMessage());
+		}
+	}
 
-    /**
-     * Add individual endpoints listening on default CoAP port on all IPv4
-     * addresses of all network interfaces.
-     */
-    private void addEndpoints(boolean udp, boolean tcp) {
-        NetworkConfig config = NetworkConfig.getStandard();
-        for (InetAddress addr : EndpointManager.getEndpointManager().getNetworkInterfaces()) {
+	/**
+	 * Add individual endpoints listening on default CoAP port on all IPv4
+	 * addresses of all network interfaces.
+	 */
+	private void addEndpoints(boolean udp, boolean tcp) {
+		NetworkConfig config = NetworkConfig.getStandard();
+		for (InetAddress addr : EndpointManager.getEndpointManager().getNetworkInterfaces()) {
 			InetSocketAddress bindToAddress = new InetSocketAddress(addr, COAP_PORT);
 			if (udp) {
-				addEndpoint(new CoapEndpoint(bindToAddress, config));
+				CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+				builder.setInetSocketAddress(bindToAddress);
+				builder.setNetworkConfig(config);
+				addEndpoint(builder.build());
 			}
 			if (tcp) {
 				TcpServerConnector connector = new TcpServerConnector(bindToAddress, TCP_THREADS, TCP_IDLE_TIMEOUT);
-				addEndpoint(new CoapEndpoint(connector, config));
+				CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+				builder.setConnector(connector);
+				builder.setNetworkConfig(config);
+				addEndpoint(builder.build());
 			}
-            
-        }
-    }
 
-    /*
-     * Constructor for a new Hello-World server. Here, the resources of the
-     * server are initialized.
-     */
-    public HelloWorldServer() throws SocketException {
+		}
+	}
 
-        // provide an instance of a Hello-World resource
-        add(new HelloWorldResource());
-    }
+	/*
+	 * Constructor for a new Hello-World server. Here, the resources of the
+	 * server are initialized.
+	 */
+	public HelloWorldServer() throws SocketException {
 
-    /*
-     * Definition of the Hello-World Resource
-     */
-    class HelloWorldResource extends CoapResource {
+		// provide an instance of a Hello-World resource
+		add(new HelloWorldResource());
+	}
 
-        public HelloWorldResource() {
+	/*
+	 * Definition of the Hello-World Resource
+	 */
+	class HelloWorldResource extends CoapResource {
 
-            // set resource identifier
-            super("helloWorld");
+		public HelloWorldResource() {
 
-            // set display name
-            getAttributes().setTitle("Hello-World Resource");
-        }
+			// set resource identifier
+			super("helloWorld");
 
-        @Override
-        public void handleGET(CoapExchange exchange) {
+			// set display name
+			getAttributes().setTitle("Hello-World Resource");
+		}
 
-            // respond to the request
-            exchange.respond("Hello World!");
-        }
-    }
+		@Override
+		public void handleGET(CoapExchange exchange) {
+
+			// respond to the request
+			exchange.respond("Hello World!");
+		}
+	}
 }

--- a/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/ClientInitializer.java
+++ b/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/ClientInitializer.java
@@ -169,7 +169,10 @@ public class ClientInitializer {
 			connector = new UDPConnector();
 		}
 
-		CoapEndpoint endpoint = new CoapEndpoint(connector, config);
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setConnector(connector);
+		builder.setNetworkConfig(config);
+		CoapEndpoint endpoint = builder.build();
 		if (verbose) {
 			endpoint.addInterceptor(new MessageTracer());
 		}

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
@@ -86,11 +86,17 @@ public abstract class AbstractTestServer extends CoapServer {
 			if (protocols.contains(Protocol.UDP) || protocols.contains(Protocol.TCP)) {
 				InetSocketAddress bindToAddress = new InetSocketAddress(addr, coapPort);
 				if (protocols.contains(Protocol.UDP)) {
-					addEndpoint(new CoapEndpoint(bindToAddress, config));
+					CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+					builder.setInetSocketAddress(bindToAddress);
+					builder.setNetworkConfig(config);
+					addEndpoint(builder.build());
 				}
 				if (protocols.contains(Protocol.TCP)) {
 					TcpServerConnector connector = new TcpServerConnector(bindToAddress, tcpThreads, tcpIdleTimeout);
-					addEndpoint(new CoapEndpoint(connector, config));
+					CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+					builder.setConnector(connector);
+					builder.setNetworkConfig(config);
+					addEndpoint(builder.build());
 				}
 			}
 			if (protocols.contains(Protocol.DTLS) || protocols.contains(Protocol.TLS)) {
@@ -107,13 +113,19 @@ public abstract class AbstractTestServer extends CoapServer {
 					dtlsConfig.setTrustStore(trustedCertificates);
 
 					DTLSConnector connector = new DTLSConnector(dtlsConfig.build());
+					CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+					builder.setConnector(connector);
+					builder.setNetworkConfig(config);
 
-					addEndpoint(new CoapEndpoint(connector, config));
+					addEndpoint(builder.build());
 				}
 				if (protocols.contains(Protocol.TLS)) {
 					TlsServerConnector connector = new TlsServerConnector(serverSslContext, bindToAddress, tcpThreads,
 							tcpIdleTimeout);
-					addEndpoint(new CoapEndpoint(connector, config));
+					CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+					builder.setConnector(connector);
+					builder.setNetworkConfig(config);
+					addEndpoint(builder.build());
 				}
 			}
 		}

--- a/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/SecureClient.java
+++ b/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/SecureClient.java
@@ -27,7 +27,6 @@ import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.CoapResponse;
 import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.core.network.CoapEndpoint;
-import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.examples.CredentialsUtil.Mode;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
@@ -50,7 +49,10 @@ public class SecureClient {
 		try {
 			URI uri = new URI(SERVER_URI);
 			CoapClient client = new CoapClient(uri);
-			client.setEndpoint(new CoapEndpoint(dtlsConnector, NetworkConfig.getStandard()));
+			CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+			builder.setConnector(dtlsConnector);
+			
+			client.setEndpoint(builder.build());
 			response = client.get();
 			client.shutdown();
 		} catch (URISyntaxException e) {

--- a/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/SecureServer.java
+++ b/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/SecureServer.java
@@ -66,8 +66,9 @@ public class SecureServer {
 		List<Mode> modes = CredentialsUtil.parse(args, CredentialsUtil.DEFAULT_MODES, SUPPORTED_MODES);
 		CredentialsUtil.setupCredentials(config, CredentialsUtil.SERVER_NAME, modes);
 		DTLSConnector connector = new DTLSConnector(config.build());
-
-		server.addEndpoint(new CoapEndpoint(connector, NetworkConfig.getStandard()));
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setConnector(connector);
+		server.addEndpoint(builder.build());
 		server.start();
 
 		// add special interceptor for message traces

--- a/demo-apps/cf-secure/src/test/java/org/eclipse/californium/secure/test/SecureObserveTest.java
+++ b/demo-apps/cf-secure/src/test/java/org/eclipse/californium/secure/test/SecureObserveTest.java
@@ -317,7 +317,10 @@ public class SecureObserveTest {
 				.setFloat(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1f).setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f)
 				.setString(NetworkConfig.Keys.DTLS_RESPONSE_MATCHING, mode.name());
 		serverConnector = new DTLSConnector(dtlsConfig);
-		serverEndpoint = new CoapEndpoint(serverConnector, config);
+		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setConnector(serverConnector);
+		builder.setNetworkConfig(config);
+		serverEndpoint = builder.build();
 
 		server = new CoapServer();
 		server.addEndpoint(serverEndpoint);
@@ -330,7 +333,10 @@ public class SecureObserveTest {
 		// prepare secure client endpoint
 		DtlsConnectorConfig clientdtlsConfig = new DtlsConnectorConfig.Builder()
 				.setAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0)).setPskStore(pskStore).build();
-		clientEndpoint = new CoapEndpoint(new DTLSConnector(clientdtlsConfig), config);
+		builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder.setConnector(new DTLSConnector(clientdtlsConfig));
+		builder.setNetworkConfig(config);
+		clientEndpoint = builder.build();
 		EndpointManager.getEndpointManager().setDefaultEndpoint(clientEndpoint);
 	}
 

--- a/demo-apps/cf-simplefile-server/src/main/java/org/eclipse/californium/examples/SimpleFileServer.java
+++ b/demo-apps/cf-simplefile-server/src/main/java/org/eclipse/californium/examples/SimpleFileServer.java
@@ -101,8 +101,9 @@ public class SimpleFileServer extends CoapServer {
 	 */
 	private void addEndpoints() {
 		for (InetAddress addr : EndpointManager.getEndpointManager().getNetworkInterfaces()) {
-			InetSocketAddress bindToAddress = new InetSocketAddress(addr, COAP_PORT);
-			addEndpoint(new CoapEndpoint(bindToAddress));
+			CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+			builder.setInetSocketAddress(new InetSocketAddress(addr, COAP_PORT));
+			addEndpoint(builder.build());
 		}
 	}
 


### PR DESCRIPTION
The deprecated constructors are intended to be removed before or after
M7.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>