### PR TITLE
Add striped executor based on exchange.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/StripedExchangeJob.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/StripedExchangeJob.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation.
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import eu.javaspecialists.tjsn.concurrency.stripedexecutor.StripedRunnable;
+
+/**
+ * Striped job using exchange as stripe object.
+ * 
+ * Intended to be used by overriding {@link #runStriped()}.
+ */
+public abstract class StripedExchangeJob implements StripedRunnable {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(StripedExchangeJob.class.getCanonicalName());
+
+	/**
+	 * Exchange for this job.
+	 */
+	protected final Exchange exchange;
+
+	public StripedExchangeJob(Exchange exchange) {
+		this.exchange = exchange;
+	}
+
+	public StripedExchangeJob(StripedExchangeJob job) {
+		this.exchange = job.exchange;
+	}
+
+	@Override
+	public Object getStripe() {
+		return exchange;
+	}
+
+	@Override
+	public void run() {
+		try {
+			runStriped();
+		} catch (Throwable t) {
+			LOGGER.error("striped exception in protocol stage thread: {}", t.getMessage(), t);
+		}
+	}
+
+	public abstract void runStriped();
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
@@ -21,6 +21,7 @@
  * Joe Magerramov (Amazon Web Services) - CoAP over TCP support.
  * Achim Kraus (Bosch Software Innovations GmbH) - derived from UDP and TCP CoAP stack
  * Bosch Software Innovations GmbH - migrate to SLF4J
+ * Achim Kraus (Bosch Software Innovations GmbH) - add striped executor
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -28,6 +29,8 @@ import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import eu.javaspecialists.tjsn.concurrency.stripedexecutor.StripedExecutorService;
 
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
@@ -115,6 +118,13 @@ public abstract class BaseCoapStack implements CoapStack {
 	public final void setExecutor(final ScheduledExecutorService executor) {
 		for (Layer layer : layers) {
 			layer.setExecutor(executor);
+		}
+	}
+
+	@Override
+	public final void setExecutor(final StripedExecutorService stripedExecutor) {
+		for (Layer layer : layers) {
+			layer.setExecutor(stripedExecutor);
 		}
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -853,7 +853,7 @@ public class BlockwiseLayer extends AbstractLayer {
 						 * exchange under a different KeyToken in exchangesByToken,
 						 * which is cleaned up in the else case below.
 						 */
-						if (!response.getOptions().hasObserve()) {
+						if (!response.isNotification()) {
 							block.setToken(response.getToken());
 						}
 
@@ -1199,12 +1199,12 @@ public class BlockwiseLayer extends AbstractLayer {
 	private ScheduledFuture<?> scheduleBlockCleanupTask(final Runnable task) {
 
 		// prevent RejectedExecutionException
-		if (executor.isShutdown()) {
+		if (isShutdown()) {
 			LOGGER.info("Endpoint is being destroyed: skipping block clean-up");
 			return null;
 
 		} else {
-			return executor.schedule(task , blockTimeout, TimeUnit.MILLISECONDS);
+			return schedule(task , blockTimeout, TimeUnit.MILLISECONDS);
 		}
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapStack.java
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2017 Institute for Pervasive Computing, ETH Zurich and others.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * <p>
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.html.
+ * <p>
+ * Contributors:
+ * (please refer to gitlog)
+ * Achim Kraus (Bosch Software Innovations GmbH) - add striped executor
+ ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
 import org.eclipse.californium.core.coap.EmptyMessage;
@@ -5,6 +21,8 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.server.MessageDeliverer;
+
+import eu.javaspecialists.tjsn.concurrency.stripedexecutor.StripedExecutorService;
 
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -32,6 +50,8 @@ public interface CoapStack {
 	void receiveEmptyMessage(Exchange exchange, EmptyMessage message);
 
 	void setExecutor(ScheduledExecutorService executor);
+	
+	void setExecutor(StripedExecutorService stripedExecutor);
 
 	void setDeliverer(MessageDeliverer deliverer);
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CongestionControlLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CongestionControlLayer.java
@@ -150,7 +150,7 @@ public abstract class CongestionControlLayer extends ReliabilityLayer {
 				// Check if NONs are already processed, if not, start bucket
 				// Thread
 				if (!getRemoteEndpoint(exchange).getProcessingNON()) {
-					executor.schedule(new BucketThread(
+					schedule(new BucketThread(
 							getRemoteEndpoint(exchange)), 0,
 							TimeUnit.MILLISECONDS);
 				}
@@ -176,7 +176,7 @@ public abstract class CongestionControlLayer extends ReliabilityLayer {
 
 			// The exchange needs to be deleted after at least 255 s TODO:
 			// should this value be calculated dynamically
-			executor.schedule(new SweepCheckTask(getRemoteEndpoint(exchange),
+			schedule(new SweepCheckTask(getRemoteEndpoint(exchange),
 					exchange), MAX_REMOTE_TRANSACTION_DURATION,
 					TimeUnit.MILLISECONDS);
 			return true;
@@ -430,7 +430,7 @@ public abstract class CongestionControlLayer extends ReliabilityLayer {
 					}
 				}
 				// schedule next transmission of a NON based on the RTO value (rate = 1/RTO)
-				executor.schedule(
+				schedule(
 						new BucketThread(getRemoteEndpoint(exchange)),
 						getRemoteEndpoint(exchange).getRTO(),
 						TimeUnit.MILLISECONDS);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Layer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Layer.java
@@ -17,6 +17,7 @@
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
  *    Bosch Software Innovations GmbH - formatting & small improvements
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add striped executor
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -31,6 +32,8 @@ import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.server.MessageDeliverer;
+
+import eu.javaspecialists.tjsn.concurrency.stripedexecutor.StripedExecutorService;
 
 /**
  * A layer processes requests, responses and empty messages. Layers can be
@@ -133,6 +136,8 @@ public interface Layer {
 	 * @param executor the new executor
 	 */
 	void setExecutor(ScheduledExecutorService executor);
+
+	void setExecutor(StripedExecutorService stripedExecutor);
 
 	/**
 	 * Stop this layer and release any resources.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
@@ -41,6 +41,7 @@ import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.Exchange.Origin;
+import org.eclipse.californium.core.network.StripedExchangeJob;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.ObserveRelation;
 
@@ -193,70 +194,66 @@ public class ObserveLayer extends AbstractLayer {
 
 		@Override
 		public void onAcknowledgement() {
-			synchronized (exchange) {
-				ObserveRelation relation = exchange.getRelation();
-				final Response next = relation.getNextControlNotification();
-				relation.setCurrentControlNotification(next);
-				 // next may be null
-				relation.setNextControlNotification(null);
-				if (next != null) {
-					LOGGER.debug("notification has been acknowledged, send the next one");
-					/*
-					 * The matcher must be able to find the NON notifications to remove
-					 * them from the exchangesByMID hashmap
-					 */
-					if (next.getType() == Type.NON) {
-						relation.addNotification(next);
-					}
-					// Create a new task for sending next response so that we
-					// can leave the sync-block
-					executor.execute(new Runnable() {
-
-						public void run() {
-							ObserveLayer.super.sendResponse(exchange, next);
-						}
-					});
+			ObserveRelation relation = exchange.getRelation();
+			final Response next = relation.getNextControlNotification();
+			relation.setCurrentControlNotification(next);
+			// next may be null
+			relation.setNextControlNotification(null);
+			if (next != null) {
+				LOGGER.debug("notification has been acknowledged, send the next one");
+				/*
+				 * The matcher must be able to find the NON notifications to
+				 * remove them from the exchangesByMID hashmap
+				 */
+				if (next.getType() == Type.NON) {
+					relation.addNotification(next);
 				}
+				// Create a new task for sending next response so that we
+				// can leave the sync-block
+				execute(new StripedExchangeJob(exchange) {
+
+					public void runStriped() {
+						ObserveLayer.super.sendResponse(exchange, next);
+					}
+				});
 			}
 		}
 
 		@Override
 		public void onRetransmission() {
-			synchronized (exchange) {
-				ObserveRelation relation = exchange.getRelation();
-				final Response next = relation.getNextControlNotification();
-				if (next != null) {
-					LOGGER.debug("notification has timed out and there is a fresher notification for the retransmission");
-					// Cancel the original retransmission and send the fresh
-					// notification here
-					response.cancel();
-					// Using new MIDs requires to cleanup the current exchange with old MID.
-					exchange.completeCurrentRequest();
-					// Convert all notification retransmissions to CON
-					if (next.getType() != Type.CON) {
-						next.setType(Type.CON);
-						prepareSelfReplacement(exchange, next);
-					}
-					relation.setCurrentControlNotification(next);
-					relation.setNextControlNotification(null);
-					// Create a new task for sending next response so that we
-					// can leave the sync-block
-					executor.execute(new Runnable() {
-
-						public void run() {
-							ObserveLayer.super.sendResponse(exchange, next);
-						}
-					});
+			ObserveRelation relation = exchange.getRelation();
+			final Response next = relation.getNextControlNotification();
+			if (next != null) {
+				LOGGER.debug("notification has timed out and there is a fresher notification for the retransmission");
+				// Cancel the original retransmission and send the fresh
+				// notification here
+				response.cancel();
+				// Using new MIDs requires to cleanup the current exchange with
+				// old MID.
+				exchange.completeCurrentRequest();
+				// Convert all notification retransmissions to CON
+				if (next.getType() != Type.CON) {
+					next.setType(Type.CON);
+					prepareSelfReplacement(exchange, next);
 				}
+				relation.setCurrentControlNotification(next);
+				relation.setNextControlNotification(null);
+				// Create a new task for sending next response so that we
+				// can leave the sync-block
+				execute(new StripedExchangeJob(exchange) {
+
+					public void runStriped() {
+						ObserveLayer.super.sendResponse(exchange, next);
+					}
+				});
 			}
 		}
 
 		@Override
 		public void onTimeout() {
 			ObserveRelation relation = exchange.getRelation();
-			LOGGER.info(
-					"notification for token [{}] timed out. Canceling all relations with source [{}]",
-					new Object[]{ relation.getExchange().getRequest().getTokenString(), relation.getSource() });
+			LOGGER.info("notification for token [{}] timed out. Canceling all relations with source [{}]",
+					new Object[] { relation.getExchange().getRequest().getTokenString(), relation.getSource() });
 			relation.cancelAll();
 		}
 


### PR DESCRIPTION
Stripe execution based on the related exchange. 
Fix for several race condition using blockwise notifies.
Note: the blockwise status still accesses the exchange
concurrent and therefore this PR doesn't completely fix
the race issues.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>