### PR TITLE
Observe benchmark

### DIFF
--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.CoapHandler;
 import org.eclipse.californium.core.CoapResponse;
+import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.MessageObserver;
 import org.eclipse.californium.core.coap.MessageObserverAdapter;
@@ -45,8 +47,13 @@ import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.eclipse.californium.core.network.config.NetworkConfigDefaultHandler;
+import org.eclipse.californium.core.observe.ObserveRelation;
+import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.californium.core.server.resources.ResourceObserver;
 import org.eclipse.californium.elements.UDPConnector;
 import org.eclipse.californium.elements.util.DaemonThreadFactory;
+import org.eclipse.californium.elements.util.NamedThreadFactory;
+import org.eclipse.californium.extplugtests.resources.Feed;
 import org.eclipse.californium.plugtests.ClientInitializer;
 import org.eclipse.californium.plugtests.ClientInitializer.Arguments;
 import org.eclipse.californium.plugtests.ClientInitializer.PlugPskStore;
@@ -71,9 +78,17 @@ public class BenchmarkClient {
 	 */
 	private static final File CONFIG_FILE = new File("CaliforniumBenchmark.properties");
 	/**
+	 * File name for observe/server network configuration.
+	 */
+	private static final File OBSERVE_CONFIG_FILE = new File("CaliforniumObserve.properties");
+	/**
 	 * Header for network configuration.
 	 */
 	private static final String CONFIG_HEADER = "Californium CoAP Properties file for Benchmark Client";
+	/**
+	 * Header for observe/server network configuration.
+	 */
+	private static final String OBSERVE_CONFIG_HEADER = "Californium CoAP Properties file for Observe-Server in Client";
 	/**
 	 * Default maximum resource size.
 	 */
@@ -83,6 +98,10 @@ public class BenchmarkClient {
 	 */
 	private static final int DEFAULT_BLOCK_SIZE = 1024;
 	/**
+	 * Default block size for observe/server.
+	 */
+	private static final int DEFAULT_OBSERVE_BLOCK_SIZE = 64;
+	/**
 	 * Default number of clients.
 	 */
 	private static final int DEFAULT_CLIENTS = 5;
@@ -90,6 +109,10 @@ public class BenchmarkClient {
 	 * Default number of requests.
 	 */
 	private static final int DEFAULT_REQUESTS = 100;
+	/**
+	 * Default number of requests.
+	 */
+	private static final int DEFAULT_NOTIFIES = 0;
 
 	/**
 	 * Special network configuration defaults handler.
@@ -114,6 +137,20 @@ public class BenchmarkClient {
 	};
 
 	/**
+	 * Special observe/server network configuration defaults handler.
+	 */
+	private static NetworkConfigDefaultHandler OBSERVE_DEFAULTS = new NetworkConfigDefaultHandler() {
+
+		@Override
+		public void applyDefaults(NetworkConfig config) {
+			DEFAULTS.applyDefaults(config);
+			config.setInt(Keys.MAX_MESSAGE_SIZE, DEFAULT_OBSERVE_BLOCK_SIZE);
+			config.setInt(Keys.PREFERRED_BLOCK_SIZE, DEFAULT_OBSERVE_BLOCK_SIZE);
+		}
+
+	};
+
+	/**
 	 * Benchmark timeout. If no messages are exchanged within this timeout, the
 	 * benchmark is stopped.
 	 */
@@ -122,6 +159,10 @@ public class BenchmarkClient {
 	 * Overall request down-counter.
 	 */
 	private static CountDownLatch overallRequestsDownCounter;
+	/**
+	 * Overall notifies down-counter.
+	 */
+	private static CountDownLatch overallNotifiesDownCounter;
 	/**
 	 * Client counter.
 	 */
@@ -145,14 +186,71 @@ public class BenchmarkClient {
 	 * Overall transmission error counter.
 	 */
 	private static final AtomicLong transmissionErrorCounter = new AtomicLong();
+
+	/**
+	 * 
+	 */
+	private static abstract class ResourceObserverAdapter implements ResourceObserver {
+
+		@Override
+		public void changedName(String old) {
+		}
+
+		@Override
+		public void changedPath(String old) {
+		}
+
+		@Override
+		public void addedChild(Resource child) {
+		}
+
+		@Override
+		public void removedChild(Resource child) {
+		}
+
+		@Override
+		public void addedObserveRelation(ObserveRelation relation) {
+			observeRegistrationCounter.incrementAndGet();
+			synchronized (observeCounter) {
+				observeCounter.incrementAndGet();
+				observeCounter.notify();
+			}
+		}
+
+		@Override
+		public void removedObserveRelation(ObserveRelation relation) {
+			synchronized (observeCounter) {
+				observeCounter.decrementAndGet();
+				observeCounter.notify();
+			}
+		}
+
+	};
+
+	/**
+	 * Observe counter.
+	 */
+	private static final AtomicInteger observeCounter = new AtomicInteger();
+	/**
+	 * Observe registration counter.
+	 */
+	private static final AtomicInteger observeRegistrationCounter = new AtomicInteger();
 	/**
 	 * Don't stop client on transmission errors.
 	 */
 	private static boolean noneStop;
+
+	private final ScheduledExecutorService executorService;
 	/**
 	 * Client to be used for benchmark.
 	 */
 	private final CoapClient client;
+	/**
+	 * Server for notifies.
+	 */
+	private final CoapServer server;
+
+	private final Feed feed;
 	/**
 	 * Endpoint to exchange messages.
 	 */
@@ -174,8 +272,26 @@ public class BenchmarkClient {
 	 * @param uri destination URI
 	 * @param endpoint local endpoint to exchange messages
 	 */
-	public BenchmarkClient(URI uri, Endpoint endpoint) {
+	public BenchmarkClient(int index, URI uri, Endpoint endpoint) {
+		int maxResourceSize = endpoint.getConfig().getInt(Keys.MAX_RESOURCE_BODY_SIZE);
+		executorService = Executors.newScheduledThreadPool(2, new NamedThreadFactory("Client-" + index + "#"));
 		client = new CoapClient(uri);
+		server = new CoapServer(endpoint.getConfig());
+		feed = new Feed(maxResourceSize, executorService, overallNotifiesDownCounter);
+		feed.addObserver(new ResourceObserverAdapter() {
+
+			@Override
+			public void removedObserveRelation(ObserveRelation relation) {
+				super.removedObserveRelation(relation);
+				if (feed.getObserverCount() == 0 && overallRequestsDownCounter.getCount() == 0
+						&& overallNotifiesDownCounter.getCount() == 0) {
+					stop();
+				}
+			}
+		});
+		server.add(feed);
+		server.setExecutor(executorService);
+		endpoint.setExecutor(executorService);
 		this.endpoint = endpoint;
 	}
 
@@ -185,6 +301,8 @@ public class BenchmarkClient {
 	 */
 	public void start() {
 		client.setEndpoint(endpoint);
+		server.addEndpoint(endpoint);
+		server.start();
 	}
 
 	/**
@@ -255,7 +373,7 @@ public class BenchmarkClient {
 					post.setURI(client.getURI());
 					post.addMessageObserver(retransmissionDetector);
 					client.advanced(this, post);
-				} else {
+				} else if (feed.getObserverCount() == 0) {
 					stop();
 				}
 			}
@@ -273,7 +391,10 @@ public class BenchmarkClient {
 		if (stop.compareAndSet(false, true)) {
 			clientCounter.decrementAndGet();
 			endpoint.stop();
+			server.stop();
 			client.shutdown();
+			executorService.shutdownNow();
+			server.destroy();
 			endpoint.destroy();
 		}
 		return requestsCounter.get();
@@ -286,27 +407,47 @@ public class BenchmarkClient {
 			System.out.println("\nCalifornium (Cf) Benchmark Client");
 			System.out.println("(c) 2018, Bosch Software Innovations GmbH and others");
 			System.out.println();
-			System.out.println("Usage: " + BenchmarkClient.class.getSimpleName() + " URI [#clients] [#requests] [nonestop]");
+			System.out.println("Usage: " + BenchmarkClient.class.getSimpleName()
+					+ " URI [#clients [#requests [nonestop [#notifies]]]]");
 			System.out.println("  URI       : The CoAP URI of the extended Plugtest server to test");
-			System.out.println("              (coap://<host>[:<port>]/benchmark  or coaps://<host>[:<port>]/benchmark)");
+			System.out
+					.println("              (coap://<host>[:<port>]/benchmark  or coaps://<host>[:<port>]/benchmark)");
 			System.out.println("  #clients  : number of clients. Default " + DEFAULT_CLIENTS + ".");
 			System.out.println("  #requests : number of requests per clients. Default " + DEFAULT_REQUESTS + ".");
-			System.out.println("  nonestop  : don't stop client if request fails (timeout)");
+			System.out.println("  nonestop  : don't stop client, if request fails (timeout).");
+			System.out.println("  #notifies : number of notifies per clients. Default " + DEFAULT_NOTIFIES + ".");
+			System.out.println("              Requires reverse observes!");
 			System.out.println();
-			System.out.println("Example: " + BenchmarkClient.class.getSimpleName() + " coap://localhost:5783/benchmark");
-			System.out.println("Note: californium.eclipse.org doesn't support a benchmark and will response with 5.01, NOT_IMPLEMENTED!");
+			System.out.println("Examples:");
+			System.out.println("  " + BenchmarkClient.class.getSimpleName()
+					+ " coap://localhost:5783/benchmark&rlen=200 500 2000");
+			System.out.println(
+					"  (Benchmark 500 clients each sending about 2000 request and the response should have 200 bytes payload.)");
+			System.out.println();
+			System.out.println("  " + BenchmarkClient.class.getSimpleName()
+					+ " coap://localhost:5783/reverse-observe?obs=25&res=feed&rlen=400 50 2 x 500");
+			System.out.println(
+					"  (Reverse-observe benchmark using 50 clients each sending about 2 request and waiting for about 500 notifies each client.");
+			System.out.println("   The notifies have 400 bytes payload and use a blocksize of 64 bytes, defined in"
+					+ OBSERVE_CONFIG_FILE + ")");
+			System.out.println();
+			System.out.println(
+					"Note: californium.eclipse.org doesn't support a benchmark and will response with 5.01, NOT_IMPLEMENTED!");
 			System.exit(-1);
 		}
 
 		NetworkConfig config = NetworkConfig.createWithFile(CONFIG_FILE, CONFIG_HEADER, DEFAULTS);
+		NetworkConfig serverConfig = NetworkConfig.createWithFile(OBSERVE_CONFIG_FILE, OBSERVE_CONFIG_HEADER,
+				OBSERVE_DEFAULTS);
 		Arguments arguments = ClientInitializer.init(config, args);
 		// random part of PSK identity
 		SecureRandom random = new SecureRandom();
 		byte[] id = new byte[8];
 
 		URI uri = null;
-		int clients = 5;
-		int requests = 100;
+		int clients = DEFAULT_CLIENTS;
+		int requests = DEFAULT_REQUESTS;
+		int notifies = DEFAULT_NOTIFIES;
 
 		if (0 < arguments.args.length) {
 			clients = Integer.parseInt(arguments.args[0]);
@@ -314,6 +455,10 @@ public class BenchmarkClient {
 				requests = Integer.parseInt(arguments.args[1]);
 				if (2 < arguments.args.length) {
 					noneStop = arguments.args[2].equalsIgnoreCase("nonestop");
+					if (3 < arguments.args.length) {
+						notifies = Integer.parseInt(arguments.args[3]);
+						config = serverConfig;
+					}
 				}
 			}
 		}
@@ -326,7 +471,10 @@ public class BenchmarkClient {
 		}
 
 		int overallRequests = (requests * clients);
+		int overallNotifies = (notifies * clients);
 		overallRequestsDownCounter = new CountDownLatch(overallRequests);
+		overallNotifiesDownCounter = new CountDownLatch(overallNotifies);
+
 		List<BenchmarkClient> clientList = new ArrayList<>(clients);
 		ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors(),
 				new DaemonThreadFactory("Aux#"));
@@ -353,7 +501,7 @@ public class BenchmarkClient {
 				dtlsBuilder.setMaxConnections(10);
 				endpointBuilder.setConnector(new DTLSConnector(dtlsBuilder.build()));
 			}
-			final BenchmarkClient client = new BenchmarkClient(uri, endpointBuilder.build());
+			final BenchmarkClient client = new BenchmarkClient(index, uri, endpointBuilder.build());
 			clientList.add(client);
 			if (index == 0) {
 				// first client, so test request
@@ -379,7 +527,8 @@ public class BenchmarkClient {
 
 		// Start Test
 		boolean stale = false;
-		long nanos = System.nanoTime();
+		long requestNanos = System.nanoTime();
+		long notifyNanos = requestNanos;
 		long lastRequestsCountDown = overallRequestsDownCounter.getCount();
 		long lastRetransmissions = retransmissionCounter.get();
 		long lastTransmissionErrrors = transmissionErrorCounter.get();
@@ -398,7 +547,7 @@ public class BenchmarkClient {
 					|| (numberOfClients == 0)) {
 				// no new requests, clients are stale, or no clients left
 				// adjust start time with timeout
-				nanos += DEFAULT_TIMEOUT_NANOS;
+				requestNanos += DEFAULT_TIMEOUT_NANOS;
 				stale = true;
 				break;
 			}
@@ -417,7 +566,30 @@ public class BenchmarkClient {
 					formatTransmissionErrors(transmissionErrorsDifference, requestDifference), numberOfClients);
 		}
 		long overallSentRequests = overallRequests - overallRequestsDownCounter.getCount();
-		nanos = System.nanoTime() - nanos;
+		requestNanos = System.nanoTime() - requestNanos;
+
+		long lastNotifiesCountDown = overallNotifiesDownCounter.getCount();
+
+		while (!overallNotifiesDownCounter.await(DEFAULT_TIMEOUT_NANOS, TimeUnit.NANOSECONDS)) {
+			long currentNotifiesCountDown = overallNotifiesDownCounter.getCount();
+			int numberOfClients = clientCounter.get();
+			int observers = observeCounter.get();
+			if ((lastNotifiesCountDown == currentNotifiesCountDown && currentNotifiesCountDown < overallNotifies)
+					|| (numberOfClients == 0) || (observers == 0)) {
+				// no new notifies, clients are stale, or no clients left
+				// adjust start time with timeout
+				notifyNanos += DEFAULT_TIMEOUT_NANOS;
+				stale = true;
+				break;
+			}
+			long notifiesDifference = (lastNotifiesCountDown - currentNotifiesCountDown);
+			long currentOverallNotifies = overallNotifies - currentNotifiesCountDown;
+			lastNotifiesCountDown = currentNotifiesCountDown;
+			System.out.format("%d notifies (%d notifies/s, %d clients)%n", currentOverallNotifies,
+					notifiesDifference / TimeUnit.NANOSECONDS.toSeconds(DEFAULT_TIMEOUT_NANOS), numberOfClients);
+		}
+		long overallSentNotifies = overallNotifies - overallNotifiesDownCounter.getCount();
+		notifyNanos = System.nanoTime() - notifyNanos;
 
 		System.out.format("Benchmark clients %s.%n", stale ? "stopped" : "finished");
 
@@ -429,8 +601,12 @@ public class BenchmarkClient {
 		}
 
 		System.out.format("%d requests sent, %d expected%n", overallSentRequests, overallRequests);
-		System.out.format("%d requests in %dms%s%n", overallSentRequests, TimeUnit.NANOSECONDS.toMillis(nanos),
-				formatRequestsPerSecond(overallSentRequests, nanos));
+		System.out.format("%d requests in %dms%s%n", overallSentRequests, TimeUnit.NANOSECONDS.toMillis(requestNanos),
+				formatPerSecond("reqs", overallSentRequests, requestNanos));
+		System.out.format("%d notifies sent, %d expected, %d observe requests%n", overallSentNotifies, overallNotifies,
+				observeRegistrationCounter.get());
+		System.out.format("%d notifies in %dms%s%n", overallSentNotifies, TimeUnit.NANOSECONDS.toMillis(notifyNanos),
+				formatPerSecond("notifies", overallSentNotifies, notifyNanos));
 		long retransmissions = retransmissionCounter.get();
 		if (retransmissions > 0) {
 			System.out.println(formatRetransmissions(retransmissions, overallSentRequests));
@@ -485,11 +661,11 @@ public class BenchmarkClient {
 		}
 	}
 
-	private static String formatRequestsPerSecond(long requests, long nanos) {
+	private static String formatPerSecond(String units, long requests, long nanos) {
 		long millis = TimeUnit.NANOSECONDS.toMillis(nanos);
 		if (millis > 0) {
 			try (Formatter formatter = new Formatter()) {
-				return formatter.format(", %d reqs/s", (requests * 1000) / millis).toString();
+				return formatter.format(", %d %s/s", (requests * 1000) / millis, units).toString();
 			}
 		}
 		return "";

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseObserve.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseObserve.java
@@ -1,0 +1,348 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.extplugtests.resources;
+
+import static org.eclipse.californium.core.coap.CoAP.ResponseCode.BAD_OPTION;
+import static org.eclipse.californium.core.coap.CoAP.ResponseCode.CONTENT;
+import static org.eclipse.californium.core.coap.CoAP.ResponseCode.NOT_ACCEPTABLE;
+import static org.eclipse.californium.core.coap.CoAP.ResponseCode.INTERNAL_SERVER_ERROR;
+import static org.eclipse.californium.core.coap.CoAP.ResponseCode.SERVICE_UNAVAILABLE;
+import static org.eclipse.californium.core.coap.MediaTypeRegistry.APPLICATION_OCTET_STREAM;
+import static org.eclipse.californium.core.coap.MediaTypeRegistry.TEXT_PLAIN;
+import static org.eclipse.californium.core.coap.MediaTypeRegistry.UNDEFINED;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.Token;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.observe.NotificationListener;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reverse observer resource.
+ * 
+ * POST request send to this resource triggers a reverse observation; a GET
+ * observe request is sent back to the original peer of the POST request.
+ * 
+ * Supported URI query parameter:
+ * 
+ * <dl>
+ * <dt>obs=number</dt>
+ * <dd>number of observes before the observation is reregistered.</dd>
+ * <dt>res=path</dt>
+ * <dd>path of resource to observe.</dd>
+ * </dl>
+ * 
+ * Additional query parameter will be send with the observer request.
+ * 
+ * Example:
+ * 
+ * <pre>
+ * coap://localhost:5783/reverse-observe?obs=25&res=feed&rlen=400
+ * </pre>
+ * 
+ * Will request an observation from the origin peer using
+ * 
+ * <pre>
+ * coap://localhost:???/feed?rlen=400
+ * </pre>
+ * 
+ */
+public class ReverseObserve extends CoapResource implements NotificationListener {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ReverseObserve.class.getCanonicalName());
+
+	private static final String RESOURCE_NAME = "reverse-observe";
+	/**
+	 * URI query parameter to specify reverse observation.
+	 */
+	private static final String URI_QUERY_OPTION_OBSERVE = "obs";
+	/**
+	 * URI query parameter to specify reverse observation.
+	 */
+	private static final String URI_QUERY_OPTION_RESOURCE = "res";
+	/**
+	 * Maximum number of notifies before reregister is triggered.
+	 */
+	private static final int MAX_NOTIFIES = 1000;
+
+	/**
+	 * Observation tokens by peer address.
+	 */
+	private ConcurrentMap<String, Token> observesByPeer = new ConcurrentHashMap<String, Token>();
+	/**
+	 * Observations by token.
+	 */
+	private ConcurrentMap<Token, Observation> observesByToken = new ConcurrentHashMap<Token, Observation>();
+	/**
+	 * Overall received notifications.
+	 */
+	private AtomicLong overallNotifies = new AtomicLong();
+	/**
+	 * Scheduler for notification timeout.
+	 */
+	private ScheduledExecutorService executor;
+
+	/**
+	 * Create reverse observation resource.
+	 * 
+	 * @param config network configuration to read HEALTH_STATUS_INTERVAL.
+	 * @param executor executor for notification timeout.
+	 */
+	public ReverseObserve(NetworkConfig config, ScheduledExecutorService executor) {
+		super(RESOURCE_NAME);
+		this.executor = executor;
+		getAttributes().setTitle("Reverse Observe");
+		getAttributes().addContentType(TEXT_PLAIN);
+		getAttributes().addContentType(APPLICATION_OCTET_STREAM);
+		if (LOGGER.isInfoEnabled()) {
+			int healthStatusInterval = config.getInt(NetworkConfig.Keys.HEALTH_STATUS_INTERVAL, 60); // seconds
+			executor.scheduleWithFixedDelay(new Runnable() {
+
+				@Override
+				public void run() {
+					if (overallNotifies.get() > 0) {
+						LOGGER.info("{} observes, {} by peers", observesByToken.size(), observesByPeer.size());
+						LOGGER.info("{} notifies overalls", overallNotifies.get());
+					}
+				}
+			}, healthStatusInterval, healthStatusInterval, TimeUnit.SECONDS);
+		}
+	}
+
+	/**
+	 * Get lookup key based on scheme and peer.
+	 * 
+	 * @param exchange exchange of request.
+	 * @return key
+	 */
+	private static String getPeerKey(CoapExchange exchange) {
+		Request request = exchange.advanced().getRequest();
+		return request.getScheme() + "://" + request.getSourceContext().getPeerAddress();
+	}
+
+	@Override
+	public void handlePOST(CoapExchange exchange) {
+
+		// get request to read out details
+		Request request = exchange.advanced().getRequest();
+
+		int accept = request.getOptions().getAccept();
+		if (accept != UNDEFINED && accept != APPLICATION_OCTET_STREAM) {
+			exchange.respond(NOT_ACCEPTABLE);
+			return;
+		}
+
+		List<String> observeUriQuery = new ArrayList<>();
+		List<String> uriQuery = request.getOptions().getUriQuery();
+		Integer observe = null;
+		String resource = null;
+		for (String query : uriQuery) {
+			if (query.startsWith(URI_QUERY_OPTION_OBSERVE + "=")) {
+				String message = null;
+				String obs = query.substring(URI_QUERY_OPTION_OBSERVE.length() + 1);
+				try {
+					observe = Integer.parseInt(obs);
+					if (observe < 0) {
+						message = "URI-query-option " + query + " is negative number!";
+					} else if (observe > MAX_NOTIFIES) {
+						message = "URI-query-option " + query + " is too large (max. " + MAX_NOTIFIES + ")!";
+					}
+				} catch (NumberFormatException ex) {
+					message = "URI-query-option " + query + " is no number!";
+				}
+				if (message != null) {
+					Response response = Response.createResponse(request, BAD_OPTION);
+					response.setPayload(message);
+					exchange.respond(response);
+					return;
+				}
+			} else if (query.startsWith(URI_QUERY_OPTION_RESOURCE + "=")) {
+				resource = query.substring(URI_QUERY_OPTION_RESOURCE.length() + 1);
+			} else {
+				observeUriQuery.add(query);
+			}
+		}
+
+		if (observe != null && resource != null) {
+			Endpoint endpoint = exchange.advanced().getEndpoint();
+			String key = getPeerKey(exchange);
+			Token token = observesByPeer.putIfAbsent(key, Token.EMPTY);
+			if (token != null && token.equals(Token.EMPTY)) {
+				LOGGER.info("Too many requests from {}", key);
+				exchange.respond(SERVICE_UNAVAILABLE);
+			}
+			else {
+				if (observe > 0) {
+					Request observeRequest = Request.newGet();
+					if (token != null) {
+						observeRequest.setToken(token);
+					}
+					observeRequest.getOptions().setUriPath(resource);
+					observeRequest.getOptions().setObserve(0);
+					for (String query : observeUriQuery) {
+						observeRequest.getOptions().addUriQuery(query);
+					}
+					observeRequest.setDestinationContext(request.getSourceContext());
+					observeRequest.addMessageObserver(new ObserveRequestObserver(exchange, observeRequest, observe));
+					observeRequest.send(endpoint);
+				} else if (token != null) {
+					LOGGER.info("Requested cancel observation {}", token);
+					endpoint.cancelObservation(token);
+				}
+			}
+		} else {
+			exchange.respond(CONTENT,
+					observesByPeer.size() + " active observes, " + overallNotifies.get() + " notifies.", TEXT_PLAIN);
+		}
+	}
+
+	@Override
+	public void onNotification(Request request, Response response) {
+		overallNotifies.incrementAndGet();
+		Observation observation = observesByToken.get(response.getToken());
+		if (observation != null) {
+			observation.onNotification();
+		}
+	}
+
+	private class ObserveRequestObserver extends MessageObserverAdapter {
+
+		private CoapExchange incomingExchange;
+		private Request outgoingObserveRequest;
+		private AtomicBoolean registered = new AtomicBoolean();
+		private int count;
+
+		public ObserveRequestObserver(CoapExchange incomingExchange, Request outgoingObserveRequest, int count) {
+			this.incomingExchange = incomingExchange;
+			this.outgoingObserveRequest = outgoingObserveRequest;
+			this.count = count;
+		}
+
+		@Override
+		public void onResponse(final Response response) {
+			if (response.isError()) {
+				LOGGER.info("Observation response error: {}", response.getCode());
+				remove(response.getCode());
+			} else if (response.isNotification()) {
+				if (registered.compareAndSet(false, true)) {
+					String key = getPeerKey(incomingExchange);
+					Endpoint endpoint = incomingExchange.advanced().getEndpoint();
+					Token token = outgoingObserveRequest.getToken();
+					Token previous = observesByPeer.put(key, token);
+					if (previous != null && !previous.equals(Token.EMPTY) && !token.equals(previous)) {
+						LOGGER.info("Cancel previous observation {}", token);
+						endpoint.cancelObservation(previous);
+					}
+					observesByToken.put(token, new Observation(incomingExchange, token, count));
+					if (!incomingExchange.advanced().isComplete()) {
+						incomingExchange.respond(CONTENT, token.getBytes(), APPLICATION_OCTET_STREAM);
+					}
+				}
+			} else {
+				LOGGER.info("Observation {} not established!", outgoingObserveRequest.getToken());
+				remove(NOT_ACCEPTABLE);
+			}
+		}
+
+		@Override
+		protected void failed() {
+			LOGGER.info("Observe request failed! {}", outgoingObserveRequest.getToken());
+			remove(INTERNAL_SERVER_ERROR);
+		}
+
+		public void remove(ResponseCode code) {
+			String key = getPeerKey(incomingExchange);
+			observesByPeer.remove(key);
+			LOGGER.info("Removed observation for {}", key);
+			if (!incomingExchange.advanced().isComplete()) {
+				incomingExchange.respond(code);
+			}
+		}
+	}
+
+	private class Observation {
+
+		private final CoapExchange incomingExchange;
+		private final Token token;
+		private final AtomicInteger countDown;
+		private final AtomicReference<Future<?>> timeout = new AtomicReference<Future<?>>();
+
+		public Observation(CoapExchange incomingExchange, Token token, int count) {
+			this.incomingExchange = incomingExchange;
+			this.token = token;
+			this.countDown = new AtomicInteger(count);
+			scheduleTimeout();
+		}
+
+		public void setTimeout(ScheduledFuture<?> future) {
+			Future<?> previous = timeout.getAndSet(future);
+			if (previous != null) {
+				previous.cancel(false);
+			}
+		}
+
+		public void scheduleTimeout() {
+			ScheduledFuture<?> future = executor.schedule(new Runnable() {
+
+				@Override
+				public void run() {
+					reregister();
+				}
+			}, 30, TimeUnit.SECONDS);
+			setTimeout(future);
+		}
+
+		public void onNotification() {
+			if (countDown.decrementAndGet() == 0) {
+				setTimeout(null);
+				reregister();
+			} else {
+				scheduleTimeout();
+			}
+		}
+
+		public void reregister() {
+			String key = getPeerKey(incomingExchange);
+			LOGGER.info("Cancel observation {} for {}", token, key);
+			incomingExchange.advanced().getEndpoint().cancelObservation(token);
+			observesByPeer.remove(key);
+			observesByToken.remove(token, this);
+			LOGGER.info("Restart observation for {}", key);
+			handlePOST(incomingExchange);
+		}
+	}
+
+}

--- a/demo-apps/cf-extplugtest-server/src/main/resources/logback.xml
+++ b/demo-apps/cf-extplugtest-server/src/main/resources/logback.xml
@@ -8,7 +8,7 @@
 		</encoder>
 	</appender>
 
-	<appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+	<appender name="ORIGINFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
 		<file>logs/origin.log</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
 			<!-- rollover monthly, or if filesize exceeds -->
@@ -25,13 +25,47 @@
 		</encoder>
 	</appender>
 
+	<appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<file>logs/messages.log</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<!-- rollover monthly, or if filesize exceeds -->
+			<fileNamePattern>logs/messages-%d{yyyy-MM}.%i.log</fileNamePattern>
+			<!-- each file should be at most 10MB, keep 200 files worth of history, but at most 2GB -->
+			<maxFileSize>10MB</maxFileSize>
+			<maxHistory>200</maxHistory>
+			<totalSizeCap>2GB</totalSizeCap>
+		</rollingPolicy>
+
+		<encoder>
+			<!-- use tab to separate timestamp from message -->
+			<pattern>%d{mm:ss.SSS} %level [%logger{0}]: %msg%n</pattern>
+		</encoder>
+	</appender>
+
 	<!-- ORIGIN only to file -->
 	<logger name="org.eclipse.californium.core.network.interceptors.OriginTracer" level="TRACE" additivity="false">
+		<appender-ref ref="ORIGINFILE" />
+	</logger>
+	
+	<logger name="org.eclipse.californium.core.network.interceptors.MessageTracer" level="INFO" additivity="false">
+		<appender-ref ref="STDOUT" />
 		<appender-ref ref="FILE" />
 	</logger>
-
-	<logger name="org.eclipse.californium.core.network.deduplication.SweepDeduplicator" level="DEBUG" additivity="false">
+	<logger name="org.eclipse.californium.core.network.InMemoryMessageExchangeStore" level="TRACE" additivity="false">
 		<appender-ref ref="STDOUT" />
+		<appender-ref ref="FILE" />
+	</logger>
+	<logger name="org.eclipse.californium.core.network.stack.BlockwiseLayer" level="INFO" additivity="false">
+		<appender-ref ref="STDOUT" />
+		<appender-ref ref="FILE" />
+	</logger>
+	<logger name="org.eclipse.californium.core.observe.InMemoryObservationStore" level="DEBUG" additivity="false">
+		<appender-ref ref="STDOUT" />
+		<appender-ref ref="FILE" />
+	</logger>
+	<logger name="org.eclipse.californium.extplugtests.resources.ReverseObserve" level="INFO" additivity="false">
+		<appender-ref ref="STDOUT" />
+		<appender-ref ref="FILE" />
 	</logger>
 
 	<!-- Strictly speaking, the level attribute is not necessary since -->

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
@@ -77,6 +77,7 @@ public abstract class AbstractTestServer extends CoapServer {
 		int maxPeers = config.getInt(Keys.MAX_ACTIVE_PEERS);
 		int sessionTimeout = config.getInt(Keys.SECURE_SESSION_TIMEOUT);
 		int staleTimeout = config.getInt(Keys.MAX_PEER_INACTIVITY_PERIOD);
+		int dtlsThreads = config.getInt(Keys.NETWORK_STAGE_SENDER_THREAD_COUNT);
 		
 		SslContextUtil.Credentials serverCredentials = null;
 		Certificate[] trustedCertificates = null;
@@ -135,6 +136,7 @@ public abstract class AbstractTestServer extends CoapServer {
 					dtlsConfig.setTrustStore(trustedCertificates);
 					dtlsConfig.setMaxConnections(maxPeers);
 					dtlsConfig.setStaleConnectionThreshold(staleTimeout);
+					dtlsConfig.setConnectionThreadCount(dtlsThreads);
 					DTLSConnector connector = new DTLSConnector(dtlsConfig.build());
 					CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
 					builder.setConnector(connector);


### PR DESCRIPTION
Add test for reverse observe. 
ExtendedTestServer is extended with the ReverseObserve resource, which registers a observation on the multiple client of the BenchmarkTest.
The leak in the message exchange store seems to be related to race conditions. Without additionally logging it seems not to appear. Using

> coap://localhost:5783/reverse-observe?obs=25&res=feed&rlen=400 50 3 x 500

result (on my machine) in:

> 09:54:49.027 INFO [ReverseObserve]: 0 observes, 0 by peers
> 09:54:49.028 INFO [ReverseObserve]: 15063 notifies overalls
> 09:54:49.388 TRACE [InMemoryMessageExchangeStore]: MessageExchangeStore contents: 8 exchanges by MID, 8 exchanges by token, 
> 09:54:49.404 TRACE [InMemoryMessageExchangeStore]: MessageExchangeStore contents: 0 exchanges by MID, 0 exchanges by token, 
> 09:54:49.669 TRACE [InMemoryMessageExchangeStore]: MessageExchangeStore contents: 0 exchanges by MID, 0 exchanges by token, 
> 09:54:49.732 TRACE [InMemoryMessageExchangeStore]: MessageExchangeStore contents: 0 exchanges by MID, 0 exchanges by token, 

The one with the 8 exchanges is the used one, the other stores are from unused endpoints.
(I will create a additional PR improve the logging, which makes it easier to see, what happens :-).

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>
