### PR TITLE
Fix issue #549.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -22,6 +22,9 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - include trustedRPKs in
  *                                                    determineCipherSuitesFromConfig
  *    Achim Kraus (Bosch Software Innovations GmbH) - add automatic resumption
+ *    Achim Kraus (Bosch Software Innovations GmbH) - issue #549
+ *                                                    trustStore := null, disable x.509
+ *                                                    trustStore := [], enable x.509, trust all
  *******************************************************************************/
 
 package org.eclipse.californium.scandium.config;
@@ -898,9 +901,6 @@ public final class DtlsConnectorConfig {
 			}
 			if (config.enableReuseAddress == null) {
 				config.enableReuseAddress = false;
-			}
-			if (config.trustStore == null) {
-				config.trustStore = new X509Certificate[0];
 			}
 			if (config.earlyStopRetransmission == null) {
 				config.earlyStopRetransmission = true;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -32,6 +32,9 @@
  *    Bosch Software Innovations GmbH - migrate to SLF4J
  *    Achim Kraus (Bosch Software Innovations GmbH) - add certificate types only,
  *                                                    if certificates are used
+ *    Achim Kraus (Bosch Software Innovations GmbH) - issue #549
+ *                                                    trustStore := null, disable x.509
+ *                                                    trustStore := [], enable x.509, trust all
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -166,7 +169,7 @@ public class ClientHandshaker extends Handshaker {
 
 			// we always support receiving a RawPublicKey from the server
 			this.supportedServerCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
-			if (rootCertificates != null && rootCertificates.length > 0) {
+			if (rootCertificates != null) {
 				int index = config.isSendRawKey() ? 1 : 0;
 				this.supportedServerCertificateTypes.add(index, CertificateType.X_509);
 			}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -35,6 +35,9 @@
  *    Ludwig Seitz (RISE SICS) - Moved certificate validation here from CertificateMessage
  *    Ludwig Seitz (RISE SICS) - Added support for raw public key validation
  *    Bosch Software Innovations GmbH - migrate to SLF4J
+ *    Achim Kraus (Bosch Software Innovations GmbH) - issue #549
+ *                                                    trustStore := null, disable x.509
+ *                                                    trustStore := [], enable x.509, trust all
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -228,7 +231,7 @@ public abstract class Handshaker {
 		this.session = session;
 		this.recordLayer = recordLayer;
 		addSessionListener(sessionListener);
-		this.rootCertificates = rootCertificates == null ? new X509Certificate[0] : rootCertificates;
+		this.rootCertificates = rootCertificates;
 		this.session.setMaxTransmissionUnit(maxTransmissionUnit);
 		this.inboundMessageBuffer = new InboundMessageBuffer();
 
@@ -983,6 +986,11 @@ public abstract class Handshaker {
 	 */
 	public void verifyCertificate(CertificateMessage message) throws HandshakeException {
 		if (message.getCertificateChain() != null) {
+
+			if (rootCertificates != null && rootCertificates.length == 0) {
+				// trust empty list of root certificates
+				return;
+			}
 
 			Set<TrustAnchor> trustAnchors = getTrustAnchors(rootCertificates);
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -41,6 +41,9 @@
  *                                                    Additionally don't send cert types, if
  *                                                    only none cert cipher suites are supported
  *                                                    (similar to PR #468)
+ *    Achim Kraus (Bosch Software Innovations GmbH) - issue #549
+ *                                                    trustStore := null, disable x.509
+ *                                                    trustStore := [], enable x.509, trust all
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -212,7 +215,7 @@ public class ServerHandshaker extends Handshaker {
 
 			if (this.clientAuthenticationRequired) {
 				this.supportedClientCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
-				if (rootCertificates != null && rootCertificates.length > 0) {
+				if (rootCertificates != null) {
 					int index = config.isSendRawKey() ? 1 : 0;
 					this.supportedClientCertificateTypes.add(index, CertificateType.X_509);
 				}


### PR DESCRIPTION
trustStore := null, disable x.509
trustStore := [], enable x.509, trust all

Simple solution without `TrustedCertificateStore`.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>