### PR TITLE
Fix issue #560

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtensions.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtensions.java
@@ -67,7 +67,7 @@ public final class HelloExtensions {
 	/**
 	 * Checks if this container actually holds any extensions.
 	 * 
-	 * @return <code>true</code> if there are any extensions
+	 * @return <code>true</code> if there are no extensions
 	 */
 	boolean isEmpty() {
 		return this.extensions.isEmpty();


### PR DESCRIPTION
If client auth is not required, don't sent client cert types in
SERVER_HELLO. Additionally don't send cert types, if only none cert
cipher suites are supported (similar to PR #468).

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>