### PR TITLE
remove etag when request next block2 payload.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -850,10 +850,6 @@ public class BlockwiseLayer extends AbstractLayer {
 						// copy options
 						block.setOptions(new OptionSet(request.getOptions()));
 						block.getOptions().setBlock2(newSzx, false, nextNum);
-						if (response.getOptions().getETagCount() > 0) {
-							// use ETag provided by peer
-							block.getOptions().addETag(response.getOptions().getETags().get(0));
-						}
 
 						// make sure NOT to use Observe for block retrieval
 						block.getOptions().removeObserve();


### PR DESCRIPTION
When we request next block of blockwise payload, it is FIRST TIME request of that block. which means we have no contents of requesting block.

Signed-off-by: Rokwoon Kim <k862390@gmail.com>