### PR TITLE
Workaround for openjdk URI bug.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
@@ -108,7 +108,8 @@ public class CoapEndpointTest {
 
 	@Test
 	public void testGetUriReturnsConnectorUri() throws URISyntaxException {
-		URI uri = new URI("coap://" + connector.getAddress().getHostString() + ":" + connector.getAddress().getPort());
+		InetSocketAddress socketAddress = connector.getAddress();
+		URI uri = new URI("coap://" + socketAddress.getAddress().getHostAddress() + ":" + socketAddress.getPort());
 		assertThat(endpoint.getUri(), is(uri));
 	}
 


### PR DESCRIPTION
JDK-8199396

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>