### PR TITLE
[backport for 1.0-x] Unknown PSK Identity and Bad PSK should be both handled in a same way

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -217,9 +217,9 @@ public class Request extends Message {
 
 		try {
 			String coapUri = uri;
-			if (!uri.startsWith("coap://") && !uri.startsWith("coaps://")) {
+			if (!uri.contains("://")) {
 				coapUri = "coap://" + uri;
-				LOGGER.log(Level.WARNING, "update your code to supply an RFC 7252 compliant URI including a valid scheme");
+				LOGGER.log(Level.WARNING, "update your code to supply an RFC 7252 compliant URI including a scheme");
 			}
 			return setURI(new URI(coapUri));
 		} catch (URISyntaxException e) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -1518,12 +1518,23 @@ public class DTLSConnector implements Connector {
 		return result;
 	}
 
-	private void handleExceptionDuringHandshake(Throwable cause, AlertLevel level, AlertDescription description, Record record) {
-		if (AlertLevel.FATAL.equals(level)) {
-			terminateOngoingHandshake(record.getPeerAddress(), cause, description);
-		} else {
+	private void handleExceptionDuringHandshake(HandshakeException cause, AlertLevel level, AlertDescription description, Record record) {
+		// discard none fatal alert exception
+		if (!AlertLevel.FATAL.equals(level)) {
 			discardRecord(record, cause);
+			return;
 		}
+
+		// "Unknown identity" and "bad PSK" should be both handled in a same way.
+		// Generally "bad PSK" means invalid MAC on FINISHED message.
+		// In production both should be silently ignored : https://bugs.eclipse.org/bugs/show_bug.cgi?id=533258
+		if (AlertDescription.UNKNOWN_PSK_IDENTITY == description) {
+			discardRecord(record, cause);
+			return;
+		}
+
+		// in other cases terminate handshake
+		terminateOngoingHandshake(record.getPeerAddress(), cause, description);
 	}
 
 	private static void discardRecord(final Record record, final Throwable cause) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AlertMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AlertMessage.java
@@ -136,7 +136,8 @@ public final class AlertMessage extends AbstractMessage {
 		INTERNAL_ERROR(80, "internal_error"),
 		USER_CANCELED(90, "user_canceled"),
 		NO_RENEGOTIATION(100, "no_negotiation"),
-		UNSUPPORTED_EXTENSION(110, "unsupported_extension");
+		UNSUPPORTED_EXTENSION(110, "unsupported_extension"),
+		UNKNOWN_PSK_IDENTITY(115, "unknown_psk_identity");
 
 		private byte code;
 		private String description;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -640,7 +640,7 @@ public class ServerHandshaker extends Handshaker {
 		if (psk == null) {
 			throw new HandshakeException(
 					String.format("Cannot authenticate client, identity [%s] is unknown", identity),
-					new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, session.getPeer()));
+					new AlertMessage(AlertLevel.FATAL, AlertDescription.UNKNOWN_PSK_IDENTITY, session.getPeer()));
 		}
 		
 		session.setPeerIdentity(new PreSharedKeyIdentity(identity));

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -79,6 +79,7 @@ import org.eclipse.californium.scandium.dtls.Record;
 import org.eclipse.californium.scandium.dtls.SessionId;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.InMemoryPskStore;
+import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
 import org.eclipse.californium.scandium.dtls.pskstore.StaticPskStore;
 import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
 import org.junit.After;
@@ -689,28 +690,43 @@ public class DTLSConnectorTest {
 		assertFalse(latch.await(500, TimeUnit.MILLISECONDS));
 		assertNull("Server should not have established a session with client", serverConnectionStore.get(clientEndpoint));
 	}
-
+	
+	/**
+	 * Verifies that connector ignores CLIENT KEY EXCHANGE with unknown PSK identity.
+	 */
 	@Test
-	public void testConnectorAbortsHandshakeOnUnknownPskIdentity() throws Exception {
+	public void testConnectorIgnoresUnknownPskIdentity() throws Exception {
+		ensureConnectorIgnoresBadCredentials(new StaticPskStore("unknownIdentity", CLIENT_IDENTITY_SECRET.getBytes()));
+	}
 
+	/**
+	 * Verifies that connector ignores FINISHED message with bad PSK.
+	 */
+	@Test
+	public void testConnectorIgnoresBadPsk() throws Exception {
+		ensureConnectorIgnoresBadCredentials(new StaticPskStore(CLIENT_IDENTITY, "bad_psk".getBytes()));
+	}
+
+	private void ensureConnectorIgnoresBadCredentials(PskStore pskStoreWithBadCredentials) throws Exception {
 		final CountDownLatch latch = new CountDownLatch(1);
 		clientConfig = new DtlsConnectorConfig.Builder(clientEndpoint)
-			.setPskStore(new StaticPskStore("unknownIdentity", CLIENT_IDENTITY_SECRET.getBytes()))
+			.setPskStore(pskStoreWithBadCredentials)
 			.build();
 		client = new DTLSConnector(clientConfig);
+		final AtomicReference<AlertDescription> alert = new AtomicReference<>();
 		client.setErrorHandler(new ErrorHandler() {
 			
 			@Override
 			public void onError(InetSocketAddress peerAddress, AlertLevel level, AlertDescription description) {
 				latch.countDown();
-				assertThat(level, is(AlertLevel.FATAL));
-				assertThat(peerAddress, is(serverEndpoint));
+				alert.set(description);
 			}
 		});
 		client.start();
 		client.send(new RawData("Hello".getBytes(), serverEndpoint));
-		
-		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
+
+		assertFalse(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
+		assertThat(alert.get(), is(nullValue()));
 	}
 
 	/**


### PR DESCRIPTION
This is backport fix of #605 for the 1.0-x branch.

531fe52 is not directly related but as this test failed on my machine, I backport the `Request.setURI` implementation of 2.0.x branch.