### PR TITLE
remove etag when request next block2 payload.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -850,10 +850,6 @@ public class BlockwiseLayer extends AbstractLayer {
 						// copy options
 						block.setOptions(new OptionSet(request.getOptions()));
 						block.getOptions().setBlock2(newSzx, false, nextNum);
-						if (response.getOptions().getETagCount() > 0) {
-							// use ETag provided by peer
-							block.getOptions().addETag(response.getOptions().getETags().get(0));
-						}
 
 						// make sure NOT to use Observe for block retrieval
 						block.getOptions().removeObserve();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -195,9 +195,9 @@ public class BlockwiseClientSideTest {
 		server.expectRequest(CON, GET, path).storeBoth("A").go();
 		server.sendResponse(ACK, CONTENT).loadBoth("A").block2(0, true, 128).size2(respPayload.length())
 			.etag(etag).payload(respPayload.substring(0, 128)).go();
-		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 128).hasEtag(etag).go();
+		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 128).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 128).etag(etag).payload(respPayload.substring(128, 256)).go();
-		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 128).hasEtag(etag).go();
+		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 128).go();
 		server.sendResponse(ACK, CONTENT).loadBoth("C").block2(2, false, 128).etag(etag).payload(respPayload.substring(256, 300)).go();
 
 		Response response = request.waitForResponse(RESPONSE_TIMEOUT_IN_MS);
@@ -675,13 +675,13 @@ public class BlockwiseClientSideTest {
 		server.sendResponse(ACK, CHANGED).loadBoth("C").block1(2, false, 128).block2(0, true, 128).size2(respPayload.length())
 				.etag(tag).payload(respPayload.substring(0, 128)).go();
 
-		server.expectRequest(CON, POST, path).storeBoth("D").hasEtag(tag).block2(1, false, 128).go();
+		server.expectRequest(CON, POST, path).storeBoth("D").block2(1, false, 128).go();
 		server.sendResponse(ACK, CHANGED).loadBoth("D").block2(1, true, 128).etag(tag).payload(respPayload.substring(128, 256)).go();
 
-		server.expectRequest(CON, POST, path).storeBoth("E").hasEtag(tag).block2(2, false, 128).go();
+		server.expectRequest(CON, POST, path).storeBoth("E").block2(2, false, 128).go();
 		server.sendResponse(ACK, CHANGED).loadBoth("E").block2(2, true, 128).etag(tag).payload(respPayload.substring(256, 384)).go();
 
-		server.expectRequest(CON, POST, path).storeBoth("F").hasEtag(tag).block2(3, false, 128).go();
+		server.expectRequest(CON, POST, path).storeBoth("F").block2(3, false, 128).go();
 		server.sendResponse(ACK, CHANGED).loadBoth("F").block2(3, false, 128).etag(tag).payload(respPayload.substring(384, 500)).go();
 
 		Response response = request.waitForResponse(RESPONSE_TIMEOUT_IN_MS);


### PR DESCRIPTION
When we request next block of blockwise payload, it is FIRST TIME request of that block. which means we have no contents of requesting block.

Signed-off-by: Rokwoon Kim <k862390@gmail.com>