### PR TITLE
Downgrade eclipse-jarsigner-plugin (1.1.4 => 1.1.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,7 @@
 					<plugin>
 						<groupId>org.eclipse.cbi.maven.plugins</groupId>
 						<artifactId>eclipse-jarsigner-plugin</artifactId>
-						<version>1.1.4</version>
+						<version>1.1.3</version>
 						<executions>
 							<execution>
 								<id>sign-jars</id>


### PR DESCRIPTION
Nightly build for 2.0.x failed because of :
```
[ERROR] Failed to execute goal org.eclipse.cbi.maven.plugins:eclipse-jarsigner-plugin:1.1.4:sign (sign-jars) on project parent: 
Execution sign-jars of goal org.eclipse.cbi.maven.plugins:eclipse-jarsigner-plugin:1.1.4:sign failed:
Unable to load the mojo 'sign' in the plugin 'org.eclipse.cbi.maven.plugins:eclipse-jarsigner-plugin:1.1.4' due to an API incompatibility:
org.codehaus.plexus.component.repository.exception.ComponentLookupException: org/eclipse/cbi/maven/plugins/jarsigner/mojo/SignMojo : Unsupported major.minor version 52.0
```
I think this is because [jarsigner 1.1.4](https://www.eclipse.org/cbi/maven-plugins/documentation/1.1.4/eclipse-jarsigner-plugin/plugin-info.html) depends on maven 3.3.1 (and jenkins uses maven 3.0.5)

I missed this details because using `mvn versions:display-plugin-updates`, I forgot to active the `eclipse_jar_signing` profile to check eclipse-jarsigner-plugin too.
(`mvn versions:display-plugin-updates -Peclipse_jar_signing`)

This PR go back to the 1.1.3 version.