### PR TITLE
Update NettyContextUtils to store the peer certificate chain

### DIFF
--- a/element-connector-tcp/src/test/java/org/eclipse/californium/elements/tcp/TlsConnectorTestUtil.java
+++ b/element-connector-tcp/src/test/java/org/eclipse/californium/elements/tcp/TlsConnectorTestUtil.java
@@ -16,7 +16,9 @@
 package org.eclipse.californium.elements.tcp;
 
 import java.security.Principal;
+import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
@@ -24,6 +26,7 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509ExtendedTrustManager;
 
+import org.eclipse.californium.elements.auth.X509CertPath;
 import org.eclipse.californium.elements.util.SslContextUtil;
 import org.eclipse.californium.elements.util.SslContextUtil.Credentials;
 
@@ -43,7 +46,9 @@ public class TlsConnectorTestUtil {
 	public static SSLContext serverSslContext;
 	public static SSLContext clientSslContext;
 	public static Principal serverSubjectDN;
+	public static X509CertPath serverCertPath;
 	public static Principal clientSubjectDN;
+	public static X509CertPath clientCertPath;
 
 	public static void initializeSsl() throws Exception {
 		KeyManager[] clientKeys = SslContextUtil.loadKeyManager(SslContextUtil.CLASSPATH_SCHEME + KEY_STORE_LOCATION,
@@ -54,7 +59,9 @@ public class TlsConnectorTestUtil {
 				.loadTrustManager(SslContextUtil.CLASSPATH_SCHEME + TRUST_STORE_LOCATION, null, TRUST_STORE_PASSWORD);
 
 		clientSubjectDN = getSubjectDN(clientKeys, CLIENT_NAME);
+		clientCertPath = getX509CertPath(clientKeys, CLIENT_NAME);
 		serverSubjectDN = getSubjectDN(serverKeys, SERVER_NAME);
+		serverCertPath = getX509CertPath(serverKeys, SERVER_NAME);
 		log("client " + clientSubjectDN, clientKeys);
 		log("server " + serverSubjectDN, serverKeys);
 		log("trusts", trusts, true);
@@ -111,6 +118,26 @@ public class TlsConnectorTestUtil {
 				}
 			}
 		}
+		return null;
+	}
+
+	public static X509CertPath getX509CertPath(KeyManager[] manager, String alias) {
+		if (manager == null || manager.length == 0 || !(manager[0] instanceof X509ExtendedKeyManager)) {
+			return null;
+		}
+
+		X509ExtendedKeyManager extendedManager = (X509ExtendedKeyManager) manager[0];
+		X509Certificate[] chain = extendedManager.getCertificateChain(alias);
+		if (chain != null && chain.length > 0) {
+			try {
+				java.security.cert.CertificateFactory cf = java.security.cert.CertificateFactory.getInstance("X.509");
+				java.security.cert.CertPath javaCertPath = cf.generateCertPath(Arrays.asList(chain));
+				return new X509CertPath(javaCertPath);
+			} catch (CertificateException e) {
+				/* ignore it */
+			}
+		}
+
 		return null;
 	}
 

--- a/element-connector-tcp/src/test/java/org/eclipse/californium/elements/tcp/TlsCorrelationTest.java
+++ b/element-connector-tcp/src/test/java/org/eclipse/californium/elements/tcp/TlsCorrelationTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.text.IsEmptyString.isEmptyOrNullString;
 
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -33,9 +34,11 @@ import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.TcpEndpointContext;
 import org.eclipse.californium.elements.TlsEndpointContext;
 import org.eclipse.californium.elements.TlsEndpointContextMatcher;
+import org.eclipse.californium.elements.auth.X509CertPath;
 import org.eclipse.californium.elements.tcp.TlsConnectorTestUtil.SSLTestContext;
 import org.eclipse.californium.elements.tcp.TlsServerConnector.ClientAuthMode;
 import org.eclipse.californium.elements.util.SimpleMessageCallback;
+import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -434,7 +437,11 @@ public class TlsCorrelationTest {
 		serverCatcher.blockUntilSize(1);
 		RawData receivedMessage = serverCatcher.getMessage(0);
 		assertThat(receivedMessage, is(notNullValue()));
-		assertThat(receivedMessage.getSenderIdentity(), is(clientSubjectDN));
+
+		assertThat(receivedMessage.getSenderIdentity(), is(CoreMatchers.<Principal>instanceOf(X509CertPath.class)));
+		X509CertPath senderCertPath = (X509CertPath)receivedMessage.getSenderIdentity();
+		assertThat(senderCertPath.getName(), is(clientCertPath.getName()));
+		assertThat(senderCertPath.getPath(), is(clientCertPath.getPath()));
 	}
 
 	/**
@@ -502,7 +509,11 @@ public class TlsCorrelationTest {
 
 		RawData receivedMessage = clientCatcher.getMessage(0);
 		assertThat(receivedMessage, is(notNullValue()));
-		assertThat(receivedMessage.getSenderIdentity(), is(serverSubjectDN));
+
+		assertThat(receivedMessage.getSenderIdentity(), is(CoreMatchers.<Principal>instanceOf(X509CertPath.class)));
+		X509CertPath senderCertPath = (X509CertPath)receivedMessage.getSenderIdentity();
+		assertThat(senderCertPath.getName(), is(serverCertPath.getName()));
+		assertThat(senderCertPath.getPath(), is(serverCertPath.getPath()));
 	}
 
 	/**

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/X509CertPath.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/X509CertPath.java
@@ -13,7 +13,7 @@
  * Contributors:
  *    Bosch Software Innovations - initial creation
  ******************************************************************************/
-package org.eclipse.californium.scandium.auth;
+package org.eclipse.californium.elements.auth;
 
 import java.io.ByteArrayInputStream;
 import java.security.Principal;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/auth/PrincipalSerializer.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/auth/PrincipalSerializer.java
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.Principal;
 
+import org.eclipse.californium.elements.auth.X509CertPath;
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 
 import org.eclipse.californium.scandium.auth.PreSharedKeyIdentity;
 import org.eclipse.californium.scandium.auth.RawPublicKeyIdentity;
-import org.eclipse.californium.scandium.auth.X509CertPath;
+import org.eclipse.californium.elements.auth.X509CertPath;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 
 import org.eclipse.californium.scandium.auth.PreSharedKeyIdentity;
 import org.eclipse.californium.scandium.auth.RawPublicKeyIdentity;
-import org.eclipse.californium.scandium.auth.X509CertPath;
+import org.eclipse.californium.elements.auth.X509CertPath;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -72,7 +72,7 @@ import org.eclipse.californium.elements.RawDataChannel;
 import org.eclipse.californium.elements.util.SimpleMessageCallback;
 import org.eclipse.californium.scandium.auth.PreSharedKeyIdentity;
 import org.eclipse.californium.scandium.auth.RawPublicKeyIdentity;
-import org.eclipse.californium.scandium.auth.X509CertPath;
+import org.eclipse.californium.elements.auth.X509CertPath;
 import org.eclipse.californium.scandium.category.Medium;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.AlertMessage;


### PR DESCRIPTION
While using TLS, we try to get the peer certificate chain (X509CertPath) or
fallback to get the peer principal (X500Principal).