### PR TITLE
[#563] Fix Maven bundle plugin warnings.

### DIFF
--- a/californium-core/pom.xml
+++ b/californium-core/pom.xml
@@ -76,21 +76,8 @@
 				<configuration>
 					<instructions>
 						<Export-Package>
-							org.eclipse.californium.core,
-							org.eclipse.californium.core.coap,
-							org.eclipse.californium.core.network,
-							org.eclipse.californium.core.network.config,
-							org.eclipse.californium.core.network.interceptors,
-							org.eclipse.californium.core.network.stack,
-							org.eclipse.californium.core.observe,
-							org.eclipse.californium.core.server,
-							org.eclipse.californium.core.server.resources
+							org.eclipse.californium.core*
 						</Export-Package>
-						<Private-Package>
-							org.eclipse.californium.core.network.deduplication,
-							org.eclipse.californium.core.network.serialization,
-							org.eclipse.californium.core.network.stack.*
-						</Private-Package>
 						<Import-Package>
 							*
 						</Import-Package>

--- a/californium-proxy/pom.xml
+++ b/californium-proxy/pom.xml
@@ -91,8 +91,8 @@
 				<configuration>
 					<instructions>
 						<Export-Package>
-							org.eclipse.californium.proxy,
-							org.eclipse.californium.proxy.resources
+							org.eclipse.californium.compat,
+							org.eclipse.californium.proxy*
 						</Export-Package>
 						<Import-Package>
 							org.apache.http; ${httpcore.version.spec},

--- a/element-connector/pom.xml
+++ b/element-connector/pom.xml
@@ -53,8 +53,8 @@
 				<configuration>
 					<instructions>
 						<Export-Package>
-							org.eclipse.californium.elements,
-							org.eclipse.californium.elements.util
+							eu.javaspecialists.tjsn.concurrency.stripedexecutor,
+							org.eclipse.californium.elements*
 						</Export-Package>
 						<Import-Package>
 							*

--- a/scandium-core/pom.xml
+++ b/scandium-core/pom.xml
@@ -130,17 +130,8 @@
 				<configuration>
 					<instructions>
 						<Export-Package>
-							org.eclipse.californium.scandium,
-							org.eclipse.californium.scandium.auth,
-							org.eclipse.californium.scandium.config,
-							org.eclipse.californium.scandium.dtls,
-							org.eclipse.californium.scandium.dtls.cipher,
-							org.eclipse.californium.scandium.dtls.pskstore,
-							org.eclipse.californium.scandium.dtls.rpkstore
+							org.eclipse.californium.scandium*
 						</Export-Package>
-						<Private-Package>
-							org.eclipse.californium.scandium.util
-						</Private-Package>
 						<Import-Package>
 							*
 						</Import-Package>


### PR DESCRIPTION
Fix warnings about references to private packages from exported
packages.

@sbernard31 can you check if the warnings during build still show up with this fix?