### PR TITLE
Make cipher threadlocal.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Record.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Record.java
@@ -36,6 +36,7 @@ import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.cipher.CCMBlockCipher;
+import org.eclipse.californium.scandium.dtls.cipher.CipherManager;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
 import org.eclipse.californium.scandium.dtls.cipher.InvalidMacException;
@@ -445,9 +446,7 @@ public class Record {
 		byte[] padding = new byte[paddingLength + 1];
 		Arrays.fill(padding, (byte) paddingLength);
 		plaintext.writeBytes(padding);
-					
-		// TODO: check if we can re-use the cipher instance
-		Cipher blockCipher = Cipher.getInstance(session.getWriteState().getCipherSuite().getTransformation());
+		Cipher blockCipher = CipherManager.getInstance(session.getWriteState().getCipherSuite().getTransformation());
 		blockCipher.init(Cipher.ENCRYPT_MODE,
 				session.getWriteState().getEncryptionKey());
 
@@ -499,8 +498,7 @@ public class Record {
 		 */
 		DatagramReader reader = new DatagramReader(ciphertextFragment);
 		byte[] iv = reader.readBytes(currentReadState.getRecordIvLength());
-		// TODO: check if we can re-use the cipher instance
-		Cipher blockCipher = Cipher.getInstance(currentReadState.getCipherSuite().getTransformation());
+		Cipher blockCipher = CipherManager.getInstance(currentReadState.getCipherSuite().getTransformation());
 		blockCipher.init(Cipher.DECRYPT_MODE,
 				currentReadState.getEncryptionKey(),
 				new IvParameterSpec(iv));

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CCMBlockCipher.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CCMBlockCipher.java
@@ -76,6 +76,7 @@ public class CCMBlockCipher {
 		 * </pre>
 		 * 
 		 * Return remaining bytes in number.
+		 * 
 		 * <pre>
 		 * blockSize = 16;
 		 * number = 0x20103
@@ -307,7 +308,7 @@ public class CCMBlockCipher {
 		 */
 
 		// instantiate the underlying block cipher
-		Cipher cipher = Cipher.getInstance(CIPHER_NAME);
+		Cipher cipher = CipherManager.getInstance(CIPHER_NAME);
 		cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, KEY_TYPE));
 
 		int lengthM = c.length - numAuthenticationBytes;
@@ -375,7 +376,7 @@ public class CCMBlockCipher {
 			throws GeneralSecurityException {
 
 		// instantiate the cipher
-		Cipher cipher = Cipher.getInstance(CIPHER_NAME);
+		Cipher cipher = CipherManager.getInstance(CIPHER_NAME);
 		cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, KEY_TYPE));
 		int blockSize = cipher.getBlockSize();
 		int lengthM = m.length;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherManager.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherManager.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation. 
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls.cipher;
+
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+
+/**
+ * Cipher manager.
+ * 
+ * Uses {@link ThreadLocal} to cache calls to
+ * {@link Cipher#getInstance(String)}.
+ */
+public class CipherManager {
+
+	private static final ThreadLocal<Map<String, Cipher>> threadLocalCipherMap = new ThreadLocal<Map<String, Cipher>>() {
+
+		@Override
+		protected Map<String, Cipher> initialValue() {
+			return new HashMap<String, Cipher>(5);
+		}
+	};
+
+	/**
+	 * Get "thread local" instance of cipher for the provided transformation.
+	 * 
+	 * @param transformation transformation. Passed to
+	 *            {@link Cipher#getInstance(String)} and used to lookup a
+	 *            already created cipher.
+	 * @return thread local cipher.
+	 * @throws NoSuchAlgorithmException if {@link Cipher#getInstance(String)}
+	 *             throws it.
+	 * @throws NoSuchPaddingException if {@link Cipher#getInstance(String)}
+	 *             throws it.
+	 */
+	public static Cipher getInstance(final String transformation)
+			throws NoSuchAlgorithmException, NoSuchPaddingException {
+		Map<String, Cipher> map = threadLocalCipherMap.get();
+		Cipher cipher = map.get(transformation);
+		if (cipher == null) {
+			cipher = Cipher.getInstance(transformation);
+			map.put(transformation, cipher);
+		}
+		return cipher;
+	}
+}


### PR DESCRIPTION
Some numbers of a thread-local implementation:

5000000 requests in 407513ms, 12269 reqs/s
5000000 requests in 407701ms, 12263 reqs/s
5000000 requests in 406746ms, 12292 reqs/s

Seem to be a little slower than #612 

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>