### PR TITLE
Add a lifetime for DTLS session

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -252,7 +252,7 @@ public class DTLSConnector implements Connector {
 	 * @param connectionStore The registry to use for managing connections to peers.
 	 * @throws NullPointerException if any of the parameters is <code>null</code>.
 	 */
-	DTLSConnector(final DtlsConnectorConfig configuration, final ResumptionSupportingConnectionStore connectionStore) {
+	public DTLSConnector(final DtlsConnectorConfig configuration, final ResumptionSupportingConnectionStore connectionStore) {
 
 		if (configuration == null) {
 			throw new NullPointerException("Configuration must not be null");

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SessionTicket.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SessionTicket.java
@@ -214,4 +214,12 @@ public final class SessionTicket {
 	public final long getTimestamp() {
 		return timestamp;
 	}
+
+	/**
+	 * @param lifeTime in seconds of the Ticket
+	 * @return true if the ticket expired
+	 */
+	public boolean isExpired(long lifeTime) {
+		return (timestamp + lifeTime) * 1000 < System.currentTimeMillis();
+	}
 }


### PR DESCRIPTION
This PR aims to add a session lifetime (see #617)

I made `DTLSConnector(final DtlsConnectorConfig configuration, final ResumptionSupportingConnectionStore connectionStore)` `public` to allow other implementation of `InMemoryConnectionStore` and so other implementation of Session lifetime.

This is a simple implementation without more thread, sessions are cleaned on "access" method of `InMemoryConnectionStore`.

I could add a DTLSConfig parameter if we agree on those first commits.

The sessionCache and sessionTicket is not so clear for me, we could discuss about this in #619.