### PR TITLE
Enable status logging triggered by first put.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -363,7 +363,7 @@ public class CoapEndpoint implements Endpoint {
 		}
 		MessageExchangeStore localExchangeStore = (null != exchangeStore) ? exchangeStore
 				: new InMemoryMessageExchangeStore(config, tokenGenerator);
-		ObservationStore observationStore = (null != store) ? store : new InMemoryObservationStore();
+		ObservationStore observationStore = (null != store) ? store : new InMemoryObservationStore(config);
 		if (null == endpointContextMatcher) {
 			endpointContextMatcher = EndpointContextMatcherFactory.create(connector, config);
 		}
@@ -1288,7 +1288,7 @@ public class CoapEndpoint implements Endpoint {
 				tokenGenerator = new RandomTokenGenerator(config);
 			}
 			if (observationStore == null) {
-				observationStore = new InMemoryObservationStore();
+				observationStore = new InMemoryObservationStore(config);
 			}
 			if (exchangeStore == null) {
 				exchangeStore = new InMemoryMessageExchangeStore(config, tokenGenerator);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
@@ -201,7 +201,7 @@ public class NetworkConfigDefaults {
 		config.setInt(Keys.HTTP_CACHE_RESPONSE_MAX_AGE, 86400);
 		config.setInt(Keys.HTTP_CACHE_SIZE, 32);
 
-		config.setInt(Keys.HEALTH_STATUS_INTERVAL, 60); // s
+		config.setInt(Keys.HEALTH_STATUS_INTERVAL, 60); // s, 0 for disable
 
 		config.setInt(Keys.TCP_CONNECTION_IDLE_TIMEOUT, DEFAULT_TCP_CONNECTION_IDLE_TIMEOUT); // s
 		config.setInt(Keys.TCP_WORKER_THREADS, 1);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTestUtils.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTestUtils.java
@@ -54,7 +54,7 @@ public final class MatcherTestUtils {
 	static TcpMatcher newTcpMatcher(EndpointContextMatcher correlationContextMatcher) {
 		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
 		TcpMatcher matcher = new TcpMatcher(config, notificationListener, new RandomTokenGenerator(config),
-				new InMemoryObservationStore(), new InMemoryMessageExchangeStore(config), correlationContextMatcher);
+				new InMemoryObservationStore(config), new InMemoryMessageExchangeStore(config), correlationContextMatcher);
 		matcher.start();
 		return matcher;
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -65,7 +65,7 @@ public class UdpMatcherTest {
 		NetworkConfig config = NetworkConfig.createStandardWithoutFile();
 		tokenProvider = new RandomTokenGenerator(config);
 		messageExchangeStore = new InMemoryMessageExchangeStore(config, tokenProvider);
-		observationStore =  new InMemoryObservationStore();
+		observationStore =  new InMemoryObservationStore(config);
 		exchangeEndpointContext = mock(EndpointContext.class);
 		responseEndpointContext = mock(EndpointContext.class);
 		endpointContextMatcher = mock(EndpointContextMatcher.class);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
@@ -63,10 +63,10 @@ import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.InMemoryMessageExchangeStore;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
 import org.eclipse.californium.core.server.resources.CoapExchange;
-import org.eclipse.californium.core.test.MessageExchangeStoreTool.TestMessageExchangeStore;
 import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -113,8 +113,8 @@ public class MemoryLeakingHashMapTest {
 	// The server endpoint that we test
 	private static CoapEndpoint serverEndpoint;
 	private static CoapEndpoint clientEndpoint;
-	private static TestMessageExchangeStore clientExchangeStore;
-	private static TestMessageExchangeStore serverExchangeStore;
+	private static InMemoryMessageExchangeStore clientExchangeStore;
+	private static InMemoryMessageExchangeStore serverExchangeStore;
 
 	private static volatile String currentRequestText;
 	private static TestResource resource;
@@ -374,7 +374,7 @@ public class MemoryLeakingHashMapTest {
 			.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, TEST_BLOCK_SIZE);
 
 		// Create the endpoint for the server and create surveillant
-		serverExchangeStore = new TestMessageExchangeStore(config);	
+		serverExchangeStore = new InMemoryMessageExchangeStore(config);	
 		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		builder.setNetworkConfig(config);
@@ -382,7 +382,7 @@ public class MemoryLeakingHashMapTest {
 		serverEndpoint = builder.build();
 		serverEndpoint.addInterceptor(new MessageTracer());
 
-		clientExchangeStore = new TestMessageExchangeStore(config);
+		clientExchangeStore = new InMemoryMessageExchangeStore(config);
 		builder = new CoapEndpoint.CoapEndpointBuilder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		builder.setNetworkConfig(config);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
@@ -84,7 +84,7 @@ public class ClusteringTest {
 				.setFloat(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1f)
 				.setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f);
 
-		store = new InMemoryObservationStore();
+		store = new InMemoryObservationStore(config);
 
 		notificationListener1 = new SynchronousNotificationListener();
 		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseObserve.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseObserve.java
@@ -127,8 +127,8 @@ public class ReverseObserve extends CoapResource implements NotificationListener
 		getAttributes().setTitle("Reverse Observe");
 		getAttributes().addContentType(TEXT_PLAIN);
 		getAttributes().addContentType(APPLICATION_OCTET_STREAM);
-		if (LOGGER.isInfoEnabled()) {
-			int healthStatusInterval = config.getInt(NetworkConfig.Keys.HEALTH_STATUS_INTERVAL, 60); // seconds
+		int healthStatusInterval = config.getInt(NetworkConfig.Keys.HEALTH_STATUS_INTERVAL, 60); // seconds
+		if (healthStatusInterval > 0 && LOGGER.isInfoEnabled()) {
 			executor.scheduleWithFixedDelay(new Runnable() {
 
 				@Override


### PR DESCRIPTION
Add logging for put exchanges and exchange dumps for status.

Together with PR #539 it shows (on my machine) the leaks in the message exchange store.

> 10:21:11.532 INFO [InMemoryMessageExchangeStore]: MessageExchangeStore contents: 13 exchanges by MID, 54 exchanges by token, 0 MIDs, 
> 10:21:11.532 INFO [InMemoryMessageExchangeStore]:   KeyMID[52028, [7f000001]:50599], complete true, retransmission 0, + CON-GET    MID=51913, Token=[8f269d7bfbda3946], OptionSet={"Observe":0, "Uri-Path":"feed", "Uri-Query":"rlen=400"}, no payload, null
> ...
> 10:21:11.532 INFO [InMemoryMessageExchangeStore]:   Token=[7084e27ba473dfb9], complete true, retransmission 0, org Token=[2138d80b39e0571b], CON-GET    MID=31064, Token=[f44c5c812c6b1cb4], OptionSet={"Uri-Path":"feed", "Uri-Query":"rlen=400", "Block2":"(szx=2/64, m=false, num=4)"}, no payload, null
> 

So it shows, that exchange doesn't contain anymore the KeyMID or Token.
 
Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>