### PR TITLE
Introduce an anonymized origin tracker.

### DIFF
--- a/californium-core/pom.xml
+++ b/californium-core/pom.xml
@@ -33,6 +33,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<scope>test</scope>

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/AnonymizedOriginTracer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/AnonymizedOriginTracer.java
@@ -1,0 +1,212 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+
+package org.eclipse.californium.core.network.interceptors;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.elements.util.LeastRecentlyUsedCache;
+import org.eclipse.californium.elements.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Origin tracer with anonymized inet addresses.
+ * 
+ * Filter InetSocketAddress to log at most one message per client every
+ * {@link #DEFAULT_MESSAGE_FILTER_TIMEOUT_IN_SECONDS}. The InetAddress is hashed
+ * and only the first {@link #ID_LENGTH} resulting bytes are written as address.
+ * Though the hash function is initialized with a random value, which is
+ * generated at startup, the addresses will only match to the same values
+ * between restarts.
+ */
+public final class AnonymizedOriginTracer extends MessageInterceptorAdapter {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(AnonymizedOriginTracer.class);
+	/**
+	 * Length of anonymized address.
+	 */
+	private static final int ID_LENGTH = 6;
+	/**
+	 * Initial capacity for filter- and address-caches.
+	 */
+	private static final int INITIAL_CAPACITY = 1000;
+	/**
+	 * Maximum capacity for filter- and address-caches.
+	 */
+	private static final int MAX_CAPACITY = 10000;
+	/**
+	 * Message filter timeout. Value in seconds.
+	 */
+	private static final long DEFAULT_MESSAGE_FILTER_TIMEOUT_IN_SECONDS = 60; // 60s
+	/**
+	 * Timeout for clients cache. Value in seconds.
+	 */
+	private static final long HOST_TIMEOUT_IN_SECONDS = 60 * 60 * 24; // 24h
+
+	/**
+	 * Cache for hashed client addresses.
+	 */
+	private static final LeastRecentlyUsedCache<InetAddress, String> CLIENT_CACHE = new LeastRecentlyUsedCache<InetAddress, String>(
+			INITIAL_CAPACITY, MAX_CAPACITY, HOST_TIMEOUT_IN_SECONDS);
+
+	/**
+	 * Hmac to anonymize the client address.
+	 */
+	private static final Mac HMAC;
+	/**
+	 * Random key to anonymize the client address. Initialized at startup.
+	 */
+	private static final SecretKeySpec KEY;
+
+	static {
+		SecureRandom rng = new SecureRandom();
+		byte[] rd = new byte[32];
+		rng.nextBytes(rd);
+		KEY = new SecretKeySpec(rd, "MAC");
+		Mac mac = null;
+		try {
+			mac = Mac.getInstance("HmacSHA256");
+		} catch (NoSuchAlgorithmException e) {
+		}
+		HMAC = mac;
+	}
+
+	/**
+	 * Cache for filter message based on inet socket address.
+	 */
+	private final LeastRecentlyUsedCache<InetSocketAddress, String> currentTests = new LeastRecentlyUsedCache<InetSocketAddress, String>(
+			INITIAL_CAPACITY, MAX_CAPACITY, DEFAULT_MESSAGE_FILTER_TIMEOUT_IN_SECONDS);
+
+	/**
+	 * Schema name. Added to log message.
+	 */
+	private final String scheme;
+
+	/**
+	 * Create tracer.
+	 * 
+	 * @param scheme scheme to be added to log. {@code null}, if no scheme
+	 *            should be added to the log.
+	 */
+	public AnonymizedOriginTracer(String scheme) {
+		this(scheme, DEFAULT_MESSAGE_FILTER_TIMEOUT_IN_SECONDS);
+	}
+
+	/**
+	 * Create tracer.
+	 * 
+	 * @param scheme scheme to be added to log. {@code null}, if no scheme
+	 *            should be added to the log.
+	 * @param filterTimeout timeout to filter messages based on their inet
+	 *            socket address. Value in seconds.
+	 */
+	public AnonymizedOriginTracer(String scheme, long filterTimeout) {
+		this.scheme = scheme;
+		currentTests.setExpirationThreshold(filterTimeout);
+	}
+
+	@Override
+	public void receiveRequest(Request request) {
+		log(request);
+	}
+
+	@Override
+	public void receiveEmptyMessage(EmptyMessage message) {
+		// only log pings
+		if (message.getType() == Type.CON) {
+			log(message);
+		}
+	}
+
+	/**
+	 * Log anonymized message origin.
+	 * 
+	 * The logging is filtered by the messages inet socket address, suppressing
+	 * additional messages for the same inet socket address until the timeout
+	 * expires.
+	 * 
+	 * @param message message to log.
+	 * @return {@code true}, if log was written, {@code false}, otherwise.
+	 */
+	public boolean log(Message message) {
+		InetSocketAddress address = message.getSourceContext().getPeerAddress();
+		synchronized (currentTests) {
+			if (currentTests.get(address) != null) {
+				// already logged in the past REQUEST_TIMEOUT
+				return false;
+			}
+			currentTests.put(address, scheme);
+		}
+		String id = getAnonymizedOrigin(address.getAddress());
+		if (id != null) {
+			if (scheme == null) {
+				LOGGER.trace("{}:{}", id, address.getPort());
+			} else {
+				LOGGER.trace("{}://{}:{}", scheme, id, address.getPort());
+			}
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Anonymize the provided address.
+	 * 
+	 * Calculate hash of address bytes using an initial random created at start
+	 * time. Only the first {@link #ID_LENGTH} bytes are then used to build the
+	 * identifier using a hexadecimal encoding. The result is cached for faster
+	 * reuse.
+	 * 
+	 * @param address address to be hashed.
+	 * @return hash of address.
+	 */
+	public static String getAnonymizedOrigin(InetAddress address) {
+		synchronized (CLIENT_CACHE) {
+			String id = CLIENT_CACHE.get(address);
+			if (id == null) {
+				byte[] raw = address.getAddress().clone();
+				try {
+					if (HMAC == null) {
+						byte[] mask = KEY.getEncoded();
+						for (int index = 0; index < raw.length; ++index) {
+							raw[index] ^= mask[index];
+						}
+					} else {
+						HMAC.init(KEY);
+						raw = HMAC.doFinal(raw);
+					}
+				} catch (InvalidKeyException e) {
+				}
+				id = StringUtil.byteArray2HexString(raw, StringUtil.NO_SEPARATOR, ID_LENGTH);
+				CLIENT_CACHE.put(address, id);
+			}
+			return id;
+		}
+	}
+
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/interceptors/AnonymizedOriginTracerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/interceptors/AnonymizedOriginTracerTest.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+
+package org.eclipse.californium.core.network.interceptors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.californium.category.Medium;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * This test tests the AnonymizedOriginTracer.
+ */
+@Category(Medium.class)
+public class AnonymizedOriginTracerTest {
+
+	private static final long FILTER_TIMEOUT_IN_SECONDS = 2;
+
+	private AnonymizedOriginTracer tracer;
+	private byte[] rawAddress;
+	private InetAddress address1;
+	private InetAddress address2;
+	private InetAddress address3;
+	private InetAddress address1_2;
+	private InetAddress address4;
+	private InetAddress address5;
+
+	@Before
+	public void init() throws UnknownHostException {
+		tracer = new AnonymizedOriginTracer("test", FILTER_TIMEOUT_IN_SECONDS);
+		address1 = InetAddress.getByName("127.0.0.1");
+		rawAddress = address1.getAddress();
+		address2 = InetAddress.getByName("192.168.0.1");
+		address3 = InetAddress.getByName("192.168.0.10");
+		address1_2 = InetAddress.getByName("127.0.0.1");
+		address4 = InetAddress.getByName("[fd00::f5cd:cdd:d48f:eeb0]");
+		address5 = InetAddress.getByName("[fd00::f5cd:cdd:d48f:eec0]");
+	}
+
+	/**
+	 * Validates, that the same address results in the same hash.
+	 */
+	@Test
+	public void testAnonymizedAddressIdentity() {
+		String hash1 = AnonymizedOriginTracer.getAnonymizedOrigin(address1);
+		String hash2 = AnonymizedOriginTracer.getAnonymizedOrigin(address2);
+		String hash3 = AnonymizedOriginTracer.getAnonymizedOrigin(address3);
+		String hash4 = AnonymizedOriginTracer.getAnonymizedOrigin(address4);
+		String hash5 = AnonymizedOriginTracer.getAnonymizedOrigin(address5);
+		String hash1_2 = AnonymizedOriginTracer.getAnonymizedOrigin(address1_2);
+		String hash2_2 = AnonymizedOriginTracer.getAnonymizedOrigin(address2);
+		String hash3_2 = AnonymizedOriginTracer.getAnonymizedOrigin(address3);
+		String hash4_2 = AnonymizedOriginTracer.getAnonymizedOrigin(address4);
+		String hash5_2 = AnonymizedOriginTracer.getAnonymizedOrigin(address5);
+
+		// anonymize twice results in same hash
+		assertThat(hash1, is(hash1_2));
+		assertThat(hash2, is(hash2_2));
+		assertThat(hash3, is(hash3_2));
+		assertThat(hash4, is(hash4_2));
+		assertThat(hash5, is(hash5_2));
+	}
+
+	/**
+	 * Validates, that the different address results mainly in different hashes.
+	 * The test ensures, that more than 95 of 100 addresses results in a
+	 * different hash.
+	 */
+	@Test
+	public void testAnonymizedAddressDiffers() throws UnknownHostException {
+		int differsCounter = 0;
+		String hash1 = AnonymizedOriginTracer.getAnonymizedOrigin(address1);
+
+		for (int tries = 0; tries < 100; ++tries) {
+			++rawAddress[0];
+			InetAddress differentAddress = InetAddress.getByAddress(rawAddress);
+			String hash2 = AnonymizedOriginTracer.getAnonymizedOrigin(differentAddress);
+			if (!hash1.equals(hash2)) {
+				++differsCounter;
+			}
+		}
+		// anonymized different addresses "mostly" results in different hash's
+		assertThat(differsCounter, is(greaterThan(95)));
+	}
+
+	@Test
+	public void testFilterLogging() throws InterruptedException {
+		assertTrue(log(address1));
+		assertTrue(log(address2));
+		// logging again within timeout is suppressed.
+		assertFalse(log(address1_2));
+		assertTrue(log(address3));
+		Thread.sleep(TimeUnit.SECONDS.toMillis(FILTER_TIMEOUT_IN_SECONDS) + 500);
+		// logging again after timeout
+		assertTrue(log(address1));
+	}
+
+	private boolean log(InetAddress address) {
+		Request message = Request.newGet();
+		AddressEndpointContext context = new AddressEndpointContext(address, 0);
+		message.setSourceContext(context);
+		return tracer.log(message);
+	}
+}

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
@@ -29,6 +29,7 @@ import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.eclipse.californium.core.network.config.NetworkConfigDefaultHandler;
+import org.eclipse.californium.core.network.interceptors.AnonymizedOriginTracer;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
 import org.eclipse.californium.core.network.interceptors.OriginTracer;
 import org.eclipse.californium.elements.util.NamedThreadFactory;
@@ -124,9 +125,11 @@ public class ExtendedTestServer extends AbstractTestServer {
 			// add special interceptor for message traces
 			for (Endpoint ep : server.getEndpoints()) {
 				System.out.println("listen on " + ep.getUri());
-				// Eclipse IoT metrics
 				if (noBenchmark) {
+					// Eclipse IoT metrics
 					ep.addInterceptor(new OriginTracer());
+					// Anonymized IoT metrics for validation. On success, remove the OriginTracer. 
+					ep.addInterceptor(new AnonymizedOriginTracer(ep.getUri().getScheme()));
 				}
 				ep.addInterceptor(new MessageTracer());
 			}

--- a/demo-apps/cf-extplugtest-server/src/main/resources/logback.xml
+++ b/demo-apps/cf-extplugtest-server/src/main/resources/logback.xml
@@ -25,6 +25,23 @@
 		</encoder>
 	</appender>
 
+	<appender name="ANONYMFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<file>logs/anonymorigin.log</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+			<!-- rollover monthly, or if filesize exceeds -->
+			<fileNamePattern>logs/anonymorigin-%d{yyyy-MM}.%i.log</fileNamePattern>
+			<!-- each file should be at most 10MB, keep 200 files worth of history, but at most 2GB -->
+			<maxFileSize>10MB</maxFileSize>
+			<maxHistory>200</maxHistory>
+			<totalSizeCap>2GB</totalSizeCap>
+		</rollingPolicy>
+
+		<encoder>
+			<!-- use tab to separate timestamp from message -->
+			<pattern>[%date{yyyy-MM-dd HH:mm:ss}]\t%msg%n</pattern>
+		</encoder>
+	</appender>
+
 	<appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
 		<file>logs/messages.log</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
@@ -42,9 +59,14 @@
 		</encoder>
 	</appender>
 
-	<!-- ORIGIN only to file -->
+	<!-- ORIGIN to file -->
 	<logger name="org.eclipse.californium.core.network.interceptors.OriginTracer" level="TRACE" additivity="false">
 		<appender-ref ref="ORIGINFILE" />
+	</logger>
+
+	<!-- ANONYMIZED ORIGIN also to file -->
+	<logger name="org.eclipse.californium.core.network.interceptors.AnonymizedOriginTracer" level="TRACE" additivity="false">
+		<appender-ref ref="ANONYMFILE" />
 	</logger>
 
 	<logger name="org.eclipse.californium.core.network.InMemoryMessageExchangeStore.health" level="DEBUG" additivity="false">

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/PlugtestServer.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/PlugtestServer.java
@@ -31,6 +31,7 @@ import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.eclipse.californium.core.network.config.NetworkConfigDefaultHandler;
+import org.eclipse.californium.core.network.interceptors.AnonymizedOriginTracer;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
 import org.eclipse.californium.core.network.interceptors.OriginTracer;
 import org.eclipse.californium.plugtests.resources.Create;
@@ -119,6 +120,8 @@ public class PlugtestServer extends AbstractTestServer {
 				ep.addInterceptor(new MessageTracer());
 				// Eclipse IoT metrics
 				ep.addInterceptor(new OriginTracer());
+				// Anonymized IoT metrics for validation. On success, remove the OriginTracer. 
+				ep.addInterceptor(new AnonymizedOriginTracer(ep.getUri().getScheme()));
 			}
 
 			System.out.println(PlugtestServer.class.getSimpleName() + " started ...");

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/StringUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/StringUtil.java
@@ -26,6 +26,8 @@ import java.net.InetSocketAddress;
  */
 public class StringUtil {
 
+	public static final char NO_SEPARATOR = 0;
+
 	/**
 	 * Workaround too support android API 16-18.
 	 * 
@@ -109,6 +111,19 @@ public class StringUtil {
 	 * @return hexadecimal string
 	 */
 	public static String byteArray2HexString(byte[] byteArray, int max) {
+		return byteArray2HexString(byteArray, ' ', max);
+	}
+
+	/**
+	 * Byte array to hexadecimal string.
+	 * 
+	 * @param byteArray byte array to be converted to string
+	 * @param sep separator. If {@link #NO_SEPARATOR}, then no separator is used
+	 *            between the bytes.
+	 * @param max maximum bytes to be converted.
+	 * @return hexadecimal string
+	 */
+	public static String byteArray2HexString(byte[] byteArray, char sep, int max) {
 
 		if (byteArray != null && byteArray.length != 0) {
 			if (max == 0 || max > byteArray.length) {
@@ -118,8 +133,8 @@ public class StringUtil {
 			for (int i = 0; i < max; i++) {
 				builder.append(String.format("%02X", 0xFF & byteArray[i]));
 
-				if (i < max - 1) {
-					builder.append(' ');
+				if (sep != NO_SEPARATOR && i < max - 1) {
+					builder.append(sep);
 				}
 			}
 			return builder.toString();


### PR DESCRIPTION
To comply with upcoming data privacy protection, this PR anonymizes the inet address used for origin tracing to create usage statistics.
My intention is to use this anonymized origin tracker in parallel to the original tracker to see, if the numbers are comparable. and if so, I would remove the original origin tracker from the sandbox configuration. 

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>