### PR TITLE
Add UdpEndpointContext for mixed matching.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MessageExchangeStoreTool.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MessageExchangeStoreTool.java
@@ -13,6 +13,8 @@
  * Contributors:
  *    Bosch Software Innovations - initial creation
  *    Achim Kraus (Bosch Software Innovations GmbH) - reduce external dependency
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add parameter for address check
+ *                                                    in UdpEndpointContextMatcher
  ******************************************************************************/
 package org.eclipse.californium.core.test;
 
@@ -70,10 +72,8 @@ public class MessageExchangeStoreTool {
 				return clientExchangeStore.isEmpty() && serverExchangeStore.isEmpty();
 			}
 		});
-		assertTrue("Client side message exchange store still contains exchanges",
-				isEmptyWithDump(clientExchangeStore));
-		assertTrue("Server side message exchange store still contains exchanges",
-				isEmptyWithDump(serverExchangeStore));
+		assertTrue("Client side message exchange store still contains exchanges", isEmptyWithDump(clientExchangeStore));
+		assertTrue("Server side message exchange store still contains exchanges", isEmptyWithDump(serverExchangeStore));
 	}
 
 	/**
@@ -168,16 +168,22 @@ public class MessageExchangeStoreTool {
 		private RequestEventChecker requestChecker;
 
 		private CoapTestEndpoint(InetSocketAddress bind, NetworkConfig config,
-				InMemoryObservationStore observationStore, InMemoryMessageExchangeStore exchangeStore) {
+				InMemoryObservationStore observationStore, InMemoryMessageExchangeStore exchangeStore,
+				boolean checkAddress) {
 			super(new UDPConnector(bind), true, config, new RandomTokenGenerator(config), observationStore,
-					exchangeStore, new UdpEndpointContextMatcher());
+					exchangeStore, new UdpEndpointContextMatcher(checkAddress));
 			this.exchangeStore = exchangeStore;
 			this.observationStore = observationStore;
 			this.requestChecker = new RequestEventChecker();
 		}
 
+		public CoapTestEndpoint(InetSocketAddress bind, NetworkConfig config, boolean checkAddress) {
+			this(bind, config, new InMemoryObservationStore(config), new InMemoryMessageExchangeStore(config),
+					checkAddress);
+		}
+
 		public CoapTestEndpoint(InetSocketAddress bind, NetworkConfig config) {
-			this(bind, config, new InMemoryObservationStore(config), new InMemoryMessageExchangeStore(config));
+			this(bind, config, true);
 		}
 
 		@Override

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -99,10 +99,8 @@ public class ObserveClientSideTest {
 
 	@Before
 	public void setupEndpoints() throws Exception {
-		//exchangeStore = new InMemoryMessageExchangeStore(CONFIG, new InMemoryRandomTokenProvider(CONFIG));
-		// bind to loopback address using an ephemeral port
-	    //CoapEndpoint udpEndpoint = new CoapEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), CONFIG, exchangeStore);
-		client = new CoapTestEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), CONFIG);
+		// don't check address, tests explicitly change it!
+		client = new CoapTestEndpoint(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), CONFIG, false);
 		client.addInterceptor(clientInterceptor);
 		client.addInterceptor(new MessageTracer());
 		client.start();

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UdpEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UdpEndpointContext.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+import java.net.InetSocketAddress;
+
+/**
+ * A endpoint context for plain UDP.
+ */
+public class UdpEndpointContext extends MapBasedEndpointContext {
+
+	public static final String KEY_PLAIN = "PLAIN";
+
+	public UdpEndpointContext(InetSocketAddress peerAddress) {
+		super(peerAddress, null, KEY_PLAIN, "");
+	}
+
+	@Override
+	public String toString() {
+		return String.format("UDP(%s:%d)", getPeerAddress().getHostString(), getPeerAddress().getPort());
+	}
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/DtlsEndpointContextMatcherTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/DtlsEndpointContextMatcherTest.java
@@ -41,8 +41,7 @@ public class DtlsEndpointContextMatcherTest {
 		relaxedMessageContext = new DtlsEndpointContext(ADDRESS, null,"session", "2", "CIPHER");
 		strictMessageContext = new DtlsEndpointContext(ADDRESS, null,"session", "1", "CIPHER");
 		differentMessageContext = new DtlsEndpointContext(ADDRESS, null,"new session", "1", "CIPHER");
-		MapBasedEndpointContext mapBasedContext = new MapBasedEndpointContext(ADDRESS, null,"ID", "session");
-		unsecureMessageContext = mapBasedContext;
+		unsecureMessageContext = new UdpEndpointContext(ADDRESS);
 		relaxedMatcher = new RelaxedDtlsEndpointContextMatcher();
 		strictMatcher = new StrictDtlsEndpointContextMatcher();
 	}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/UdpEndpointContextMatcherTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/UdpEndpointContextMatcherTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.InetSocketAddress;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class UdpEndpointContextMatcherTest {
+
+	private static final InetSocketAddress ADDRESS = new InetSocketAddress(5683);
+	private static final InetSocketAddress CHANGED_ADDRESS = new InetSocketAddress(5684);
+	
+	private EndpointContext connectorContext;
+	private EndpointContext addressContext;
+	private EndpointContext messageContext;
+	private EndpointContext changedAddressContext;
+	private EndpointContext secureMessageContext;
+	private EndpointContextMatcher matcher;
+
+	@Before
+	public void setup() {
+		connectorContext = new UdpEndpointContext(ADDRESS);
+		addressContext = new AddressEndpointContext(ADDRESS);
+		messageContext = new UdpEndpointContext(ADDRESS);
+		changedAddressContext = new UdpEndpointContext(CHANGED_ADDRESS);
+		secureMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
+		matcher = new UdpEndpointContextMatcher();
+	}
+
+	@Test
+	public void testSending() {
+		assertThat(matcher.isToBeSent(addressContext, connectorContext), is(true));
+		assertThat(matcher.isToBeSent(messageContext, connectorContext), is(true));
+		assertThat(matcher.isToBeSent(secureMessageContext, connectorContext), is(false));
+	}
+
+	@Test
+	public void testResponse() {
+		assertThat(matcher.isResponseRelatedToRequest(messageContext, messageContext), is(true));
+		assertThat(matcher.isResponseRelatedToRequest(messageContext, secureMessageContext), is(false));
+		assertThat(matcher.isResponseRelatedToRequest(secureMessageContext, messageContext), is(false));
+		assertThat(matcher.isResponseRelatedToRequest(addressContext, messageContext), is(true));
+		assertThat(matcher.isResponseRelatedToRequest(messageContext, addressContext), is(false));
+		assertThat(matcher.isResponseRelatedToRequest(messageContext, changedAddressContext), is(false));
+		assertThat(matcher.isResponseRelatedToRequest(changedAddressContext, messageContext), is(false));
+	}
+
+
+}


### PR DESCRIPTION
Prevent `DtlsEndpointContext` matching with `UdpEndpointContext` using a
`UdpEndpointContextMatcher`. 
Leshan use the same `ObservationStore` for secure and unsecure communication. Without this change, a message received with the unsecure connector would match messages sent with a secure connector, because the `UdpEndpointContextMatcher` will not check for additional context fields, which are unknown by that matcher..

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>