### PR TITLE
Add ASN.1 DER decoder.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/Asn1DerDecoder.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/Asn1DerDecoder.java
@@ -1,0 +1,312 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import java.util.Arrays;
+
+/**
+ * ASN.1 DER decoder for SEQUENCEs and OIDs.
+ */
+public class Asn1DerDecoder {
+
+	/**
+	 * Maximum supported length for ASN.1 SEQUENCE.
+	 */
+	private static final int MAX_SEQUENCE_LENGTH = 0x10000;
+	/**
+	 * Tag for ASN.1 SEQUENCE.
+	 */
+	private static final int TAG_SEQUENCE = 0x30;
+	/**
+	 * Maximum supported length for ASN.1 OID.
+	 */
+	private static final int MAX_OID_LENGTH = 0x20;
+	/**
+	 * Tag for ASN.1 OIDE.
+	 */
+	private static final int TAG_OID = 0x06;
+	/**
+	 * ASN.1 OID for RSA public key.
+	 */
+	private static final byte[] OID_RSA_PUBLIC_KEY = { 0x2A, (byte) 0x86, 0x48, (byte) 0x86, (byte) 0xF7, 0x0D, 0x01,
+			0x01, 0x01 };
+	/**
+	 * ASN.1 OID for DH public key.
+	 */
+	private static final byte[] OID_DH_PUBLIC_KEY = { 0x2A, (byte) 0x86, 0x48, (byte) 0x86, (byte) 0xF7, 0x0D, 0x01,
+			0x03, 0x01 };
+	/**
+	 * ASN.1 OID for DSA public key.
+	 */
+	private static final byte[] OID_DSA_PUBLIC_KEY = { 0x2A, (byte) 0x86, 0x48, (byte) 0xCE, 0x38, 0x04, 0x01 };
+	/**
+	 * ASN.1 OID for EC public key.
+	 */
+	private static final byte[] OID_EC_PUBLIC_KEY = { 0x2A, (byte) 0x86, 0x48, (byte) 0xCE, 0x3D, 0x02, 0x01 };
+	/**
+	 * ASN.1 entity definition for SEQUENCE.
+	 */
+	private static final EntityDefinition SEQUENCE = new EntityDefinition(TAG_SEQUENCE, MAX_SEQUENCE_LENGTH,
+			"SEQUENCE");
+	/**
+	 * ASN.1 entity definition for OID.
+	 */
+	private static final EntityDefinition OID = new EntityDefinition(TAG_OID, MAX_OID_LENGTH, "OID");
+
+	/**
+	 * Read entity of ASN.1 SEQUENCE into byte array.
+	 * 
+	 * Returns entity, including tag and length. Intended to be passed to other
+	 * security readers as KeyFacotry or X509CertPath.
+	 * 
+	 * @param reader reader containing the bytes to read.
+	 * @return byte array containing the SEQUENCE entity.
+	 * @throws IllegalArgumentException if provided bytes doesn't contain a
+	 *             SEQUENCE.
+	 */
+	public static byte[] readSequenceEntity(final DatagramReader reader) {
+		return SEQUENCE.readEntity(reader);
+	}
+
+	/**
+	 * Read value of ASN.1 SEQUENCE into byte array.
+	 * 
+	 * Returns only the value, excluding tag and length.
+	 * 
+	 * @param reader reader containing the bytes to read.
+	 * @return byte array containing the SEQUENCE value.
+	 * @throws IllegalArgumentException if provided bytes doesn't contain a
+	 *             SEQUENCE.
+	 */
+	public static byte[] readSequenceValue(final DatagramReader reader) {
+		return SEQUENCE.readValue(reader);
+	}
+
+	/**
+	 * Read value of ASN.1 OID into byte array.
+	 * 
+	 * Read only value, excluding tag and length.
+	 * 
+	 * @param reader reader containing the bytes to read.
+	 * @return byte array containing the OID value.
+	 * @throws IllegalArgumentException if provided bytes doesn't contain a OID.
+	 */
+	public static byte[] readOidValue(final DatagramReader reader) {
+		return OID.readValue(reader);
+	}
+
+	/**
+	 * Read key algorithm from subjects public key.
+	 * 
+	 * Read key algorithm from subjects public key encoded in ASN.1 DER.
+	 * 
+	 * <pre>
+	 * SubjectPublicKeyInfo ::= SEQUENCE { 
+	 *    algorithm AlgorithmIdentifier,
+	 *    subjectPublicKey BIT STRING 
+	 * } 
+	 * 
+	 * AlgorithmIdentifier ::= SEQUENCE {
+	 *    algorithm OBJECT IDENTIFIER, 
+	 *    parameters ANY DEFINED BY algorithm OPTIONAL
+	 * }
+	 * </pre>
+	 * 
+	 * Figure 2: SubjectPublicKeyInfo ASN.1 Structure
+	 * 
+	 * @param data byte array containing the subject public key.
+	 * @return key algorithm name to be used by KeyFactory. Maybe {@code null},
+	 *         if the OID of the subject public key is unknown.
+	 * @throws IllegalArgumentException if provided bytes doesn't contain a
+	 *             subject public key.
+	 */
+	public static String readSubjectPublicKeyAlgorithm(final byte[] data) {
+		// outer sequence, SubjectPublicKeyInfo
+		DatagramReader reader = new DatagramReader(data);
+		byte[] value = readSequenceValue(reader);
+		// inner sequence, AlgorithmIdentifier
+		reader = new DatagramReader(value);
+		value = readSequenceValue(reader);
+		// oid, algorithm
+		reader = new DatagramReader(value);
+		value = readOidValue(reader);
+
+		if (Arrays.equals(value, OID_EC_PUBLIC_KEY)) {
+			return "EC";
+		}
+		if (Arrays.equals(value, OID_RSA_PUBLIC_KEY)) {
+			return "RSA";
+		}
+		if (Arrays.equals(value, OID_DSA_PUBLIC_KEY)) {
+			return "DSA";
+		}
+		if (Arrays.equals(value, OID_DH_PUBLIC_KEY)) {
+			return "DH";
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check for equal key algorithm synonyms.
+	 * 
+	 * Currently on "DH" and "DiffieHellman" are supported synonyms.
+	 * 
+	 * @param keyAlgorithm1 key algorithm 1
+	 * @param keyAlgorithm2 key algorithm 2
+	 * @return {@code true}, if the key algorithms are equal or synonyms,
+	 *         {@code false}, otherwise.
+	 */
+	public static boolean equalKeyAlgorithmSynonyms(String keyAlgorithm1, String keyAlgorithm2) {
+		if (!keyAlgorithm1.equals(keyAlgorithm2)) {
+			// currently just hard encoded check.
+			if (keyAlgorithm1.equals("DH") && keyAlgorithm2.equals("DiffieHellman")) {
+				return true;
+			} else if (keyAlgorithm2.equals("DH") && keyAlgorithm1.equals("DiffieHellman")) {
+				return true;
+			}
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * ASN.1 entity definition.
+	 */
+	private static class EntityDefinition {
+
+		/**
+		 * Header length of an entity. Tag and length bytes.
+		 */
+		private static final int HEADER_LENGTH = 2;
+		/**
+		 * Expected tag.
+		 */
+		private final int expectedTag;
+		/**
+		 * Maximum supported length.
+		 */
+		private final int maxLength;
+		/**
+		 * Entity description for error handling.
+		 */
+		private final String description;
+
+		/**
+		 * Create specific entity description.
+		 * 
+		 * @param expectedTag expected tag for this entity.
+		 * @param maxLength maximum length for this entity.
+		 * @param description description for error handling
+		 */
+		public EntityDefinition(int expectedTag, int maxLength, String description) {
+			this.expectedTag = expectedTag;
+			this.maxLength = maxLength;
+			this.description = description;
+		}
+
+		/**
+		 * Read entity including tag and length into byte array.
+		 * 
+		 * @param reader reader containing the bytes to read.
+		 * @return byte array containing the entity.
+		 * @throws IllegalArgumentException if provided bytes doesn't contain
+		 *             this valid entity.
+		 */
+		public byte[] readEntity(DatagramReader reader) {
+			return read(reader, true);
+		}
+
+		/**
+		 * Read value excluding tag and length into byte array.
+		 * 
+		 * @param reader reader containing the bytes to read.
+		 * @return byte array containing the value.
+		 * @throws IllegalArgumentException if provided bytes doesn't contain
+		 *             this valid entity.
+		 */
+		public byte[] readValue(DatagramReader reader) {
+			return read(reader, false);
+		}
+
+		/**
+		 * Read value or entity.
+		 * 
+		 * @param reader reader containing the bytes to read.
+		 * @param entity {@code true} to return the entity including the tag and
+		 *            length, {@code false} to return the value excluding the
+		 *            tag and length
+		 * @return byte array containing the value or entity.
+		 * @throws IllegalArgumentException if provided bytes doesn't contain
+		 *             this valid entity.
+		 */
+		public byte[] read(DatagramReader reader, boolean entity) {
+			int leftBytes = reader.bitsLeft() / Byte.SIZE;
+			if (leftBytes < HEADER_LENGTH) {
+				throw new IllegalArgumentException(String.format("Not enough bytes for %s! Required %d, available %d.",
+						description, HEADER_LENGTH, leftBytes));
+			}
+			// mark reader, if the entity must be returned
+			if (entity) {
+				reader.mark();
+			}
+			// check tag
+			int tag = reader.read(Byte.SIZE);
+			if (tag != expectedTag) {
+				throw new IllegalArgumentException(
+						String.format("No %s, found %02x instead of %02x!", description, tag, expectedTag));
+			}
+			// read length
+			int length = reader.read(Byte.SIZE);
+			int entityLength = length + HEADER_LENGTH;
+			if (length > 127) {
+				// multi bytes length
+				length &= 0x7f;
+				if (length > 4) {
+					throw new IllegalArgumentException(
+							String.format("%s length-size %d too long!", description, length));
+				}
+				leftBytes = reader.bitsLeft() / Byte.SIZE;
+				if (length > leftBytes) {
+					throw new IllegalArgumentException(
+							String.format("%s length %d exceeds available bytes %d!", description, length, leftBytes));
+				}
+				byte[] lengthBytes = reader.readBytes(length);
+				// decode multi bytes length
+				length = 0;
+				for (int index = 0; index < lengthBytes.length; ++index) {
+					length <<= 8;
+					length += (lengthBytes[index] & 0xff);
+				}
+				entityLength = length + HEADER_LENGTH + lengthBytes.length;
+			}
+			if (length > maxLength) {
+				throw new IllegalArgumentException(
+						String.format("%s lenght %d too large! (supported maxium %d)", description, length, maxLength));
+			}
+			leftBytes = reader.bitsLeft() / Byte.SIZE;
+			if (length > leftBytes) {
+				throw new IllegalArgumentException(
+						String.format("%s lengh %d exceeds available bytes %d!", description, length, leftBytes));
+			}
+			if (entity) {
+				reader.reset();
+				length = entityLength;
+			}
+			return reader.readBytes(length);
+		}
+	}
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramReader.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramReader.java
@@ -13,6 +13,7 @@
  * Contributors:
  *    Matthias Kovatsch - creator and main architect
  *    Stefan Jucker - DTLS implementation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add "mark" and "reset"
  ******************************************************************************/
 package org.eclipse.californium.elements.util;
 
@@ -32,13 +33,21 @@ public final class DatagramReader {
 	private byte currentByte;
 	private int currentBitIndex;
 
+	/**
+	 * Copy of {@link #currentByte}, when {@link #mark()} is called.
+	 */
+	private byte markByte;
+	/**
+	 * Copy of {@link #currentBitIndex}, when {@link #mark()} is called.
+	 */
+	private int markBitIndex;
+
 	// Constructors ////////////////////////////////////////////////////////////
 
 	/**
 	 * Creates a new reader for an array of bytes.
 	 * 
-	 * @param byteArray
-	 *            The byte array to read from.
+	 * @param byteArray The byte array to read from.
 	 */
 	public DatagramReader(final byte[] byteArray) {
 
@@ -48,9 +57,33 @@ public final class DatagramReader {
 		// initialize bit buffer
 		currentByte = 0;
 		currentBitIndex = -1; // indicates that no byte read yet
+		markByte = currentByte;
+		markBitIndex = currentBitIndex;
 	}
 
 	// Methods /////////////////////////////////////////////////////////////////
+
+	/**
+	 * Mark current position to be reseted afterwards.
+	 * 
+	 * @see #reset()
+	 */
+	public void mark() {
+		markByte = currentByte;
+		markBitIndex = currentBitIndex;
+		byteStream.mark(0);
+	}
+
+	/**
+	 * Reset reader to last mark.
+	 * 
+	 * @see #mark()
+	 */
+	public void reset() {
+		byteStream.reset();
+		currentByte = markByte;
+		currentBitIndex = markBitIndex;
+	}
 
 	/**
 	 * 

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/Asn1DerDecoderTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/Asn1DerDecoderTest.java
@@ -1,0 +1,221 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Verifies behavior of {@link Asn1DerDecoder}.
+ */
+public class Asn1DerDecoderTest {
+
+	/**
+	 * DH subject public key, ASN.1 DER / Base64 encoded.
+	 */
+	private static final String DH_BASE64 = "MIIBpjCCARsGCSqGSIb3DQEDATCCAQwCgYEA/X9TgR11EilS30qcLuzk5/YRt1I870QAwx4/gLZRJmlFXUAiUftZPY1Y+r/F9bow9subVWzXgTuAHTRv8mZgt2uZUKWkn5/oBHsQIsJPu6nX/rfGG/g7V+fGqKYVDwT7g/bTxR7DAjVUE1oWkTL2dfOuK2HXKu/yIgMZndFIAccCgYEA9+GghdabPd7LvKtcNrhXuXmUr7v6OuqC+VdMCz0HgmdRWVeOutRZT+ZxBxCBgLRJFnEj6EwoFhO3zwkyjMim4TwWeotUfI0o4KOuHiuzpnWRbqN/C/ohNWLx+2J6ASQ7zKTxvqhRkImog9/hWuWfBpKLZl6Ae1UlZAFMO/7PSSoCAgIAA4GEAAKBgH5J+o19W2ct7iGFz0/dLMaYLjCuw7TdaU2QtzZb5FmGj1TyglARYb9V3nKoqifSKlgnwFU8RBu61Sw5/gZYhAeap8kvPH7dwIrBNc4wbt5CMdicCZlSluOPrX6mYn9HzvuIaS0V8G11soSHikCCIp9gFeMLfI0AtbPOYDYD0jHA";
+	/**
+	 * EC subject public key, ASN.1 DER / Base64 encoded.
+	 */
+	private static final String EC_BASE64 = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEx4ABEJuzneP12mmh/RLlE6lM58MIrngQtfOK/eguzwNuTEP0wrE3H0p9rg1fZywtwleyl7lYUcxa8mQPOi4mRA==";
+	/**
+	 * DSA subject public key, ASN.1 DER / Base64 encoded.
+	 */
+	private static final String DSA_BASE64 = "MIIBtzCCASwGByqGSM44BAEwggEfAoGBAP1/U4EddRIpUt9KnC7s5Of2EbdSPO9EAMMeP4C2USZpRV1AIlH7WT2NWPq/xfW6MPbLm1Vs14E7gB00b/JmYLdrmVClpJ+f6AR7ECLCT7up1/63xhv4O1fnxqimFQ8E+4P208UewwI1VBNaFpEy9nXzrith1yrv8iIDGZ3RSAHHAhUAl2BQjxUjC8yykrmCouuEC/BYHPUCgYEA9+GghdabPd7LvKtcNrhXuXmUr7v6OuqC+VdMCz0HgmdRWVeOutRZT+ZxBxCBgLRJFnEj6EwoFhO3zwkyjMim4TwWeotUfI0o4KOuHiuzpnWRbqN/C/ohNWLx+2J6ASQ7zKTxvqhRkImog9/hWuWfBpKLZl6Ae1UlZAFMO/7PSSoDgYQAAoGAdp65TFSOhis6Ezu3Hq5LmKuu1eVDFkb1G/YuLOCYnkjG976B8G+W4TIVdM5yg7+Q0DU35mb2jrKHnRqnf5hRODnlp7kmUE2y1VBpgkx/9y+NYVMmfCqFqEn3c4DbWJvDcmvlKxG0okcSUdHcfxsF7grsyKB0RUTaXpwzdskHYo0=";
+	/**
+	 * RSA subject public key, ASN.1 DER / Base64 encoded.
+	 */
+	private static final String RSA_BASE64 = "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCNPpjuSuq6BQ3/YGWbVpmNa0q+/vURtkbwPJIocT/b8QqmqdebnQxvADv9UpwWSrEyPkzY8Mq9bJRzRokJ8KQKbf9DTVFQmRmzikIk/Jwcm4+ST2plfHxDnywT9EYPrnNf6TrL/6fZsN0x1NMtr5unnlTND66HGNp+YMjqFgfnWwIDAQAB";
+
+	/**
+	 * Sequence, ASN.1 DER encoded.
+	 */
+	private static byte[] sequence;
+
+	/**
+	 * Creates a ASN.1 SEQUENCE.
+	 * 
+	 * @throws IOException
+	 */
+	@BeforeClass
+	public static void init() throws IOException {
+		// use subject public key as SEQUENCE
+		sequence = Base64.decode(RSA_BASE64);
+	}
+
+	/**
+	 * Test, if decoder can read entity (tag, length, and value).
+	 */
+	@Test
+	public void testSequenceEntityDecoder() throws NoSuchAlgorithmException {
+		DatagramReader reader = new DatagramReader(sequence);
+		byte[] sequenceEntity = Asn1DerDecoder.readSequenceEntity(reader);
+		assertThat(sequenceEntity, is(sequence));
+	}
+
+	/**
+	 * Test, if decoder can read entity (tag, length, and value), when more data
+	 * is available.
+	 */
+	@Test
+	public void testSequenceEntityDecoderProvideMoreData() throws NoSuchAlgorithmException {
+		byte[] more = Arrays.copyOf(sequence, sequence.length * 2);
+		DatagramReader reader = new DatagramReader(more);
+		byte[] sequenceEntity = Asn1DerDecoder.readSequenceEntity(reader);
+		assertThat(sequenceEntity, is(sequence));
+	}
+
+	/**
+	 * Test, if decoder can read RSA subject public key algorithm.
+	 */
+	@Test
+	public void testKeyAlgorithmRsa() throws IOException {
+		byte[] data = Base64.decode(RSA_BASE64);
+		assertThat(Asn1DerDecoder.readSubjectPublicKeyAlgorithm(data), is("RSA"));
+	}
+
+	/**
+	 * Test, if decoder can read DSA subject public key algorithm.
+	 */
+	@Test
+	public void testKeyAlgorithmDsa() throws IOException {
+		byte[] data = Base64.decode(DSA_BASE64);
+		assertThat(Asn1DerDecoder.readSubjectPublicKeyAlgorithm(data), is("DSA"));
+	}
+
+	/**
+	 * Test, if decoder can read EC subject public key algorithm.
+	 */
+	@Test
+	public void testKeyAlgorithmEc() throws IOException {
+		byte[] data = Base64.decode(EC_BASE64);
+		assertThat(Asn1DerDecoder.readSubjectPublicKeyAlgorithm(data), is("EC"));
+	}
+
+	/**
+	 * Test, if decoder can read DH subject public key algorithm.
+	 */
+	@Test
+	public void testKeyAlgorithmDH() throws IOException {
+		byte[] data = Base64.decode(DH_BASE64);
+		assertThat(Asn1DerDecoder.readSubjectPublicKeyAlgorithm(data), is("DH"));
+	}
+
+	/**
+	 * Test, if decoder handles the key algorithm synonym proper.
+	 */
+	@Test
+	public void testEqualKeyAlgorithmSynonyms() throws NoSuchAlgorithmException {
+		assertSynonym(true, "RSA", "RSA");
+		assertSynonym(true, "DH", "DiffieHellman");
+		assertSynonym(true, "DiffieHellman", "DiffieHellman");
+		assertSynonym(true, "DiffieHellman", "DH");
+		assertSynonym(false, "DH", "RSA");
+		assertSynonym(false, "DSA", "DiffieHellman");
+	}
+
+	/**
+	 * Assert, that the provided key algorithms are handled as synonyms.
+	 * 
+	 * @param expected {@code true}, if key algorithms should be valid synonyms,
+	 *            {@code false}, otherwise.
+	 * @param keyAlgorithm1 key algorithm
+	 * @param keyAlgorithm2 key algorithm
+	 */
+	private void assertSynonym(boolean expected, String keyAlgorithm1, String keyAlgorithm2) {
+		if (expected != Asn1DerDecoder.equalKeyAlgorithmSynonyms(keyAlgorithm1, keyAlgorithm2)) {
+			if (expected) {
+				fail(keyAlgorithm1 + " should be a valid synonym for " + keyAlgorithm2);
+			} else {
+				fail(keyAlgorithm1 + " should not be a valid synonym for " + keyAlgorithm2);
+			}
+		}
+	}
+
+	/**
+	 * Test, that an IllegalArgumentException is thrown, if input data is too
+	 * short.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testViolatesMinimumEntityLength() {
+		byte[] data = { 0x30 };
+		DatagramReader reader = new DatagramReader(data);
+		Asn1DerDecoder.readSequenceEntity(reader);
+	}
+
+	/**
+	 * Test, that an IllegalArgumentException is thrown, if input data contains
+	 * no sequence.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testNoSequence() {
+		byte[] data = { 0x31, 0x01, 0x01 };
+		DatagramReader reader = new DatagramReader(data);
+		Asn1DerDecoder.readSequenceEntity(reader);
+	}
+
+	/**
+	 * Test, that an IllegalArgumentException is thrown, if input data contains
+	 * a too large length field.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testSequenceExceedsSupportedLengthBytes() {
+		byte[] data = { 0x30, (byte) 0x85, 0x01, 0x01 };
+		DatagramReader reader = new DatagramReader(data);
+		Asn1DerDecoder.readSequenceEntity(reader);
+	}
+
+	/**
+	 * Test, that an IllegalArgumentException is thrown, if input data contains
+	 * a length, which exceeds the provided data.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testSequenceExceedsSupportedLength() {
+		byte[] data = { 0x30, (byte) 0x83, 0x01, 0x01, 0x01 };
+		DatagramReader reader = new DatagramReader(data);
+		Asn1DerDecoder.readSequenceEntity(reader);
+	}
+
+	/**
+	 * Test, that an IllegalArgumentException is thrown, if input data contains
+	 * no OID.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testNoOid() {
+		byte[] data = { 0x31, 0x01, 0x01 };
+		DatagramReader reader = new DatagramReader(data);
+		Asn1DerDecoder.readOidValue(reader);
+	}
+
+	/**
+	 * Test, that an IllegalArgumentException is thrown, if input data contains
+	 * a too large OID.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testOidExceedsSupportedLength() {
+		byte[] data = { 0x30, 0x63, 0x01 };
+		DatagramReader reader = new DatagramReader(data);
+		Asn1DerDecoder.readOidValue(reader);
+	}
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/DatagramReaderTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/DatagramReaderTest.java
@@ -31,13 +31,13 @@ public class DatagramReaderTest {
 
 	@Test
 	public void testBitsLeftWorksForEmptyBuffer() {
-		givenABuffer(new byte[]{});
+		givenABuffer(new byte[] {});
 		assertThat(reader.bitsLeft(), is(0));
 	}
 
 	@Test
 	public void testBitsLeftWorksForByteWiseReading() {
-		givenABuffer(new byte[]{0x01, 0x02, 0x03});
+		givenABuffer(new byte[] { 0x01, 0x02, 0x03 });
 		assertThat(reader.bitsLeft(), is(24));
 
 		reader.readBytes(1);
@@ -51,7 +51,7 @@ public class DatagramReaderTest {
 
 	@Test
 	public void testBitsLeftWorksForBitWiseReading() {
-		givenABuffer(new byte[]{0x01, 0x02, 0x03});
+		givenABuffer(new byte[] { 0x01, 0x02, 0x03 });
 
 		reader.read(6);
 		assertThat(reader.bitsLeft(), is(18));
@@ -61,6 +61,51 @@ public class DatagramReaderTest {
 
 		reader.read(10);
 		assertThat(reader.bitsLeft(), is(0));
+	}
+
+	@Test
+	public void testMarkAndResetBits() {
+		givenABuffer(new byte[] { 0x01, 0x02, 0x03 });
+
+		int value = reader.read(6);
+		assertThat(value, is(0));
+		assertThat(reader.bitsLeft(), is(18));
+
+		reader.mark();
+
+		value = reader.readBytes(1)[0] & 0xff;
+		assertThat(value, is(0x40));
+		assertThat(reader.bitsLeft(), is(10));
+
+		reader.reset();
+		assertThat(reader.bitsLeft(), is(18));
+
+		value = reader.readBytes(1)[0] & 0xff;
+		assertThat(value, is(0x40));
+		assertThat(reader.bitsLeft(), is(10));
+	}
+
+	@Test
+	public void testMarkAndResetBytes() {
+		givenABuffer(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06 });
+
+		int value = reader.read(Byte.SIZE);
+		assertThat(value, is(1));
+
+		value = reader.read(Byte.SIZE);
+		assertThat(value, is(2));
+
+		reader.mark();
+
+		value = reader.read(Byte.SIZE);
+		assertThat(value, is(3));
+
+		value = reader.read(Byte.SIZE);
+		assertThat(value, is(4));
+
+		reader.reset();
+		byte[] bytes = reader.readBytes(4);
+		assertThat(bytes, is(new byte[] { 0x03, 0x04, 0x05, 0x06 }));
 	}
 
 	private void givenABuffer(byte[] buffer) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.californium.elements.auth.X509CertPath;
+import org.eclipse.californium.elements.util.Asn1DerDecoder;
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.elements.util.StringUtil;
@@ -331,14 +332,13 @@ public final class CertificateMessage extends HandshakeMessage {
 		if (rawPublicKeyBytes == null) {
 			if (certPath != null && !certPath.getCertificates().isEmpty()) {
 				publicKey = certPath.getCertificates().get(0).getPublicKey();
-			}// else : no public key in this certificate message
+			} // else : no public key in this certificate message
 		} else {
 			// get server's public key from Raw Public Key
 			EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(rawPublicKeyBytes);
 			try {
-				// TODO make instance variable
-				// TODO dynamically determine algorithm for KeyFactory creation
-				publicKey = KeyFactory.getInstance("EC").generatePublic(publicKeySpec);
+				String keyAlgorithm = Asn1DerDecoder.readSubjectPublicKeyAlgorithm(rawPublicKeyBytes);
+				publicKey = KeyFactory.getInstance(keyAlgorithm).generatePublic(publicKeySpec);
 			} catch (GeneralSecurityException e) {
 				LOGGER.error("Could not reconstruct the peer's public key", e);
 			}


### PR DESCRIPTION
Read length and key algorithms from ASN.1 DER encoded data.
For future support of additional key algorithms.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>