### PR TITLE
Add auto-resume for NAT support.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -21,6 +21,7 @@
  *    Ludwig Seitz (RISE SICS) - Added support for raw public key validation
  *    Achim Kraus (Bosch Software Innovations GmbH) - include trustedRPKs in
  *                                                    determineCipherSuitesFromConfig
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add automatic resumption
  *******************************************************************************/
 
 package org.eclipse.californium.scandium.config;
@@ -129,6 +130,14 @@ public final class DtlsConnectorConfig {
 	private ServerNameResolver serverNameResolver;
 
 	private Integer connectionThreadCount;;
+
+	/**
+	 * Automatic session resumption timeout. Triggers session resumption
+	 * automatically, if no messages are exchanged for this timeout. Intended to
+	 * be used, if traffic is routed through a NAT. If {@code null}, no
+	 * automatic session resumption is used. Value is in milliseconds.
+	 */
+	private Long autoResumptionTimeoutMillis;
 
 	private DtlsConnectorConfig() {
 		// empty
@@ -354,6 +363,20 @@ public final class DtlsConnectorConfig {
 	 */
 	public Integer getConnectionThreadCount() {
 		return connectionThreadCount;
+	}
+
+	/**
+	 * Get the timeout for automatic session resumption.
+	 * 
+	 * If no messages are exchanged for this timeout, the next message will
+	 * trigger a session resumption automatically. Intended to be used, if
+	 * traffic is routed over a NAT.
+	 * 
+	 * @return timeout in milliseconds, or {@code null}, if no automatic resumption
+	 *         is intended.
+	 */
+	public Long getAutoResumptionTimeoutMillis() {
+		return autoResumptionTimeoutMillis;
 	}
 
 	/**
@@ -817,6 +840,18 @@ public final class DtlsConnectorConfig {
 		 */
 		public Builder setConnectionThreadCount(int threadCount) {
 			config.connectionThreadCount = threadCount;
+			return this;
+		}
+
+		/**
+		 * Set the timeout of automatic session resumption in milliseconds.
+		 * <p>
+		 * The default value is {@code null}, no automatic session resumption.
+		 * 
+		 * @return this builder for command chaining.
+		 */
+		public Builder setAutoResumptionTimeoutMillis(long timeoutInMillis) {
+			config.autoResumptionTimeoutMillis = timeoutInMillis;
 			return this;
 		}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStoreTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStoreTest.java
@@ -135,7 +135,7 @@ public class InMemoryConnectionStoreTest {
 	private Connection newConnection(long ip) throws HandshakeException, UnknownHostException {
 		InetAddress addr = InetAddress.getByAddress(longToIp(ip));
 		InetSocketAddress peerAddress = new InetSocketAddress(addr, 0);
-		Connection con = new Connection(peerAddress);
+		Connection con = new Connection(peerAddress, null);
 		con.sessionEstablished(null, newSession(peerAddress));
 		return con;
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemorySessionCache.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemorySessionCache.java
@@ -19,6 +19,7 @@ package org.eclipse.californium.scandium.dtls;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
@@ -30,6 +31,11 @@ import org.eclipse.californium.elements.util.DatagramWriter;
 public class InMemorySessionCache implements SessionCache {
 
 	private final Map<SessionId, byte[]> cache = new ConcurrentHashMap<>();
+
+	/**
+	 * Count for {@link #put(DTLSSession)} calls.
+	 */
+	public final AtomicInteger establishedSessionCounter = new AtomicInteger();
 
 	/**
 	 * Puts a ticket to the cache.
@@ -50,6 +56,7 @@ public class InMemorySessionCache implements SessionCache {
 	@Override
 	public void put(final DTLSSession session) {
 		if (session != null) {
+			establishedSessionCounter.incrementAndGet();
 			put(session.getSessionIdentifier(), session.getSessionTicket());
 		}
 	}


### PR DESCRIPTION
Triggers session resume, if no messages are exchanged for a configurable period of time.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>