### PR TITLE
Change return type from entries Set to Map.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/AddressEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/AddressEndpointContext.java
@@ -20,7 +20,6 @@ import java.net.InetSocketAddress;
 import java.security.Principal;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A endpoint context providing the inet socket address and a optional principal.
@@ -81,8 +80,8 @@ public class AddressEndpointContext implements EndpointContext {
 	}
 
 	@Override
-	public Set<Map.Entry<String, String>> entrySet() {
-		return Collections.emptySet();
+	public Map<String, String> entries() {
+		return Collections.emptyMap();
 	}
 
 	@Override

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContext.java
@@ -72,7 +72,7 @@ public interface EndpointContext {
 	 *
 	 * @return A set of a map entry containing the key value pair.
 	 */
-	Set<Map.Entry<String, String>> entrySet();
+	Map<String, String> entries();
 
 	/**
 	 * Check, if the correlation information contained, will inhibit a new

--- a/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
@@ -27,7 +27,6 @@ import java.security.Principal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A map based endpoint context.
@@ -109,8 +108,8 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 	}
 
 	@Override
-	public Set<Map.Entry<String, String>> entrySet() {
-		return entries.entrySet();
+	public Map<String, String> entries() {
+		return entries;
 	}
 
 	@Override


### PR DESCRIPTION
With the unmodifiable map it's possible to return that directly.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>