### PR TITLE
[#339] Replace ErrorHandler from DTLSConnector with AlertHandler.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/AlertHandler.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/AlertHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2015, 2018 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,13 +12,13 @@
  * 
  * Contributors:
  *    Kai Hudalla (Bosch Software Innovations GmbH) - Initial creation
+ *    Bosch Software Innovations GmbH - Rename and move to scandium.dtls package
  ******************************************************************************/
 package org.eclipse.californium.scandium;
 
 import java.net.InetSocketAddress;
 
-import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
-import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
+import org.eclipse.californium.scandium.dtls.AlertMessage;
 
 /**
  * A call back to be invoked when an <em>ALERT</em> message is received from a peer.
@@ -26,14 +26,13 @@ import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
  * Applications can register such a call back in order to be able to react to e.g. aborted
  * handshakes etc.
  */
-public interface ErrorHandler {
+public interface AlertHandler {
 
 	/**
 	 * Indicates that an <em>ALERT</em> message has been received from a peer.
 	 * 
-	 * @param peerAddress the IP address and port of the peer the alert has been received from 
-	 * @param level the severity level of the alert
-	 * @param description the reason of the alert
+	 * @param peer The peer that the alert has been received from.
+	 * @param alert The alert.
 	 */
-	void onError(InetSocketAddress peerAddress, AlertLevel level, AlertDescription description);
+	void onAlert(InetSocketAddress peer, AlertMessage alert);
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
@@ -43,14 +43,15 @@ import org.slf4j.LoggerFactory;
 public final class Connection implements SessionListener {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(Connection.class.getName());
+
 	private final InetSocketAddress peerAddress;
-	private volatile DTLSSession establishedSession;
 	private final SessionTicket ticket;
 	private final AtomicReference<Handshaker> ongoingHandshake = new AtomicReference<Handshaker>();
 	private final AtomicReference<DTLSFlight> pendingFlight = new AtomicReference<DTLSFlight>();
 	private final AtomicLong lastMessage = new AtomicLong();
 	private final Long autoResumptionTimeout;
-	
+
+	private volatile DTLSSession establishedSession;
 	// Used to know when an abbreviated handshake should be initiated
 	private volatile boolean resumptionRequired = false; 
 
@@ -58,6 +59,7 @@ public final class Connection implements SessionListener {
 	 * Creates a new connection to a given peer.
 	 * 
 	 * @param peerAddress the IP address and port of the peer the connection exists with
+	 * @param autoResumptionTimeout
 	 * @throws NullPointerException if the peer address is <code>null</code>
 	 */
 	public Connection(final InetSocketAddress peerAddress, final Long autoResumptionTimeout) {
@@ -84,7 +86,8 @@ public final class Connection implements SessionListener {
 	 * 
 	 * @param peerAddress the IP address and port of the peer the connection exists with
 	 * @param ongoingHandshake the object responsible for managing the already ongoing
-	 *                   handshake with the peer 
+	 *                   handshake with the peer
+	 * @param autoResumptionTimeout
 	 * @throws NullPointerException if the peer address is <code>null</code>
 	 */
 	public Connection(final InetSocketAddress peerAddress, final Handshaker ongoingHandshake, final Long autoResumptionTimeout) {

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -142,7 +142,7 @@ public class ConnectorHelper {
 	public void cleanUpServer() {
 		serverConnectionStore.clear();
 		serverRawDataChannel.setProcessor(serverRawDataProcessor);
-		server.setErrorHandler(null);
+		server.setAlertHandler(null);
 	}
 
 	static DtlsConnectorConfig newStandardClientConfig(final InetSocketAddress bindAddress) throws IOException, GeneralSecurityException {


### PR DESCRIPTION
It looks like the original `ErrorHandler` can be put to good use at the `Connection` level in order to support cases where you want to react to ALERT messages that have been received outside the scope of a handshake or a request (for which we can use the `MessageCallback`).
