### PR TITLE
Fix rare race condition in tls reconnect test.

### DIFF
--- a/element-connector-tcp/src/main/java/org/eclipse/californium/elements/tcp/NettyContextUtils.java
+++ b/element-connector-tcp/src/main/java/org/eclipse/californium/elements/tcp/NettyContextUtils.java
@@ -17,6 +17,7 @@
  *                                                    add TLS information to
  *                                                    correlation context
  *    Bosch Software Innovations GmbH - migrate to SLF4J
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add id to logs
  ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
@@ -89,16 +90,16 @@ public class NettyContextUtils {
 				}
 
 				if (principal == null) {
-					LOGGER.debug("Principal missing");
+					LOGGER.debug("TLS({}) principal missing", id);
 				} else {
-					LOGGER.debug("Principal {}", principal.getName());
+					LOGGER.debug("TLS({}) principal {}", id, principal.getName());
 				}
 
 				byte[] sessionId = sslSession.getId();
 				if (sessionId != null && sessionId.length > 0) {
 					String sslId = StringUtil.byteArray2HexString(sessionId, 0);
 					String cipherSuite = sslSession.getCipherSuite();
-					LOGGER.debug("TLS({},{},{})", id, StringUtil.trunc(sslId, 14), cipherSuite);
+					LOGGER.debug("TLS({},{},{})", id, StringUtil.trunc(sslId, 12), cipherSuite);
 					return new TlsEndpointContext(address, principal, id, sslId, cipherSuite);
 				}
 			}

--- a/element-connector-tcp/src/main/java/org/eclipse/californium/elements/tcp/TcpClientConnector.java
+++ b/element-connector-tcp/src/main/java/org/eclipse/californium/elements/tcp/TcpClientConnector.java
@@ -30,6 +30,7 @@
  *                                                 after TLS handshake completes overwriting
  *                                                 this method in a sub-class.
  * Bosch Software Innovations GmbH - migrate to SLF4J
+ * Achim Kraus (Bosch Software Innovations GmbH) - add logs for create and close channel
  ******************************************************************************/
 package org.eclipse.californium.elements.tcp;
 
@@ -261,6 +262,7 @@ public class TcpClientConnector implements Connector {
 
 		@Override
 		public void channelCreated(Channel ch) throws Exception {
+			LOGGER.debug("new channel to {}", key);
 			onNewChannelCreated(key, ch);
 
 			// Handler order:
@@ -293,6 +295,7 @@ public class TcpClientConnector implements Connector {
 			// Otherwise it's not save to remove and
 			// close the pool as soon as a single channel is closed.
 			poolMap.remove(key);
+			LOGGER.debug("closed channel to {}", key);
 		}
 	}
 }


### PR DESCRIPTION
In some rare cases the client side of the connection is not terminated fast enough for this reconnect test. Therefore it tries to resend the message in that cases.

Also improve logging.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>