### PR TITLE
Introduce Token and KeyToken.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
@@ -34,12 +34,12 @@
  *    Bosch Software Innovations GmbH - migrate to SLF4J
  *    Achim Kraus (Bosch Software Innovations GmbH) - get default timeout from configuration
  *                                                    of effective endpoint
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -56,6 +56,7 @@ import org.eclipse.californium.core.coap.MessageObserver;
 import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.EndpointManager;
 import org.eclipse.californium.core.network.config.NetworkConfig;
@@ -388,7 +389,7 @@ public class CoapClient {
 	private boolean ping(Long timeout) {
 		try {
 			Request request = new Request(null, Type.CON);
-			request.setToken(new byte[0]);
+			request.setToken(Token.EMPTY);
 			request.setURI(uri);
 			Endpoint outEndpoint = getEffectiveEndpoint(request);
 			if (timeout == null) {
@@ -1179,7 +1180,7 @@ public class CoapClient {
 
 		@Override
 		public void onNotification(Request request, Response response) {
-			if (Arrays.equals(request.getToken(), req.getToken())) {
+			if (request.getToken().equals(req.getToken())) {
 				obs.onResponse(response);
 			}
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
@@ -182,7 +182,7 @@ public class CoapObserveRelation {
 	 * Cancel observer.
 	 */
 	private void cancel() {
-		endpoint.cancelObservation(request.getToken());
+		endpoint.cancelObservation(request.getToken(), request.getDestinationContext());
 		setCanceled(true);
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/EmptyMessage.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/EmptyMessage.java
@@ -18,10 +18,9 @@
  *    Kai Hudalla - logging
  *    Achim Kraus (Bosch Software Innovations GmbH) - use source and destination
  *                                                    EndpointContext
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
-
-import java.util.Arrays;
 
 import org.eclipse.californium.core.coap.CoAP.Type;
 
@@ -47,20 +46,24 @@ public class EmptyMessage extends Message {
 	public String toString() {
 		String appendix = "";
 		// crude way to check nothing extra is set in an empty message
-		if (!hasEmptyToken()
-				|| getOptions().asSortedList().size()>0
-				|| getPayloadSize()>0) {
+		if (!hasEmptyToken() || getOptions().asSortedList().size() > 0 || getPayloadSize() > 0) {
 			String payload = getPayloadString();
 			if (payload == null) {
 				payload = "no payload";
 			} else {
 				int len = payload.length();
-				if (payload.indexOf("\n")!=-1) payload = payload.substring(0, payload.indexOf("\n"));
-				if (payload.length() > 24) payload = payload.substring(0,20);
-				payload = "\""+payload+"\"";
-				if (payload.length() != len+2) payload += ".. " + payload.length() + " bytes";
+				if (payload.indexOf("\n") != -1) {
+					payload = payload.substring(0, payload.indexOf("\n"));
+				}
+				if (payload.length() > 24) {
+					payload = payload.substring(0, 20);
+				}
+				payload = "\"" + payload + "\"";
+				if (payload.length() != len + 2) {
+					payload += ".. " + payload.length() + " bytes";
+				}
 			}
-			appendix = " NON-EMPTY: Token="+Arrays.toString(getToken())+", "+getOptions()+", "+payload;
+			appendix = " NON-EMPTY: Token=" + getTokenString() + ", " + getOptions() + ", " + payload;
 		}
 		return String.format("%s        MID=%5d%s", getType(), getMID(), appendix);
 	}
@@ -82,7 +85,7 @@ public class EmptyMessage extends Message {
 		ack.setMID(message.getMID());
 		return ack;
 	}
-	
+
 	/**
 	 * Create a new reset message for the specified message.
 	 *
@@ -95,5 +98,5 @@ public class EmptyMessage extends Message {
 		rst.setMID(message.getMID());
 		return rst;
 	}
-	
+
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
@@ -34,6 +34,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - introduce source and destination
  *                                                    EndpointContext
  *    Bosch Software Innovations GmbH - migrate to SLF4J
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
@@ -102,7 +103,7 @@ public abstract class Message {
 	 * empty array would not work here because it is already a valid token
 	 * according to the CoAP spec.
 	 */
-	private volatile byte[] token = null;
+	private volatile Token token = null;
 
 	/** The set of options of this message. */
 	private OptionSet options;
@@ -111,14 +112,12 @@ public abstract class Message {
 	private byte[] payload;
 
 	/**
-	 * Destination endpoint context.
-	 * Used for outgoing messages.
+	 * Destination endpoint context. Used for outgoing messages.
 	 */
 	private volatile EndpointContext destinationContext;
 
 	/**
-	 * Source endpoint context.
-	 * Used for incoming messages.
+	 * Source endpoint context. Used for incoming messages.
 	 */
 	private volatile EndpointContext sourceContext;
 
@@ -153,11 +152,12 @@ public abstract class Message {
 	 * and from then on must never again become null.
 	 */
 	private final AtomicReference<List<MessageObserver>> messageObservers = new AtomicReference<List<MessageObserver>>();
-	
+
 	/**
 	 * A unmodifiable facade for the list of all {@link ObserveManager}.
+	 * 
 	 * @see #messageObservers
-	 * @see #getMessageObservers() 
+	 * @see #getMessageObservers()
 	 */
 	private volatile List<MessageObserver> unmodifiableMessageObserversFacade = null;
 
@@ -286,7 +286,16 @@ public abstract class Message {
 	 *         length 0.
 	 */
 	public boolean hasEmptyToken() {
-		return token == null || token.length == 0;
+		return token == null || token.isEmpty();
+	}
+
+	/**
+	 * Gets this message's token.
+	 *
+	 * @return the token
+	 */
+	public Token getToken() {
+		return token;
 	}
 
 	/**
@@ -294,8 +303,8 @@ public abstract class Message {
 	 *
 	 * @return the token
 	 */
-	public byte[] getToken() {
-		return token;
+	public byte[] getTokenBytes() {
+		return token == null ? null : token.getBytes();
 	}
 
 	/**
@@ -304,21 +313,35 @@ public abstract class Message {
 	 * @return the token as string
 	 */
 	public String getTokenString() {
-		return Utils.toHexString(getToken());
+		return token == null ? "null" : token.getAsString();
 	}
 
 	/**
-	 * Sets the token, which can be 0--8 bytes.
+	 * Sets the token bytes, which can be 0--8 bytes.
+	 * 
+	 * Provides a fluent API to chain setters.
+	 *
+	 * @param token the new token bytes
+	 * @return this Message
+	 */
+	public Message setToken(byte[] token) {
+		if (token == null) {
+			this.token = null;
+		} else {
+			this.token = new Token(token);
+		}
+		return this;
+	}
+
+	/**
+	 * Sets the token.
 	 * 
 	 * Provides a fluent API to chain setters.
 	 *
 	 * @param token the new token
 	 * @return this Message
 	 */
-	public Message setToken(byte[] token) {
-		if (token != null && token.length > 8) {
-			throw new IllegalArgumentException("Token length must be between 0 and 8 inclusive");
-		}
+	public Message setToken(Token token) {
 		this.token = token;
 		return this;
 	}
@@ -447,7 +470,7 @@ public abstract class Message {
 		this.payload = payload;
 		return this;
 	}
-	
+
 	/**
 	 * Gets the destination address.
 	 *

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Token.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Token.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.californium.core.coap;
+
+import java.util.Arrays;
+
+import org.eclipse.californium.core.Utils;
+import org.eclipse.californium.core.network.KeyToken;
+import org.eclipse.californium.core.network.KeyTokenFactory;
+
+/**
+ * Implementation of CoAP token.
+ * 
+ * Note: the {@link KeyToken} implements relation is only temporary!
+ * Introducing the {@link KeyTokenFactory} requires many changes and will
+ * be applied in late.
+ */
+public class Token implements KeyToken {
+
+	/**
+	 * Empty token.
+	 */
+	public static final Token EMPTY = new Token(new byte[0]);
+
+	/**
+	 * token data.
+	 */
+	private final byte[] token;
+	/**
+	 * Pre-calculated hash.
+	 * 
+	 * @see #hashCode()
+	 */
+	private final int hash;
+
+	/**
+	 * Create token from bytes.
+	 * 
+	 * @param token token bytes to be copied
+	 */
+	public Token(byte[] token) {
+		this(token, true);
+	}
+
+	/**
+	 * Create token from bytes.
+	 * 
+	 * @param token token bytes
+	 * @param copy {@code true}, to copy the bytes, {@code false}, to use the
+	 *            bytes without copy
+	 * @throws NullPointerException if token is {@code null}
+	 * @throws IllegalArgumentException if tokens length is larger than 8 (as
+	 *             specified in CoAP)
+	 */
+	private Token(byte[] token, boolean copy) {
+		if (token == null) {
+			throw new NullPointerException("token bytes must not be null");
+		} else if (token.length > 8) {
+			throw new IllegalArgumentException("Token length must be between 0 and 8 inclusive");
+		}
+		if (copy && token.length > 0) {
+			this.token = Arrays.copyOf(token, token.length);
+		} else {
+			this.token = token;
+		}
+		this.hash = Arrays.hashCode(this.token);
+	}
+
+	@Override
+	public String toString() {
+		return new StringBuilder("Token[").append(Utils.toHexString(token)).append("]").toString();
+	}
+
+	@Override
+	public int hashCode() {
+		return hash;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Token other = (Token) obj;
+		return Arrays.equals(token, other.token);
+	}
+
+	/**
+	 * Get token bytes.
+	 * 
+	 * @return token bytes. Not Copied!
+	 */
+	public byte[] getBytes() {
+		return token;
+	}
+
+	/**
+	 * Get token bytes as (hexadecimal) string.
+	 * 
+	 * @return token bytes as (hexadecimal) string
+	 */
+	public String getAsString() {
+		return Utils.toHexString(token);
+	}
+
+	/**
+	 * Check, if token is empty.
+	 * 
+	 * @return {@code true}, if token is empty, {@code false}, otherwise
+	 */
+	public boolean isEmpty() {
+		return token.length == 0;
+	}
+
+	/**
+	 * Return number of token bytes.
+	 * 
+	 * @return number of token bytes. 0 to 8.
+	 */
+	public int length() {
+		return token.length;
+	}
+
+	@Override
+	public Token getToken() {
+		return this;
+	}
+
+	/**
+	 * Create token from provider token.
+	 * 
+	 * Doesn't copy the provided token.
+	 * 
+	 * @param token token, not copied!
+	 * @return created Token
+	 */
+	public static Token fromProvider(byte[] token) {
+		return new Token(token, false);
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
@@ -63,6 +63,7 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.observe.Observation;
 import org.eclipse.californium.core.observe.ObservationStore;
+import org.eclipse.californium.elements.EndpointContext;
 
 /**
  * A base class for implementing Matchers that provides support for using a
@@ -244,15 +245,8 @@ public abstract class BaseMatcher implements Matcher {
 		return exchange;
 	}
 
-	/**
-	 * Cancels all pending blockwise requests that have been induced by a
-	 * notification we have received indicating a blockwise transfer of the
-	 * resource.
-	 * 
-	 * @param token the token of the observation.
-	 */
 	@Override
-	public void cancelObserve(Token token) {
+	public void cancelObserve(Token token, EndpointContext context) {
 		// TODO: change to use KeyTokenFactory
 		final KeyToken idByToken = token;
 		// we do not know the destination endpoint the requests have been sent

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
@@ -46,6 +46,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - forward error notifies
  *                                                    issue 465
  *    Achim Kraus (Bosch Software Innovations GmbH) - adjust to use Token and KeyToken
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -150,7 +151,7 @@ public abstract class BaseMatcher implements Matcher {
 				&& !request.getOptions().getBlock2().isM()) {
 			// add request to the store
 			// TODO: change to use KeyTokenFactory
-			final KeyToken idByToken = new Token(request.getToken());
+			final KeyToken idByToken = request.getToken();
 			LOG.debug("registering observe request {}", request);
 			observationStore.add(idByToken, new Observation(request, null));
 			// remove it if the request is cancelled, rejected, timedout, or send error
@@ -182,7 +183,7 @@ public abstract class BaseMatcher implements Matcher {
 		Exchange exchange = null;
 		if (!CoAP.ResponseCode.isSuccess(response.getCode()) || response.getOptions().hasObserve()) {
 			// TODO: change to use KeyTokenFactory
-			final KeyToken idByToken = new Token(response.getToken());
+			final KeyToken idByToken = response.getToken();
 
 			final Observation obs = observationStore.get(idByToken);
 			if (obs != null) {
@@ -251,9 +252,9 @@ public abstract class BaseMatcher implements Matcher {
 	 * @param token the token of the observation.
 	 */
 	@Override
-	public void cancelObserve(final byte[] token) {
+	public void cancelObserve(Token token) {
 		// TODO: change to use KeyTokenFactory
-		final KeyToken idByToken = new Token(token);
+		final KeyToken idByToken = token;
 		// we do not know the destination endpoint the requests have been sent
 		// to therefore we need to find them by token only
 		// Note: observe exchanges are not longer stored, so this almost in vain,

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
@@ -45,6 +45,7 @@
  *    Bosch Software Innovations GmbH - migrate to SLF4J
  *    Achim Kraus (Bosch Software Innovations GmbH) - forward error notifies
  *                                                    issue 465
+ *    Achim Kraus (Bosch Software Innovations GmbH) - adjust to use Token and KeyToken
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -55,7 +56,7 @@ import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
-import org.eclipse.californium.core.network.Exchange.KeyToken;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.NotificationListener;
@@ -148,9 +149,10 @@ public abstract class BaseMatcher implements Matcher {
 		if (!request.getOptions().hasBlock2() || request.getOptions().getBlock2().getNum() == 0
 				&& !request.getOptions().getBlock2().isM()) {
 			// add request to the store
-			final KeyToken idByToken = KeyToken.fromOutboundMessage(request);
+			// TODO: change to use KeyTokenFactory
+			final KeyToken idByToken = new Token(request.getToken());
 			LOG.debug("registering observe request {}", request);
-			observationStore.add(new Observation(request, null));
+			observationStore.add(idByToken, new Observation(request, null));
 			// remove it if the request is cancelled, rejected, timedout, or send error
 			request.addMessageObserver(new MessageObserverAdapter() {
 				@Override
@@ -160,8 +162,8 @@ public abstract class BaseMatcher implements Matcher {
 				
 				@Override
 				protected void failed() {
-					observationStore.remove(request.getToken());
-					exchangeStore.releaseToken(idByToken);
+					observationStore.remove(idByToken);
+					exchangeStore.releaseToken(idByToken.getToken());
 				}
 			});
 		}
@@ -179,9 +181,10 @@ public abstract class BaseMatcher implements Matcher {
 
 		Exchange exchange = null;
 		if (!CoAP.ResponseCode.isSuccess(response.getCode()) || response.getOptions().hasObserve()) {
-			final Exchange.KeyToken idByToken = Exchange.KeyToken.fromInboundMessage(response);
+			// TODO: change to use KeyTokenFactory
+			final KeyToken idByToken = new Token(response.getToken());
 
-			final Observation obs = observationStore.get(response.getToken());
+			final Observation obs = observationStore.get(idByToken);
 			if (obs != null) {
 				// there is an observation for the token from the response
 				// re-create a corresponding Exchange object for it so
@@ -209,8 +212,8 @@ public abstract class BaseMatcher implements Matcher {
 								LOG.debug(
 										"response to observe request with token {} does not contain observe option, removing request from observation store",
 										idByToken);
-								observationStore.remove(request.getToken());
-								exchangeStore.releaseToken(idByToken);
+								observationStore.remove(idByToken);
+								exchangeStore.releaseToken(idByToken.getToken());
 							}
 						}
 					}
@@ -231,8 +234,8 @@ public abstract class BaseMatcher implements Matcher {
 
 					@Override
 					protected void failed() {
-						observationStore.remove(request.getToken());
-						exchangeStore.releaseToken(idByToken);
+						observationStore.remove(idByToken);
+						exchangeStore.releaseToken(idByToken.getToken());
 					}
 				});
 			}
@@ -249,11 +252,13 @@ public abstract class BaseMatcher implements Matcher {
 	 */
 	@Override
 	public void cancelObserve(final byte[] token) {
+		// TODO: change to use KeyTokenFactory
+		final KeyToken idByToken = new Token(token);
 		// we do not know the destination endpoint the requests have been sent
 		// to therefore we need to find them by token only
 		// Note: observe exchanges are not longer stored, so this almost in vain,
 		// except, when a blockwise notify is pending.
-		for (Exchange exchange : exchangeStore.findByToken(token)) {
+		for (Exchange exchange : exchangeStore.findByToken(idByToken.getToken())) {
 			Request request = exchange.getRequest();
 			if (request.isObserve()) {
 				// cancel only observe requests, 
@@ -263,7 +268,7 @@ public abstract class BaseMatcher implements Matcher {
 				exchange.setComplete();
 			}
 		}
-		observationStore.remove(token);
+		observationStore.remove(idByToken);
 	}
 
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -982,8 +982,8 @@ public class CoapEndpoint implements Endpoint {
 	}
 
 	@Override
-	public void cancelObservation(Token token) {
-		matcher.cancelObserve(token);
+	public void cancelObservation(Token token, EndpointContext context) {
+		matcher.cancelObserve(token, context);
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -47,6 +47,7 @@
  *    Bosch Software Innovations GmbH - migrate to SLF4J
  *    Achim Kraus (Bosch Software Innovations GmbH) - add Builder and deprecate 
  *                                                    constructors
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -68,6 +69,7 @@ import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.MessageFormatException;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.EndpointManager.ClientMessageDeliverer;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
@@ -980,7 +982,7 @@ public class CoapEndpoint implements Endpoint {
 	}
 
 	@Override
-	public void cancelObservation(byte[] token) {
+	public void cancelObservation(Token token) {
 		matcher.cancelObserve(token);
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
@@ -17,6 +17,8 @@
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
  *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
+ *    Achim Kraus (Bosch Software Innovations GmbH) - correct signature of
+ *                                                    cancelObservation
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -34,6 +36,7 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.server.MessageDeliverer;
+import org.eclipse.californium.elements.EndpointContext;
 
 /**
  * A communication endpoint multiplexing CoAP message exchanges between (potentially multiple) clients and servers.
@@ -103,7 +106,7 @@ public interface Endpoint {
 	 * @param obs the observer
 	 */
 	void removeObserver(EndpointObserver obs);
-	
+
 	/**
 	 * Adds a listener for observe notification (This is related to CoAP
 	 * observe)
@@ -201,6 +204,8 @@ public interface Endpoint {
 	 * @param token
 	 *            the token of the original request which establishes the
 	 *            observe relation to cancel.
+	 * @param context 
+	 *            endpoint context used for the observation
 	 */
-	void cancelObservation(Token token);
+	void cancelObservation(Token token, EndpointContext context);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
@@ -16,6 +16,7 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -28,6 +29,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
 import org.eclipse.californium.core.observe.NotificationListener;
@@ -200,5 +202,5 @@ public interface Endpoint {
 	 *            the token of the original request which establishes the
 	 *            observe relation to cancel.
 	 */
-	void cancelObservation(byte[] token);
+	void cancelObservation(Token token);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -32,6 +32,8 @@
  *                                                    completeCurrentRequest.
  *    Achim Kraus (Bosch Software Innovations GmbH) - rename CorrelationContext to
  *                                                    EndpointContext.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - remove KeyToken, replaced by 
+ *                                                    KeyToken interface
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -737,117 +739,6 @@ public class Exchange {
 		public static KeyMID fromOutboundMessage(Message message) {
 			InetSocketAddress address = message.getDestinationContext().getPeerAddress();
 			return new KeyMID(message.getMID(), address.getAddress().getAddress(), address.getPort());
-		}
-	}
-
-	/**
-	 * A CoAP message token scoped to a remote endpoint.
-	 * <p>
-	 * This class is used by the matcher to correlate messages by their token
-	 * and endpoint address.
-	 */
-	public static final class KeyToken {
-
-		private static final int MAX_PORT_NO = (1 << 16) - 1;
-		private final byte[] token;
-		private final byte[] address;
-		private final int port;
-		private final int hash;
-
-		private KeyToken(byte[] token, byte[] address, int port) {
-			if (token == null) {
-				throw new NullPointerException("token bytes must not be null");
-			} else if (address == null) {
-				throw new NullPointerException("address must not be null");
-			} else if (port < 0 || port > MAX_PORT_NO) {
-				throw new IllegalArgumentException("port must be a 16 bit unsigned int");
-			}
-			this.token = Arrays.copyOf(token, token.length);
-			this.address = address;
-			this.port = port;
-			this.hash = createHash();
-		}
-
-		/**
-		 * Creates a new key for an inbound CoAP message.
-		 * <p>
-		 * The key will be scoped to the message's source endpoint.
-		 * 
-		 * @param message the message.
-		 * @return the key.
-		 */
-		public static KeyToken fromInboundMessage(final Message message) {
-			InetSocketAddress address = message.getSourceContext().getPeerAddress();
-			return new KeyToken(message.getToken(), address.getAddress().getAddress(), address.getPort());
-		}
-
-		/**
-		 * Creates a new key for an outbound CoAP message.
-		 * <p>
-		 * The key will be scoped to the message's destination endpoint.
-		 * 
-		 * @param message the message.
-		 * @return the key.
-		 */
-		public static KeyToken fromOutboundMessage(final Message message) {
-			InetSocketAddress address = message.getDestinationContext().getPeerAddress();
-			return new KeyToken(message.getToken(), address.getAddress().getAddress(), address.getPort());
-		}
-
-		/**
-		 * Creates a new key for a token and an endpoint address.
-		 * 
-		 * @param token the token.
-		 * @param address the endpoint's address.
-		 * @param port the endpoint's port.
-		 * @return the key.
-		 * @throws NullPointerException if token or address is {@code null}
-		 * @throws IllegalArgumentException if port &lt; 0 or port &gt; 65535.
-		 */
-		public static KeyToken fromValues(byte[] token, byte[] address, int port) {
-			return new KeyToken(token, address, port);
-		}
-
-		private int createHash() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + port;
-			result = prime * result + Arrays.hashCode(address);
-			result = prime * result + Arrays.hashCode(token);
-			return result;
-		}
-
-		@Override
-		public String toString() {
-			return new StringBuilder("KeyToken[").append(Utils.toHexString(token)).append(", ")
-					.append(Utils.toHexString(address)).append(":").append(port).append("]").toString();
-		}
-
-		@Override
-		public int hashCode() {
-			return hash;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			KeyToken other = (KeyToken) obj;
-			if (!Arrays.equals(address, other.address))
-				return false;
-			if (port != other.port)
-				return false;
-			if (!Arrays.equals(token, other.token))
-				return false;
-			return true;
-		}
-
-		public byte[] getToken() {
-			return Arrays.copyOf(token, token.length);
 		}
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
@@ -26,12 +26,12 @@
  *                                                    issue #311
  *    Bosch Software Innovations GmbH - migrate to SLF4J
  *    Achim Kraus (Bosch Software Innovations GmbH) - adjust to use Token and KeyToken
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -216,12 +216,11 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 
 	private void registerWithToken(final Exchange exchange) {
 		Request request = exchange.getCurrentRequest();
-		Token token;
-		if (request.getToken() == null) {
+		Token token = request.getToken();
+		if (token == null) {
 			token = tokenProvider.getUnusedToken();
-			request.setToken(token.getBytes());
+			request.setToken(token);
 		} else {
-			token = new Token(request.getToken());
 			// ongoing requests may reuse token
 			if (!(exchange.getFailedTransmissionCount() > 0 || request.getOptions().hasBlock1()
 					|| request.getOptions().hasBlock2() || request.getOptions().hasObserve())
@@ -369,7 +368,7 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 			for (Entry<KeyToken, Exchange> entry : exchangesByToken.entrySet()) {
 				if (entry.getValue().isOfLocalOrigin()) {
 					Request request = entry.getValue().getRequest();
-					if (request != null && Arrays.equals(token.getBytes(), request.getToken())) {
+					if (request != null && token.equals(request.getToken())) {
 						result.add(entry.getValue());
 					}
 				}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
@@ -361,14 +361,15 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 	}
 
 	@Override
-	public List<Exchange> findByToken(Token token) {
+	public List<Exchange> findByToken(KeyToken keyToken) {
 		List<Exchange> result = new ArrayList<>();
-		if (token != null) {
+		if (keyToken != null) {
 			// TODO: remove the for ... 
 			for (Entry<KeyToken, Exchange> entry : exchangesByToken.entrySet()) {
 				if (entry.getValue().isOfLocalOrigin()) {
 					Request request = entry.getValue().getRequest();
-					if (request != null && token.equals(request.getToken())) {
+					// TODO: change to use KeyTokenFactory for request token
+					if (request != null && keyToken.equals(request.getToken())) {
 						result.add(entry.getValue());
 					}
 				}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/KeyToken.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/KeyToken.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial API
+ *******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import org.eclipse.californium.core.coap.Token;
+import org.eclipse.californium.core.observe.ObservationStore;
+
+/**
+ * A interface to enable a {@link Token} to be used as bas for a key for
+ * {@link MessageExchangeStore} and {@link ObservationStore}.
+ */
+public interface KeyToken {
+
+	/**
+	 * Returns the related token.
+	 * 
+	 * @return related token
+	 */
+	Token getToken();
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/KeyTokenFactory.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/KeyTokenFactory.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial API
+ *******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import org.eclipse.californium.core.coap.Token;
+import org.eclipse.californium.elements.EndpointContext;
+
+/**
+ * A factory interface to create {@link KeyToken} from {@link Token} and
+ * {@link EndpointContext}.
+ * </p>
+ * Enables upper layers to supplement additional information extracted from the
+ * context to identify exchanges and observes.
+ */
+public interface KeyTokenFactory {
+
+	/**
+	 * Create key token based on the provided token and context.
+	 * 
+	 * Depending on the implementation, the context must contain the specific
+	 * information.
+	 * 
+	 * @param token token for the key
+	 * @param context context for the key
+	 * @return create key token
+	 * @throws NullPointerException if {@code token} or {@code context} is
+	 *             {@code null}.
+	 * @throws IllegalArgumentException if {@code context} doesn't contain the
+	 *             required data.
+	 */
+	KeyToken create(Token token, EndpointContext context);
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
@@ -15,14 +15,16 @@
  *    (a lot of changes from different authors, please refer to gitlog).
  *    Achim Kraus (Bosch Software Innovations GmbH) - make exchangeStore final
  *                                                    remove setMessageExchangeStore
- *    Achim Kraus (Bosch Software Innovations GmbH) - replace parameter EndpointContext 
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace parameter EndpointContext
  *                                                    by EndpointContext of response.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.Token;
 
 /**
  * The Matcher is the component at the bottom of the CoAP stack.
@@ -152,5 +154,5 @@ public interface Matcher {
 	 * 
 	 * @param token the token of the observation.
 	 */
-	void cancelObserve(byte[] token);
+	void cancelObserve(Token token);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
@@ -18,6 +18,8 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - replace parameter EndpointContext
  *                                                    by EndpointContext of response.
  *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
+ *    Achim Kraus (Bosch Software Innovations GmbH) - correct signature of
+ *                                                    cancelObservation
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -25,6 +27,7 @@ import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.Token;
+import org.eclipse.californium.elements.EndpointContext;
 
 /**
  * The Matcher is the component at the bottom of the CoAP stack.
@@ -153,6 +156,7 @@ public interface Matcher {
 	 * we have received indicating a blockwise transfer of the resource.
 	 * 
 	 * @param token the token of the observation.
+	 * @param context endpoint context used for the observation.
 	 */
-	void cancelObserve(Token token);
+	void cancelObserve(Token token, EndpointContext context);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
@@ -183,12 +183,12 @@ public interface MessageExchangeStore {
 
 	/**
 	 * Gets all message exchanges of local origin that contain a request
-	 * with a given token.
+	 * with a given key token.
 	 * 
-	 * @param token the token to look for.
+	 * @param keyToken the key token to look for.
 	 * @return the exchanges.
 	 */
-	List<Exchange> findByToken(Token token);
+	List<Exchange> findByToken(KeyToken keyToken);
 
 	/**
 	 * Releases the given token to be used again.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
@@ -15,14 +15,15 @@
  *                                                    save cleanup.
  *    Achim Kraus (Bosch Software Innovations GmbH) - remove setContext().
  *                                                    issue #311
+ *    Achim Kraus (Bosch Software Innovations GmbH) - adjust to use Token
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
 import java.util.List;
 
 import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.Exchange.KeyMID;
-import org.eclipse.californium.core.network.Exchange.KeyToken;
 
 /**
  * A registry for keeping track of message exchanges with peers.
@@ -110,10 +111,10 @@ public interface MessageExchangeStore {
 	/**
 	 * Removes the exchange registered under a given token.
 	 * 
-	 * @param token the token of the exchange to remove.
-	 * @param exchange Exchange to be removed, if registered with provided token.
+	 * @param keyToken the key token of the exchange to remove.
+	 * @param exchange Exchange to be removed, if registered with provided key token.
 	 */
-	void remove(KeyToken token, Exchange exchange);
+	void remove(KeyToken keyToken, Exchange exchange);
 
 	/**
 	 * Removes the exchange registered under a given message ID.
@@ -130,10 +131,10 @@ public interface MessageExchangeStore {
 	/**
 	 * Gets the exchange registered under a given token.
 	 * 
-	 * @param token the token under which the exchange has been registered.
-	 * @return the exchange or {@code null} if no exchange exists for the given token.
+	 * @param keyToken the key token under which the exchange has been registered.
+	 * @return the exchange or {@code null} if no exchange exists for the given key token.
 	 */
-	Exchange get(KeyToken token);
+	Exchange get(KeyToken keyToken);
 
 	/**
 	 * Gets the exchange registered under a given message ID.
@@ -148,18 +149,18 @@ public interface MessageExchangeStore {
 	 * exchange and otherwise associates the key with the exchange specified. 
 	 * This method can also be thought of as <em>put if absent</em>.
 	 * This is equivalent to
-     * <pre>
-     *   if (!duplicator.containsKey(key))
-     *       return duplicator.put(key, value);
-     *   else
-     *       return duplicator.get(key);
-     * </pre>
-     * except that the action is performed atomically.
+	 * <pre>
+	 *   if (!duplicator.containsKey(key))
+	 *       return duplicator.put(key, value);
+	 *   else
+	 *       return duplicator.get(key);
+	 * </pre>
+	 * except that the action is performed atomically.
 	 * 
 	 * @param messageId the message ID of the request
 	 * @param exchange the exchange
 	 * @return the previous exchange associated with the specified key, or
-     *         <tt>null</tt> if there was no mapping for the key.
+	 *         <tt>null</tt> if there was no mapping for the key.
 	 */
 	Exchange findPrevious(KeyMID messageId, Exchange exchange);
 
@@ -187,12 +188,12 @@ public interface MessageExchangeStore {
 	 * @param token the token to look for.
 	 * @return the exchanges.
 	 */
-	List<Exchange> findByToken(byte[] token);
-	
+	List<Exchange> findByToken(Token token);
+
 	/**
 	 * Releases the given token to be used again.
 	 * 
-	 * @param keyToken the KeyToken to release.
+	 * @param token the token to release.
 	 */
-	void releaseToken(KeyToken keyToken);
+	void releaseToken(Token token);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -37,6 +37,7 @@
  *                                                 by EndpointContext of response.
  * Bosch Software Innovations GmbH - migrate to SLF4J
  * Achim Kraus (Bosch Software Innovations GmbH) - adjust to use Token and KeyToken
+ * Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -110,7 +111,7 @@ public final class TcpMatcher extends BaseMatcher {
 	public void sendEmptyMessage(Exchange exchange, EmptyMessage message) {
 		// ensure Token is set
 		if (message.isConfirmable()) {
-			message.setToken(new byte[0]);
+			message.setToken(Token.EMPTY);
 		} else {
 			throw new UnsupportedOperationException("sending empty message (ACK/RST) over tcp is not supported!");
 		}
@@ -128,7 +129,7 @@ public final class TcpMatcher extends BaseMatcher {
 	public Exchange receiveResponse(final Response response) {
 
 		// TODO: change to use KeyTokenFactory
-		final KeyToken idByToken = new Token(response.getToken());
+		final KeyToken idByToken = response.getToken();
 		Exchange exchange = exchangeStore.get(idByToken);
 
 		if (exchange == null) {
@@ -177,7 +178,7 @@ public final class TcpMatcher extends BaseMatcher {
 									exchange.getOrigin()});
 				} else {
 					// TODO: change to use KeyTokenFactory
-					KeyToken idByToken = new Token(originRequest.getToken());
+					KeyToken idByToken = originRequest.getToken();
 					exchangeStore.remove(idByToken, exchange);
 					if(!originRequest.isObserve()) {
 						exchangeStore.releaseToken(idByToken.getToken());
@@ -195,7 +196,7 @@ public final class TcpMatcher extends BaseMatcher {
 			Request request = exchange.getRequest(); 
 			if (request != null && request.isObserve()) {
 				// TODO: change to use KeyTokenFactory
-				KeyToken idByToken = new Token(request.getToken());
+				KeyToken idByToken = request.getToken();
 				observationStore.setContext(idByToken, exchange.getEndpointContext());
 			}
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TokenProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TokenProvider.java
@@ -13,16 +13,16 @@
  * Contributors:
  *     Daniel Maier (Bosch Software Innovations GmbH)
  *                                - initial API and implementation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - adjust to use Token
  *******************************************************************************/
 package org.eclipse.californium.core.network;
 
-import org.eclipse.californium.core.coap.Message;
-import org.eclipse.californium.core.network.Exchange.KeyToken;
+import org.eclipse.californium.core.coap.Token;
 
 /**
  * A {@link TokenProvider} provides CoAP tokens that are guaranteed to be not in
  * use. To not run out of unused tokens, used tokens MUST be released with
- * {@link #releaseToken(KeyToken)} after usage.
+ * {@link #releaseToken(Token)} after usage.
  *
  * Implementations of {@link TokenProvider} MUST be thread-safe.
  */
@@ -30,27 +30,26 @@ public interface TokenProvider {
 
 	/**
 	 * Returns a token that is not in use. After this token is not in use
-	 * anymore it must be released with {@link #releaseToken(KeyToken)}.
+	 * anymore it must be released with {@link #releaseToken(Token)}.
 	 * 
-	 * @param message The message to get a token for.
 	 * @return a token that is not in use
 	 */
-	KeyToken getUnusedToken(Message message);
+	Token getUnusedToken();
 
 	/**
 	 * Releases the given token to be used again.
 	 * 
-	 * @param keyToken the token to be released
+	 * @param token the token to be released
 	 */
-	void releaseToken(KeyToken keyToken);
+	void releaseToken(Token token);
 
 	/**
 	 * Indicates if the given token is in use, i.e. was returned by
-	 * {@link #getUnusedToken(Message)} but not yet released by
-	 * {@link #releaseToken(KeyToken)}.
+	 * {@link #getUnusedToken()} but not yet released by
+	 * {@link #releaseToken(Token)}.
 	 * 
-	 * @param keyToken the token to be checked
-	 * @return <code>true</code> if the given token is still in use, <code>false</code> otherwise
+	 * @param token the token to be checked
+	 * @return {@code true}, if the given token is still in use, {@code false}, otherwise
 	 */
-	boolean isTokenInUse(KeyToken keyToken);
+	boolean isTokenInUse(Token token);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -40,6 +40,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - replace parameter EndpointContext 
  *                                                    by EndpointContext of response.
  *    Bosch Software Innovations GmbH - migrate to SLF4J
+ *    Achim Kraus (Bosch Software Innovations GmbH) - adjust to use Token and KeyToken
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -52,8 +53,8 @@ import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.Exchange.KeyMID;
-import org.eclipse.californium.core.network.Exchange.KeyToken;
 import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.NotificationListener;
@@ -207,7 +208,8 @@ public final class UdpMatcher extends BaseMatcher {
 		 */
 
 		KeyMID idByMID = KeyMID.fromInboundMessage(response);
-		final KeyToken idByToken = KeyToken.fromInboundMessage(response);
+		// TODO: change to use KeyTokenFactory
+		final KeyToken idByToken = new Token(response.getToken());
 		LOGGER.trace("received response {}", response);
 		Exchange exchange = exchangeStore.get(idByToken);
 		boolean isNotify = false; // don't remove MID for notifies. May be already reused.
@@ -351,14 +353,15 @@ public final class UdpMatcher extends BaseMatcher {
 					// this should not happen because we only register the observer
 					// if we have successfully registered the exchange
 					LOGGER.warn(
-							"exchange observer has been completed on unregistered exchange [peer: {}:{}, origin: {}]",
-							new Object[]{ originRequest.getDestination(), originRequest.getDestinationPort(),
+							"exchange observer has been completed on unregistered exchange [peer: {}, origin: {}]",
+							new Object[]{ originRequest.getDestinationContext().getPeerAddress(),
 									exchange.getOrigin()});
 				} else {
-					KeyToken idByToken = KeyToken.fromOutboundMessage(originRequest);
+					// TODO: change to use KeyTokenFactory
+					KeyToken idByToken = new Token(originRequest.getToken());
 					exchangeStore.remove(idByToken, exchange);
 					if (!originRequest.isObserve()) {
-						exchangeStore.releaseToken(idByToken);
+						exchangeStore.releaseToken(idByToken.getToken());
 					}
 					/* filter calls by completeCurrentRequest */
 					if (exchange.isComplete()) {
@@ -370,10 +373,11 @@ public final class UdpMatcher extends BaseMatcher {
 						if (request != originRequest && null != request.getToken()
 								&& !Arrays.equals(request.getToken(), originRequest.getToken())) {
 							// remove starting request also
-							idByToken = KeyToken.fromOutboundMessage(request);
+							// TODO: change to use KeyTokenFactory
+							idByToken = new Token(request.getToken());
 							exchangeStore.remove(idByToken, exchange);
 							if (!request.isObserve()) {
-								exchangeStore.releaseToken(idByToken);
+								exchangeStore.releaseToken(idByToken.getToken());
 							}
 						}
 					}
@@ -415,7 +419,9 @@ public final class UdpMatcher extends BaseMatcher {
 		public void contextEstablished(final Exchange exchange) {
 			Request request = exchange.getRequest(); 
 			if (request != null && request.isObserve()) {
-				observationStore.setContext(request.getToken(), exchange.getEndpointContext());
+				// TODO: change to use KeyTokenFactory
+				KeyToken idByToken = new Token(request.getToken());
+				observationStore.setContext(idByToken, exchange.getEndpointContext());
 			}
 		}
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -41,10 +41,10 @@
  *                                                    by EndpointContext of response.
  *    Bosch Software Innovations GmbH - migrate to SLF4J
  *    Achim Kraus (Bosch Software Innovations GmbH) - adjust to use Token and KeyToken
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -160,7 +160,7 @@ public final class UdpMatcher extends BaseMatcher {
 	public void sendEmptyMessage(final Exchange exchange, final EmptyMessage message) {
 
 		// ensure Token is set
-		message.setToken(new byte[0]);
+		message.setToken(Token.EMPTY);
 
 		if (message.getType() == Type.RST && exchange != null) {
 			// We have rejected the request or response
@@ -209,7 +209,7 @@ public final class UdpMatcher extends BaseMatcher {
 
 		KeyMID idByMID = KeyMID.fromInboundMessage(response);
 		// TODO: change to use KeyTokenFactory
-		final KeyToken idByToken = new Token(response.getToken());
+		final KeyToken idByToken = response.getToken();
 		LOGGER.trace("received response {}", response);
 		Exchange exchange = exchangeStore.get(idByToken);
 		boolean isNotify = false; // don't remove MID for notifies. May be already reused.
@@ -358,7 +358,7 @@ public final class UdpMatcher extends BaseMatcher {
 									exchange.getOrigin()});
 				} else {
 					// TODO: change to use KeyTokenFactory
-					KeyToken idByToken = new Token(originRequest.getToken());
+					KeyToken idByToken = originRequest.getToken();
 					exchangeStore.remove(idByToken, exchange);
 					if (!originRequest.isObserve()) {
 						exchangeStore.releaseToken(idByToken.getToken());
@@ -371,10 +371,10 @@ public final class UdpMatcher extends BaseMatcher {
 						 */
 						Request request = exchange.getRequest();
 						if (request != originRequest && null != request.getToken()
-								&& !Arrays.equals(request.getToken(), originRequest.getToken())) {
+								&& !request.getToken().equals(originRequest.getToken())) {
 							// remove starting request also
 							// TODO: change to use KeyTokenFactory
-							idByToken = new Token(request.getToken());
+							idByToken = request.getToken();
 							exchangeStore.remove(idByToken, exchange);
 							if (!request.isObserve()) {
 								exchangeStore.releaseToken(idByToken.getToken());
@@ -420,7 +420,7 @@ public final class UdpMatcher extends BaseMatcher {
 			Request request = exchange.getRequest(); 
 			if (request != null && request.isObserve()) {
 				// TODO: change to use KeyTokenFactory
-				KeyToken idByToken = new Token(request.getToken());
+				KeyToken idByToken = request.getToken();
 				observationStore.setContext(idByToken, exchange.getEndpointContext());
 			}
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/MessageHeader.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/MessageHeader.java
@@ -12,10 +12,12 @@
  * <p>
  * Contributors:
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ * Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.network.serialization;
 
 import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.Token;
 
 /**
  * Message header common to all messages.
@@ -24,12 +26,12 @@ public class MessageHeader {
 
 	private final int version;
 	private final CoAP.Type type;
-	private final byte[] token;
+	private final Token token;
 	private final int code;
 	private final int mid;
 	private final int bodyLength;
 
-	MessageHeader(int version, CoAP.Type type, byte[] token, int code, int mid, int bodyLength) {
+	MessageHeader(int version, CoAP.Type type, Token token, int code, int mid, int bodyLength) {
 		this.version = version;
 		this.type = type;
 		this.token = token;
@@ -51,7 +53,7 @@ public class MessageHeader {
 		return type;
 	}
 
-	public byte[] getToken() {
+	public Token getToken() {
 		return token;
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataParser.java
@@ -19,11 +19,13 @@
  * Bosch Software Innovations GmbH - introduce dedicated MessageFormatException
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
  * Achim Kraus (Bosch Software Innovations GmbH) - use Message.NONE as mid
+ * Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.network.serialization;
 
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.elements.util.DatagramReader;
 
 import static org.eclipse.californium.core.coap.CoAP.MessageFormat.*;
@@ -51,7 +53,7 @@ public final class TcpDataParser extends DataParser {
 		}
 		reader.readBytes(lengthSize);
 		int code = reader.read(CODE_BITS);
-		byte token[] = reader.readBytes(tokenLength);
+		Token token = Token.fromProvider(reader.readBytes(tokenLength));
 
 		// No MID/Type/VERSION in TCP message. Use defaults.
 		return new MessageHeader(CoAP.VERSION, CoAP.Type.CON, token, code, Message.NONE, 0);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataSerializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataSerializer.java
@@ -18,6 +18,7 @@
  * Kai Hudalla - logging
  * Bosch Software Innovations GmbH - turn into utility class with static methods only
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ * Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.network.serialization;
 
@@ -35,22 +36,22 @@ public final class TcpDataSerializer extends DataSerializer {
 		// Variable length encoding per: https://tools.ietf.org/html/draft-ietf-core-coap-tcp-tls-02
 		if (header.getBodyLength() < 13) {
 			writer.write(header.getBodyLength(), LENGTH_NIBBLE_BITS);
-			writer.write(header.getToken().length, TOKEN_LENGTH_BITS);
+			writer.write(header.getToken().length(), TOKEN_LENGTH_BITS);
 		} else if (header.getBodyLength() < (1 << 8) + 13) {
 			writer.write(13, LENGTH_NIBBLE_BITS);
-			writer.write(header.getToken().length, TOKEN_LENGTH_BITS);
+			writer.write(header.getToken().length(), TOKEN_LENGTH_BITS);
 			writer.write(header.getBodyLength() - 13, Byte.SIZE);
 		} else if (header.getBodyLength() < (1 << 16) + 269) {
 			writer.write(14, LENGTH_NIBBLE_BITS);
-			writer.write(header.getToken().length, TOKEN_LENGTH_BITS);
+			writer.write(header.getToken().length(), TOKEN_LENGTH_BITS);
 			writer.write(header.getBodyLength() - 269, 2 * Byte.SIZE);
 		} else {
 			writer.write(15, LENGTH_NIBBLE_BITS);
-			writer.write(header.getToken().length, TOKEN_LENGTH_BITS);
+			writer.write(header.getToken().length(), TOKEN_LENGTH_BITS);
 			writer.write(header.getBodyLength() - 65805, 4 * Byte.SIZE);
 		}
 
 		writer.write(header.getCode(), CODE_BITS);
-		writer.writeBytes(header.getToken());
+		writer.writeBytes(header.getToken().getBytes());
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/UdpDataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/UdpDataParser.java
@@ -18,11 +18,13 @@
  * Kai Hudalla - logging
  * Bosch Software Innovations GmbH - introduce dedicated MessageFormatException
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ * Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.network.serialization;
 
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.MessageFormatException;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.elements.util.DatagramReader;
 
 import static org.eclipse.californium.core.coap.CoAP.MessageFormat.*;
@@ -41,7 +43,7 @@ public final class UdpDataParser extends DataParser {
 		assertValidTokenLength(tokenLength);
 		int code = reader.read(CODE_BITS);
 		int mid = reader.read(MESSAGE_ID_BITS);
-		byte token[] = reader.readBytes(tokenLength);
+		Token token = Token.fromProvider(reader.readBytes(tokenLength));
 
 		return new MessageHeader(version, CoAP.Type.valueOf(type), token, code, mid, 0);
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/UdpDataSerializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/UdpDataSerializer.java
@@ -18,6 +18,7 @@
  * Kai Hudalla - logging
  * Bosch Software Innovations GmbH - turn into utility class with static methods only
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
+ * Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.network.serialization;
 
@@ -33,9 +34,9 @@ public final class UdpDataSerializer extends DataSerializer {
 	@Override protected void serializeHeader(final DatagramWriter writer, final MessageHeader header) {
 		writer.write(VERSION, VERSION_BITS);
 		writer.write(header.getType().value, TYPE_BITS);
-		writer.write(header.getToken().length, TOKEN_LENGTH_BITS);
+		writer.write(header.getToken().length(), TOKEN_LENGTH_BITS);
 		writer.write(header.getCode(), CODE_BITS);
 		writer.write(header.getMID(), MESSAGE_ID_BITS);
-		writer.writeBytes(header.getToken());
+		writer.writeBytes(header.getToken().getBytes());
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
@@ -13,10 +13,9 @@
  * Contributors:
  *    Bosch Software Innovations - initial creation
  *    Achim Kraus (Bosch Software Innovations GmbH) - use EndpointContext
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
-
-import java.util.Arrays;
 
 import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.OptionSet;
@@ -163,6 +162,6 @@ final class Block1BlockwiseStatus extends BlockwiseStatus {
 	 * @return {@code true} if the tokens match.
 	 */
 	boolean hasMatchingToken(final Response response) {
-		return request != null && Arrays.equals(request.getToken(), response.getToken());
+		return request != null && request.getToken().equals(response.getToken());
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -40,10 +40,10 @@
  *    Bosch Software Innovations GmbH - migrate to SLF4J
  *    Achim Kraus (Bosch Software Innovations GmbH) - keep original response, if
  *                                                    current request is the original
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
-import java.util.Arrays;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -791,7 +791,7 @@ public class BlockwiseLayer extends AbstractLayer {
 
 				Block2BlockwiseStatus status = getInboundBlock2Status(key, exchange, response);
 
-				if (block2.getNum() == status.getCurrentNum() && (block2.getNum() == 0 || Arrays.equals(response.getToken(), exchange.getCurrentRequest().getToken()))) {
+				if (block2.getNum() == status.getCurrentNum() && (block2.getNum() == 0 || response.getToken().equals(exchange.getCurrentRequest().getToken()))) {
 
 					// check token to avoid mixed blockwise transfers (possible with observe) 
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationStore.java
@@ -10,9 +10,13 @@
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  * 
+ * Contributors:
+ *    initial implementation please refer gitlog
+ *    Achim Kraus (Bosch Software Innovations GmbH) - adjust to use KeyToken
  ******************************************************************************/
 package org.eclipse.californium.core.observe;
 
+import org.eclipse.californium.core.network.KeyToken;
 import org.eclipse.californium.elements.EndpointContext;
 
 /**
@@ -32,14 +36,14 @@ public interface ObservationStore {
 	 * @param obs The observation to add.
 	 * @throws NullPointerException if observation is {@code null}.
 	 */
-	void add(Observation obs);
+	void add(KeyToken token, Observation obs);
 
 	/**
 	 * Removes the observation initiated by the request with the given token.
 	 * 
 	 * @param token The token of the observation to remove.
 	 */
-	void remove(byte[] token);
+	void remove(KeyToken token);
 
 	/**
 	 * Gets the observation initiated by the request with the given token.
@@ -47,7 +51,7 @@ public interface ObservationStore {
 	 * @param token The token of the initiating request.
 	 * @return The corresponding observation or {@code null} if no observation is registered for the given token.
 	 */
-	Observation get(byte[] token);
+	Observation get(KeyToken token);
 
 	/**
 	 * Sets the endpoint context on the observation initiated by the request
@@ -63,5 +67,5 @@ public interface ObservationStore {
 	 * @param token The token of the observation to set the context on.
 	 * @param endpointContext The context to set.
 	 */
-	void setContext(byte[] token, EndpointContext endpointContext);
+	void setContext(KeyToken token, EndpointContext endpointContext);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveManager.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveManager.java
@@ -16,11 +16,14 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.observe;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.californium.core.coap.Token;
 
 /**
  * The observe manager holds a mapping of endpoint addresses to
@@ -89,7 +92,7 @@ public class ObserveManager {
 		}
 	}
 
-	public ObserveRelation getRelation(InetSocketAddress source, byte[] token) {
+	public ObserveRelation getRelation(InetSocketAddress source, Token token) {
 		ObservingEndpoint remote = getObservingEndpoint(source);
 		if (remote!=null) {
 			return remote.getObserveRelation(token);

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservingEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservingEndpoint.java
@@ -16,13 +16,15 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.observe;
 
 import java.net.InetSocketAddress;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.californium.core.coap.Token;
 
 /**
  * This class represents an observing endpoint. It holds all observe relations
@@ -80,9 +82,9 @@ public class ObservingEndpoint {
 		return address;
 	}
 
-	public ObserveRelation getObserveRelation(byte[] token) {
+	public ObserveRelation getObserveRelation(Token token) {
 		for (ObserveRelation relation:relations) {
-			if (Arrays.equals(relation.getExchange().getRequest().getToken(), token)) {
+			if (relation.getExchange().getRequest().getToken().equals(token)) {
 				return relation;
 			}
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
@@ -18,6 +18,7 @@
  *    Kai Hudalla - logging
  *    Kai Hudalla (Bosch Software Innovations GmbH) - use Logger's message formatting instead of
  *                                                    explicit String concatenation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.server;
 
@@ -105,8 +106,8 @@ public class ServerMessageDeliverer implements MessageDeliverer {
 					resource.handleRequest(exchange);
 				}
 			} else {
-				LOGGER.info("did not find resource {} requested by {}:{}",
-						new Object[]{path, request.getSource(), request.getSourcePort()});
+				LOGGER.info("did not find resource {} requested by {}",
+						new Object[]{path, request.getSourceContext().getPeerAddress()});
 				exchange.sendResponse(new Response(ResponseCode.NOT_FOUND));
 			}
 		}
@@ -145,13 +146,13 @@ public class ServerMessageDeliverer implements MessageDeliverer {
 		Request request = exchange.getRequest();
 		if (request.getCode() == Code.GET && request.getOptions().hasObserve() && resource.isObservable()) {
 
-			InetSocketAddress source = new InetSocketAddress(request.getSource(), request.getSourcePort());
+			InetSocketAddress source = request.getSourceContext().getPeerAddress();
 
 			if (request.getOptions().getObserve() == 0) {
 				// Requests wants to observe and resource allows it :-)
 				LOGGER.debug(
-						"initiating an observe relation between {}:{} and resource {}",
-						new Object[]{request.getSource(), request.getSourcePort(), resource.getURI()});
+						"initiating an observe relation between {} and resource {}",
+						new Object[]{source, resource.getURI()});
 				ObservingEndpoint remote = observeManager.findObservingEndpoint(source);
 				ObserveRelation relation = new ObserveRelation(remote, resource, exchange);
 				remote.addObserveRelation(relation);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -145,7 +145,7 @@ public class UdpMatcherTest {
 		Exchange exchange = sendObserveRequest(dest, matcher, exchangeEndpointContext);
 
 		// WHEN canceling any observe relations for the exchange's token
-		matcher.cancelObserve(exchange.getCurrentRequest().getToken());
+		matcher.cancelObserve(exchange.getCurrentRequest().getToken(), exchangeEndpointContext);
 
 		// THEN the token has been released for re-use
 		Token token = exchange.getCurrentRequest().getToken();

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -119,7 +119,7 @@ public class UdpMatcherTest {
 		exchange.completeCurrentRequest();
 
 		// THEN assert that token got released
-		Token token = new Token(exchange.getCurrentRequest().getToken());
+		Token token = exchange.getCurrentRequest().getToken();
 		assertThat(tokenProvider.isTokenInUse(token), is(false));
 	}
 
@@ -133,7 +133,7 @@ public class UdpMatcherTest {
 		exchange.completeCurrentRequest();
 
 		// THEN assert that token got not released
-		Token token = new Token(exchange.getCurrentRequest().getToken());
+		Token token = exchange.getCurrentRequest().getToken();
 		assertThat(tokenProvider.isTokenInUse(token), is(true));
 	}
 
@@ -148,7 +148,7 @@ public class UdpMatcherTest {
 		matcher.cancelObserve(exchange.getCurrentRequest().getToken());
 
 		// THEN the token has been released for re-use
-		Token token = new Token(exchange.getCurrentRequest().getToken());
+		Token token = exchange.getCurrentRequest().getToken();
 		assertThat(tokenProvider.isTokenInUse(token), is(false));
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -16,6 +16,7 @@
  *                                                    (fix GitHub issue #104)
  *    Achim Kraus (Bosch Software Innovations GmbH) - use EndpointContext and
  *                                                    EndpointContextMatcher mocks
+ *    Achim Kraus (Bosch Software Innovations GmbH) - adjust to use Token
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -31,7 +32,7 @@ import java.net.InetSocketAddress;
 import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
-import org.eclipse.californium.core.network.Exchange.KeyToken;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.InMemoryObservationStore;
@@ -118,8 +119,8 @@ public class UdpMatcherTest {
 		exchange.completeCurrentRequest();
 
 		// THEN assert that token got released
-		KeyToken keyToken = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
-		assertThat(tokenProvider.isTokenInUse(keyToken), is(false));
+		Token token = new Token(exchange.getCurrentRequest().getToken());
+		assertThat(tokenProvider.isTokenInUse(token), is(false));
 	}
 
 	@Test
@@ -132,8 +133,8 @@ public class UdpMatcherTest {
 		exchange.completeCurrentRequest();
 
 		// THEN assert that token got not released
-		KeyToken keyToken = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
-		assertThat(tokenProvider.isTokenInUse(keyToken), is(true));
+		Token token = new Token(exchange.getCurrentRequest().getToken());
+		assertThat(tokenProvider.isTokenInUse(token), is(true));
 	}
 
 	@Test
@@ -147,8 +148,8 @@ public class UdpMatcherTest {
 		matcher.cancelObserve(exchange.getCurrentRequest().getToken());
 
 		// THEN the token has been released for re-use
-		KeyToken keyToken = KeyToken.fromOutboundMessage(exchange.getCurrentRequest());
-		assertThat(tokenProvider.isTokenInUse(keyToken), is(false));
+		Token token = new Token(exchange.getCurrentRequest().getToken());
+		assertThat(tokenProvider.isTokenInUse(token), is(false));
 	}
 
 	/**

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataParserTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataParserTest.java
@@ -23,7 +23,6 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network.serialization;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -40,6 +39,7 @@ import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.Option;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.RawData;
@@ -88,7 +88,7 @@ import org.junit.runners.Parameterized;
 //		Request result = parser.parseRequest(rawData);
 		Request result = (Request) parser.parseMessage(rawData);
 		assertEquals(request.getMID(), result.getMID());
-		assertArrayEquals(request.getToken(), result.getToken());
+		assertEquals(request.getToken(), result.getToken());
 		assertEquals(request.getOptions().asSortedList(), result.getOptions().asSortedList());
 	}
 
@@ -186,7 +186,7 @@ import org.junit.runners.Parameterized;
 
 		Response result = (Response) parser.parseMessage(rawData);
 		assertEquals(response.getMID(), result.getMID());
-		assertArrayEquals(response.getToken(), result.getToken());
+		assertEquals(response.getToken(), result.getToken());
 		assertEquals(response.getOptions().asSortedList(), result.getOptions().asSortedList());
 	}
 
@@ -195,7 +195,7 @@ import org.junit.runners.Parameterized;
 		response.setDestinationContext(ENDPOINT_CONTEXT);
 		response.setType(Type.NON);
 		response.setMID(expectedMid);
-		response.setToken(new byte[] {});
+		response.setToken(Token.EMPTY);
 		response.getOptions().addLocationPath("ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ").addLocationPath("γλώσσα")
 				.addLocationPath("пустынных").addLocationQuery("ვეპხის=யாமறிந்த").addLocationQuery("⠊⠀⠉⠁⠝=⠑⠁⠞⠀⠛⠇⠁⠎⠎");
 		response.setPayload("⠊⠀⠉⠁⠝⠀⠑⠁⠞⠀⠛⠇⠁⠎⠎⠀⠁⠝⠙⠀⠊⠞⠀⠙⠕⠑⠎⠝⠞⠀⠓⠥⠗⠞⠀⠍⠑");

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataSerializerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataSerializerTest.java
@@ -33,6 +33,7 @@ import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.DtlsEndpointContext;
@@ -139,7 +140,7 @@ public class DataSerializerTest {
 		request.setMID(1);
 
 		EmptyMessage ack = EmptyMessage.newACK(request);
-		ack.setToken(new byte[0]);
+		ack.setToken(Token.EMPTY);
 		RawData data = serializer.serializeEmptyMessage(ack, null);
 
 		assertThat(data.getEndpointContext(), is(equalTo(ENDPOINT_CONTEXT)));

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceAttributesTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceAttributesTest.java
@@ -33,6 +33,7 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.EndpointManager;
 import org.eclipse.californium.core.network.EndpointObserver;
@@ -212,7 +213,7 @@ public class ResourceAttributesTest {
 		}
 
 		@Override
-		public void cancelObservation(byte[] token) {
+		public void cancelObservation(Token token) {
 		}
 		
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceAttributesTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceAttributesTest.java
@@ -45,6 +45,7 @@ import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.server.MessageDeliverer;
 import org.eclipse.californium.core.server.resources.DiscoveryResource;
 import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.californium.elements.EndpointContext;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -213,7 +214,7 @@ public class ResourceAttributesTest {
 		}
 
 		@Override
-		public void cancelObservation(Token token) {
+		public void cancelObservation(Token token, EndpointContext context) {
 		}
 		
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
@@ -16,6 +16,7 @@
  *                                                    sending to "any" doesn't work on windows
  *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
  *                                                    setup of test-network
+ *    Achim Kraus (Bosch Software Innovations GmbH) - adjust to use Token and KeyToken
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
@@ -37,8 +38,10 @@ import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.KeyToken;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
 import org.eclipse.californium.core.observe.InMemoryObservationStore;
@@ -310,7 +313,9 @@ public class ClusteringTest {
 		// cancel observation
 		System.out.println();
 		System.out.println(System.lineSeparator() + "Cancel Observation.");
-		store.remove(request.getToken());
+		// TODO: change to use KeyTokenFactory
+		KeyToken keyToken = new Token(request.getToken());
+		store.remove(keyToken);
 
 		// server send new response to client 1
 		System.out.println();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
@@ -314,7 +314,7 @@ public class ClusteringTest {
 		System.out.println();
 		System.out.println(System.lineSeparator() + "Cancel Observation.");
 		// TODO: change to use KeyTokenFactory
-		KeyToken keyToken = new Token(request.getToken());
+		KeyToken keyToken = request.getToken();
 		store.remove(keyToken);
 
 		// server send new response to client 1

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/IntegrationTestTools.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/IntegrationTestTools.java
@@ -16,6 +16,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - use waitForCondition
  *    Achim Kraus (Bosch Software Innovations GmbH) - move waitUntilDeduplicatorShouldBeEmpty
  *                                                    to MessageExchangeStoreTool
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
@@ -29,6 +30,7 @@ import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.Token;
 
 /**
  * Common functionality for integration tests.
@@ -97,8 +99,8 @@ public final class IntegrationTestTools {
 		interceptor.clear();
 	}
 
-	public static byte[] generateNextToken() {
-		return b(++currentToken);
+	public static Token generateNextToken() {
+		return Token.fromProvider(b(++currentToken));
 	}
 
 	private static byte[] b(int... is) {

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -48,7 +48,6 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.californium.category.Large;
-import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
@@ -1027,7 +1026,7 @@ public class ObserveClientSideTest {
 		printServerLog(clientInterceptor);
 
 		client.cancelObservation(server.getToken("A"));
-		System.out.println("Cancel observation " + Utils.toHexString(server.getToken("A")));
+		System.out.println("Cancel observation " + server.getToken("A").getAsString());
 
 		assertTrue("ObservationStore must be empty", client.getObservationStore().isEmpty());
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -314,7 +314,7 @@ public class ObserveClientSideTest {
 		server.goMultiExpectation();
 
 		// canceling in the middle of blockwise transfer
-		client.cancelObservation(request.getToken());
+		client.cancelObservation(request.getToken(), request.getDestinationContext());
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
 
 		// notification must not be delivered
@@ -1025,7 +1025,7 @@ public class ObserveClientSideTest {
 		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 16).go();
 		printServerLog(clientInterceptor);
 
-		client.cancelObservation(server.getToken("A"));
+		client.cancelObservation(server.getToken("A"), request.getDestinationContext());
 		System.out.println("Cancel observation " + server.getToken("A").getAsString());
 
 		assertTrue("ObservationStore must be empty", client.getObservationStore().isEmpty());

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveServerSideTest.java
@@ -27,6 +27,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - use renamed sameMID instead
  *                                                    of loadMID
  *    Bosch Software Innovations GmbH - migrate to SLF4J
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
@@ -54,9 +55,9 @@ import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.resources.CoapExchange;
-import org.eclipse.californium.elements.UDPConnector;
 import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -155,7 +156,7 @@ public class ObserveServerSideTest {
 
 		System.out.println("Establish an observe relation. Cancellation after timeout");
 		respPayload = generateRandomPayload(30);
-		byte[] tok = generateNextToken();
+		Token tok = generateNextToken();
 
 		respType = null;
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
@@ -207,7 +208,7 @@ public class ObserveServerSideTest {
 	public void testEstablishmentAndTimeoutWithUpdateInMiddle() throws Exception {
 		System.out.println("Establish an observe relation. Cancellation after timeout. During the timeouts, the resource still changes.");
 		respPayload = generateRandomPayload(30);
-		byte[] tok = generateNextToken();
+		Token tok = generateNextToken();
 
 		respType = null;
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
@@ -246,7 +247,7 @@ public class ObserveServerSideTest {
 	public void testEstablishmentAndRejectCancellation() throws Exception {
 		System.out.println("Establish an observe relation. Cancellation due to a reject from the client");
 		respPayload = generateRandomPayload(30);
-		byte[] tok = generateNextToken();
+		Token tok = generateNextToken();
 
 		respType = null;
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
@@ -272,7 +273,7 @@ public class ObserveServerSideTest {
 	public void testObserveWithBlock() throws Exception {
 		System.out.println("Observe with blockwise");
 		respPayload = generateRandomPayload(80);
-		byte[] tok = generateNextToken();
+		Token tok = generateNextToken();
 
 		// Establish relation
 		respType = null; // first type is normal ACK
@@ -283,7 +284,7 @@ public class ObserveServerSideTest {
 		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
 
 		// Get remaining blocks
-		byte[] tok2 = generateNextToken();
+		Token tok2 = generateNextToken();
 		client.sendRequest(CON, GET, tok2, ++mid).path(RESOURCE_PATH).loadETag("tag").block2(1, false, 32).go();
 		client.expectResponse(ACK, CONTENT, tok2, mid).block2(1, true, 32).payload(respPayload, 32, 64).go();
 		client.sendRequest(CON, GET, tok2, ++mid).path(RESOURCE_PATH).loadETag("tag").block2(2, false, 32).go();
@@ -299,7 +300,7 @@ public class ObserveServerSideTest {
 		client.sendEmpty(ACK).loadMID("MID").go();
 
 		// Get remaining blocks
-		byte[] tok3 = generateNextToken();
+		Token tok3 = generateNextToken();
 		client.sendRequest(CON, GET, tok3, ++mid).path(RESOURCE_PATH).loadETag("tag").block2(1, false, 32).go();
 		client.expectResponse(ACK, CONTENT, tok3, mid).block2(1, true, 32).payload(respPayload, 32, 64).go();
 		client.sendRequest(CON, GET, tok3, ++mid).path(RESOURCE_PATH).loadETag("tag").block2(2, false, 32).go();
@@ -323,7 +324,7 @@ public class ObserveServerSideTest {
 
 		System.out.println("Establish an observe relation and receive NON notifications");
 		respPayload = generateRandomPayload(30);
-		byte[] tok = generateNextToken();
+		Token tok = generateNextToken();
 
 		respType = null;
 		client.sendRequest(NON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
@@ -359,7 +360,7 @@ public class ObserveServerSideTest {
 
 		System.out.println("Establish an observe relation and receive NON notifications");
 		respPayload = generateRandomPayload(30);
-		byte[] tok = generateNextToken();
+		Token tok = generateNextToken();
 
 		respType = null;
 		client.sendRequest(NON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).block2(0, false, 16).go();
@@ -402,7 +403,7 @@ public class ObserveServerSideTest {
 	public void testQuickChangeAndTimeout() throws Exception {
 		System.out.println("Establish an observe relation to a quickly changing resource and do no longer respond");
 		respPayload = generateRandomPayload(20);
-		byte[] tok = generateNextToken();
+		Token tok = generateNextToken();
 
 		respType = null;
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
@@ -453,7 +454,7 @@ public class ObserveServerSideTest {
 	public void testIncompleteBlock2Notification() throws Exception {
 		System.out.println("Observe with blockwise");
 		respPayload = generateRandomPayload(32);
-		byte[] tok = generateNextToken();
+		Token tok = generateNextToken();
 
 		// Establish observe relation
 		respType = null; // first type is normal ACK
@@ -471,7 +472,7 @@ public class ObserveServerSideTest {
 		client.sendEmpty(ACK).loadMID("MID").go();
 
 		// Get remaining blocks
-		byte[] tok3 = generateNextToken();
+		Token tok3 = generateNextToken();
 		client.sendRequest(CON, GET, tok3, ++mid).path(RESOURCE_PATH).loadETag("tag").block2(1, false, 32).go();
 		client.expectResponse(ACK, CONTENT, tok3, mid).block2(1, true, 32).payload(respPayload, 32, 64).go();
 		// we don't send last request, @after should check is there is

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ServerDeduplicationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ServerDeduplicationTest.java
@@ -33,6 +33,7 @@ import java.net.InetSocketAddress;
 import org.eclipse.californium.category.Medium;
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
@@ -115,7 +116,7 @@ public class ServerDeduplicationTest {
 	@Test
 	public void testServerRespondsToDuplicateRequest() throws Exception {
 
-		byte[] token = new byte[]{0x00, 0x00};
+		Token token = Token.fromProvider(new byte[]{0x00, 0x00});
 		int mid = 1234;
 
 		client.sendRequest(CON, GET, token, mid).path(resourceName).go();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/SynchronousNotificationListener.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/SynchronousNotificationListener.java
@@ -13,10 +13,10 @@
  * Contributors:
  *    Matthias Kovatsch - creator and main architect
  *    Achim Kraus (Bosch Software Innovations GmbH) - collect notifies for log.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -61,7 +61,7 @@ public class SynchronousNotificationListener implements NotificationListener {
 
 	@Override
 	public void onNotification(final Request req, final Response resp) {
-		if (request == null || Arrays.equals(request.getToken(), req.getToken())) {
+		if (request == null || request.getToken().equals(req.getToken())) {
 			synchronized (lock) {
 				notifies.add(resp);
 				response = resp;

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/PlugtestChecker.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/PlugtestChecker.java
@@ -13,6 +13,7 @@
  * Contributors:
  *    Matthias Kovatsch - creator and main architect
  *    Bosch Software Innovations GmbH - migrate to SLF4J
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 
 package org.eclipse.californium.plugtests;
@@ -39,6 +40,7 @@ import org.eclipse.californium.core.coap.Option;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.resources.Resource;
 
@@ -666,7 +668,7 @@ public class PlugtestChecker {
 				System.out.println("FAIL: Response without Token");
 			} else {
 				System.out.printf("PASS: Token (%s)\n",
-						Utils.toHexString(response.getToken()));
+						response.getTokenString());
 			}
 
 			return success;
@@ -684,7 +686,7 @@ public class PlugtestChecker {
 
 			if (!success) {
 				System.out.println("FAIL: Expected no token but had "
-						+ Utils.toHexString(response.getToken()));
+						+ response.getTokenString());
 			} else {
 				System.out.printf("PASS: No Token\n");
 			}
@@ -866,18 +868,18 @@ public class PlugtestChecker {
 		 *            the actual token
 		 * @return true, if successful
 		 */
-		protected boolean checkToken(byte[] expectedToken, byte[] actualToken) {
+		protected boolean checkToken(Token expectedToken, Token actualToken) {
 
 			boolean success = true;
 
-			if (expectedToken == null || expectedToken.length == 0) {
+			if (expectedToken == null || expectedToken.isEmpty()) {
 
-				success = actualToken == null || actualToken.length == 0;
+				success = actualToken == null || actualToken.isEmpty();
 
 				if (!success) {
 					System.out.printf(
 							"FAIL: Expected empty token, but was %s\n",
-							Utils.toHexString(actualToken));
+							actualToken.getAsString());
 				} else {
 					System.out.println("PASS: Correct empty token");
 				}
@@ -886,27 +888,27 @@ public class PlugtestChecker {
 
 			} else {
 
-				success = actualToken.length <= 8;
-				success &= actualToken.length >= 1;
+				success = actualToken.length() <= 8;
+				success &= actualToken.length() >= 1;
 
 				// eval token length
 				if (!success) {
 					System.out
 							.printf("FAIL: Expected token %s, but %s has illeagal length\n",
-									Utils.toHexString(expectedToken),
-									Utils.toHexString(actualToken));
+									expectedToken.getAsString(),
+									actualToken.getAsString());
 					return success;
 				}
 
-				success &= Arrays.equals(expectedToken, actualToken);
+				success &= expectedToken.equals(actualToken);
 
 				if (!success) {
 					System.out.printf("FAIL: Expected token %s, but was %s\n",
-							Utils.toHexString(expectedToken),
-							Utils.toHexString(actualToken));
+							expectedToken.getAsString(),
+							actualToken.getAsString());
 				} else {
 					System.out.printf("PASS: Correct token (%s)\n",
-							Utils.toHexString(actualToken));
+							actualToken.getAsString());
 				}
 
 				return success;

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/resources/DefaultTest.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/resources/DefaultTest.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *    Matthias Kovatsch - creator and main architect
+ *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
  ******************************************************************************/
 package org.eclipse.californium.plugtests.resources;
 
@@ -47,11 +48,14 @@ public class DefaultTest extends CoapResource {
 				request.getCode(), 
 				request.getMID()));
 
-		if (request.getToken().length > 0) {
+		if (request.getToken() != null) {
 			payload.append("\nToken: ");
-			StringBuilder tok = new StringBuilder(request.getToken()==null?"null":"");
-			if (request.getToken()!=null) for(byte b:request.getToken()) tok.append(String.format("%02x", b&0xff));
-			payload.append(tok);
+			if (request.hasEmptyToken()) {
+				payload.append("[]");
+			} else {
+				for (byte b : request.getTokenBytes())
+					payload.append(String.format("%02x", b & 0xff));
+			}
 		}
 
 		if (payload.length() > 64) {

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/resources/Validate.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/resources/Validate.java
@@ -71,7 +71,7 @@ public class Validate extends CoapResource {
 								request.getCode(),
 								request.getMID()));
 		
-				if (request.getToken().length > 0) {
+				if (!request.hasEmptyToken()) {
 					payload.append("\nToken: ");
 					payload.append(request.getTokenString());
 				}


### PR DESCRIPTION
Introduce Token and KeyToken.

Change API of MessageExchangeStore and ObservationStore accordingly.
To limit the scope of the changes, the KeyTokenFactory is not used but
TODOs are added.
Replace byte array token by Token.

That are the base changes for issue #500.
Based on that, the implementations for variant 2 or 3 will (hopefully)  be easier and isolate the required changes for the different approaches.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>
  