### PR TITLE
fix jar-with-dependencies given priority to module files when duplicates

### DIFF
--- a/enhanced-jar-with-dependencies.xml
+++ b/enhanced-jar-with-dependencies.xml
@@ -1,0 +1,27 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+	<id>jar-with-dependencies</id>
+
+	<!-- This descriptor behave like maven "jar-with-dependency" except it ensure 
+		that current module files have always priority on dependency files in case 
+		of duplicate -->
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.outputDirectory}</directory>
+			<outputDirectory/>
+		</fileSet>
+	</fileSets>
+	<dependencySets>
+		<dependencySet>
+			<outputDirectory>/</outputDirectory>
+			<useProjectArtifact>false</useProjectArtifact>
+			<unpack>true</unpack>
+			<scope>runtime</scope>
+		</dependencySet>
+	</dependencySets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -280,9 +280,9 @@
 								<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
 							</manifest>
 						</archive>
-						<descriptorRefs>
-							<descriptorRef>jar-with-dependencies</descriptorRef>
-						</descriptorRefs>
+						<descriptors>
+							<descriptor>enhanced-jar-with-dependencies.xml</descriptor>
+						</descriptors>
 					</configuration>
 					<executions>
 						<execution>


### PR DESCRIPTION
A lot of modules in `demo-apps` are executables.
Most of them add a `logback.xml` config in `src/main/resources`.
Some of demo app depends on other demo apps.
For most of this executable we create an uber-jar using `maven-assembly-plugin` and the descriptor `jar-with-dependencies`.

**Problems :** the `logback.xml` files could be present in the main module and in its dependencies and there is nothing which ensures that the main module file will be chosen.  I face this issue with `cf-extplugtest-*` which depends on `cf-plugtest-*`.

**What I understand of this problems :**
[`jar-with-dependencies` descriptors](https://maven.apache.org/plugins/maven-assembly-plugin/descriptor-refs.html#jar-with-dependencies) uses the attribute `useProjectArtifact` which includes the current project as `dependencySet`, so all duplicate files have the same priority and so no guarantee about which files will be used. 

**Solution :**
Set `useProjectArtifact` to false and add files of current module using a `fileSet` which have priority on `dependencySet` (for more [details](https://maven.apache.org/plugins/maven-assembly-plugin/advanced-descriptor-topics.html#Archive_file_resolution))

This sounds to make the tricks.
I opened a [bug](https://issues.apache.org/jira/browse/MASSEMBLY-877) to maven-assembly to see what they think about this solution.
This only fixes the problem at maven side and we face the same kind of issue when we run executable in eclipse. Fixing this in eclipse also need more modifications. You can look at what I have done in Leshan ( https://github.com/eclipse/leshan/pull/475 https://github.com/eclipse/leshan/issues/473).

Here what we could try to achieve about logs : 
 - no mixed log config for tests in maven : already done.
 - no mixed log config for executable in maven : done in this PR.
 - be able to use log config for tests in eclipse without -D  option : it should look like this https://github.com/eclipse/leshan/pull/475/commits/c46ca49278c13897d4cb8b596f088321a2ace220
 - be able to use log config for executable in eclipse without -D  option.

For the last point, there is many solutions, depending if we want an "in jar" default log config, or an "out jar" default log config or if we want both. In Leshan I propose a PR with both, but  a simple solution for the "in jar" config could be to add this for each executable.
```java
static {
    // MUST BE SET BEFORE THE FIRST CALL to  LoggerFactory.getLogger();
    System.setProperty("logback.configurationFile", "src/main/resources/logback.xml");
}  
```

Just let me know which kind of goal we want to achieve and I could provide others PR.

(So many lines, just to making logs works...)








