### PR TITLE
[#511] Remove hash and equals from EndpointContext implementations.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2015, 2018 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -49,7 +49,6 @@ import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.EndpointContextMatcher;
 import org.eclipse.californium.elements.DtlsEndpointContext;
-import org.eclipse.californium.elements.MapBasedEndpointContext;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
 import org.junit.After;
@@ -74,7 +73,7 @@ public class CoapEndpointTest {
 
 	@Before
 	public void setUp() throws Exception {
-		establishedContext = new MapBasedEndpointContext(CONNECTOR_ADDRESS, null);
+		establishedContext = new AddressEndpointContext(CONNECTOR_ADDRESS, null);
 		receivedRequests = new ArrayList<Request>();
 		connector = new SimpleConnector();
 		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();

--- a/element-connector-tcp/src/test/java/org/eclipse/californium/elements/tcp/TcpEndpointContextTest.java
+++ b/element-connector-tcp/src/test/java/org/eclipse/californium/elements/tcp/TcpEndpointContextTest.java
@@ -121,14 +121,12 @@ public class TcpEndpointContextTest {
 
 		EndpointContext serverContext = serverCallback.getEndpointContext(CONTEXT_TIMEOUT_IN_MS);
 		assertThat("Serverside no TCP Endpoint Context", serverContext, is(instanceOf(TcpEndpointContext.class)));
-		assertThat(serverContext, is(receivingServerContext));
 		assertThat(serverContext.get(TcpEndpointContext.KEY_CONNECTION_ID),
 				is(receivingServerContext.get(TcpEndpointContext.KEY_CONNECTION_ID)));
 
 		// check response endpoint context
 		EndpointContext responseContext = clientCatcher.getMessage(0).getEndpointContext();
 		assertThat("no response TCP Endpoint Context", responseContext, is(instanceOf(TcpEndpointContext.class)));
-		assertThat(responseContext, is(clientContext));
 		assertThat(responseContext.get(TcpEndpointContext.KEY_CONNECTION_ID),
 				is(clientContext.get(TcpEndpointContext.KEY_CONNECTION_ID)));
 
@@ -140,7 +138,6 @@ public class TcpEndpointContextTest {
 
 		EndpointContext context2 = clientCallback.getEndpointContext(ConnectorTestUtil.CONTEXT_TIMEOUT_IN_MS);
 		assertThat("no TCP Endpoint Context", context2, is(instanceOf(TcpEndpointContext.class)));
-		assertThat(context2, is(clientContext));
 		assertThat(context2.get(TcpEndpointContext.KEY_CONNECTION_ID),
 				is(clientContext.get(TcpEndpointContext.KEY_CONNECTION_ID)));
 	}
@@ -487,7 +484,6 @@ public class TcpEndpointContextTest {
 			EndpointContext context1 = callbacks.get(index).getEndpointContext(CONTEXT_TIMEOUT_IN_MS);
 			EndpointContext context2 = followupCallbacks.get(index).getEndpointContext(CONTEXT_TIMEOUT_IN_MS);
 			// same connection id used for follow up message
-			assertThat(context1, is(context2));
 			assertThat(context1.get(TcpEndpointContext.KEY_CONNECTION_ID),
 					is(context2.get(TcpEndpointContext.KEY_CONNECTION_ID)));
 		}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/AddressEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/AddressEndpointContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -36,23 +36,9 @@ public class AddressEndpointContext implements EndpointContext {
 	private final Principal peerIdentity;
 
 	/**
-	 * Create endpoint context without principal.
+	 * Creates a context for an IP address and port.
 	 * 
-	 * @param peerAddress socket address of peer's service
-	 * @throws NullPointerException if provided peer address is {@code null}.
-	 */
-	public AddressEndpointContext(InetSocketAddress peerAddress) {
-		if (peerAddress == null) {
-			throw new NullPointerException("missing peer socket address!");
-		}
-		this.peerAddress = peerAddress;
-		this.peerIdentity = null;
-	}
-
-	/**
-	 * Create endpoint context without principal.
-	 * 
-	 * @param address inet address of peer
+	 * @param address IP address of peer
 	 * @param port port of peer
 	 * @throws NullPointerException if provided address is {@code null}.
 	 */
@@ -65,7 +51,17 @@ public class AddressEndpointContext implements EndpointContext {
 	}
 
 	/**
-	 * Create endpoint context with principal.
+	 * Creates a context for a socket address.
+	 * 
+	 * @param peerAddress socket address of peer's service
+	 * @throws NullPointerException if provided peer address is {@code null}.
+	 */
+	public AddressEndpointContext(InetSocketAddress peerAddress) {
+		this(peerAddress, null);
+	}
+
+	/**
+	 * Creates a context for a socket address and an authenticated identity.
 	 * 
 	 * @param peerAddress socket address of peer's service
 	 * @param peerIdentity peer's principal
@@ -79,11 +75,21 @@ public class AddressEndpointContext implements EndpointContext {
 		this.peerIdentity = peerIdentity;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @return {@code null}
+	 */
 	@Override
 	public String get(String key) {
 		return null;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @return an empty map
+	 */
 	@Override
 	public Map<String, String> entries() {
 		return Collections.emptyMap();
@@ -95,45 +101,13 @@ public class AddressEndpointContext implements EndpointContext {
 	}
 
 	@Override
-	public Principal getPeerIdentity() {
+	public final Principal getPeerIdentity() {
 		return peerIdentity;
 	}
 
 	@Override
-	public InetSocketAddress getPeerAddress() {
+	public final InetSocketAddress getPeerAddress() {
 		return peerAddress;
-	}
-
-	@Override
-	public int hashCode() {
-		int result = peerAddress.hashCode();
-		if (peerIdentity != null) {
-			result = peerIdentity.hashCode();
-		}
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (!(obj instanceof AddressEndpointContext)) {
-			return false;
-		}
-		AddressEndpointContext other = (AddressEndpointContext) obj;
-		if (!peerAddress.equals(other.getPeerAddress())) {
-			return false;
-		}
-		if (peerIdentity != null) {
-			if (!peerIdentity.equals(other.getPeerIdentity())) {
-				return false;
-			}
-		}
-		return true;
 	}
 
 	@Override

--- a/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
@@ -25,7 +25,7 @@ import java.security.Principal;
 import org.eclipse.californium.elements.util.StringUtil;
 
 /**
- * A endpoint context that explicitly supports DTLS specific properties.
+ * An endpoint context that explicitly supports DTLS specific properties.
  */
 public class DtlsEndpointContext extends MapBasedEndpointContext {
 
@@ -34,15 +34,15 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 	public static final String KEY_CIPHER = "DTLS_CIPHER";
 
 	/**
-	 * Creates a new endpoint context from DTLS session parameters.
+	 * Creates a context for DTLS session parameters.
 	 * 
 	 * @param peerAddress peer address of endpoint context
 	 * @param peerIdentity peer identity of endpoint context
 	 * @param sessionId the session's ID.
 	 * @param epoch the session's current read/write epoch.
 	 * @param cipher the cipher suite of the session's current read/write state.
-	 * @throws NullPointerException if any of the params (except peerIdentity)
-	 *             is {@code null}.
+	 * @throws NullPointerException if any of the parameters other than peerIdentity
+	 *             are {@code null}.
 	 */
 	public DtlsEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity, String sessionId, String epoch,
 			String cipher) {

--- a/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2016, 2018 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -36,33 +36,24 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 	private final Map<String, String> entries;
 
 	/**
-	 * Creates a new endpoint context with correlation context support.
+	 * Creates a context for a socket address, authenticated identity and arbitrary
+	 * key/value pairs.
 	 * 
 	 * @param peerAddress peer address of endpoint context
 	 * @param peerIdentity peer identity of endpoint context
-	 * @throws NullPointerException if provided peer address is {@code null}.
-	 */
-	public MapBasedEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity) {
-		super(peerAddress, peerIdentity);
-		entries = Collections.emptyMap();
-	}
-
-	/**
-	 * Creates a new endpoint context with correlation context support.
-	 * 
-	 * @param peerAddress peer address of endpoint context
-	 * @param peerIdentity peer identity of endpoint context
-	 * @param attributes list of attributes (name-value pairs, e.g. key_1,
+	 * @param attributes list of attributes (key/value pairs, e.g. key_1,
 	 *            value_1, key_2, value_2 ...)
 	 * @throws NullPointerException if provided peer address is {@code null}, or
 	 *             one of the attributes is {@code null}.
 	 * @throws IllegalArgumentException if provided attributes list has odd
-	 *             size, or a key in the attributes list is reused.
+	 *             size or contains a duplicate key.
 	 */
 	public MapBasedEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity, String... attributes) {
+
 		super(peerAddress, peerIdentity);
+
 		if ((attributes.length & 1) == 0) {
-			Map<String, String> entries = new HashMap<>();
+			Map<String, String> newEntries = new HashMap<>();
 			for (int index = 0; index < attributes.length; ++index) {
 				String key = attributes[index];
 				String value = attributes[++index];
@@ -72,12 +63,12 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 				if (null == value) {
 					throw new NullPointerException((index / 2) + ". value is null");
 				}
-				String old = entries.put(key, value);
+				String old = newEntries.put(key, value);
 				if (null != old) {
 					throw new IllegalArgumentException((index / 2) + ". key '" + key + "' is provided twice");
 				}
 			}
-			this.entries = Collections.unmodifiableMap(entries);
+			this.entries = Collections.unmodifiableMap(newEntries);
 		} else {
 			throw new IllegalArgumentException("number of attributes must be even, not " + attributes.length + "!");
 		}
@@ -98,8 +89,7 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 		if (attributes == null) {
 			throw new NullPointerException("missing attributes map, must not be null!");
 		}
-		Map<String, String> entries = new HashMap<>(attributes);
-		this.entries = Collections.unmodifiableMap(entries);
+		this.entries = Collections.unmodifiableMap(new HashMap<>(attributes));
 	}
 
 	@Override
@@ -115,56 +105,6 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 	@Override
 	public boolean inhibitNewConnection() {
 		return !entries.isEmpty();
-	}
-
-	/**
-	 * Creates a hash code based on the entries stored in this context.
-	 * <p>
-	 * The hash code for two instances will be the same if they contain the same
-	 * keys and values.
-	 * </p>
-	 * 
-	 * @return the hash code.
-	 */
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = super.hashCode();
-		result = prime * result + ((entries == null) ? 0 : entries.hashCode());
-		return result;
-	}
-
-	/**
-	 * Checks if this endpoint context has the same entries as another instance.
-	 * 
-	 * @param obj the object to compare this context to.
-	 * @return <code>true</code> if the other object also is a
-	 *         <code>MapBasedEndpointContext</code> and has the same entries as
-	 *         this context.
-	 */
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (!(obj instanceof MapBasedEndpointContext)) {
-			return false;
-		}
-		if (!super.equals(obj)) {
-			return false;
-		}
-		MapBasedEndpointContext other = (MapBasedEndpointContext) obj;
-		if (entries == null) {
-			if (other.entries != null) {
-				return false;
-			}
-		} else if (!entries.equals(other.entries)) {
-			return false;
-		}
-		return true;
 	}
 
 	@Override

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UdpEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UdpEndpointContext.java
@@ -22,10 +22,10 @@ import java.net.InetSocketAddress;
  */
 public class UdpEndpointContext extends MapBasedEndpointContext {
 
-	static final String KEY_PLAIN = "PLAIN";
+	public static final String KEY_PLAIN = "PLAIN";
 
 	/**
-	 * Creates a new context for an IP address and port.
+	 * Creates a new context for a socket address.
 	 * 
 	 * @param peerAddress The peer's address.
 	 */

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -202,9 +202,7 @@ public class DTLSEndpointContextTest {
 		client.send(outboundMessage);
 
 		// THEN assert that the EndpointContextMatcher is invoked
-		assertThat(endpointMatcher.await(TIMEOUT_IN_MILLIS, TimeUnit.MILLISECONDS), is(true));
-		assertThat(endpointMatcher.getConnectionEndpointContext(2), is(endpointContext));
-		assertThat(endpointMatcher.getMessageEndpointContext(2), is(endpointContext));
+		assertTrue(endpointMatcher.await(TIMEOUT_IN_MILLIS, TimeUnit.MILLISECONDS));
 
 		// THEN wait for response from server before shutdown client
 		assertTrue("DTLS client timed out after " + MAX_TIME_TO_WAIT_SECS + " seconds waiting for response!",


### PR DESCRIPTION
The hash and equals methods are not used for matching responses with
requests or for sending a message.

This is the first (small) step in a sequence of PRs that in total should then fix #511.