### PR TITLE
Configure the X.509 certificate chain validation

### DIFF
--- a/scandium-core/pom.xml
+++ b/scandium-core/pom.xml
@@ -136,7 +136,8 @@
 							org.eclipse.californium.scandium.dtls,
 							org.eclipse.californium.scandium.dtls.cipher,
 							org.eclipse.californium.scandium.dtls.pskstore,
-							org.eclipse.californium.scandium.dtls.rpkstore
+							org.eclipse.californium.scandium.dtls.rpkstore,
+							org.eclipse.californium.scandium.dtls.x509
 						</Export-Package>
 						<Private-Package>
 							org.eclipse.californium.scandium.util

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -152,8 +152,8 @@ public class ClientHandshaker extends Handshaker {
 	 */
 	public ClientHandshaker(DTLSSession session, RecordLayer recordLayer, SessionListener sessionListener,
 			DtlsConnectorConfig config, int maxTransmissionUnit) {
-		super(true, session, recordLayer, sessionListener, config.getTrustStore(), maxTransmissionUnit, 
-		        config.getRpkTrustStore());
+		super(true, session, recordLayer, sessionListener, config.getCertificateVerifier(), maxTransmissionUnit,
+				config.getRpkTrustStore());
 		this.privateKey = config.getPrivateKey();
 		this.certificateChain = config.getCertificateChain();
 		this.publicKey = config.getPublicKey();
@@ -170,7 +170,7 @@ public class ClientHandshaker extends Handshaker {
 
 			// we always support receiving a RawPublicKey from the server
 			this.supportedServerCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
-			if (rootCertificates != null) {
+			if (certificateVerifier.getAcceptedIssuers() != null) {
 				int index = config.isSendRawKey() ? 1 : 0;
 				this.supportedServerCertificateTypes.add(index, CertificateType.X_509);
 			}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -194,8 +194,8 @@ public class ServerHandshaker extends Handshaker {
 	 */
 	public ServerHandshaker(int initialMessageSequenceNo, DTLSSession session, RecordLayer recordLayer, SessionListener sessionListener,
 			DtlsConnectorConfig config, int maxTransmissionUnit) { 
-		super(false, initialMessageSequenceNo, session, recordLayer, sessionListener, config.getTrustStore(), maxTransmissionUnit,
-		        config.getRpkTrustStore());
+		super(false, initialMessageSequenceNo, session, recordLayer, sessionListener, config.getCertificateVerifier(),
+				maxTransmissionUnit, config.getRpkTrustStore());
 
 		this.supportedCipherSuites = Arrays.asList(config.getSupportedCipherSuites());
 
@@ -216,7 +216,7 @@ public class ServerHandshaker extends Handshaker {
 
 			if (this.clientAuthenticationRequired) {
 				this.supportedClientCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
-				if (rootCertificates != null) {
+				if (config.getCertificateVerifier().getAcceptedIssuers() != null) {
 					int index = config.isSendRawKey() ? 1 : 0;
 					this.supportedClientCertificateTypes.add(index, CertificateType.X_509);
 				}
@@ -638,7 +638,7 @@ public class ServerHandshaker extends Handshaker {
 			// TODO make this variable, reasonable values
 			certificateRequest.addCertificateType(ClientCertificateType.ECDSA_SIGN);
 			certificateRequest.addSignatureAlgorithm(new SignatureAndHashAlgorithm(signatureAndHashAlgorithm.getHash(), signatureAndHashAlgorithm.getSignature()));
-			certificateRequest.addCertificateAuthorities(rootCertificates);
+			certificateRequest.addCertificateAuthorities(certificateVerifier.getAcceptedIssuers());
 
 			flight.addMessage(wrapMessage(certificateRequest));
 			md.update(certificateRequest.toByteArray());

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/CertificateVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/CertificateVerifier.java
@@ -1,0 +1,34 @@
+package org.eclipse.californium.scandium.dtls.x509;
+
+import java.security.cert.X509Certificate;
+
+import org.eclipse.californium.scandium.dtls.CertificateMessage;
+import org.eclipse.californium.scandium.dtls.DTLSSession;
+import org.eclipse.californium.scandium.dtls.HandshakeException;
+
+/**
+ * A class in charge of verifying a X.509 certificate chain provided by a peer.
+ * 
+ * @see StaticCertificateVerifier
+ */
+public interface CertificateVerifier {
+
+	/**
+	 * Validates the X.509 certificate chain provided by the the peer as part of
+	 * this message.
+	 * 
+	 * @param message
+	 * @param session
+	 * @throws HandshakeException
+	 */
+	void verifyCertificate(CertificateMessage message, DTLSSession session) throws HandshakeException;
+
+	/**
+	 * Return an array of certificate authority certificates which are trusted
+	 * for authenticating peers.
+	 * 
+	 * @return the trusted CA certificates (possibly <code>null</code>)
+	 */
+	X509Certificate[] getAcceptedIssuers();
+
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticCertificateVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticCertificateVerifier.java
@@ -1,0 +1,94 @@
+package org.eclipse.californium.scandium.dtls.x509;
+
+import java.security.GeneralSecurityException;
+import java.security.cert.CertPathValidator;
+import java.security.cert.PKIXParameters;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.californium.scandium.dtls.AlertMessage;
+import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
+import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
+import org.eclipse.californium.scandium.dtls.CertificateMessage;
+import org.eclipse.californium.scandium.dtls.DTLSSession;
+import org.eclipse.californium.scandium.dtls.HandshakeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This implementation uses a static set of trusted root certificates to
+ * validate the chain.
+ */
+public class StaticCertificateVerifier implements CertificateVerifier {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(StaticCertificateVerifier.class.getName());
+
+	private final X509Certificate[] rootCertificates;
+
+	public StaticCertificateVerifier(X509Certificate[] rootCertificates) {
+		this.rootCertificates = rootCertificates;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * This method checks
+	 * <ol>
+	 * <li>that each certificate's issuer DN equals the subject DN of the next
+	 * certificate in the chain</li>
+	 * <li>that each certificate is currently valid according to its validity
+	 * period</li>
+	 * <li>that the chain is rooted at a trusted CA</li>
+	 * </ol>
+	 * 
+	 * @throws HandshakeException if any of the checks fails
+	 */
+	@Override
+	public void verifyCertificate(CertificateMessage message, DTLSSession session) throws HandshakeException {
+
+		if (rootCertificates != null && rootCertificates.length == 0) {
+			// trust empty list of root certificates
+			return;
+		}
+
+		Set<TrustAnchor> trustAnchors = getTrustAnchors(rootCertificates);
+
+		try {
+			PKIXParameters params = new PKIXParameters(trustAnchors);
+			// TODO: implement alternative means of revocation checking
+			params.setRevocationEnabled(false);
+
+			CertPathValidator validator = CertPathValidator.getInstance("PKIX");
+			validator.validate(message.getCertificateChain(), params);
+
+		} catch (GeneralSecurityException e) {
+			if (LOGGER.isTraceEnabled()) {
+				LOGGER.trace("Certificate validation failed", e);
+			} else if (LOGGER.isDebugEnabled()) {
+				LOGGER.debug("Certificate validation failed due to {}", e.getMessage());
+			}
+			AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.BAD_CERTIFICATE,
+					session.getPeer());
+			throw new HandshakeException("Certificate chain could not be validated", alert);
+		}
+
+	}
+
+	@Override
+	public X509Certificate[] getAcceptedIssuers() {
+		return rootCertificates;
+	}
+
+	private static Set<TrustAnchor> getTrustAnchors(X509Certificate[] trustedCertificates) {
+		Set<TrustAnchor> result = new HashSet<>();
+		if (trustedCertificates != null) {
+			for (X509Certificate cert : trustedCertificates) {
+				result.add(new TrustAnchor((X509Certificate) cert, null));
+			}
+		}
+		return result;
+	}
+
+}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
@@ -28,7 +28,7 @@ package org.eclipse.californium.scandium.dtls;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -46,6 +46,7 @@ import org.eclipse.californium.elements.auth.RawPublicKeyIdentity;
 import org.eclipse.californium.scandium.category.Medium;
 import org.eclipse.californium.scandium.dtls.rpkstore.InMemoryRpkTrustStore;
 import org.eclipse.californium.scandium.dtls.rpkstore.TrustedRpkStore;
+import org.eclipse.californium.scandium.dtls.x509.StaticCertificateVerifier;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -87,7 +88,9 @@ public class HandshakerTest {
 		serverPublicKey = DtlsTestTools.getPublicKey();
 		peerAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 5684);
 		rpkStore = new InMemoryRpkTrustStore(Collections.singleton(new RawPublicKeyIdentity(serverPublicKey)));
-		handshaker = new Handshaker(false, session, recordLayer, null, null, 1500, rpkStore) {
+		handshaker = new Handshaker(false, session, recordLayer, null, new StaticCertificateVerifier(null), 1500,
+				rpkStore) {
+
 			@Override
 			public void startHandshake() {
 			}
@@ -101,19 +104,21 @@ public class HandshakerTest {
 			}
 		};
 		
-		handshakerWithAnchors = new Handshaker(false, session, recordLayer, null, trustAnchor, 1500, rpkStore) {
-            @Override
-            public void startHandshake() {
-            }
+		handshakerWithAnchors = new Handshaker(false, session, recordLayer, null,
+				new StaticCertificateVerifier(trustAnchor), 1500, rpkStore) {
 
-            @Override
-            protected void doProcessMessage(DTLSMessage message) throws GeneralSecurityException, HandshakeException {
-                if (message instanceof HandshakeMessage) {
-                    receivedMessages[((HandshakeMessage) message).getMessageSeq()] += 1;
-                    incrementNextReceiveSeq();
-                }
-            }
-        };
+			@Override
+			public void startHandshake() {
+			}
+
+			@Override
+			protected void doProcessMessage(DTLSMessage message) throws GeneralSecurityException, HandshakeException {
+				if (message instanceof HandshakeMessage) {
+					receivedMessages[((HandshakeMessage) message).getMessageSeq()] += 1;
+					incrementNextReceiveSeq();
+				}
+			}
+		};
 	}
 
 	@Test


### PR DESCRIPTION
This PR is a starting point to introduce some flexibility in the validation of the peer's certificate chain.

I introduce a CertificateVerifier interface which is close to the `X509TrustManager` class of java. In this version, the `DTLSSession` is available, adding the possibility to get some additional information (e.g. negociated cipher suite).

Signed-off-by: Manuel Sangoi <msangoi@sierrawireless.com>
