### PR TITLE
Unknown PSK Identity and Bad PSK should be both handled in a same way

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AlertMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AlertMessage.java
@@ -136,7 +136,8 @@ public final class AlertMessage extends AbstractMessage {
 		INTERNAL_ERROR(80, "internal_error"),
 		USER_CANCELED(90, "user_canceled"),
 		NO_RENEGOTIATION(100, "no_negotiation"),
-		UNSUPPORTED_EXTENSION(110, "unsupported_extension");
+		UNSUPPORTED_EXTENSION(110, "unsupported_extension"),
+		UNKNOWN_PSK_IDENTITY(115, "unknown_psk_identity");
 
 		private byte code;
 		private String description;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -689,7 +689,7 @@ public class ServerHandshaker extends Handshaker {
 		if (psk == null) {
 			throw new HandshakeException(
 					String.format("Cannot authenticate client, identity [%s] is unknown", identity),
-					new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, session.getPeer()));
+					new AlertMessage(AlertLevel.FATAL, AlertDescription.UNKNOWN_PSK_IDENTITY, session.getPeer()));
 		} else {
 			session.setPeerIdentity(new PreSharedKeyIdentity(identity));
 			return generatePremasterSecretFromPSK(psk);


### PR DESCRIPTION
This PR aims to fix this issue : https://bugs.eclipse.org/bugs/show_bug.cgi?id=533258.

An "unknown PSK identity" will be ignored as a "bad PSK".