### PR TITLE
FETCH/PATCH framework added and tests updated

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
@@ -217,6 +217,8 @@ public  class CoapResource implements Resource {
 			case POST:	handlePOST(new CoapExchange(exchange, this)); break;
 			case PUT:	handlePUT(new CoapExchange(exchange, this)); break;
 			case DELETE: handleDELETE(new CoapExchange(exchange, this)); break;
+			case FETCH: handleFETCH(new CoapExchange(exchange, this)); break;
+			case PATCH: handlePATCH(new CoapExchange(exchange, this)); break;
 		}
 	}
 	
@@ -265,6 +267,30 @@ public  class CoapResource implements Resource {
 	 * @param exchange the CoapExchange for the simple API
 	 */
 	public void handleDELETE(CoapExchange exchange) {
+		exchange.respond(ResponseCode.METHOD_NOT_ALLOWED);
+	}
+	
+	/**
+	 * Handles the FETCH request in the given CoAPExchange. By default it
+	 * responds with a 4.05 (Method Not Allowed). Override this method to
+	 * respond differently to FETCH requests. The response code to a FETCH
+	 * request should be a Content (2.05).
+	 *
+	 * @param exchange the CoapExchange for the simple API
+	 */
+	public void handleFETCH(CoapExchange exchange) {
+		exchange.respond(ResponseCode.METHOD_NOT_ALLOWED);
+	}
+	
+	/**
+	 * Handles the PATCH request in the given CoAPExchange. By default it
+	 * responds with a 4.05 (Method Not Allowed). Override this method to
+	 * respond differently to PATCH requests. The response code to a PATCH
+	 * requests are Created (2.01) and Changed (2.04).
+	 *
+	 * @param exchange the CoapExchange for the simple API
+	 */
+	public void handlePATCH(CoapExchange exchange) {
 		exchange.respond(ResponseCode.METHOD_NOT_ALLOWED);
 	}
 	

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAP.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAP.java
@@ -367,7 +367,13 @@ public final class CoAP {
 		PUT(3),
 
 		/** The DELETE code. */
-		DELETE(4);
+		DELETE(4),
+		
+		/** The FETCH code. */
+		FETCH(5),
+		
+		/** The PATCH code. */
+		PATCH(6);
 
 		/** The code value. */
 		public final int value;
@@ -399,6 +405,8 @@ public final class CoAP {
 				case 2: return POST;
 				case 3: return PUT;
 				case 4: return DELETE;
+				case 5: return FETCH;
+				case 6: return PATCH;
 				default: throw new MessageFormatException(String.format("Unknown CoAP request code: %s", formatCode(classCode, detailCode)));
 			}
 		}
@@ -427,9 +435,11 @@ public final class CoAP {
 		METHOD_NOT_ALLOWED(CodeClass.ERROR_RESPONSE, 5),
 		NOT_ACCEPTABLE(CodeClass.ERROR_RESPONSE, 6),
 		REQUEST_ENTITY_INCOMPLETE(CodeClass.ERROR_RESPONSE, 8),
+		CONFLICT(CodeClass.ERROR_RESPONSE, 9),
 		PRECONDITION_FAILED(CodeClass.ERROR_RESPONSE, 12),
 		REQUEST_ENTITY_TOO_LARGE(CodeClass.ERROR_RESPONSE, 13),
 		UNSUPPORTED_CONTENT_FORMAT(CodeClass.ERROR_RESPONSE, 15),
+		UNPROCESSABLE_ENTITY(CodeClass.ERROR_RESPONSE, 22),
 
 		// Server error: 5.00 - 5.31
 		INTERNAL_SERVER_ERROR(CodeClass.SERVER_ERROR_RESPONSE, 0),
@@ -500,9 +510,11 @@ public final class CoAP {
 			case 5: return METHOD_NOT_ALLOWED;
 			case 6: return NOT_ACCEPTABLE;
 			case 8: return REQUEST_ENTITY_INCOMPLETE;
+			case 9: return CONFLICT;
 			case 12: return PRECONDITION_FAILED;
 			case 13: return REQUEST_ENTITY_TOO_LARGE;
 			case 15: return UNSUPPORTED_CONTENT_FORMAT;
+			case 22: return UNPROCESSABLE_ENTITY;
 			default:
 				return BAD_REQUEST;
 			}

--- a/californium-core/src/test/java/org/eclipse/californium/core/coap/CoapTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/coap/CoapTest.java
@@ -85,7 +85,9 @@ public class CoapTest {
 		assertThat(CoAP.getCodeClass(ResponseCode.CONTINUE.value), is(CodeClass.SUCCESS_RESPONSE.value));
 		// errors
 		assertThat(CoAP.getCodeClass(ResponseCode.BAD_REQUEST.value), is(CodeClass.ERROR_RESPONSE.value));
+		assertThat(CoAP.getCodeClass(ResponseCode.CONFLICT.value), is(CodeClass.ERROR_RESPONSE.value));
 		assertThat(CoAP.getCodeClass(ResponseCode.UNSUPPORTED_CONTENT_FORMAT.value), is(CodeClass.ERROR_RESPONSE.value));
+		assertThat(CoAP.getCodeClass(ResponseCode.UNPROCESSABLE_ENTITY.value), is(CodeClass.ERROR_RESPONSE.value));
 		// server errors
 		assertThat(CoAP.getCodeClass(ResponseCode.INTERNAL_SERVER_ERROR.value),
 				is(CodeClass.SERVER_ERROR_RESPONSE.value));
@@ -98,13 +100,17 @@ public class CoapTest {
 		// Requests
 		assertThat(CoAP.getCodeDetail(Code.GET.value), is(1));
 		assertThat(CoAP.getCodeDetail(Code.DELETE.value), is(4));
+		assertThat(CoAP.getCodeDetail(Code.FETCH.value), is(5));
+		assertThat(CoAP.getCodeDetail(Code.PATCH.value), is(6));
 		// success
 		assertThat(CoAP.getCodeDetail(ResponseCode.CREATED.value), is(1));
 		assertThat(CoAP.getCodeDetail(ResponseCode.CHANGED.value), is(4));
 		assertThat(CoAP.getCodeDetail(ResponseCode.CONTINUE.value), is(31));
 		// errors
 		assertThat(CoAP.getCodeDetail(ResponseCode.BAD_REQUEST.value), is(0));
+		assertThat(CoAP.getCodeDetail(ResponseCode.CONFLICT.value), is(9));
 		assertThat(CoAP.getCodeDetail(ResponseCode.UNSUPPORTED_CONTENT_FORMAT.value), is(15));
+		assertThat(CoAP.getCodeDetail(ResponseCode.UNPROCESSABLE_ENTITY.value), is(22));
 		// server errors
 		assertThat(CoAP.getCodeDetail(ResponseCode.INTERNAL_SERVER_ERROR.value), is(0));
 		assertThat(CoAP.getCodeDetail(ResponseCode.NOT_IMPLEMENTED.value), is(1));
@@ -116,6 +122,8 @@ public class CoapTest {
 		// Requests
 		assertThat(CoAP.formatCode(Code.GET.value), is("0.01"));
 		assertThat(CoAP.formatCode(Code.POST.value), is("0.02"));
+		assertThat(CoAP.formatCode(Code.FETCH.value), is("0.05"));
+		assertThat(CoAP.formatCode(Code.PATCH.value), is("0.06"));
 		// success
 		assertThat(CoAP.formatCode(ResponseCode.CREATED.value), is("2.01"));
 		assertThat(CoAP.formatCode(ResponseCode.CHANGED.value), is("2.04"));
@@ -123,8 +131,10 @@ public class CoapTest {
 		// errors
 		assertThat(CoAP.formatCode(ResponseCode.BAD_REQUEST.value), is("4.00"));
 		assertThat(CoAP.formatCode(ResponseCode.REQUEST_ENTITY_INCOMPLETE.value), is("4.08"));
+		assertThat(CoAP.formatCode(ResponseCode.CONFLICT.value), is("4.09"));
 		assertThat(CoAP.formatCode(ResponseCode.REQUEST_ENTITY_TOO_LARGE.value), is("4.13"));
 		assertThat(CoAP.formatCode(ResponseCode.UNSUPPORTED_CONTENT_FORMAT.value), is("4.15"));
+		assertThat(CoAP.formatCode(ResponseCode.UNPROCESSABLE_ENTITY.value), is("4.22"));
 		// server errors
 		assertThat(CoAP.formatCode(ResponseCode.INTERNAL_SERVER_ERROR.value), is("5.00"));
 		assertThat(CoAP.formatCode(ResponseCode.NOT_IMPLEMENTED.value), is("5.01"));

--- a/californium-core/src/test/java/org/eclipse/californium/core/coap/RequestTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/coap/RequestTest.java
@@ -233,7 +233,7 @@ public class RequestTest {
 	@Test
 	public void setObserveFailsForNonGetRequest() {
 
-		Code[] illegalCodes = new Code[]{ Code.DELETE, Code.POST, Code.PUT };
+		Code[] illegalCodes = new Code[]{ Code.PATCH, Code.FETCH, Code.DELETE, Code.POST, Code.PUT };
 
 		for (Code code : illegalCodes) {
 			try {
@@ -252,7 +252,7 @@ public class RequestTest {
 	@Test
 	public void setObserveCancelFailsForNonGetRequest() {
 
-		Code[] illegalCodes = new Code[]{ Code.DELETE, Code.POST, Code.PUT };
+		Code[] illegalCodes = new Code[]{ Code.PATCH, Code.FETCH, Code.DELETE, Code.POST, Code.PUT };
 
 		for (Code code : illegalCodes) {
 			try {


### PR DESCRIPTION
OSCORE processing uses FETCH as dummy code during Observe functionality, see [OSCORE draft](https://github.com/core-wg/oscoap). OSCORE also supports PATCH.