### PR TITLE
Fix for issue #567.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/Utils.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/Utils.java
@@ -27,6 +27,7 @@ package org.eclipse.californium.core;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.elements.util.StringUtil;
 
 /**
  * Auxiliary helper methods for Californium.
@@ -74,11 +75,11 @@ public final class Utils {
 		if (bytes == null) return "null";
 		if (length > bytes.length) length = bytes.length;
 		StringBuilder sb = new StringBuilder();
-		if (16 < length) sb.append(System.lineSeparator());
+		if (16 < length) sb.append(StringUtil.lineSeparator());
 		for(int index = 0; index < length; ++index) {
 			sb.append(String.format("%02x", bytes[index] & 0xFF));
 			if (31 == (31 & index)) {
-				sb.append(System.lineSeparator());
+				sb.append(StringUtil.lineSeparator());
 			} else {
 				sb.append(' ');
 			}
@@ -99,17 +100,17 @@ public final class Utils {
 
 		StringBuilder sb = new StringBuilder();
 
-		sb.append("==[ CoAP Request ]=============================================").append(System.lineSeparator());
-		sb.append(String.format("MID    : %d", r.getMID())).append(System.lineSeparator());
-		sb.append(String.format("Token  : %s", r.getTokenString())).append(System.lineSeparator());
-		sb.append(String.format("Type   : %s", r.getType().toString())).append(System.lineSeparator());
-		sb.append(String.format("Method : %s", r.getCode().toString())).append(System.lineSeparator());
-		sb.append(String.format("Options: %s", r.getOptions().toString())).append(System.lineSeparator());
-		sb.append(String.format("Payload: %d Bytes", r.getPayloadSize())).append(System.lineSeparator());
+		sb.append("==[ CoAP Request ]=============================================").append(StringUtil.lineSeparator());
+		sb.append(String.format("MID    : %d", r.getMID())).append(StringUtil.lineSeparator());
+		sb.append(String.format("Token  : %s", r.getTokenString())).append(StringUtil.lineSeparator());
+		sb.append(String.format("Type   : %s", r.getType().toString())).append(StringUtil.lineSeparator());
+		sb.append(String.format("Method : %s", r.getCode().toString())).append(StringUtil.lineSeparator());
+		sb.append(String.format("Options: %s", r.getOptions().toString())).append(StringUtil.lineSeparator());
+		sb.append(String.format("Payload: %d Bytes", r.getPayloadSize())).append(StringUtil.lineSeparator());
 		if (r.getPayloadSize() > 0 && MediaTypeRegistry.isPrintable(r.getOptions().getContentFormat())) {
-			sb.append("---------------------------------------------------------------").append(System.lineSeparator());
+			sb.append("---------------------------------------------------------------").append(StringUtil.lineSeparator());
 			sb.append(r.getPayloadString());
-			sb.append(System.lineSeparator());
+			sb.append(StringUtil.lineSeparator());
 		}
 		sb.append("===============================================================");
 
@@ -135,20 +136,20 @@ public final class Utils {
 	public static String prettyPrint(Response r) {
 		StringBuilder sb = new StringBuilder();
 
-		sb.append("==[ CoAP Response ]============================================").append(System.lineSeparator());
-		sb.append(String.format("MID    : %d", r.getMID())).append(System.lineSeparator());
-		sb.append(String.format("Token  : %s", r.getTokenString())).append(System.lineSeparator());
-		sb.append(String.format("Type   : %s", r.getType().toString())).append(System.lineSeparator());
-		sb.append(String.format("Status : %s", r.getCode().toString())).append(System.lineSeparator());
-		sb.append(String.format("Options: %s", r.getOptions().toString())).append(System.lineSeparator());
+		sb.append("==[ CoAP Response ]============================================").append(StringUtil.lineSeparator());
+		sb.append(String.format("MID    : %d", r.getMID())).append(StringUtil.lineSeparator());
+		sb.append(String.format("Token  : %s", r.getTokenString())).append(StringUtil.lineSeparator());
+		sb.append(String.format("Type   : %s", r.getType().toString())).append(StringUtil.lineSeparator());
+		sb.append(String.format("Status : %s", r.getCode().toString())).append(StringUtil.lineSeparator());
+		sb.append(String.format("Options: %s", r.getOptions().toString())).append(StringUtil.lineSeparator());
 		if (r.getRTT() != null) {
-			sb.append(String.format("RTT    : %d ms", r.getRTT())).append(System.lineSeparator());
+			sb.append(String.format("RTT    : %d ms", r.getRTT())).append(StringUtil.lineSeparator());
 		}
-		sb.append(String.format("Payload: %d Bytes", r.getPayloadSize())).append(System.lineSeparator());
+		sb.append(String.format("Payload: %d Bytes", r.getPayloadSize())).append(StringUtil.lineSeparator());
 		if (r.getPayloadSize() > 0 && MediaTypeRegistry.isPrintable(r.getOptions().getContentFormat())) {
-			sb.append("---------------------------------------------------------------").append(System.lineSeparator());
+			sb.append("---------------------------------------------------------------").append(StringUtil.lineSeparator());
 			sb.append(r.getPayloadString());
-			sb.append(System.lineSeparator());
+			sb.append(StringUtil.lineSeparator());
 		}
 		sb.append("===============================================================");
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/WebLink.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/WebLink.java
@@ -21,6 +21,7 @@ package org.eclipse.californium.core;
 
 import org.eclipse.californium.core.coap.LinkFormat;
 import org.eclipse.californium.core.server.resources.ResourceAttributes;
+import org.eclipse.californium.elements.util.StringUtil;
 
 /**
  * The WebLink class can be used to programmatically browse a remote CoAP endoint.
@@ -60,19 +61,19 @@ public class WebLink implements Comparable<WebLink> {
 		builder.append('>');
 		builder.append(' ').append(this.attributes.getTitle());
 		if (this.attributes.containsAttribute(LinkFormat.RESOURCE_TYPE)) {
-			builder.append(System.lineSeparator()).append("\t").append(LinkFormat.RESOURCE_TYPE).append(":\t").append(this.attributes.getResourceTypes());
+			builder.append(StringUtil.lineSeparator()).append("\t").append(LinkFormat.RESOURCE_TYPE).append(":\t").append(this.attributes.getResourceTypes());
 		}
 		if (this.attributes.containsAttribute(LinkFormat.INTERFACE_DESCRIPTION)) {
-			builder.append(System.lineSeparator()).append("\t").append(LinkFormat.INTERFACE_DESCRIPTION).append(":\t").append(this.attributes.getInterfaceDescriptions());
+			builder.append(StringUtil.lineSeparator()).append("\t").append(LinkFormat.INTERFACE_DESCRIPTION).append(":\t").append(this.attributes.getInterfaceDescriptions());
 		}
 		if (this.attributes.containsAttribute(LinkFormat.CONTENT_TYPE)) {
-			builder.append(System.lineSeparator()).append("\t").append(LinkFormat.CONTENT_TYPE).append(":\t").append(this.attributes.getContentTypes());
+			builder.append(StringUtil.lineSeparator()).append("\t").append(LinkFormat.CONTENT_TYPE).append(":\t").append(this.attributes.getContentTypes());
 		}
 		if (this.attributes.containsAttribute(LinkFormat.MAX_SIZE_ESTIMATE)) {
-			builder.append(System.lineSeparator()).append("\t").append(LinkFormat.MAX_SIZE_ESTIMATE).append(":\t").append(this.attributes.getMaximumSizeEstimate());
+			builder.append(StringUtil.lineSeparator()).append("\t").append(LinkFormat.MAX_SIZE_ESTIMATE).append(":\t").append(this.attributes.getMaximumSizeEstimate());
 		}
 		if (this.attributes.hasObservable()) {
-			builder.append(System.lineSeparator()).append("\t").append(LinkFormat.OBSERVABLE);
+			builder.append(StringUtil.lineSeparator()).append("\t").append(LinkFormat.OBSERVABLE);
 		}
 		return builder.toString();
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAP.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAP.java
@@ -27,7 +27,8 @@ package org.eclipse.californium.core.coap;
 import static org.eclipse.californium.core.coap.CoAP.MessageFormat.*;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+
+import org.eclipse.californium.elements.util.StandardCharsets;
 
 /**
  * CoAP defines several constants.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -38,11 +38,22 @@ import java.io.InputStream;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
+
+import org.eclipse.californium.elements.util.NotForAndroid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * The configuration for a Californium server, endpoint and/or connector.
+ * Depending on the environment, the configuration is stored and loaded from
+ * properties files. If file access is not possible, there are variants, which
+ * are marked as "WithoutFile" or variants, which use a {@link InputStream} to
+ * read the properties.
+ * 
+ * Note: For Android it's recommended to use the AssetManager and pass in the
+ * InputStream to the variants using that as parameter. Alternatively you may
+ * chose to use the "WithoutFile" variant and, if required, adjust the defaults
+ * in your code.
  */
 public final class NetworkConfig {
 
@@ -217,6 +228,12 @@ public final class NetworkConfig {
 	 * or server is created without a specific network configuration, it will
 	 * use this standard configuration.
 	 * 
+	 * For Android, please ensure, that either
+	 * {@link NetworkConfig#setStandard(NetworkConfig)},
+	 * {@link NetworkConfig#createStandardWithoutFile()}, or
+	 * {@link NetworkConfig#createStandardFromStream(InputStream)} is called
+	 * before!
+	 * 
 	 * @return the standard configuration
 	 */
 	public static NetworkConfig getStandard() {
@@ -268,7 +285,8 @@ public final class NetworkConfig {
 	 * @param customHandler custom defaults handler. Maybe {@code null}.
 	 * @return the configuration
 	 */
-	public static NetworkConfig createFromStream(InputStream inStream, final NetworkConfigDefaultHandler customHandler) {
+	public static NetworkConfig createFromStream(InputStream inStream,
+			final NetworkConfigDefaultHandler customHandler) {
 		LOGGER.info("Creating network configuration properties from stream");
 		NetworkConfig standard = new NetworkConfig();
 		if (customHandler != null) {
@@ -286,10 +304,15 @@ public final class NetworkConfig {
 	 * Creates the standard with a file. If the provided file exists, the
 	 * configuration reads the properties from this file. Otherwise it creates
 	 * the file.
+	 *
+	 * For Android, please use
+	 * {@link NetworkConfig#createStandardWithoutFile()}, or
+	 * {@link NetworkConfig#createStandardFromStream(InputStream)}.
 	 * 
 	 * @param file the configuration file
 	 * @return the network configuration
 	 */
+	@NotForAndroid
 	public static NetworkConfig createStandardWithFile(final File file) {
 		standard = createWithFile(file, DEFAULT_HEADER, null);
 		return standard;
@@ -300,12 +323,18 @@ public final class NetworkConfig {
 	 * configuration reads the properties from this file. Otherwise it creates
 	 * the file with the provided header.
 	 * 
+	 * For Android, please use {@link NetworkConfig#NetworkConfig()}, and load
+	 * the values using {@link NetworkConfig#load(InputStream)} or adjust the in
+	 * your code.
+	 * 
 	 * @param file the configuration file
 	 * @param header The header to write to the top of the file.
 	 * @param customHandler custom defaults handler. Maybe {@code null}.
 	 * @return the network configuration
 	 */
-	public static NetworkConfig createWithFile(final File file, final String header, final NetworkConfigDefaultHandler customHandler) {
+	@NotForAndroid
+	public static NetworkConfig createWithFile(final File file, final String header,
+			final NetworkConfigDefaultHandler customHandler) {
 		NetworkConfig standard = new NetworkConfig();
 		if (customHandler != null) {
 			customHandler.applyDefaults(standard);
@@ -330,9 +359,12 @@ public final class NetworkConfig {
 	/**
 	 * Loads properties from a file.
 	 *
+	 * For Android, please use {@link NetworkConfig#load(InputStream)}.
+	 * 
 	 * @param file the file
 	 * @throws NullPointerException if the file is {@code null}.
 	 */
+	@NotForAndroid
 	public void load(final File file) {
 		if (file == null) {
 			throw new NullPointerException("file must not be null");
@@ -362,10 +394,13 @@ public final class NetworkConfig {
 
 	/**
 	 * Stores the configuration to a file.
+	 * 
+	 * For available for Android!
 	 *
 	 * @param file The file to write to.
 	 * @throws NullPointerException if the file is {@code null}.
 	 */
+	@NotForAndroid
 	public void store(final File file) {
 		store(file, DEFAULT_HEADER);
 	}
@@ -373,10 +408,13 @@ public final class NetworkConfig {
 	/**
 	 * Stores the configuration to a file using a given header.
 	 * 
+	 * For available for Android!
+	 * 
 	 * @param file The file to write to.
 	 * @param header The header to write to the top of the file.
 	 * @throws NullPointerException if the file is {@code null}.
 	 */
+	@NotForAndroid
 	public void store(File file, String header) {
 		if (file == null) {
 			throw new NullPointerException("file must not be null");

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/RandomAccessBlockTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/RandomAccessBlockTest.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.assertTrue;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.eclipse.californium.category.Medium;
@@ -38,6 +37,7 @@ import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapResponse;
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.BlockOption;
+import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
@@ -168,7 +168,7 @@ public class RandomAccessBlockTest {
 		private BlockwiseResource(String name, String responsePayload) {
 			super(name);
 			this.responsePayload = responsePayload;
-			buf = ByteBuffer.wrap(responsePayload.getBytes(StandardCharsets.US_ASCII));
+			buf = ByteBuffer.wrap(responsePayload.getBytes(CoAP.UTF8_CHARSET));
 		}
 
 		@Override

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
@@ -19,8 +19,8 @@
  ******************************************************************************/
 package org.eclipse.californium.proxy;
 
-import static java.nio.charset.StandardCharsets.ISO_8859_1;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.eclipse.californium.elements.util.StandardCharsets.ISO_8859_1;
+import static org.eclipse.californium.elements.util.StandardCharsets.UTF_8;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;

--- a/californium-proxy/src/test/java/org/eclipse/californium/proxy/HttpTranslatorTest.java
+++ b/californium-proxy/src/test/java/org/eclipse/californium/proxy/HttpTranslatorTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
@@ -27,6 +26,7 @@ import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.elements.util.StandardCharsets;
 import org.junit.Test;
 
 public class HttpTranslatorTest {

--- a/element-connector-tcp/src/main/java/org/eclipse/californium/elements/tcp/TlsClientConnector.java
+++ b/element-connector-tcp/src/main/java/org/eclipse/californium/elements/tcp/TlsClientConnector.java
@@ -33,6 +33,7 @@ import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.EndpointContextMatcher;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.TlsEndpointContext;
+import org.eclipse.californium.elements.util.NotForAndroid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,7 +154,7 @@ public class TlsClientConnector extends TcpClientConnector {
 		if (remoteAddress instanceof InetSocketAddress) {
 			InetSocketAddress remote = (InetSocketAddress) remoteAddress;
 			LOGGER.info("Connection to inet {}", remote);
-			return sslContext.createSSLEngine(remote.getHostString(), remote.getPort());
+			return sslContext.createSSLEngine(remote.getAddress().getHostAddress(), remote.getPort());
 		} else {
 			LOGGER.info("Connection to {}", remoteAddress);
 			return sslContext.createSSLEngine();

--- a/element-connector-tcp/src/main/java/org/eclipse/californium/elements/tcp/TlsServerConnector.java
+++ b/element-connector-tcp/src/main/java/org/eclipse/californium/elements/tcp/TlsServerConnector.java
@@ -27,6 +27,7 @@ import java.net.SocketAddress;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
+import org.eclipse.californium.elements.util.NotForAndroid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,7 +145,7 @@ public class TlsServerConnector extends TcpServerConnector {
 		if (remoteAddress instanceof InetSocketAddress) {
 			InetSocketAddress remote = (InetSocketAddress) remoteAddress;
 			LOGGER.info("Connection from inet {}", remote);
-			return sslContext.createSSLEngine(remote.getHostString(), remote.getPort());
+			return sslContext.createSSLEngine(remote.getAddress().getHostAddress(), remote.getPort());
 		} else {
 			LOGGER.info("Connection from {}", remoteAddress);
 			return sslContext.createSSLEngine();

--- a/element-connector/src/main/java/org/eclipse/californium/elements/AddressEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/AddressEndpointContext.java
@@ -21,10 +21,15 @@ import java.security.Principal;
 import java.util.Collections;
 import java.util.Map;
 
+import org.eclipse.californium.elements.util.StringUtil;
+
 /**
- * A endpoint context providing the inet socket address and a optional principal.
+ * A endpoint context providing the inet socket address and a optional
+ * principal.
  */
 public class AddressEndpointContext implements EndpointContext {
+
+	protected static final int ID_TRUNC_LENGTH = 6;
 
 	private final InetSocketAddress peerAddress;
 
@@ -133,7 +138,10 @@ public class AddressEndpointContext implements EndpointContext {
 
 	@Override
 	public String toString() {
-		return String.format("IP(%s:%d)", peerAddress.getHostString(), peerAddress.getPort());
+		return String.format("IP(%s)", getPeerAddressAsString());
 	}
 
+	protected String getPeerAddressAsString() {
+		return StringUtil.toString(peerAddress);
+	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
@@ -22,6 +22,8 @@ package org.eclipse.californium.elements;
 import java.net.InetSocketAddress;
 import java.security.Principal;
 
+import org.eclipse.californium.elements.util.StringUtil;
+
 /**
  * A endpoint context that explicitly supports DTLS specific properties.
  */
@@ -61,7 +63,7 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 
 	@Override
 	public String toString() {
-		return String.format("DTLS(%s:%d,ID:%s)", getPeerAddress().getHostString(), getPeerAddress().getPort(),
-				getSessionId());
+		return String.format("DTLS(%s,ID:%s)", getPeerAddressAsString(),
+				StringUtil.trunc(getSessionId(), ID_TRUNC_LENGTH));
 	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
@@ -169,7 +169,7 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 
 	@Override
 	public String toString() {
-		return String.format("MAP(%s:%d)", getPeerAddress().getHostString(), getPeerAddress().getPort());
+		return String.format("MAP(%s)", getPeerAddressAsString());
 	}
 
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/TcpEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/TcpEndpointContext.java
@@ -22,6 +22,8 @@ package org.eclipse.californium.elements;
 import java.net.InetSocketAddress;
 import java.security.Principal;
 
+import org.eclipse.californium.elements.util.StringUtil;
+
 /**
  * A endpoint context that explicitly supports TCP specific properties.
  */
@@ -72,8 +74,8 @@ public class TcpEndpointContext extends MapBasedEndpointContext {
 
 	@Override
 	public String toString() {
-		return String.format("TCP(%s:%d,ID:%s)", getPeerAddress().getHostString(), getPeerAddress().getPort(),
-				getConnectionId());
+		return String.format("TCP(%s,ID:%s)", getPeerAddressAsString(),
+				StringUtil.trunc(getConnectionId(), ID_TRUNC_LENGTH));
 	}
 
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/TlsEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/TlsEndpointContext.java
@@ -62,7 +62,9 @@ public class TlsEndpointContext extends TcpEndpointContext {
 
 	@Override
 	public String toString() {
-		return String.format("TLS(%s,%s,%s)", getConnectionId(), StringUtil.trunc(getSessionId(), 15), getCipher());
+		return String.format("TLS(%s,%s,%s,%s)", getPeerAddressAsString(),
+				StringUtil.trunc(getConnectionId(), ID_TRUNC_LENGTH), StringUtil.trunc(getSessionId(), ID_TRUNC_LENGTH),
+				getCipher());
 	}
 
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/NotForAndroid.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/NotForAndroid.java
@@ -13,23 +13,12 @@
  * Contributors:
  *    Bosch Software Innovations GmbH - initial implementation
  ******************************************************************************/
-package org.eclipse.californium.elements;
-
-import java.net.InetSocketAddress;
+package org.eclipse.californium.elements.util;
 
 /**
- * A endpoint context for plain UDP.
+ * Methods or classes marked by this annotation are not intended to be used for
+ * Android! Please use the documented alternatives, if available.
  */
-public class UdpEndpointContext extends MapBasedEndpointContext {
+public @interface NotForAndroid {
 
-	public static final String KEY_PLAIN = "PLAIN";
-
-	public UdpEndpointContext(InetSocketAddress peerAddress) {
-		super(peerAddress, null, KEY_PLAIN, "");
-	}
-
-	@Override
-	public String toString() {
-		return String.format("UDP(%s)", getPeerAddressAsString());
-	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/StandardCharsets.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/StandardCharsets.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation
+ *                                      fix for issue #567
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import java.nio.charset.Charset;
+
+/**
+ * Used standard character sets for californium.
+ * 
+ * Replacement of java.nio.charset.StandardCharsets, which requires java 1.7, to
+ * support older android versions.
+ */
+public interface StandardCharsets {
+	/**
+	 * UTF 8 character set. Default for most cases in CoAP.
+	 */
+	Charset UTF_8 = Charset.forName("UTF-8");
+	/**
+	 * US ASCII character set. Used by some encryption functions.
+	 */
+	Charset US_ASCII = Charset.forName("US-ASCII");
+	/**
+	 * ISO 8859 1 character set. Used by some HTTP proxy functions.
+	 */
+	Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
+
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/StringUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/StringUtil.java
@@ -17,10 +17,52 @@
  ******************************************************************************/
 package org.eclipse.californium.elements.util;
 
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
 /**
  * String utils (as there are so many already out).
  */
 public class StringUtil {
+
+	/**
+	 * Workaround too support android API 16-18.
+	 * 
+	 * @see #lineSeparator()
+	 */
+	public static final String lineSeparator = System.getProperty("line.separator");
+
+	/**
+	 * Flag indicating, that InetSocketAddress supports "getHostString".
+	 */
+	public static final boolean SUPPORT_HOST_STRING;
+
+	static {
+		boolean support = false;
+		try {
+			Method method = InetSocketAddress.class.getMethod("getHostString");
+			support = method != null;
+		} catch (NoSuchMethodException e) {
+			// android before API 18
+		}
+		SUPPORT_HOST_STRING = support;
+	}
+
+	@NotForAndroid
+	private static String toHostString(InetSocketAddress address) {
+		return address.getHostString();
+	}
+
+	/**
+	 * Return line separator.
+	 * 
+	 * @return line separator
+	 * @see #lineSeparator
+	 */
+	public static String lineSeparator() {
+		return lineSeparator;
+	}
 
 	/**
 	 * Convert hexadecimal String into decoded character array. Intended to be
@@ -101,4 +143,35 @@ public class StringUtil {
 		return text;
 	}
 
+	/**
+	 * Get address as string for logging.
+	 * 
+	 * @param address address to be converted to string
+	 * @return the host address, or {@code null}, if address is {@code null}.
+	 */
+	public static String toString(InetAddress address) {
+		if (address == null) {
+			return null;
+		}
+		return address.getHostAddress();
+	}
+
+	/**
+	 * Get socket address as string for logging.
+	 * 
+	 * @param address socket address to be converted to string
+	 * @return the host string, if available, otherwise the host address
+	 *         appended with ":" and the port. Or {@code null}, if address is
+	 *         {@code null}.
+	 */
+	public static String toString(InetSocketAddress address) {
+		if (address == null) {
+			return null;
+		}
+		if (SUPPORT_HOST_STRING) {
+			return toHostString(address);
+		} else {
+			return address.getAddress().getHostAddress() + ":" + address.getPort();
+		}
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -363,9 +363,12 @@
 					<configuration>
 						<signature>
 							<groupId>net.sf.androidscents.signature</groupId>
-							<artifactId>android-api-level-19</artifactId>
-							<version>4.4_r1</version>
+							<artifactId>android-api-level-16</artifactId>
+							<version>4.1.2_r5</version>
 						</signature>
+						<annotations>
+							<annotation>org.eclipse.californium.elements.util.NotForAndroid</annotation>
+						</annotations>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -105,6 +105,7 @@ import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
 import org.eclipse.californium.elements.util.DaemonThreadFactory;
 import org.eclipse.californium.elements.util.NamedThreadFactory;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.AlertMessage;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
@@ -972,7 +973,7 @@ public class DTLSConnector implements Connector {
 		if (LOGGER.isDebugEnabled()) {
 			StringBuilder msg = new StringBuilder("Processing CLIENT_HELLO from peer [").append(record.getPeerAddress()).append("]");
 			if (LOGGER.isTraceEnabled()) {
-				msg.append(":").append(System.lineSeparator()).append(record);
+				msg.append(":").append(StringUtil.lineSeparator()).append(record);
 			}
 			LOGGER.debug(msg.toString());
 		}
@@ -1003,7 +1004,7 @@ public class DTLSConnector implements Connector {
 		if (LOGGER.isDebugEnabled()) {
 			StringBuilder msg = new StringBuilder("Processing CLIENT_HELLO from peer [").append(record.getPeerAddress()).append("]");
 			if (LOGGER.isTraceEnabled()) {
-				msg.append(":").append(System.lineSeparator()).append(record);
+				msg.append(":").append(StringUtil.lineSeparator()).append(record);
 			}
 			LOGGER.debug(msg.toString());
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/auth/PrincipalSerializer.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/auth/PrincipalSerializer.java
@@ -1,6 +1,5 @@
 package org.eclipse.californium.scandium.auth;
 
-import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.Principal;
 
@@ -9,6 +8,7 @@ import org.eclipse.californium.elements.auth.RawPublicKeyIdentity;
 import org.eclipse.californium.elements.auth.X509CertPath;
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StandardCharsets;
 
 /**
  * A helper for serializing and deserializing principals supported by Scandium.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AlertMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AlertMessage.java
@@ -22,6 +22,7 @@ import java.net.InetSocketAddress;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 
 /**
  * 
@@ -180,9 +181,9 @@ public final class AlertMessage extends AbstractMessage {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("\tAlert Protocol").append(System.lineSeparator());
-		sb.append("\tLevel: ").append(level).append(System.lineSeparator());
-		sb.append("\tDescription: ").append(description).append(System.lineSeparator());
+		sb.append("\tAlert Protocol").append(StringUtil.lineSeparator());
+		sb.append("\tLevel: ").append(level).append(StringUtil.lineSeparator());
+		sb.append("\tDescription: ").append(description).append(StringUtil.lineSeparator());
 
 		return sb.toString();
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ApplicationMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ApplicationMessage.java
@@ -21,6 +21,7 @@ package org.eclipse.californium.scandium.dtls;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.util.ByteArrayUtils;
 
 
@@ -62,7 +63,7 @@ public final class ApplicationMessage extends AbstractMessage {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("\tApplication Data: ").append(ByteArrayUtils.toHexString(data)).append(System.lineSeparator());
+		sb.append("\tApplication Data: ").append(ByteArrayUtils.toHexString(data)).append(StringUtil.lineSeparator());
 		return sb.toString();
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
@@ -39,14 +39,15 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.eclipse.californium.elements.auth.X509CertPath;
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The server MUST send a Certificate message whenever the agreed-upon key
@@ -206,17 +207,17 @@ public final class CertificateMessage extends HandshakeMessage {
 		StringBuilder sb = new StringBuilder();
 		sb.append(super.toString());
 		if (rawPublicKeyBytes == null && certPath != null) {
-			sb.append("\t\tCertificate chain length: ").append(getMessageLength() - 3).append(System.lineSeparator());
+			sb.append("\t\tCertificate chain length: ").append(getMessageLength() - 3).append(StringUtil.lineSeparator());
 			int index = 0;
 			for (Certificate cert : certPath.getCertificates()) {
-				sb.append("\t\t\tCertificate Length: ").append(encodedChain.get(index).length).append(System.lineSeparator());
-				sb.append("\t\t\tCertificate: ").append(cert).append(System.lineSeparator());
+				sb.append("\t\t\tCertificate Length: ").append(encodedChain.get(index).length).append(StringUtil.lineSeparator());
+				sb.append("\t\t\tCertificate: ").append(cert).append(StringUtil.lineSeparator());
 				index++;
 			}
 		} else if (rawPublicKeyBytes != null && certPath == null) {
 			sb.append("\t\tRaw Public Key: ");
 			sb.append(getPublicKey().toString());
-			sb.append(System.lineSeparator());
+			sb.append(StringUtil.lineSeparator());
 		}
 
 		return sb.toString();

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
@@ -32,15 +32,16 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.security.auth.x500.X500Principal;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm.HashAlgorithm;
 import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm.SignatureAlgorithm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -148,21 +149,21 @@ public final class CertificateRequest extends HandshakeMessage {
 	public String toString() {
 		StringBuilder sb = new StringBuilder(super.toString());
 		if (!certificateTypes.isEmpty()) {
-			sb.append("\t\tClient certificate type:").append(System.lineSeparator());
+			sb.append("\t\tClient certificate type:").append(StringUtil.lineSeparator());
 			for (ClientCertificateType type : certificateTypes) {
-				sb.append(THREE_TABS).append(type).append(System.lineSeparator());
+				sb.append(THREE_TABS).append(type).append(StringUtil.lineSeparator());
 			}
 		}
 		if (!supportedSignatureAlgorithms.isEmpty()) {
-			sb.append("\t\tSignature and hash algorithm:").append(System.lineSeparator());
+			sb.append("\t\tSignature and hash algorithm:").append(StringUtil.lineSeparator());
 			for (SignatureAndHashAlgorithm algo : supportedSignatureAlgorithms) {
-				sb.append(THREE_TABS).append(algo.jcaName()).append(System.lineSeparator());
+				sb.append(THREE_TABS).append(algo.jcaName()).append(StringUtil.lineSeparator());
 			}
 		}
 		if (!certificateAuthorities.isEmpty()) {
-			sb.append("\t\tCertificate authorities:").append(System.lineSeparator());
+			sb.append("\t\tCertificate authorities:").append(StringUtil.lineSeparator());
 			for (X500Principal subject : certificateAuthorities) {
-				sb.append(THREE_TABS).append(subject.getName()).append(System.lineSeparator());
+				sb.append(THREE_TABS).append(subject.getName()).append(StringUtil.lineSeparator());
 			}
 		}
 		return sb.toString();

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientCertificateTypeExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientCertificateTypeExtension.java
@@ -19,6 +19,8 @@ package org.eclipse.californium.scandium.dtls;
 
 import java.util.List;
 
+import org.eclipse.californium.elements.util.StringUtil;
+
 
 public class ClientCertificateTypeExtension extends CertificateTypeExtension {
 
@@ -55,7 +57,7 @@ public class ClientCertificateTypeExtension extends CertificateTypeExtension {
 		StringBuilder sb = new StringBuilder(super.toString());
 
 		for (CertificateType type : certificateTypes) {
-			sb.append("\t\t\t\tClient certificate type: ").append(type).append(System.lineSeparator());
+			sb.append("\t\t\t\tClient certificate type: ").append(type).append(StringUtil.lineSeparator());
 		}
 
 		return sb.toString();

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -48,11 +48,11 @@ import java.security.interfaces.ECPublicKey;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import org.eclipse.californium.elements.auth.PreSharedKeyIdentity;
 import org.eclipse.californium.elements.auth.RawPublicKeyIdentity;
 import org.eclipse.californium.elements.auth.X509CertPath;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
@@ -62,6 +62,8 @@ import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
 import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
 import org.eclipse.californium.scandium.util.ByteArrayUtils;
 import org.eclipse.californium.scandium.util.ServerNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ClientHandshaker does the protocol handshaking from the point of view of a
@@ -204,7 +206,7 @@ public class ClientHandshaker extends Handshaker {
 					"Processing %s message from peer [%s]",
 					message.getContentType(), message.getPeer()));
 			if (LOGGER.isTraceEnabled()) {
-				msg.append(":").append(System.lineSeparator()).append(message);
+				msg.append(":").append(StringUtil.lineSeparator()).append(message);
 			}
 			LOGGER.debug(msg.toString());
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHello.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHello.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.CertificateTypeExtension.CertificateType;
 import org.eclipse.californium.scandium.dtls.HelloExtension.ExtensionType;
 import org.eclipse.californium.scandium.dtls.SupportedPointFormatsExtension.ECPointFormat;
@@ -315,27 +316,27 @@ public final class ClientHello extends HandshakeMessage {
 		StringBuilder sb = new StringBuilder();
 		sb.append(super.toString());
 		sb.append("\t\tVersion: ").append(clientVersion.getMajor()).append(", ").append(clientVersion.getMinor());
-		sb.append(System.lineSeparator()).append("\t\tRandom:").append(System.lineSeparator()).append(random);
+		sb.append(StringUtil.lineSeparator()).append("\t\tRandom:").append(StringUtil.lineSeparator()).append(random);
 		sb.append("\t\tSession ID Length: ").append(sessionId.length());
 		if (sessionId.length() > 0) {
-			sb.append(System.lineSeparator()).append("\t\tSession ID: ").append(ByteArrayUtils.toHexString(sessionId.getId()));
+			sb.append(StringUtil.lineSeparator()).append("\t\tSession ID: ").append(ByteArrayUtils.toHexString(sessionId.getId()));
 		}
-		sb.append(System.lineSeparator()).append("\t\tCookie Length: ").append(cookie.length);
+		sb.append(StringUtil.lineSeparator()).append("\t\tCookie Length: ").append(cookie.length);
 		if (cookie.length > 0) {
-			sb.append(System.lineSeparator()).append("\t\tCookie: ").append(ByteArrayUtils.toHexString(cookie));
+			sb.append(StringUtil.lineSeparator()).append("\t\tCookie: ").append(ByteArrayUtils.toHexString(cookie));
 		}
-		sb.append(System.lineSeparator()).append("\t\tCipher Suites Length: ").append(supportedCipherSuites.size() * 2);
-		sb.append(System.lineSeparator()).append("\t\tCipher Suites (").append(supportedCipherSuites.size()).append(" suites)");
+		sb.append(StringUtil.lineSeparator()).append("\t\tCipher Suites Length: ").append(supportedCipherSuites.size() * 2);
+		sb.append(StringUtil.lineSeparator()).append("\t\tCipher Suites (").append(supportedCipherSuites.size()).append(" suites)");
 		for (CipherSuite cipher : supportedCipherSuites) {
-			sb.append(System.lineSeparator()).append("\t\t\tCipher Suite: ").append(cipher);
+			sb.append(StringUtil.lineSeparator()).append("\t\t\tCipher Suite: ").append(cipher);
 		}
-		sb.append(System.lineSeparator()).append("\t\tCompression Methods Length: ").append(compressionMethods.size());
-		sb.append(System.lineSeparator()).append("\t\tCompression Methods (").append(compressionMethods.size()).append(" method)");
+		sb.append(StringUtil.lineSeparator()).append("\t\tCompression Methods Length: ").append(compressionMethods.size());
+		sb.append(StringUtil.lineSeparator()).append("\t\tCompression Methods (").append(compressionMethods.size()).append(" method)");
 		for (CompressionMethod method : compressionMethods) {
-			sb.append(System.lineSeparator()).append("\t\t\tCompression Method: ").append(method);
+			sb.append(StringUtil.lineSeparator()).append("\t\t\tCompression Method: ").append(method);
 		}
 		if (extensions != null) {
-			sb.append(System.lineSeparator()).append(extensions);
+			sb.append(StringUtil.lineSeparator()).append(extensions);
 		}
 
 		return sb.toString();

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
@@ -24,6 +24,7 @@ package org.eclipse.californium.scandium.dtls;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 
 /**
@@ -201,11 +202,11 @@ class DTLSConnectionState {
 	@Override
 	public final String toString() {
 		StringBuilder b = new StringBuilder("DTLSConnectionState:");
-		b.append(System.lineSeparator()).append("\tCipher suite: ").append(cipherSuite);
-		b.append(System.lineSeparator()).append("\tCompression method: ").append(compressionMethod);
-		b.append(System.lineSeparator()).append("\tIV: ").append(iv == null ? "null" : "not null");
-		b.append(System.lineSeparator()).append("\tMAC key: ").append(macKey == null ? "null" : "not null");
-		b.append(System.lineSeparator()).append("\tEncryption key: ").append(encryptionKey == null ? "null" : "not null");
+		b.append(StringUtil.lineSeparator()).append("\tCipher suite: ").append(cipherSuite);
+		b.append(StringUtil.lineSeparator()).append("\tCompression method: ").append(compressionMethod);
+		b.append(StringUtil.lineSeparator()).append("\tIV: ").append(iv == null ? "null" : "not null");
+		b.append(StringUtil.lineSeparator()).append("\tMAC key: ").append(macKey == null ? "null" : "not null");
+		b.append(StringUtil.lineSeparator()).append("\tEncryption key: ").append(encryptionKey == null ? "null" : "not null");
 		return b.toString();
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -39,12 +39,13 @@ import java.security.Principal;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.eclipse.californium.elements.DtlsEndpointContext;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents a DTLS session between two peers. Keeps track of the current and
@@ -444,7 +445,7 @@ public final class DTLSSession {
 		}
 		this.readState = readState;
 		incrementReadEpoch();
-		LOGGER.trace("Setting current read state to{}{}", System.lineSeparator(), readState);
+		LOGGER.trace("Setting current read state to{}{}", StringUtil.lineSeparator(), readState);
 	}
 
 	/**
@@ -499,7 +500,7 @@ public final class DTLSSession {
 		incrementWriteEpoch();
 		// re-calculate maximum fragment length based on cipher suite from updated write state
 		determineMaxFragmentLength(maxFragmentLength);
-		LOGGER.trace("Setting current write state to{}{}", System.lineSeparator(), writeState);
+		LOGGER.trace("Setting current write state to{}{}", StringUtil.lineSeparator(), writeState);
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHClientKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHClientKeyExchange.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
 import org.eclipse.californium.scandium.util.ByteArrayUtils;
 
@@ -124,7 +125,7 @@ public final class ECDHClientKeyExchange extends ClientKeyExchange {
 		sb.append(super.toString());
 		sb.append("\t\tDiffie-Hellman public value: ");
 		sb.append(ByteArrayUtils.toHexString(pointEncoded));
-		sb.append(System.lineSeparator());
+		sb.append(StringUtil.lineSeparator());
 
 		return sb.toString();
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchange.java
@@ -31,17 +31,16 @@ import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 import java.security.spec.ECPublicKeySpec;
 import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
-import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm.HashAlgorithm;
-import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm.SignatureAlgorithm;
 import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
 import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -398,7 +397,7 @@ public final class ECDHServerKeyExchange extends ServerKeyExchange {
 		sb.append("\t\tDiffie-Hellman public key: ");
 		sb.append(getPublicKey().toString());
 		// bug in ECPublicKey.toString() gives object pointer
-		sb.append(System.lineSeparator());
+		sb.append(StringUtil.lineSeparator());
 
 		return sb.toString();
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Finished.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Finished.java
@@ -22,16 +22,17 @@ package org.eclipse.californium.scandium.dtls;
 
 import java.net.InetSocketAddress;
 import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
 import org.eclipse.californium.scandium.dtls.cipher.PseudoRandomFunction;
 import org.eclipse.californium.scandium.dtls.cipher.PseudoRandomFunction.Label;
 import org.eclipse.californium.scandium.util.ByteArrayUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Finished message is always sent immediately after a
@@ -111,8 +112,8 @@ public final class Finished extends HandshakeMessage {
 			StringBuilder msg = new StringBuilder("Verification of peer's [").append(getPeer())
 					.append("] FINISHED message failed");
 			if (LOG.isTraceEnabled()) {
-				msg.append(System.lineSeparator()).append("Expected: ").append(ByteArrayUtils.toHexString(myVerifyData));
-				msg.append(System.lineSeparator()).append("Received: ").append(ByteArrayUtils.toHexString(verifyData));
+				msg.append(StringUtil.lineSeparator()).append("Expected: ").append(ByteArrayUtils.toHexString(myVerifyData));
+				msg.append(StringUtil.lineSeparator()).append("Received: ").append(ByteArrayUtils.toHexString(verifyData));
 			}
 			LOG.debug(msg.toString());
 			AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, getPeer());
@@ -144,7 +145,7 @@ public final class Finished extends HandshakeMessage {
 	@Override
 	public String toString() {
 		return new StringBuilder(super.toString())
-				.append("\t\tVerify Data: ").append(ByteArrayUtils.toHexString(verifyData)).append(System.lineSeparator())
+				.append("\t\tVerify Data: ").append(ByteArrayUtils.toHexString(verifyData)).append(StringUtil.lineSeparator())
 				.toString();
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/FragmentedHandshakeMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/FragmentedHandshakeMessage.java
@@ -20,6 +20,7 @@ package org.eclipse.californium.scandium.dtls;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.util.ByteArrayUtils;
 
 
@@ -106,8 +107,8 @@ public final class FragmentedHandshakeMessage extends HandshakeMessage {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append(super.toString());
-		sb.append("\t\t\tFragmented Handshake Message: ").append(fragmentedBytes.length).append(" bytes").append(System.lineSeparator());
-		sb.append("\t\t\t\t").append(ByteArrayUtils.toHexString(fragmentedBytes)).append(System.lineSeparator());
+		sb.append("\t\t\tFragmented Handshake Message: ").append(fragmentedBytes.length).append(" bytes").append(StringUtil.lineSeparator());
+		sb.append("\t\t\t\t").append(ByteArrayUtils.toHexString(fragmentedBytes)).append(StringUtil.lineSeparator());
 
 		return sb.toString();
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeMessage.java
@@ -21,14 +21,15 @@ package org.eclipse.californium.scandium.dtls;
 
 import java.net.InetSocketAddress;
 import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -133,12 +134,12 @@ public abstract class HandshakeMessage extends AbstractMessage {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("\tHandshake Protocol");
-		sb.append(System.lineSeparator()).append("\tType: ").append(getMessageType());
-		sb.append(System.lineSeparator()).append("\tPeer: ").append(getPeer());
-		sb.append(System.lineSeparator()).append("\tMessage Sequence No: ").append(messageSeq);
-		sb.append(System.lineSeparator()).append("\tFragment Offset: ").append(fragmentOffset);
-		sb.append(System.lineSeparator()).append("\tFragment Length: ").append(fragmentLength);
-		sb.append(System.lineSeparator()).append("\tLength: ").append(getMessageLength()).append(System.lineSeparator());
+		sb.append(StringUtil.lineSeparator()).append("\tType: ").append(getMessageType());
+		sb.append(StringUtil.lineSeparator()).append("\tPeer: ").append(getPeer());
+		sb.append(StringUtil.lineSeparator()).append("\tMessage Sequence No: ").append(messageSeq);
+		sb.append(StringUtil.lineSeparator()).append("\tFragment Offset: ").append(fragmentOffset);
+		sb.append(StringUtil.lineSeparator()).append("\tFragment Length: ").append(fragmentLength);
+		sb.append(StringUtil.lineSeparator()).append("\tLength: ").append(getMessageLength()).append(StringUtil.lineSeparator());
 
 		return sb.toString();
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -61,22 +61,23 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.eclipse.californium.elements.auth.RawPublicKeyIdentity;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
+import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
 import org.eclipse.californium.scandium.dtls.cipher.PseudoRandomFunction;
 import org.eclipse.californium.scandium.dtls.cipher.PseudoRandomFunction.Label;
 import org.eclipse.californium.scandium.dtls.rpkstore.TrustedRpkStore;
-import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
 import org.eclipse.californium.scandium.util.ByteArrayUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -442,7 +443,7 @@ public abstract class Handshaker {
 			}
 		} else {
 			LOGGER.trace("Discarding duplicate HANDSHAKE message received from peer [{}]:{}{}",
-					new Object[]{record.getPeerAddress(), System.lineSeparator(), record});
+					new Object[]{record.getPeerAddress(), StringUtil.lineSeparator(), record});
 		}
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtensions.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtensions.java
@@ -26,14 +26,15 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
 import org.eclipse.californium.scandium.dtls.HelloExtension.ExtensionType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -97,7 +98,7 @@ public final class HelloExtensions {
 		StringBuilder sb = new StringBuilder();
 		sb.append("\t\tExtensions Length: ").append(getLength());
 		for (HelloExtension ext : extensions) {
-			sb.append(System.lineSeparator()).append(ext);
+			sb.append(StringUtil.lineSeparator()).append(ext);
 		}
 		return sb.toString();
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloVerifyRequest.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloVerifyRequest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.util.ByteArrayUtils;
 
 /**
@@ -111,9 +112,9 @@ public final class HelloVerifyRequest extends HandshakeMessage {
 		StringBuilder sb = new StringBuilder();
 		sb.append(super.toString());
 		sb.append("\t\tServer Version: ").append(serverVersion.getMajor()).append(", ").append(serverVersion.getMinor())
-			.append(System.lineSeparator());
-		sb.append("\t\tCookie Length: ").append(cookie.length).append(System.lineSeparator());
-		sb.append("\t\tCookie: ").append(ByteArrayUtils.toHexString(cookie)).append(System.lineSeparator());
+			.append(StringUtil.lineSeparator());
+		sb.append("\t\tCookie Length: ").append(cookie.length).append(StringUtil.lineSeparator());
+		sb.append("\t\tCookie: ").append(ByteArrayUtils.toHexString(cookie)).append(StringUtil.lineSeparator());
 
 		return sb.toString();
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PSKClientKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PSKClientKeyExchange.java
@@ -17,8 +17,9 @@
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
+import static org.eclipse.californium.elements.util.StandardCharsets.UTF_8;
+
 import java.net.InetSocketAddress;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 
 import org.eclipse.californium.elements.util.DatagramReader;
@@ -38,8 +39,6 @@ public final class PSKClientKeyExchange extends ClientKeyExchange {
 
 	private static final int IDENTITY_LENGTH_BITS = 16;
 
-	private static final Charset CHAR_SET_UTF8 = Charset.forName("UTF8");
-
 	// Members ////////////////////////////////////////////////////////
 
 	/**
@@ -56,14 +55,14 @@ public final class PSKClientKeyExchange extends ClientKeyExchange {
 
 	public PSKClientKeyExchange(String identity, InetSocketAddress peerAddress) {
 		super(peerAddress);
-		this.identityEncoded = identity.getBytes(CHAR_SET_UTF8);
+		this.identityEncoded = identity.getBytes(UTF_8);
 		this.identity = identity;
 	}
 	
 	private PSKClientKeyExchange(byte[] identityEncoded, InetSocketAddress peerAddress) {
 		super(peerAddress);
 		this.identityEncoded = Arrays.copyOf(identityEncoded, identityEncoded.length);
-		this.identity = new String(this.identityEncoded, CHAR_SET_UTF8);
+		this.identity = new String(this.identityEncoded, UTF_8);
 	}
 
 	// Methods ////////////////////////////////////////////////////////

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PSKClientKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PSKClientKeyExchange.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 
 
 /**
@@ -77,7 +78,7 @@ public final class PSKClientKeyExchange extends ClientKeyExchange {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder(super.toString());
-		sb.append("\t\tPSK Identity: ").append(identity).append(System.lineSeparator());
+		sb.append("\t\tPSK Identity: ").append(identity).append(StringUtil.lineSeparator());
 
 		return sb.toString();
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PSKServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PSKServerKeyExchange.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 
 /**
  * The key exchange message sent when using the preshared key key exchange
@@ -77,7 +78,7 @@ public final class PSKServerKeyExchange extends ServerKeyExchange {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder(super.toString());
-		sb.append("\t\tPSK Identity Hint: ").append(hint).append(System.lineSeparator());
+		sb.append("\t\tPSK Identity Hint: ").append(hint).append(StringUtil.lineSeparator());
 
 		return sb.toString();
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PSKServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PSKServerKeyExchange.java
@@ -17,13 +17,13 @@
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
+import static org.eclipse.californium.elements.util.StandardCharsets.UTF_8;
+
 import java.net.InetSocketAddress;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
-
 
 /**
  * The key exchange message sent when using the preshared key key exchange
@@ -38,8 +38,6 @@ public final class PSKServerKeyExchange extends ServerKeyExchange {
 	// DTLS-specific constants ////////////////////////////////////////
 
 	private static final int IDENTITY_HINT_LENGTH_BITS = 16;
-	
-	private static final Charset CHAR_SET_UTF8 = Charset.forName("UTF8");
 
 	// Members ////////////////////////////////////////////////////////
 
@@ -58,13 +56,13 @@ public final class PSKServerKeyExchange extends ServerKeyExchange {
 	public PSKServerKeyExchange(String hint, InetSocketAddress peerAddress) {
 		super(peerAddress);
 		this.hint = hint;
-		this.hintEncoded = hint.getBytes(CHAR_SET_UTF8);
+		this.hintEncoded = hint.getBytes(UTF_8);
 	}
 	
 	private PSKServerKeyExchange(byte[] hintEncoded, InetSocketAddress peerAddress) {
 		super(peerAddress);
 		this.hintEncoded = Arrays.copyOf(hintEncoded, hintEncoded.length);
-		this.hint = new String(this.hintEncoded, CHAR_SET_UTF8);
+		this.hint = new String(this.hintEncoded, UTF_8);
 	}
 
 	// Methods ////////////////////////////////////////////////////////

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Random.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Random.java
@@ -20,6 +20,7 @@ import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Date;
 
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.util.ByteArrayUtils;
 
 /**
@@ -101,11 +102,11 @@ public class Random {
 
 		Date date = new Date(gmtUnixTime * 1000L);
 
-		sb.append("\t\t\tGMT Unix Time: ").append(date).append(System.lineSeparator());
+		sb.append("\t\t\tGMT Unix Time: ").append(date).append(StringUtil.lineSeparator());
 
 		// output the remaining 28 random bytes
 		byte[] rand = Arrays.copyOfRange(randomBytes, 4, 32);
-		sb.append("\t\t\tRandom Bytes: ").append(ByteArrayUtils.toHexString(rand)).append(System.lineSeparator());
+		sb.append("\t\t\tRandom Bytes: ").append(ByteArrayUtils.toHexString(rand)).append(StringUtil.lineSeparator());
 
 		return sb.toString();
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Record.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Record.java
@@ -27,8 +27,6 @@ import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.crypto.Cipher;
 import javax.crypto.Mac;
@@ -36,11 +34,14 @@ import javax.crypto.spec.IvParameterSpec;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.cipher.CCMBlockCipher;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
 import org.eclipse.californium.scandium.dtls.cipher.InvalidMacException;
 import org.eclipse.californium.scandium.util.ByteArrayUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An object representation of the DTLS <em>Record</em> layer data structure(s).
@@ -309,7 +310,7 @@ public class Record {
 		byte[] encryptedFragment = plaintextFragment;
 
 		CipherSuite cipherSuite = session.getWriteState().getCipherSuite();
-		LOGGER.trace("Encrypting record fragment using current write state{}{}", System.lineSeparator(), session.getWriteState());
+		LOGGER.trace("Encrypting record fragment using current write state{}{}", StringUtil.lineSeparator(), session.getWriteState());
 		
 		switch (cipherSuite.getCipherType()) {
 		case NULL:
@@ -358,7 +359,7 @@ public class Record {
 		byte[] result = ciphertextFragment;
 
 		CipherSuite cipherSuite = currentReadState.getCipherSuite();
-		LOGGER.trace("Decrypting record fragment using current read state{}{}", System.lineSeparator(), currentReadState);
+		LOGGER.trace("Decrypting record fragment using current read state{}{}", StringUtil.lineSeparator(), currentReadState);
 		
 		switch (cipherSuite.getCipherType()) {
 		case NULL:
@@ -610,8 +611,8 @@ public class Record {
 		byte[] explicitNonceUsed = reader.readBytes(8);
 		if (LOGGER.isDebugEnabled() && !Arrays.equals(explicitNonce, explicitNonceUsed)) {
 			StringBuilder b = new StringBuilder("The explicit nonce used by the sender does not match the values provided in the DTLS record");
-			b.append(System.lineSeparator()).append("Used    : ").append(ByteArrayUtils.toHexString(explicitNonceUsed));
-			b.append(System.lineSeparator()).append("Expected: ").append(ByteArrayUtils.toHexString(explicitNonce));
+			b.append(StringUtil.lineSeparator()).append("Used    : ").append(ByteArrayUtils.toHexString(explicitNonceUsed));
+			b.append(StringUtil.lineSeparator()).append("Expected: ").append(ByteArrayUtils.toHexString(explicitNonce));
 			LOGGER.debug(b.toString());
 		}
 
@@ -896,7 +897,7 @@ public class Record {
 		//  are encapsulated within one or more TLSPlaintext structures, which
 		//  are processed and transmitted as specified by the current active session state."
 		if (LOGGER.isTraceEnabled()) {
-			LOGGER.trace("Decrypting HANDSHAKE message ciphertext{}{}", System.lineSeparator(),
+			LOGGER.trace("Decrypting HANDSHAKE message ciphertext{}{}", StringUtil.lineSeparator(),
 				ByteArrayUtils.toHexString(fragmentBytes));
 		}
 		byte[] decryptedMessage = decryptFragment(fragmentBytes, currentReadState);
@@ -914,7 +915,7 @@ public class Record {
 					"Parsing HANDSHAKE message plaintext using KeyExchange [{}] and receiveRawPublicKey [{}]");
 			Object[] params = new Object[]{keyExchangeAlgorithm, receiveRawPublicKey, null};
 			if (LOGGER.isTraceEnabled()) {
-				msg.append(":").append(System.lineSeparator()).append(ByteArrayUtils.toHexString(decryptedMessage));
+				msg.append(":").append(StringUtil.lineSeparator()).append(ByteArrayUtils.toHexString(decryptedMessage));
 			}
 			LOGGER.debug(msg.toString(), params);
 		}
@@ -962,19 +963,19 @@ public class Record {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("==[ DTLS Record ]==============================================");
-		sb.append(System.lineSeparator()).append("Content Type: ").append(type.toString());
-		sb.append(System.lineSeparator()).append("Peer address: ").append(getPeerAddress());
-		sb.append(System.lineSeparator()).append("Version: ").append(version.getMajor()).append(", ").append(version.getMinor());
-		sb.append(System.lineSeparator()).append("Epoch: ").append(epoch);
-		sb.append(System.lineSeparator()).append("Sequence Number: ").append(sequenceNumber);
-		sb.append(System.lineSeparator()).append("Length: ").append(length);
-		sb.append(System.lineSeparator()).append("Fragment:");
+		sb.append(StringUtil.lineSeparator()).append("Content Type: ").append(type.toString());
+		sb.append(StringUtil.lineSeparator()).append("Peer address: ").append(getPeerAddress());
+		sb.append(StringUtil.lineSeparator()).append("Version: ").append(version.getMajor()).append(", ").append(version.getMinor());
+		sb.append(StringUtil.lineSeparator()).append("Epoch: ").append(epoch);
+		sb.append(StringUtil.lineSeparator()).append("Sequence Number: ").append(sequenceNumber);
+		sb.append(StringUtil.lineSeparator()).append("Length: ").append(length);
+		sb.append(StringUtil.lineSeparator()).append("Fragment:");
 		if (fragment != null) {
-			sb.append(System.lineSeparator()).append(fragment);
+			sb.append(StringUtil.lineSeparator()).append(fragment);
 		} else {
-			sb.append(System.lineSeparator()).append("fragment is not decrypted yet");
+			sb.append(StringUtil.lineSeparator()).append("fragment is not decrypted yet");
 		}
-		sb.append(System.lineSeparator()).append("===============================================================");
+		sb.append(StringUtil.lineSeparator()).append("===============================================================");
 
 		return sb.toString();
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
@@ -30,12 +30,13 @@ package org.eclipse.californium.scandium.dtls;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -118,7 +119,7 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 			StringBuilder msg = new StringBuilder();
 			msg.append("Processing {} message from peer [{}]");
 			if (LOGGER.isTraceEnabled()) {
-				msg.append(":").append(System.lineSeparator()).append(message);
+				msg.append(":").append(StringUtil.lineSeparator()).append(message);
 			}
 			LOGGER.debug(msg.toString(), message.getContentType(), message.getPeer());
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingServerHandshaker.java
@@ -29,12 +29,13 @@ package org.eclipse.californium.scandium.dtls;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The resuming server handshaker executes an abbreviated handshake when
@@ -72,7 +73,7 @@ public class ResumingServerHandshaker extends ServerHandshaker {
 			StringBuilder msg = new StringBuilder();
 			msg.append("Processing {} message from peer [{}]");
 			if (LOGGER.isTraceEnabled()) {
-				msg.append(":").append(System.lineSeparator()).append(message);
+				msg.append(":").append(StringUtil.lineSeparator()).append(message);
 			}
 			LOGGER.debug(msg.toString(), message.getContentType(), message.getPeer());
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerCertificateTypeExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerCertificateTypeExtension.java
@@ -19,6 +19,8 @@ package org.eclipse.californium.scandium.dtls;
 
 import java.util.List;
 
+import org.eclipse.californium.elements.util.StringUtil;
+
 
 public class ServerCertificateTypeExtension extends CertificateTypeExtension {
 
@@ -55,7 +57,7 @@ public class ServerCertificateTypeExtension extends CertificateTypeExtension {
 		StringBuilder sb = new StringBuilder(super.toString());
 
 		for (CertificateType type : certificateTypes) {
-			sb.append("\t\t\t\tServer certificate type: ").append(type).append(System.lineSeparator());
+			sb.append("\t\t\t\tServer certificate type: ").append(type).append(StringUtil.lineSeparator());
 		}
 
 		return sb.toString();

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -54,11 +54,11 @@ import java.security.cert.CertPath;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import org.eclipse.californium.elements.auth.PreSharedKeyIdentity;
 import org.eclipse.californium.elements.auth.RawPublicKeyIdentity;
 import org.eclipse.californium.elements.auth.X509CertPath;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
@@ -72,6 +72,8 @@ import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedG
 import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
 import org.eclipse.californium.scandium.util.ByteArrayUtils;
 import org.eclipse.californium.scandium.util.ServerNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Server handshaker does the protocol handshaking from the point of view of a
@@ -257,7 +259,7 @@ public class ServerHandshaker extends Handshaker {
 			StringBuilder msg = new StringBuilder();
 			msg.append("Processing {} message from peer [{}]");
 			if (LOGGER.isTraceEnabled()) {
-				msg.append(":").append(System.lineSeparator()).append(message);
+				msg.append(":").append(StringUtil.lineSeparator()).append(message);
 			}
 			LOGGER.debug(msg.toString(), message.getContentType(), message.getPeer());
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHello.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHello.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
 import org.eclipse.californium.scandium.dtls.CertificateTypeExtension.CertificateType;
@@ -361,16 +362,16 @@ public final class ServerHello extends HandshakeMessage {
 		StringBuilder sb = new StringBuilder();
 		sb.append(super.toString());
 		sb.append("\t\tServer Version: ").append(serverVersion.getMajor()).append(", ").append(serverVersion.getMinor());
-		sb.append(System.lineSeparator()).append("\t\tRandom:").append(random);
-		sb.append(System.lineSeparator()).append("\t\tSession ID Length: ").append(sessionId.length());
+		sb.append(StringUtil.lineSeparator()).append("\t\tRandom:").append(random);
+		sb.append(StringUtil.lineSeparator()).append("\t\tSession ID Length: ").append(sessionId.length());
 		if (sessionId.length() > 0) {
-			sb.append(System.lineSeparator()).append("\t\tSession ID: ").append(ByteArrayUtils.toHexString(sessionId.getId()));
+			sb.append(StringUtil.lineSeparator()).append("\t\tSession ID: ").append(ByteArrayUtils.toHexString(sessionId.getId()));
 		}
-		sb.append(System.lineSeparator()).append("\t\tCipher Suite: ").append(cipherSuite);
-		sb.append(System.lineSeparator()).append("\t\tCompression Method: ").append(compressionMethod);
+		sb.append(StringUtil.lineSeparator()).append("\t\tCipher Suite: ").append(cipherSuite);
+		sb.append(StringUtil.lineSeparator()).append("\t\tCompression Method: ").append(compressionMethod);
 
 		if (extensions != null) {
-			sb.append(System.lineSeparator()).append(extensions);
+			sb.append(StringUtil.lineSeparator()).append(extensions);
 		}
 
 		return sb.toString();

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerNameExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerNameExtension.java
@@ -16,7 +16,6 @@
 package org.eclipse.californium.scandium.dtls;
 
 import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
@@ -84,7 +83,7 @@ public final class ServerNameExtension extends HelloExtension {
 	 * @throws NullPointerException if the host name is {@code null}.
 	 */
 	public static ServerNameExtension forHostName(final String hostName) {
-		return new ServerNameExtension(ServerNames.newInstance(ServerName.from(NameType.HOST_NAME, hostName.getBytes(StandardCharsets.US_ASCII))));
+		return new ServerNameExtension(ServerNames.newInstance(ServerName.from(NameType.HOST_NAME, hostName.getBytes(ServerName.CHARSET))));
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SupportedEllipticCurvesExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SupportedEllipticCurvesExtension.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedGroup;
 
 
@@ -113,12 +114,12 @@ public final class SupportedEllipticCurvesExtension extends HelloExtension {
 	public String toString() {
 		StringBuilder sb = new StringBuilder(super.toString());
 		sb.append("\t\t\t\tLength: ").append(getLength() - 4);
-		sb.append(System.lineSeparator()).append("\t\t\t\tElliptic Curves Length: ").append(getLength() - 6);
-		sb.append(System.lineSeparator()).append("\t\t\t\tElliptic Curves (").append(supportedGroups.size()).append(" curves):");
+		sb.append(StringUtil.lineSeparator()).append("\t\t\t\tElliptic Curves Length: ").append(getLength() - 6);
+		sb.append(StringUtil.lineSeparator()).append("\t\t\t\tElliptic Curves (").append(supportedGroups.size()).append(" curves):");
 
 		for (Integer curveId : supportedGroups) {
 			SupportedGroup group = SupportedGroup.fromId(curveId);
-			sb.append(System.lineSeparator()).append("\t\t\t\t\tElliptic Curve: ");
+			sb.append(StringUtil.lineSeparator()).append("\t\t\t\t\tElliptic Curve: ");
 			if (group != null) {
 				sb.append(group.name());
 			} else {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SupportedPointFormatsExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SupportedPointFormatsExtension.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
 
 
 /**
@@ -68,11 +69,11 @@ public class SupportedPointFormatsExtension extends HelloExtension {
 	public String toString() {
 		StringBuilder sb = new StringBuilder(super.toString());
 		sb.append("\t\t\t\tLength: ").append(getLength() - 4);
-		sb.append(System.lineSeparator()).append("\t\t\t\tEC point formats length: ").append(getLength() - 5);
-		sb.append(System.lineSeparator()).append("\t\t\t\tElliptic Curves Point Formats (").append(ecPointFormatList.size()).append("):");
+		sb.append(StringUtil.lineSeparator()).append("\t\t\t\tEC point formats length: ").append(getLength() - 5);
+		sb.append(StringUtil.lineSeparator()).append("\t\t\t\tElliptic Curves Point Formats (").append(ecPointFormatList.size()).append("):");
 
 		for (ECPointFormat format : ecPointFormatList) {
-			sb.append(System.lineSeparator()).append("\t\t\t\t\tEC point format: ").append(format.toString());
+			sb.append(StringUtil.lineSeparator()).append("\t\t\t\t\tEC point format: ").append(format.toString());
 		}
 
 		return sb.toString();

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/PseudoRandomFunction.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/PseudoRandomFunction.java
@@ -16,13 +16,13 @@
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls.cipher;
 
-import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
+import org.eclipse.californium.elements.util.StandardCharsets;
 import org.eclipse.californium.scandium.util.ByteArrayUtils;
 
 /**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/util/ServerName.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/util/ServerName.java
@@ -15,15 +15,18 @@
  ******************************************************************************/
 package org.eclipse.californium.scandium.util;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.util.Arrays;
+
+import org.eclipse.californium.elements.util.StandardCharsets;
 
 /**
  * A typed server name as defined by RFC 6066, Section 3.
  *
  */
 public class ServerName {
-
+	public static final Charset CHARSET = StandardCharsets.US_ASCII;
+	
 	private final NameType type;
 	private final byte[] name;
 
@@ -62,7 +65,7 @@ public class ServerName {
 		if (hostName == null) {
 			throw new NullPointerException("host name must not be null");
 		} else {
-			return new ServerName(NameType.HOST_NAME, hostName.getBytes(StandardCharsets.US_ASCII));
+			return new ServerName(NameType.HOST_NAME, hostName.getBytes(CHARSET));
 		}
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.*;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.cert.Certificate;
 
@@ -53,7 +52,7 @@ public class ClientHandshakerTest {
 
 	final InetSocketAddress localPeer = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 	final SimpleRecordLayer recordLayer = new SimpleRecordLayer();
-	final byte[] serverName = "iot.eclipse.org".getBytes(StandardCharsets.US_ASCII);
+	final byte[] serverName = "iot.eclipse.org".getBytes(ServerName.CHARSET);
 
 	ClientHandshaker handshaker;
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DtlsTestTools.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DtlsTestTools.java
@@ -21,7 +21,6 @@ package org.eclipse.californium.scandium.dtls;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -37,6 +36,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
+import org.eclipse.californium.scandium.util.ServerName;
 
 public final class DtlsTestTools {
 
@@ -166,7 +166,7 @@ public final class DtlsTestTools {
 
 	public static byte[] newServerNameExtension(final String hostName) {
 
-		byte[] name = hostName.getBytes(StandardCharsets.US_ASCII);
+		byte[] name = hostName.getBytes(ServerName.CHARSET);
 		DatagramWriter writer = new DatagramWriter();
 		writer.write(name.length + 3, 16); //server_name_list_length
 		writer.writeByte((byte) 0x00);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerNameExtensionTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerNameExtensionTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.*;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 
 import org.eclipse.californium.scandium.category.Small;
 import org.eclipse.californium.scandium.dtls.HelloExtension.ExtensionType;
@@ -37,7 +36,7 @@ public class ServerNameExtensionTest {
 
 	byte[] serverNameStructure;
 	ServerNameExtension extension;
-	byte[] iotEclipseOrg = "iot.eclipse.org".getBytes(StandardCharsets.US_ASCII);
+	byte[] iotEclipseOrg = "iot.eclipse.org".getBytes(ServerName.CHARSET);
 	byte[] emptyExtension = new byte[]{
 			(byte) 0x00, (byte) 0x00, // extension code 0x0000
 			(byte) 0x00, (byte) 0x00  // length: 0 bytes

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/cipher/PseudoRandomFunctionTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/cipher/PseudoRandomFunctionTest.java
@@ -18,8 +18,7 @@ package org.eclipse.californium.scandium.dtls.cipher;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
-import java.nio.charset.StandardCharsets;
-
+import org.eclipse.californium.elements.util.StandardCharsets;
 import org.eclipse.californium.scandium.category.Small;
 import org.eclipse.californium.scandium.dtls.cipher.PseudoRandomFunction.Label;
 import org.junit.Before;


### PR DESCRIPTION
Replacement of java.nio.charset.StandardCharsets, which requires java
1.7, to support older android versions.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>