### PR TITLE
Create unique tokens with server/system scope.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
@@ -148,7 +148,7 @@ public abstract class BaseMatcher implements Matcher {
 		if (!request.getOptions().hasBlock2() || request.getOptions().getBlock2().getNum() == 0
 				&& !request.getOptions().getBlock2().isM()) {
 			// add request to the store
-			final KeyToken idByToken = KeyToken.fromOutboundMessage(request);
+			final KeyToken idByToken = KeyToken.fromMessage(request);
 			LOG.debug("registering observe request {}", request);
 			observationStore.add(new Observation(request, null));
 			// remove it if the request is cancelled, rejected, timedout, or send error
@@ -179,7 +179,7 @@ public abstract class BaseMatcher implements Matcher {
 
 		Exchange exchange = null;
 		if (!CoAP.ResponseCode.isSuccess(response.getCode()) || response.getOptions().hasObserve()) {
-			final Exchange.KeyToken idByToken = Exchange.KeyToken.fromInboundMessage(response);
+			final Exchange.KeyToken idByToken = Exchange.KeyToken.fromMessage(response);
 
 			final Observation obs = observationStore.get(response.getToken());
 			if (obs != null) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
@@ -214,10 +214,10 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 		Request request = exchange.getCurrentRequest();
 		KeyToken idByToken;
 		if (request.getToken() == null) {
-			idByToken = tokenProvider.getUnusedToken(request);
+			idByToken = tokenProvider.getUnusedToken();
 			request.setToken(idByToken.getToken());
 		} else {
-			idByToken = KeyToken.fromOutboundMessage(request);
+			idByToken = KeyToken.fromMessage(request);
 			// ongoing requests may reuse token
 			if (!(exchange.getFailedTransmissionCount() > 0 || request.getOptions().hasBlock1()
 					|| request.getOptions().hasBlock2() || request.getOptions().hasObserve())

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryRandomTokenProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryRandomTokenProvider.java
@@ -15,10 +15,11 @@
  *                                - initial API and implementation
  *     Achim Kraus (Bosch Software Innovations GmbH) - cleanup
  *     Bosch Software Innovations GmbH - migrate to SLF4J
+ *     Achim Kraus (Bosch Software Innovations GmbH) - cleanup
+ *     Achim Kraus (Bosch Software Innovations GmbH) - remove address from KeyToken
  *******************************************************************************/
 package org.eclipse.californium.core.network;
 
-import java.net.InetSocketAddress;
 import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.Set;
@@ -26,7 +27,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.network.Exchange.KeyToken;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 
@@ -63,8 +63,8 @@ public class InMemoryRandomTokenProvider implements TokenProvider {
 	}
 
 	@Override
-	public KeyToken getUnusedToken(final Message message) {
-		return createUnusedToken(message);
+	public KeyToken getUnusedToken() {
+		return createUnusedToken();
 	}
 
 	@Override
@@ -77,15 +77,13 @@ public class InMemoryRandomTokenProvider implements TokenProvider {
 		return usedTokens.contains(keyToken);
 	}
 
-	private KeyToken createUnusedToken(final Message message) {
-		InetSocketAddress socketAddress = message.getDestinationContext().getPeerAddress();
-		byte[] address = socketAddress.getAddress().getAddress();
+	private KeyToken createUnusedToken() {
 		byte[] token = new byte[tokenSizeLimit];
 		KeyToken result;
 		// TODO what to do when there are no more unused tokens left?
 		do {
 			rng.nextBytes(token);
-			result =  KeyToken.fromValues(token, address, socketAddress.getPort());
+			result =  KeyToken.fromValues(token);
 		} while (!usedTokens.add(result));
 		return result;
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -126,7 +126,7 @@ public final class TcpMatcher extends BaseMatcher {
 	@Override
 	public Exchange receiveResponse(final Response response) {
 
-		final Exchange.KeyToken idByToken = Exchange.KeyToken.fromInboundMessage(response);
+		final Exchange.KeyToken idByToken = Exchange.KeyToken.fromMessage(response);
 		Exchange exchange = exchangeStore.get(idByToken);
 
 		if (exchange == null) {
@@ -170,11 +170,11 @@ public final class TcpMatcher extends BaseMatcher {
 					// this should not happen because we only register the observer
 					// if we have successfully registered the exchange
 					LOGGER.warn(
-							"exchange observer has been completed on unregistered exchange [peer: {}:{}, origin: {}]",
-							new Object[]{ originRequest.getDestination(), originRequest.getDestinationPort(),
+							"exchange observer has been completed on unregistered exchange [peer: {}, origin: {}]",
+							new Object[]{ originRequest.getDestinationContext().getPeerAddress(),
 									exchange.getOrigin()});
 				} else {
-					KeyToken idByToken = KeyToken.fromOutboundMessage(originRequest);
+					KeyToken idByToken = KeyToken.fromMessage(originRequest);
 					exchangeStore.remove(idByToken, exchange);
 					if(!originRequest.isObserve()) {
 						exchangeStore.releaseToken(idByToken);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TokenProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TokenProvider.java
@@ -13,10 +13,11 @@
  * Contributors:
  *     Daniel Maier (Bosch Software Innovations GmbH)
  *                                - initial API and implementation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - create tokens unique in 
+ *                                                    the scope of the server
  *******************************************************************************/
 package org.eclipse.californium.core.network;
 
-import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.network.Exchange.KeyToken;
 
 /**
@@ -32,10 +33,9 @@ public interface TokenProvider {
 	 * Returns a token that is not in use. After this token is not in use
 	 * anymore it must be released with {@link #releaseToken(KeyToken)}.
 	 * 
-	 * @param message The message to get a token for.
 	 * @return a token that is not in use
 	 */
-	KeyToken getUnusedToken(Message message);
+	KeyToken getUnusedToken();
 
 	/**
 	 * Releases the given token to be used again.
@@ -46,11 +46,11 @@ public interface TokenProvider {
 
 	/**
 	 * Indicates if the given token is in use, i.e. was returned by
-	 * {@link #getUnusedToken(Message)} but not yet released by
+	 * {@link #getUnusedToken()} but not yet released by
 	 * {@link #releaseToken(KeyToken)}.
 	 * 
 	 * @param keyToken the token to be checked
-	 * @return <code>true</code> if the given token is still in use, <code>false</code> otherwise
+	 * @return {@code true}, if the given token is still in use, {@code false}, otherwise
 	 */
 	boolean isTokenInUse(KeyToken keyToken);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -207,7 +207,7 @@ public final class UdpMatcher extends BaseMatcher {
 		 */
 
 		KeyMID idByMID = KeyMID.fromInboundMessage(response);
-		final KeyToken idByToken = KeyToken.fromInboundMessage(response);
+		final KeyToken idByToken = KeyToken.fromMessage(response);
 		LOGGER.trace("received response {}", response);
 		Exchange exchange = exchangeStore.get(idByToken);
 		boolean isNotify = false; // don't remove MID for notifies. May be already reused.
@@ -351,11 +351,11 @@ public final class UdpMatcher extends BaseMatcher {
 					// this should not happen because we only register the observer
 					// if we have successfully registered the exchange
 					LOGGER.warn(
-							"exchange observer has been completed on unregistered exchange [peer: {}:{}, origin: {}]",
-							new Object[]{ originRequest.getDestination(), originRequest.getDestinationPort(),
+							"exchange observer has been completed on unregistered exchange [peer: {}, origin: {}]",
+							new Object[]{ originRequest.getDestinationContext().getPeerAddress(),
 									exchange.getOrigin()});
 				} else {
-					KeyToken idByToken = KeyToken.fromOutboundMessage(originRequest);
+					KeyToken idByToken = KeyToken.fromMessage(originRequest);
 					exchangeStore.remove(idByToken, exchange);
 					if (!originRequest.isObserve()) {
 						exchangeStore.releaseToken(idByToken);
@@ -370,7 +370,7 @@ public final class UdpMatcher extends BaseMatcher {
 						if (request != originRequest && null != request.getToken()
 								&& !Arrays.equals(request.getToken(), originRequest.getToken())) {
 							// remove starting request also
-							idByToken = KeyToken.fromOutboundMessage(request);
+							idByToken = KeyToken.fromMessage(request);
 							exchangeStore.remove(idByToken, exchange);
 							if (!request.isObserve()) {
 								exchangeStore.releaseToken(idByToken);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -118,7 +118,7 @@ public class UdpMatcherTest {
 		exchange.completeCurrentRequest();
 
 		// THEN assert that token got released
-		KeyToken keyToken = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
+		KeyToken keyToken = KeyToken.fromMessage(exchange.getCurrentRequest());
 		assertThat(tokenProvider.isTokenInUse(keyToken), is(false));
 	}
 
@@ -132,7 +132,7 @@ public class UdpMatcherTest {
 		exchange.completeCurrentRequest();
 
 		// THEN assert that token got not released
-		KeyToken keyToken = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
+		KeyToken keyToken = KeyToken.fromMessage(exchange.getCurrentRequest());
 		assertThat(tokenProvider.isTokenInUse(keyToken), is(true));
 	}
 
@@ -147,7 +147,7 @@ public class UdpMatcherTest {
 		matcher.cancelObserve(exchange.getCurrentRequest().getToken());
 
 		// THEN the token has been released for re-use
-		KeyToken keyToken = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
+		KeyToken keyToken = KeyToken.fromMessage(exchange.getCurrentRequest());
 		assertThat(tokenProvider.isTokenInUse(keyToken), is(false));
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -29,6 +29,9 @@
  *                                                    notify. Issue #451
  *                                                    Correct type of MAX_RETRANSMIT
  *                                                    from float to int.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - ignore address on request/response
+ *                                                    matching to support tests using
+ *                                                    changed addresses.
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
@@ -103,7 +106,7 @@ public class ObserveClientSideTest {
 		//exchangeStore = new InMemoryMessageExchangeStore(CONFIG, new InMemoryRandomTokenProvider(CONFIG));
 		// bind to loopback address using an ephemeral port
 	    //CoapEndpoint udpEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), CONFIG, exchangeStore);
-		client = new CoapTestEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), CONFIG);
+		client = new CoapTestEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), CONFIG, true);
 		client.addInterceptor(clientInterceptor);
 		client.addInterceptor(new MessageTracer());
 		client.start();

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UdpEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UdpEndpointContextMatcher.java
@@ -19,6 +19,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - use inhibitNewConnection
  *                                                    to distinguish from 
  *                                                    none plain UDP contexts.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - check address for plain udp
  ******************************************************************************/
 package org.eclipse.californium.elements;
 
@@ -40,6 +41,9 @@ public class UdpEndpointContextMatcher implements EndpointContextMatcher {
 
 	@Override
 	public boolean isResponseRelatedToRequest(EndpointContext requestContext, EndpointContext responseContext) {
+		if (!requestContext.getPeerAddress().equals(responseContext.getPeerAddress())) {
+			return false;
+		}
 		return internalMatch(requestContext, responseContext);
 	}
 
@@ -48,7 +52,7 @@ public class UdpEndpointContextMatcher implements EndpointContextMatcher {
 		return internalMatch(messageContext, connectorContext);
 	}
 
-	private final boolean internalMatch(EndpointContext requestedContext, EndpointContext availableContext) {
+	protected final boolean internalMatch(EndpointContext requestedContext, EndpointContext availableContext) {
 		return (null == requestedContext) || !requestedContext.inhibitNewConnection() || (null != availableContext);
 	}
 


### PR DESCRIPTION
Remove address usage in KeyToken.
Use address in upd endpoint context matcher.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>