### PR TITLE
Redesign message exchange

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
@@ -775,6 +775,13 @@ public abstract class Message {
 		}
 	}
 
+	public void onComplete() {
+		LOGGER.trace("Message completed {}", this);
+		for (MessageObserver handler : getMessageObservers()) {
+			handler.onComplete();
+		}
+	}
+
 	/**
 	 * Checks if this message is a duplicate.
 	 *

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
@@ -35,6 +35,9 @@
  *                                                    EndpointContext
  *    Bosch Software Innovations GmbH - migrate to SLF4J
  *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
+ *    Achim Kraus (Bosch Software Innovations GmbH) - move onContextEstablished
+ *                                                    to MessageObserver.
+ *                                                    Issue #487
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
@@ -750,6 +753,24 @@ public abstract class Message {
 		if (sendError != null) {
 			for (MessageObserver handler : getMessageObservers()) {
 				handler.onSendError(sendError);
+			}
+		}
+	}
+
+	/**
+	 * Report resulting endpoint context.
+	 * 
+	 * The {@link #destinationContext} may not contain all information, but the
+	 * connector will fill these information and report it. This method doesn't
+	 * change the {@link #destinationContext} but calls
+	 * {@link MessageObserver#onContextEstablished(EndpointContext)}.
+	 * 
+	 * @param endpointContext resulting endpoint context.
+	 */
+	public void onContextEstablished(EndpointContext endpointContext) {
+		if (endpointContext != null) {
+			for (MessageObserver handler : getMessageObservers()) {
+				handler.onContextEstablished(endpointContext);
 			}
 		}
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserver.java
@@ -22,9 +22,13 @@
  *                                                    race condition in block1wise
  *                                                    when the generated token was 
  *                                                    copied too late (after sending). 
+ *    Achim Kraus (Bosch Software Innovations GmbH) - move onContextEstablished
+ *                                                    to MessageObserver.
+ *                                                    Issue #487
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
+import org.eclipse.californium.elements.EndpointContext;
 
 /**
  * A callback that gets invoked on a message's life cycle events.
@@ -38,7 +42,8 @@ package org.eclipse.californium.core.coap;
  * still has not received anything from the remote endpoint</li>
  * <li>{@link #onCancel()} when the message has been canceled</li>
  * <li>{@link #onReadyToSend()} right before the message is being sent</li>
- * <li>{@link #onSent()} right after the message has been sent (successfully)</li>
+ * <li>{@link #onSent()} right after the message has been sent
+ * (successfully)</li>
  * <li>{@link #onSendError(Throwable)} if the message cannot be sent</li>
  * </ul>
  * <p>
@@ -91,16 +96,16 @@ public interface MessageObserver {
 	/**
 	 * Invoked when the message has been canceled.
 	 * <p>
-	 * For instance, a user might cancel a request or a CoAP resource that is being
-	 * observed might cancel a response to send another one instead.
+	 * For instance, a user might cancel a request or a CoAP resource that is
+	 * being observed might cancel a response to send another one instead.
 	 */
 	void onCancel();
 
 	/**
 	 * Invoked when the message was built and is ready to be sent.
 	 * <p>
-	 * Triggered, before the message was sent by a connector.
-	 * MID and token is prepared.
+	 * Triggered, before the message was sent by a connector. MID and token is
+	 * prepared.
 	 */
 	void onReadyToSend();
 
@@ -114,9 +119,22 @@ public interface MessageObserver {
 	/**
 	 * Invoked when sending the message caused an error.
 	 * <p>
-	 * For instance, if the message is not sent, because the endpoint context has changed.
+	 * For instance, if the message is not sent, because the endpoint context
+	 * has changed.
 	 * 
 	 * @param error The cause of the failure to send the message.
 	 */
 	void onSendError(Throwable error);
+
+	/**
+	 * Invoked when the resulting endpoint context is reported by the connector.
+	 * 
+	 * Note: usually this callback must be processed in a synchronous manner,
+	 * because if it returns, the message is sent. Therefore take special care
+	 * in methods called on this callback.
+	 * 
+	 * @param endpointContext resulting endpoint context
+	 */
+	void onContextEstablished(EndpointContext endpointContext);
+
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserver.java
@@ -136,5 +136,6 @@ public interface MessageObserver {
 	 * @param endpointContext resulting endpoint context
 	 */
 	void onContextEstablished(EndpointContext endpointContext);
-
+	
+	void onComplete();
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserverAdapter.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserverAdapter.java
@@ -24,8 +24,13 @@
  *                                                    race condition in block1wise
  *                                                    when the generated token was 
  *                                                    copied too late (after sending). 
+ *    Achim Kraus (Bosch Software Innovations GmbH) - move onContextEstablished
+ *                                                    to MessageObserver.
+ *                                                    Issue #487
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
+
+import org.eclipse.californium.elements.EndpointContext;
 
 /**
  * An abstract adapter class for reacting to a message's lifecylce events.
@@ -86,6 +91,11 @@ public abstract class MessageObserverAdapter implements MessageObserver {
 	@Override
 	public void onSendError(Throwable error) {
 		failed();
+	}
+
+	@Override
+	public void onContextEstablished(EndpointContext endpointContext) {
+		// empty default implementation
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserverAdapter.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserverAdapter.java
@@ -98,6 +98,11 @@ public abstract class MessageObserverAdapter implements MessageObserver {
 		// empty default implementation
 	}
 
+	@Override
+	public void onComplete() {
+		// empty default implementation
+	}
+
 	/**
 	 * Common method to be overwritten to catch failed messages.
 	 * 

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Response.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Response.java
@@ -23,6 +23,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - introduce source and destination
  *                                                    EndpointContext
  *    Achim Kraus (Bosch Software Innovations GmbH) - change type for rtt to Long
+ *    Achim Kraus (Bosch Software Innovations GmbH) - remove "is last", not longer meaningful
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
@@ -49,8 +50,6 @@ public class Response extends Message {
 	 * RTT (round trip time) in milliseconds.
 	 */
 	private Long rtt;
-
-	private boolean last = true;
 
 	/**
 	 * Creates a response to the provided received request with the specified
@@ -101,27 +100,6 @@ public class Response extends Message {
 	public String toString() {
 		String payload = getPayloadTracingString();
 		return String.format("%s-%-6s MID=%5d, Token=%s, OptionSet=%s, %s", getType(), getCode(), getMID(), getTokenString(), getOptions(), payload);
-	}
-
-	/**
-	 * Checks whether this is the last response expected for the exchange it is part of.
-	 * 
-	 * @return {@code true} if this is the last expected response.
-	 */
-	public boolean isLast() {
-		return last;
-	}
-
-	/**
-	 * Defines whether this response is the last response of an exchange.
-	 * <p>
-	 * If this is only a block or a notification, the response might not be the
-	 * last one.
-	 * 
-	 * @param last if this is the last response of an exchange
-	 */
-	public void setLast(boolean last) {
-		this.last = last;
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
@@ -55,6 +55,9 @@
  *                                                    observation store remove.
  *                                                    Remove observation, if response
  *                                                    doesn't contain an observe option 
+ *    Achim Kraus (Bosch Software Innovations GmbH) - move onContextEstablished
+ *                                                    to MessageObserver.
+ *                                                    Issue #487
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -73,6 +76,7 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.observe.Observation;
 import org.eclipse.californium.core.observe.ObservationStore;
+import org.eclipse.californium.elements.EndpointContext;
 
 /**
  * A base class for implementing Matchers that provides support for using a
@@ -324,6 +328,11 @@ public abstract class BaseMatcher implements Matcher {
 			if (removed.compareAndSet(false, true)) {
 				observationStore.remove(token);
 			}
+		}
+
+		@Override
+		public void onContextEstablished(EndpointContext endpointContext) {
+			observationStore.setContext(token, endpointContext);
 		}
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
@@ -201,7 +201,7 @@ public abstract class BaseMatcher implements Matcher {
 				// that the "upper" layers can correctly process the
 				// notification response
 				final Request request = obs.getRequest();
-				exchange = new Exchange(request, Origin.LOCAL, obs.getContext());
+				exchange = new Exchange(request, Origin.LOCAL, obs.getContext(), true);
 				exchange.setRequest(request);
 				LOG.debug("re-created exchange from original observe request: {}", request);
 				request.addMessageObserver(new ObservationObserverAdapter(token) {
@@ -213,7 +213,7 @@ public abstract class BaseMatcher implements Matcher {
 						try {
 							notificationListener.onNotification(request, response);
 						} finally {
-							if (!response.getOptions().hasObserve()) {
+							if (!response.isNotification()) {
 								// Observe response received with no observe
 								// option set. It could be that the Client was
 								// not able to establish the observe. So remove

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -655,7 +655,8 @@ public class CoapEndpoint implements Endpoint {
 		public void sendRequest(final Exchange exchange, final Request request) {
 
 			assertMessageHasDestinationAddress(request);
-			matcher.sendRequest(exchange, request);
+			exchange.setCurrentRequest(request);
+			matcher.sendRequest(exchange);
 
 			/* 
 			 * Logging here causes significant performance loss.
@@ -691,7 +692,8 @@ public class CoapEndpoint implements Endpoint {
 		public void sendResponse(Exchange exchange, Response response) {
 
 			assertMessageHasDestinationAddress(response);
-			matcher.sendResponse(exchange, response);
+			exchange.setCurrentResponse(response);
+			matcher.sendResponse(exchange);
 
 			/* 
 			 * Logging here causes significant performance loss.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -38,6 +38,9 @@
  *                                                    for house-keeping. Introduce
  *                                                    keepRequestInStore for flexible
  *                                                    blockwise observe support.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - move onContextEstablished
+ *                                                    to MessageObserver.
+ *                                                    Issue #487
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -773,10 +776,7 @@ public class Exchange {
 	 */
 	public void setEndpointContext(final EndpointContext ctx) {
 		if (endpointContext.compareAndSet(null, ctx)) {
-			ExchangeObserver obs = this.observer;
-			if (obs != null) {
-				obs.contextEstablished(this);
-			}
+			getCurrentRequest().onContextEstablished(ctx);
 		} else {
 			endpointContext.set(ctx);
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -531,15 +531,15 @@ public class Exchange {
 	 * @param message message, which transmission has reached the timeout.
 	 */
 	public void setTimedOut(Message message) {
-		this.timedOut = true;
-		// clean up
-		this.setComplete();
-		// forward timeout to message
-		message.setTimedOut(true);
-		Request request = this.request.get();
-		if (request != null && request != message && currentRequest.get() == message) {
-			// forward timeout to request
-			request.setTimedOut(true);
+		if (this.setComplete()) {
+			this.timedOut = true;
+			// forward timeout to message
+			message.setTimedOut(true);
+			Request request = this.request.get();
+			if (request != null && request != message && currentRequest.get() == message) {
+				// forward timeout to request
+				request.setTimedOut(true);
+			}
 		}
 	}
 
@@ -643,8 +643,9 @@ public class Exchange {
 	 * ExchangeObserverImpl. Usually, it is called automatically when reaching
 	 * the StackTopAdapter in the {@link CoapStack}, when timing out, when
 	 * rejecting a response, or when sending the (last) response.
+	 * @return {@code true}, if complete is set the first time, {@code false}, if it is repeated.
 	 */
-	public void setComplete() {
+	public boolean setComplete() {
 		if (complete.compareAndSet(false, true)) {
 			setRetransmissionHandle(null);
 			ExchangeObserver obs = this.observer;
@@ -675,6 +676,10 @@ public class Exchange {
 					removeNotifications();
 				}
 			}
+			return true;
+		}
+		else {
+			return false;
 		}
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/ExchangeObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/ExchangeObserver.java
@@ -19,9 +19,13 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - adjust comment for
  *                                                    contextEstablished.
  *                                                    issue #311
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add remove to ensure 
+ *                                                    message exchange house-keeping
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
+import org.eclipse.californium.core.coap.Token;
+import org.eclipse.californium.core.network.Exchange.KeyMID;
 
 /**
  * The exchange observer can be added to an {@link Exchange} and will be invoked
@@ -31,20 +35,31 @@ package org.eclipse.californium.core.network;
 public interface ExchangeObserver {
 
 	/**
+	 * Remove exchange from store.
+	 * 
+	 * @param exchange exchange to remove from store
+	 * @param token token to remove exchange. Maybe {@code null}.
+	 * @param key mid key to remove exchange. Maybe {@code null}.
+	 */
+	void remove(Exchange exchange, Token token, KeyMID key);
+
+	/**
 	 * Invoked when the exchange has completed.
 	 * 
 	 * @param exchange the exchange
+	 * @deprecated intended to be cleaned up.
 	 */
 	void completed(Exchange exchange);
 
 	/**
 	 * Invoked when the first endpoint context is set.
 	 * 
-	 * Note: usually this callback must be processed in a synchronous manner, because
-	 * if it returns, the message is sent. Therefore take special care in methods called
-	 * on this callback.
+	 * Note: usually this callback must be processed in a synchronous manner,
+	 * because if it returns, the message is sent. Therefore take special care
+	 * in methods called on this callback.
 	 * 
 	 * @param exchange the exchange
+	 * @deprecated intended to be moved to MessageObserver.
 	 */
 	void contextEstablished(Exchange exchange);
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/ExchangeObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/ExchangeObserver.java
@@ -21,6 +21,9 @@
  *                                                    issue #311
  *    Achim Kraus (Bosch Software Innovations GmbH) - add remove to ensure 
  *                                                    message exchange house-keeping
+ *    Achim Kraus (Bosch Software Innovations GmbH) - move onContextEstablished
+ *                                                    to MessageObserver.
+ *                                                    Issue #487
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -29,8 +32,7 @@ import org.eclipse.californium.core.network.Exchange.KeyMID;
 
 /**
  * The exchange observer can be added to an {@link Exchange} and will be invoked
- * when it has completed, i.e. when the last response has been sent and
- * acknowledged or after the exchange lifecycle time.
+ * for release the exchange from the exchange store.
  */
 public interface ExchangeObserver {
 
@@ -42,17 +44,4 @@ public interface ExchangeObserver {
 	 * @param key mid key to remove exchange. Maybe {@code null}.
 	 */
 	void remove(Exchange exchange, Token token, KeyMID key);
-
-	/**
-	 * Invoked when the first endpoint context is set.
-	 * 
-	 * Note: usually this callback must be processed in a synchronous manner,
-	 * because if it returns, the message is sent. Therefore take special care
-	 * in methods called on this callback.
-	 * 
-	 * @param exchange the exchange
-	 * @deprecated intended to be moved to MessageObserver.
-	 */
-	void contextEstablished(Exchange exchange);
-
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/ExchangeObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/ExchangeObserver.java
@@ -44,14 +44,6 @@ public interface ExchangeObserver {
 	void remove(Exchange exchange, Token token, KeyMID key);
 
 	/**
-	 * Invoked when the exchange has completed.
-	 * 
-	 * @param exchange the exchange
-	 * @deprecated intended to be cleaned up.
-	 */
-	void completed(Exchange exchange);
-
-	/**
 	 * Invoked when the first endpoint context is set.
 	 * 
 	 * Note: usually this callback must be processed in a synchronous manner,

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
@@ -73,9 +73,8 @@ public interface Matcher {
 	 * </ul>
 	 * 
 	 * @param exchange the message exchange that the request is sent as part of.
-	 * @param request the request message being sent.
 	 */
-	void sendRequest(Exchange exchange, Request request);
+	void sendRequest(Exchange exchange);
 
 	/**
 	 * Notifies this matcher about a response message being sent to a peer.
@@ -89,9 +88,8 @@ public interface Matcher {
 	 * to an ACK or RST sent by the peer in response.
 	 * 
 	 * @param exchange the message exchange that the response is sent as part of.
-	 * @param response the response message being sent.
 	 */
-	void sendResponse(Exchange exchange, Response response);
+	void sendResponse(Exchange exchange);
 
 	/**
 	 * Notifies this matcher about an empty ACK or RST being sent to a peer.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
@@ -18,9 +18,12 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - adjust to use Token
  *                                                    Remove not longer
  *                                                    required releaseToken.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add javadoc for
+ *                                                    ConcurrentModificationException
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
+import java.util.ConcurrentModificationException;
 import java.util.List;
 
 import org.eclipse.californium.core.coap.Message;
@@ -60,53 +63,66 @@ public interface MessageExchangeStore {
 	/**
 	 * Registers an exchange for an outbound request.
 	 * <p>
-	 * This method assigns an unused message ID to the request contained in the exchange
-	 * and marks it as being <em>in-use</em>.
-	 * If the request does not already contain a token, this method also generates a valid
-	 * token and sets it on the request.
+	 * This method assigns an unused message ID to the request contained in the
+	 * exchange and marks it as being <em>in-use</em>. If the request does not
+	 * already contain a token, this method also generates a valid token and
+	 * sets it on the request.
 	 * <p>
-	 * The exchange can later be retrieved from this store using the corresponding <em>get</em>
-	 * method.
+	 * The exchange can later be retrieved from this store using the
+	 * corresponding <em>get</em> method.
 	 * 
 	 * @param exchange the exchange to register.
-	 * @return {@code true} if the request has been registered successfully.
-	 * @throws NullPointerException if any of the given params is {@code null}.
-	 * @throws IllegalArgumentException if the exchange does not contain a (current) request
-	 *                                  or if the request already has a message ID that is still in use.
+	 * @return {@code true} if the request has been registered successfully,
+	 *         {@code false}, otherwise.
+	 * @throws NullPointerException if exchange is {@code null}.
+	 * @throws IllegalArgumentException if the exchange does not contain a
+	 *             (current) request or if the request already has a message ID
+	 *             that is still in use.
+	 * @throws ConcurrentModificationException if the exchange's current request
+	 *             was modified during registration.
 	 */
 	boolean registerOutboundRequest(Exchange exchange);
 
 	/**
 	 * Registers an exchange for an outbound request.
 	 * <p>
-	 * If the request does not already contain a token, this method generates a valid
-	 * and (currently) unused token and sets it on the request. The exchange is then
-	 * registered under the request's token.
+	 * If the request does not already contain a token, this method generates a
+	 * valid and (currently) unused token and sets it on the request. The
+	 * exchange is then registered under the request's token.
 	 * <p>
-	 * The exchange can later be retrieved from this store using the corresponding <em>get</em>
-	 * method.
+	 * The exchange can later be retrieved from this store using the
+	 * corresponding <em>get</em> method.
 	 * 
 	 * @param exchange the exchange to register.
-	 * @return {@code true} if the request has been registered successfully.
-	 * @throws NullPointerException if any of the given params is {@code null}.
-	 * @throws IllegalArgumentException if the exchange does not contain a (current) request.
+	 * @return {@code true} if the request has been registered successfully,
+	 *         {@code false}, otherwise.
+	 * @throws NullPointerException if exchange is {@code null}.
+	 * @throws IllegalArgumentException if the exchange does not contain a
+	 *             (current) request.
+	 * @throws ConcurrentModificationException if the exchange's current request
+	 *             was modified during registration.
 	 */
 	boolean registerOutboundRequestWithTokenOnly(Exchange exchange);
 
 	/**
 	 * Registers an exchange for an outbound response.
 	 * <p>
-	 * If the response contained in the exchange does not already contain a message ID, this method
-	 * assigns an unused message ID to the request and marks the message ID as being <em>in-use</em>.
+	 * If the response contained in the exchange does not already contain a
+	 * message ID, this method assigns an unused message ID to the request and
+	 * marks the message ID as being <em>in-use</em>.
 	 * <p>
-	 * The exchange can later be retrieved from this store using the corresponding <em>get</em>
-	 * method.
+	 * The exchange can later be retrieved from this store using the
+	 * corresponding <em>get</em> method.
 	 * 
 	 * @param exchange the exchange to register.
-	 * @return {@code true} if the response has been registered successfully.
-	 * @throws NullPointerException if any of the given params is {@code null}.
-	 * @throws IllegalArgumentException if the exchange does not contain a (current) response
-	 *                                  or if the response already has a message ID that is still in use.
+	 * @return {@code true} if the response has been registered successfully,
+	 *         {@code false}, otherwise.
+	 * @throws NullPointerException if exchange is {@code null}.
+	 * @throws IllegalArgumentException if the exchange does not contain a
+	 *             (current) response or if the response already has a message
+	 *             ID that is still in use.
+	 * @throws ConcurrentModificationException if the exchange's current
+	 *             response was modified during registration.
 	 */
 	boolean registerOutboundResponse(Exchange exchange);
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -75,11 +75,12 @@ public final class TcpMatcher extends BaseMatcher {
 	 * @param config the configuration to use.
 	 * @param notificationListener the callback to invoke for notifications
 	 *            received from peers.
-	 * @param tokenGenerator token generator to create tokens for 
-	 *            observations created by the endpoint this matcher is part of.
+	 * @param tokenGenerator token generator to create tokens for observations
+	 *            created by the endpoint this matcher is part of.
 	 * @param observationStore the object to use for keeping track of
 	 *            observations created by the endpoint this matcher is part of.
-	 * @param exchangeStore The store to use for keeping track of message exchanges.
+	 * @param exchangeStore The store to use for keeping track of message
+	 *            exchanges.
 	 * @param endpointContextMatcher endpoint context matcher to relate
 	 *            responses with requests
 	 * @throws NullPointerException if one of the parameters is {@code null}.
@@ -147,7 +148,8 @@ public final class TcpMatcher extends BaseMatcher {
 		if (exchange == null) {
 			// There is no exchange with the given token - ignore response
 			return null;
-		} else if (endpointContextMatcher.isResponseRelatedToRequest(exchange.getEndpointContext(), response.getSourceContext())) {
+		} else if (endpointContextMatcher.isResponseRelatedToRequest(exchange.getEndpointContext(),
+				response.getSourceContext())) {
 			return exchange;
 		} else {
 			LOGGER.info("ignoring potentially forged response for token {} with non-matching endpoint context",
@@ -170,14 +172,6 @@ public final class TcpMatcher extends BaseMatcher {
 				exchangeStore.remove(token, exchange);
 			}
 			// ignore key, MID is not used for TCP!
-		}
-
-		@Override
-		public void contextEstablished(final Exchange exchange) {
-			Request request = exchange.getRequest();
-			if (request != null && request.isObserve()) {
-				observationStore.setContext(request.getToken(), exchange.getEndpointContext());
-			}
 		}
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -94,8 +94,9 @@ public final class TcpMatcher extends BaseMatcher {
 	}
 
 	@Override
-	public void sendRequest(Exchange exchange, final Request request) {
+	public void sendRequest(Exchange exchange) {
 
+		Request request = exchange.getCurrentRequest();
 		if (request.isObserve()) {
 			registerObserve(request);
 		}
@@ -105,7 +106,8 @@ public final class TcpMatcher extends BaseMatcher {
 	}
 
 	@Override
-	public void sendResponse(Exchange exchange, Response response) {
+	public void sendResponse(Exchange exchange) {
+		Response response = exchange.getCurrentResponse();
 
 		// ensure Token is set
 		response.setToken(exchange.getCurrentRequest().getToken());

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -43,6 +43,7 @@
  * Achim Kraus (Bosch Software Innovations GmbH) - add token generator
  * Achim Kraus (Bosch Software Innovations GmbH) - provide ExchangeObserver
  *                                                 remove implementation
+ * Achim Kraus (Bosch Software Innovations GmbH) - remove "is last", not longer meaningful
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -110,9 +111,7 @@ public final class TcpMatcher extends BaseMatcher {
 		response.setToken(exchange.getCurrentRequest().getToken());
 
 		// Only Observes keep the exchange active (CoAP server side)
-		if (response.isLast()) {
-			exchange.setComplete();
-		}
+		exchange.setComplete();
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -173,27 +173,6 @@ public final class TcpMatcher extends BaseMatcher {
 		}
 
 		@Override
-		public void completed(final Exchange exchange) {
-			if (exchange.getOrigin() == Exchange.Origin.LOCAL) {
-				// this endpoint created the Exchange by issuing a request
-				Request originRequest = exchange.getCurrentRequest();
-				if (originRequest.getToken() == null) {
-					// this should not happen because we only register the observer
-					// if we have successfully registered the exchange
-					LOGGER.warn(
-							"exchange observer has been completed on unregistered exchange [peer: {}, origin: LOCAL]",
-							originRequest.getDestinationContext().getPeerAddress());
-				} else {
-					Token idByToken = originRequest.getToken();
-					exchangeStore.remove(idByToken, exchange);
-					LOGGER.debug("Exchange [{}, origin: LOCAL] completed", idByToken);
-				}
-			} else { // Origin.REMOTE
-				// nothing to do
-			}
-		}
-
-		@Override
 		public void contextEstablished(final Exchange exchange) {
 			Request request = exchange.getRequest();
 			if (request != null && request.isObserve()) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -47,6 +47,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - add token generator
  *    Achim Kraus (Bosch Software Innovations GmbH) - provide ExchangeObserver
  *                                                    remove implementation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - remove "is last", not longer meaningful
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -158,7 +159,7 @@ public final class UdpMatcher extends BaseMatcher {
 		}
 
 		// Only CONs and Observe keep the exchange active (CoAP server side)
-		if (response.getType() != Type.CON && response.isLast()) {
+		if (response.getType() != Type.CON && !response.isNotification()) {
 			exchange.setComplete();
 		}
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -50,7 +50,6 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
-import java.util.Iterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +63,6 @@ import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.observe.ObservationStore;
-import org.eclipse.californium.core.observe.ObserveRelation;
 import org.eclipse.californium.elements.EndpointContextMatcher;
 
 /**
@@ -135,7 +133,7 @@ public final class UdpMatcher extends BaseMatcher {
 
 		// If this is a CON notification we now can forget all previous NON
 		// notifications
-		if (response.getType() == Type.CON || response.getType() == Type.ACK) {
+		if (response.getType() == Type.CON) {
 			exchange.removeNotifications();
 		}
 
@@ -146,19 +144,15 @@ public final class UdpMatcher extends BaseMatcher {
 		} else if (response.getType() == Type.NON) {
 			if (response.getOptions().hasObserve()) {
 				// this is a NON notification
-				// we need to register it so that we can match an RST sent by a
-				// peer
-				// that wants to cancel the observation
+				// we need to register it so that we can match an RST sent
+				// by a peer that wants to cancel the observation
 				// these NON notifications will later be removed from the
-				// exchange store
-				// when ExchangeObserverImpl.completed() is called
+				// exchange store when Exchange.setComplete() is called
 				exchangeStore.registerOutboundResponse(exchange);
 			} else {
 				// we only need to assign an unused MID but we do not need to
-				// register
-				// the exchange under the MID since we do not expect/want a
-				// reply
-				// that we would need to match it against
+				// register the exchange under the MID since we do not
+				// expect/want a reply that we would need to match it against
 				exchangeStore.assignMessageId(response);
 			}
 		}
@@ -184,11 +178,14 @@ public final class UdpMatcher extends BaseMatcher {
 	@Override
 	public Exchange receiveRequest(final Request request) {
 		/*
-		 * This request could be - Complete origin request => deliver with new
-		 * exchange - One origin block => deliver with ongoing exchange -
-		 * Complete duplicate request or one duplicate block (because client got
-		 * no ACK) => if ACK got lost => resend ACK if ACK+response got lost =>
-		 * resend ACK+response if nothing has been sent yet => do nothing
+		 * This request could be
+		 *  - Complete origin request => deliver with new exchange
+		 *  - One origin block        => deliver with ongoing exchange
+		 *  - Complete duplicate request or one duplicate block (because client got no ACK)
+		 *      =>
+		 * 		if ACK got lost => resend ACK
+		 * 		if ACK+response got lost => resend ACK+response
+		 * 		if nothing has been sent yet => do nothing
 		 * (Retransmission is supposed to be done by the retransm. layer)
 		 */
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -101,9 +101,10 @@ public final class UdpMatcher extends BaseMatcher {
 	}
 
 	@Override
-	public void sendRequest(final Exchange exchange, final Request request) {
+	public void sendRequest(final Exchange exchange) {
 
 		// for observe request.
+		Request request = exchange.getCurrentRequest();
 		if (request.isObserve() && 0 == exchange.getFailedTransmissionCount()) {
 			registerObserve(request);
 		}
@@ -127,8 +128,9 @@ public final class UdpMatcher extends BaseMatcher {
 	}
 
 	@Override
-	public void sendResponse(final Exchange exchange, final Response response) {
-
+	public void sendResponse(final Exchange exchange) {
+		
+		Response response = exchange.getCurrentResponse();
 		// ensure Token is set
 		response.setToken(exchange.getCurrentRequest().getToken());
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
@@ -170,6 +170,7 @@ public abstract class BaseCoapStack implements CoapStack {
 		@Override
 		public void receiveResponse(final Exchange exchange, final Response response) {
 			exchange.setComplete();
+			exchange.getRequest().onComplete();
 			if (hasDeliverer()) {
 				// notify request that response has arrived
 				deliverer.deliverResponse(exchange, response);
@@ -195,6 +196,12 @@ public abstract class BaseCoapStack implements CoapStack {
 		@Override
 		public void sendResponse(Exchange exchange, Response response) {
 			outbox.sendResponse(exchange, response);
+			BlockOption block2 = response.getOptions().getBlock2();
+			if (block2 == null || !block2.isM()) {
+				// for blockwise, the original response shares
+				// the MessageObserver with the block response
+				response.onComplete();
+			}
 		}
 
 		@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
@@ -14,6 +14,7 @@
  *    Bosch Software Innovations - initial creation
  *    Achim Kraus (Bosch Software Innovations GmbH) - use EndpointContext
  *    Achim Kraus (Bosch Software Innovations GmbH) - replace byte array token by Token
+ *    Achim Kraus (Bosch Software Innovations GmbH) - remove "is last", not longer meaningful
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -120,8 +121,8 @@ final class Block1BlockwiseStatus extends BlockwiseStatus {
 		block.setDestinationContext(request.getDestinationContext());
 		// copy options
 		block.setOptions(new OptionSet(request.getOptions()));
-		// copy message observers so that a failing blockwise request also notifies observers registered with
-		// the original request
+		// copy message observers so that a failing blockwise request also 
+		// notifies observers registered with the original request
 		block.addMessageObservers(request.getMessageObservers());
 		if (num == 0) {
 			// indicate overall body size to peer

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
@@ -21,6 +21,7 @@
  *                                                    from BlockwiseStatus
  *    Achim Kraus (Bosch Software Innovations GmbH) - use EndpointContext
  *    Bosch Software Innovations GmbH - migrate to SLF4J
+ *    Achim Kraus (Bosch Software Innovations GmbH) - remove "is last", not longer meaningful
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -29,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.eclipse.californium.core.coap.BlockOption;
-import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
@@ -296,12 +296,7 @@ final class Block2BlockwiseStatus extends BlockwiseStatus {
 			block.setOptions(new OptionSet(response.getOptions()));
 			// observe option must only be included in first block
 			block.getOptions().removeObserve();
-			block.addMessageObserver(new MessageObserverAdapter() {
-				@Override
-				public void onTimeout() {
-					response.setTimedOut(true);
-				}
-			});
+			block.addMessageObservers(response.getMessageObservers());
 		}
 
 		if (getCurrentNum() == 0 && response.getOptions().getSize2() == null) {
@@ -324,17 +319,9 @@ final class Block2BlockwiseStatus extends BlockwiseStatus {
 			buf.position(from);
 			buf.get(blockPayload, 0, length);
 			block.setPayload(blockPayload);
-
-			// do not complete notifications
-			block.setLast(!m && !response.getOptions().hasObserve());
-
-			setComplete(!m);
-
-		} else {
-
-			block.setLast(true);
-			setComplete(true);
 		}
+		setComplete(!m);
+
 		block.getOptions().setBlock2(getCurrentSzx(), m, getCurrentNum());
 		return block;
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
@@ -364,8 +364,6 @@ final class Block2BlockwiseStatus extends BlockwiseStatus {
 				exchange.setComplete();
 			}
 			else {
-				// complete current exchange
-				exchange.completeCurrentRequest();
 				// reset to origin request
 				exchange.setCurrentRequest(exchange.getRequest());
 			}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -891,18 +891,6 @@ public class BlockwiseLayer extends AbstractLayer {
 						// set overall transfer RTT
 						assembled.setRTT(exchange.calculateRTT());
 
-						if (status.isNotification()) {
-							/*
-							 * When retrieving the rest of a blockwise notification
-							 * with a different token, the additional Matcher state
-							 * must be cleaned up through the call below.
-							 */
-							if (!response.getOptions().hasObserve()) {
-								// call the clean-up mechanism for the additional Matcher entry in exchangesByToken
-								exchange.completeCurrentRequest();
-							}
-						}
-
 						clearBlock2Status(key);
 						LOGGER.debug("assembled response: {}", assembled);
 						// Set the original request as current request so that

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -853,7 +853,7 @@ public class BlockwiseLayer extends AbstractLayer {
 						 * exchange under a different KeyToken in exchangesByToken,
 						 * which is cleaned up in the else case below.
 						 */
-						if (!response.getOptions().hasObserve()) {
+						if (!response.isNotification()) {
 							block.setToken(response.getToken());
 						}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -47,6 +47,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - copy token and mid for error responses
  *                                                    copy scheme to assembled blockwise 
  *                                                    payload.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - remove "is last", not longer meaningful
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -386,7 +387,6 @@ public class BlockwiseLayer extends AbstractLayer {
 
 					Response piggybacked = Response.createResponse(request, ResponseCode.CONTINUE);
 					piggybacked.getOptions().setBlock1(block1.getSzx(), true, block1.getNum());
-					piggybacked.setLast(false);
 
 					exchange.setCurrentResponse(piggybacked);
 					lower().sendResponse(exchange, piggybacked);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -490,6 +490,7 @@ public class BlockwiseLayer extends AbstractLayer {
 						responseToSend = Response.createResponse(exchange.getRequest(), ResponseCode.INTERNAL_SERVER_ERROR);
 						responseToSend.setType(response.getType());
 						responseToSend.setMID(response.getMID());
+						responseToSend.addMessageObservers(response.getMessageObservers());
 					}
 
 				} else if (response.hasBlock(requestBlock2)) {
@@ -506,7 +507,7 @@ public class BlockwiseLayer extends AbstractLayer {
 					responseToSend.setType(response.getType());
 					responseToSend.setMID(response.getMID());
 					responseToSend.getOptions().setBlock2(requestBlock2);
-
+					responseToSend.addMessageObservers(response.getMessageObservers());
 				}
 
 			} else if (requiresBlockwise(exchange, response, requestBlock2)) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
@@ -28,6 +28,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - complete old notification
  *                                                    exchange
  *    Bosch Software Innovations GmbH - migrate to SLF4J
+ *    Achim Kraus (Bosch Software Innovations GmbH) - remove "is last", not longer meaningful
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -86,9 +87,6 @@ public class ObserveLayer extends AbstractLayer {
 					}
 				}
 			}
-
-			// This is a notification
-			response.setLast(false);
 
 			/*
 			 * Only one Confirmable message is allowed to be in transit. A CON

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
@@ -230,8 +230,6 @@ public class ObserveLayer extends AbstractLayer {
 					// Cancel the original retransmission and send the fresh
 					// notification here
 					response.cancel();
-					// Using new MIDs requires to cleanup the current exchange with old MID.
-					exchange.completeCurrentRequest();
 					// Convert all notification retransmissions to CON
 					if (next.getType() != Type.CON) {
 						next.setType(Type.CON);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpObserveLayer.java
@@ -15,6 +15,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - Initial implementation,
  *                                                    Derived from ObserveLayer
  *    Bosch Software Innovations GmbH - migrate to SLF4J
+ *    Achim Kraus (Bosch Software Innovations GmbH) - remove "is last", not longer meaningful
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -61,9 +62,6 @@ public class TcpObserveLayer extends AbstractLayer {
 			if (!response.getOptions().hasObserve()) {
 				/* response for cancel request */
 				relation.cancel();
-				response.setLast(true);
-			} else {
-				response.setLast(false);
 			}
 		} // else no observe was requested or the resource does not allow it
 		lower().sendResponse(exchange, response);

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
@@ -202,6 +202,7 @@ public class ObserveRelation {
 	
 	public void addNotification(Response notification) {
 		notifications.add(notification);
+		LOGGER.trace("{} add notification {} (size {}).", resource.getURI(), notification.getMID(), notifications.size());
 	}
 	
 	public Iterator<Response> getNotificationIterator() {

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
@@ -139,7 +139,6 @@ public class InMemoryMessageExchangeStoreTest {
 	private Exchange newOutboundRequest() {
 		Request request = Request.newGet();
 		request.setURI("coap://127.0.0.1:" + PEER_PORT + "/test");
-		request.prepareDestinationContext();
 		Exchange exchange = new Exchange(request, Origin.LOCAL);
 		return exchange;
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTestUtils.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTestUtils.java
@@ -73,8 +73,7 @@ public final class MatcherTestUtils {
 		Request request = Request.newGet();
 		request.setDestinationContext(new AddressEndpointContext(dest));
 		Exchange exchange = new Exchange(request, Origin.LOCAL);
-		exchange.setRequest(request);
-		matcher.sendRequest(exchange, request);
+		matcher.sendRequest(exchange);
 		exchange.setEndpointContext(exchangeContext);
 		return exchange;
 	}
@@ -84,8 +83,7 @@ public final class MatcherTestUtils {
 		request.setDestinationContext(new AddressEndpointContext(dest));
 		request.setObserve();
 		Exchange exchange = new Exchange(request, Origin.LOCAL);
-		exchange.setRequest(request);
-		matcher.sendRequest(exchange, request);
+		matcher.sendRequest(exchange);
 		exchange.setEndpointContext(exchangeContext);
 		return exchange;
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -168,7 +168,6 @@ public class UdpMatcherTest {
 		Request request = Request.newGet();
 		request.setDestinationContext(new AddressEndpointContext(dest));
 		Exchange exchange = new Exchange(request, Origin.LOCAL);
-		exchange.setRequest(request);
 
 		MessageExchangeStore exchangeStore = mock(MessageExchangeStore.class);
 		when(exchangeStore.registerOutboundRequest(exchange)).thenReturn(false);
@@ -176,7 +175,7 @@ public class UdpMatcherTest {
 		UdpMatcher matcher = MatcherTestUtils.newUdpMatcher(exchangeStore, observationStore, endpointContextMatcher);
 
 		// WHEN the request is being sent
-		matcher.sendRequest(exchange, request);
+		matcher.sendRequest(exchange);
 
 		// THEN the request has no MID and token assigned and the exchange has not observer registered
 		assertThat(request.getToken(), is(nullValue()));

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -116,10 +116,10 @@ public class UdpMatcherTest {
 		// GIVEN a request without token sent
 		UdpMatcher matcher = newUdpMatcher();
 		Exchange exchange = sendRequest(dest, matcher, null);
-				// WHEN request gets completed
-		exchange.completeCurrentRequest();
+		// WHEN request gets completed
+		exchange.setComplete();
 
-		// THEN assert that token got released
+		// THEN assert that token got released in both stores
 		Token token = exchange.getCurrentRequest().getToken();
 		assertThat(messageExchangeStore.get(token), is(nullValue()));
 		assertThat(observationStore.get(token), is(nullValue()));
@@ -132,9 +132,10 @@ public class UdpMatcherTest {
 		Exchange exchange = sendObserveRequest(dest, matcher, exchangeEndpointContext);
 
 		// WHEN observe request gets completed
-		exchange.completeCurrentRequest();
+		exchange.setComplete();
 
-		// THEN assert that token got not released
+		// THEN assert that token got released in message exchange store
+		// THEN assert that token got not released in observation store
 		Token token = exchange.getCurrentRequest().getToken();
 		assertThat(messageExchangeStore.get(token), is(nullValue()));
 		assertThat(observationStore.get(token), is(notNullValue()));

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/BlockwiseLayerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/BlockwiseLayerTest.java
@@ -110,13 +110,12 @@ public class BlockwiseLayerTest {
 
 		Request req = Request.newGet();
 		req.setURI("coap://127.0.0.1/bigResource");
-		req.prepareDestinationContext();
 		req.addMessageObserver(requestObserver);
 
 		Response response = receiveResponseFor(req);
 		response.getOptions().setSize2(256).setBlock2(BlockOption.size2Szx(64), true, 0);
 
-		Exchange exchange = new Exchange(null, Origin.LOCAL);
+		Exchange exchange = new Exchange(req, Origin.LOCAL);
 		exchange.setRequest(req);
 		blockwiseLayer.receiveResponse(exchange, response);
 
@@ -139,8 +138,7 @@ public class BlockwiseLayerTest {
 		// GIVEN an established observation of a resource with a body requiring blockwise transfer
 		Request req = Request.newGet();
 		req.setURI("coap://127.0.0.1/bigResource");
-		req.prepareDestinationContext();
-		Exchange exchange = new Exchange(null, Origin.LOCAL);
+		Exchange exchange = new Exchange(req, Origin.LOCAL);
 		exchange.setRequest(req);
 
 		// WHEN the request used to establish the observe relation has been canceled

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
@@ -20,11 +20,10 @@ package org.eclipse.californium.proxy.resources;
 
 import org.eclipse.californium.compat.CompletableFuture;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
-import org.eclipse.californium.core.coap.MessageObserver;
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.EndpointManager;
-import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.proxy.CoapTranslator;
 import org.eclipse.californium.proxy.EndPointManagerPool;
 import org.eclipse.californium.proxy.TranslationException;
@@ -76,20 +75,13 @@ public class ProxyCoapClientResource extends ForwardingResource {
 			outgoingRequest = CoapTranslator.getRequest(incomingRequest);
 
 			// receive the response
-			outgoingRequest.addMessageObserver(new MessageObserver() {
-				@Override
-				public void onRetransmission() {
-				}
+			outgoingRequest.addMessageObserver(new MessageObserverAdapter() {
 
 				@Override
 				public void onResponse(Response incomingResponse) {
 					LOGGER.debug("ProxyCoapClientResource received {}", incomingResponse);
 					future.complete(CoapTranslator.getResponse(incomingResponse));
 					EndPointManagerPool.putClient(endpointManager);
-				}
-
-				@Override
-				public void onAcknowledgement() {
 				}
 
 				@Override
@@ -114,23 +106,12 @@ public class ProxyCoapClientResource extends ForwardingResource {
 				}
 
 				@Override
-				public void onSent() {
-				}
-
-				@Override
-				public void onReadyToSend() {
-				}
-
-				@Override
 				public void onSendError(Throwable e) {
 					future.complete(new Response(ResponseCode.SERVICE_UNAVAILABLE));
 					LOGGER.warn("Send error", e);
 					EndPointManagerPool.putClient(endpointManager);
 				}
 
-				@Override
-				public void onContextEstablished(EndpointContext endpointContext) {
-				}
 			});
 
 			// execute the request

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
@@ -24,6 +24,7 @@ import org.eclipse.californium.core.coap.MessageObserver;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.EndpointManager;
+import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.proxy.CoapTranslator;
 import org.eclipse.californium.proxy.EndPointManagerPool;
 import org.eclipse.californium.proxy.TranslationException;
@@ -125,6 +126,10 @@ public class ProxyCoapClientResource extends ForwardingResource {
 					future.complete(new Response(ResponseCode.SERVICE_UNAVAILABLE));
 					LOGGER.warn("Send error", e);
 					EndPointManagerPool.putClient(endpointManager);
+				}
+
+				@Override
+				public void onContextEstablished(EndpointContext endpointContext) {
 				}
 			});
 

--- a/demo-apps/cf-extplugtest-client/src/main/resources/logback.xml
+++ b/demo-apps/cf-extplugtest-client/src/main/resources/logback.xml
@@ -8,10 +8,52 @@
 		</encoder>
 	</appender>
 
-	<!-- Strictly speaking, the level attribute is not necessary since -->
-	<!-- the level of the root level is set to DEBUG by default. -->
-	<root level="WARN">
+	<appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<file>logs/messages.log</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<!-- rollover monthly, or if filesize exceeds -->
+			<fileNamePattern>logs/messages-%d{yyyy-MM}.%i.log</fileNamePattern>
+			<!-- each file should be at most 10MB, keep 200 files worth of history, but at most 2GB -->
+			<maxFileSize>10MB</maxFileSize>
+			<maxHistory>200</maxHistory>
+			<totalSizeCap>2GB</totalSizeCap>
+		</rollingPolicy>
+
+		<encoder>
+			<!-- use tab to separate timestamp from message -->
+			<pattern>%d{mm:ss.SSS} %level [%logger{0}]: %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<!-- ORIGIN only to file -->
+	<logger name="org.eclipse.californium.core.network.interceptors.MessageTracer" level="INFO" additivity="false">
 		<appender-ref ref="STDOUT" />
-	</root>
+		<appender-ref ref="FILE" />
+	</logger>
+	<logger name="org.eclipse.californium.core.network.UdpMatcher" level="TRACE" additivity="false">
+		<appender-ref ref="STDOUT" />
+		<appender-ref ref="FILE" />
+	</logger>
+	<logger name="org.eclipse.californium.core.network.Exchange" level="TRACE" additivity="false">
+		<appender-ref ref="STDOUT" />
+		<appender-ref ref="FILE" />
+	</logger>
+	<logger name="org.eclipse.californium.core.network.InMemoryMessageExchangeStore" level="TRACE" additivity="false">
+		<appender-ref ref="STDOUT" />
+		<appender-ref ref="FILE" />
+	</logger>
+	<logger name="org.eclipse.californium.core.network.stack.BlockwiseLayer" level="INFO" additivity="false">
+		<appender-ref ref="STDOUT" />
+		<appender-ref ref="FILE" />
+	</logger>
+	<logger name="org.eclipse.californium.core.observe.ObserveRelation" level="TRACE" additivity="false">
+		<appender-ref ref="STDOUT" />
+		<appender-ref ref="FILE" />
+	</logger>
+
+	<logger level="WARN" >
+		<appender-ref ref="FILE" />
+		<appender-ref ref="STDOUT" />
+	</logger>
 
 </configuration>

--- a/demo-apps/cf-extplugtest-server/src/main/resources/logback.xml
+++ b/demo-apps/cf-extplugtest-server/src/main/resources/logback.xml
@@ -51,6 +51,14 @@
 		<appender-ref ref="STDOUT" />
 		<appender-ref ref="FILE" />
 	</logger>
+	<logger name="org.eclipse.californium.core.network.UdpMatcher" level="TRACE" additivity="false">
+		<appender-ref ref="STDOUT" />
+		<appender-ref ref="FILE" />
+	</logger>
+	<logger name="org.eclipse.californium.core.network.Exchange" level="TRACE" additivity="false">
+		<appender-ref ref="STDOUT" />
+		<appender-ref ref="FILE" />
+	</logger>
 	<logger name="org.eclipse.californium.core.network.InMemoryMessageExchangeStore" level="TRACE" additivity="false">
 		<appender-ref ref="STDOUT" />
 		<appender-ref ref="FILE" />


### PR DESCRIPTION
Add ExchangeObserver remove to ensure message exchange
house-keeping. This only a very early stage. The clean up will follow.
Testing with blockwise notifes showed, that there are race conditions.
I tried to limit the defect using the striped executor. I hope I can provide
also a early preview for that in the afternoon. 

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>