### PR TITLE
Issue #609, reuse cipher.

### DIFF
--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DTLSSessionTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DTLSSessionTest.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *    Kai Hudalla (Bosch Software Innovations GmbH) - initial creator
+ *    Achim Kraus (Bosch Software Innovations GmbH) - issue #609, reuse cipher
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -73,7 +74,7 @@ public class DTLSSessionTest {
 	}
 
 	@Test
-	public void testMaxFragmentLengthIsAdjustedToCipherSuite() {
+	public void testMaxFragmentLengthIsAdjustedToCipherSuite() throws GeneralSecurityException {
 		// given a handshake over an ethernet connection (MTU 1500 bytes)
 		int mtu = 1500;
 		session.setMaxTransmissionUnit(mtu);
@@ -205,7 +206,11 @@ public class DTLSSessionTest {
 		}
 		SecretKey encryptionKey = new SecretKeySpec(getRandomBytes(cipherSuite.getEncKeyLength()), "AES");
 		IvParameterSpec iv = new IvParameterSpec(getRandomBytes(cipherSuite.getFixedIvLength()));
-		return new DTLSConnectionState(cipherSuite, CompressionMethod.NULL, encryptionKey, iv, macKey);
+		try {
+			return new DTLSConnectionState(cipherSuite, CompressionMethod.NULL, encryptionKey, iv, macKey);
+		} catch (GeneralSecurityException ex) {
+			throw new RuntimeException(ex);
+		}
 	}
 
 	private static byte[] getRandomBytes(int length) {

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordTest.java
@@ -14,6 +14,7 @@
  *    Matthias Kovatsch - creator and main architect
  *    Stefan Jucker - DTLS implementation
  *    Kai Hudalla (Bosch Software Innovations GmbH) - add test cases for verifying sequence number handling
+ *    Achim Kraus (Bosch Software Innovations GmbH) - issue #609, reuse cipher
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -168,8 +169,7 @@ public class RecordTest {
 		byte[] explicitNonce = new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
 		// nonce used for encryption, "implicit" part + "explicit" part
 		byte[] nonce = ByteArrayUtils.concatenate(client_iv, explicitNonce);
-		
-		byte[] encryptedData = CCMBlockCipher.encrypt(key.getEncoded(), nonce, additionalData, payloadData, 8);
+		byte[] encryptedData = CCMBlockCipher.encrypt(CCMBlockCipher.createCipher(key.getEncoded()), nonce, additionalData, payloadData, 8);
 		
 		// prepend the "explicit" part of nonce to the encrypted data to form the GenericAEADCipher struct
 		return ByteArrayUtils.concatenate(explicitNonce, encryptedData);


### PR DESCRIPTION
This variant reuses the Cipher instance.
With Record.CIPHER_INIT_ON_MESSAGE it's possible to test with or without init for each message.
Doesn't differ much, if init is repeated:

// init once
5000000 requests in 385612ms, 12966 reqs/s
5000000 requests in 381313ms, 13112 reqs/s
5000000 requests in 387289ms, 12910 reqs/s

// init on message
5000000 requests in 392561ms, 12736 reqs/s
5000000 requests in 388110ms, 12882 reqs/s
5000000 requests in 384122ms, 13016 reqs/s

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>