### PR TITLE
[#511] Add virtualHost property to EndpointContext.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -357,12 +357,12 @@ public class Request extends Message {
 			}
 		}
 
-		String scheme = uri.getScheme().toLowerCase();
+		String uriScheme = uri.getScheme().toLowerCase();
 		// The Uri-Port is only for special cases where it differs from
 		// the UDP port, usually when Proxy-Scheme is used.
 		int port = uri.getPort();
 		if (port <= 0) {
-			port = CoAP.getDefaultPort(scheme);
+			port = CoAP.getDefaultPort(uriScheme);
 		}
 
 		EndpointContext destinationContext = getDestinationContext();
@@ -377,9 +377,9 @@ public class Request extends Message {
 		}
 
 		if (destinationContext == null) {
-			setDestinationContext(new AddressEndpointContext(new InetSocketAddress(destination, port), null));
+			setDestinationContext(new AddressEndpointContext(new InetSocketAddress(destination, port), getOptions().getUriHost(), null));
 		}
-		this.scheme = scheme;
+		this.scheme = uriScheme;
 		// do not set the Uri-Port option unless it is used for proxying
 		// (setting Uri-Scheme option)
 
@@ -537,8 +537,7 @@ public class Request extends Message {
 	 * 
 	 * @throws IllegalStateException if no destination endpoint context is
 	 *             available and the destination is missing
-	 * @deprecated
-	 * Note: intended to be removed with {@link #setDestination(InetAddress)} and 
+	 * @deprecated intended to be removed with {@link #setDestination(InetAddress)} and 
 	 * {@link #setDestinationPort(int)}
 	 */
 	public void prepareDestinationContext() {
@@ -547,7 +546,10 @@ public class Request extends Message {
 			if (destination == null) {
 				throw new IllegalStateException("missing destination!");
 			}
-			context = new AddressEndpointContext(destination, destinationPort);
+			context = new AddressEndpointContext(
+					new InetSocketAddress(destination, destinationPort),
+					getOptions().getUriHost(),
+					null);
 			super.setDestinationContext(context);
 		}
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/coap/RequestTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/coap/RequestTest.java
@@ -197,6 +197,29 @@ public class RequestTest {
 		assertThat(req.getOptions().getUriHost(), is("localhost"));
 	}
 
+	/**
+	 * Verifies that the destination context contains the Uri-Host
+	 * option value.
+	 */
+	@Test
+	public void testSetURISetsVirtualHostOnDestinationContext() {
+
+		assumeTrue(dnsIsWorking());
+		Request req = Request.newGet().setURI("coap://localhost");
+		assertThat(req.getDestinationContext().getVirtualHost(), is("localhost"));
+	}
+
+	/**
+	 * Verifies that the destination context does not contain a virtual
+	 * host if a literal IP address is used as the target.
+	 */
+	@Test
+	public void testSetURIDoesNotSetVirtualHostOnDestinationContextForLiteralIP() {
+
+		Request req = Request.newGet().setURI("coap://127.0.0.1");
+		assertThat(req.getDestinationContext().getVirtualHost(), is(nullValue()));
+	}
+
 	@Test
 	public void testSetURISetsDestinationPortBasedOnUriScheme() {
 		Request req = Request.newGet().setURI("coap://127.0.0.1");

--- a/element-connector/src/main/java/org/eclipse/californium/elements/AddressEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/AddressEndpointContext.java
@@ -35,6 +35,8 @@ public class AddressEndpointContext implements EndpointContext {
 
 	private final Principal peerIdentity;
 
+	private final String virtualHost;
+
 	/**
 	 * Creates a context for an IP address and port.
 	 * 
@@ -48,6 +50,7 @@ public class AddressEndpointContext implements EndpointContext {
 		}
 		this.peerAddress = new InetSocketAddress(address, port);
 		this.peerIdentity = null;
+		this.virtualHost = null;
 	}
 
 	/**
@@ -57,7 +60,7 @@ public class AddressEndpointContext implements EndpointContext {
 	 * @throws NullPointerException if provided peer address is {@code null}.
 	 */
 	public AddressEndpointContext(InetSocketAddress peerAddress) {
-		this(peerAddress, null);
+		this(peerAddress, null, null);
 	}
 
 	/**
@@ -68,10 +71,23 @@ public class AddressEndpointContext implements EndpointContext {
 	 * @throws NullPointerException if provided peer address is {@code null}.
 	 */
 	public AddressEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity) {
+		this(peerAddress, null, peerIdentity);
+	}
+
+	/**
+	 * Create endpoint context with principal.
+	 * 
+	 * @param peerAddress socket address of peer's service
+	 * @param virtualHost the name of the virtual host at the peer
+	 * @param peerIdentity peer's principal
+	 * @throws NullPointerException if provided peer address is {@code null}.
+	 */
+	public AddressEndpointContext(InetSocketAddress peerAddress, String virtualHost, Principal peerIdentity) {
 		if (peerAddress == null) {
 			throw new NullPointerException("missing peer socket address, must not be null!");
 		}
 		this.peerAddress = peerAddress;
+		this.virtualHost = virtualHost == null ? null : virtualHost.toLowerCase();
 		this.peerIdentity = peerIdentity;
 	}
 
@@ -111,11 +127,16 @@ public class AddressEndpointContext implements EndpointContext {
 	}
 
 	@Override
+	public final String getVirtualHost() {
+		return virtualHost;
+	}
+
+	@Override
 	public String toString() {
 		return String.format("IP(%s)", getPeerAddressAsString());
 	}
 
-	protected String getPeerAddressAsString() {
+	protected final String getPeerAddressAsString() {
 		return StringUtil.toString(peerAddress);
 	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2016, 2018 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -29,8 +29,19 @@ import org.eclipse.californium.elements.util.StringUtil;
  */
 public class DtlsEndpointContext extends MapBasedEndpointContext {
 
+	/**
+	 * The name of the attribute that contains the DTLS session ID.
+	 */
 	public static final String KEY_SESSION_ID = "DTLS_SESSION_ID";
+	/**
+	 * The name of the attribute that contains the <em>epoch</em> of the
+	 * DTLS session.
+	 */
 	public static final String KEY_EPOCH = "DTLS_EPOCH";
+	/**
+	 * The name of the attribute that contains the cipher suite used with
+	 * the DTLS session.
+	 */
 	public static final String KEY_CIPHER = "DTLS_CIPHER";
 
 	/**
@@ -44,20 +55,54 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 	 * @throws NullPointerException if any of the parameters other than peerIdentity
 	 *             are {@code null}.
 	 */
-	public DtlsEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity, String sessionId, String epoch,
-			String cipher) {
-		super(peerAddress, peerIdentity, KEY_SESSION_ID, sessionId, KEY_CIPHER, cipher, KEY_EPOCH, epoch);
+	public DtlsEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity,
+			String sessionId, String epoch, String cipher) {
+
+		this(peerAddress, null, peerIdentity, sessionId, epoch, cipher);
 	}
 
-	public String getSessionId() {
+	/**
+	 * Creates a context for DTLS session parameters.
+	 * 
+	 * @param peerAddress peer address of endpoint context
+	 * @param virtualHost the name of the virtual host at the peer
+	 * @param peerIdentity peer identity of endpoint context
+	 * @param sessionId the session's ID.
+	 * @param epoch the session's current read/write epoch.
+	 * @param cipher the cipher suite of the session's current read/write state.
+	 * @throws NullPointerException if any of the parameters other than peerIdentity
+	 *             are {@code null}.
+	 */
+	public DtlsEndpointContext(InetSocketAddress peerAddress, String virtualHost, Principal peerIdentity,
+			String sessionId, String epoch, String cipher) {
+
+		super(peerAddress, virtualHost, peerIdentity, KEY_SESSION_ID, sessionId, KEY_CIPHER, cipher, KEY_EPOCH, epoch);
+	}
+
+	/**
+	 * Gets the identifier of the DTLS session.
+	 * 
+	 * @return The identifier.
+	 */
+	public final String getSessionId() {
 		return get(KEY_SESSION_ID);
 	}
 
-	public String getEpoch() {
+	/**
+	 * Gets the current epoch of the DTLS session.
+	 * 
+	 * @return The epoch number.
+	 */
+	public final String getEpoch() {
 		return get(KEY_EPOCH);
 	}
 
-	public String getCipher() {
+	/**
+	 * Gets the name of the cipher suite in use for the DTLS session.
+	 * 
+	 * @return The name.
+	 */
+	public final String getCipher() {
 		return get(KEY_CIPHER);
 	}
 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2016, 2018 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -84,16 +84,24 @@ public interface EndpointContext {
 	boolean inhibitNewConnection();
 
 	/**
-	 * Get identity of peer the message is for or from.
+	 * Gets the identity of the peer that the message is for or from.
 	 * 
 	 * @return identity of peer. {@code null}, if not available.
 	 */
 	Principal getPeerIdentity();
 
 	/**
-	 * Get inet address of peer the message is for or from.
+	 * Gets the inet address of the peer that the message is for or from.
 	 * 
 	 * @return address of peer
 	 */
 	InetSocketAddress getPeerAddress();
+
+	/**
+	 * Gets the name of the virtual host that this endpoint
+	 * is scoped to.
+	 * 
+	 * @return the name or {@code null} if no virtual host is set.
+	 */
+	String getVirtualHost();
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
@@ -50,7 +50,27 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 	 */
 	public MapBasedEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity, String... attributes) {
 
-		super(peerAddress, peerIdentity);
+		this(peerAddress, null, peerIdentity, attributes);
+	}
+
+	/**
+	 * Creates a context for a socket address, authenticated identity and arbitrary
+	 * key/value pairs.
+	 * 
+	 * @param peerAddress peer address of endpoint context
+	 * @param virtualHost the name of the virtual host at the peer
+	 * @param peerIdentity peer identity of endpoint context
+	 * @param attributes list of attributes (key/value pairs, e.g. key_1,
+	 *            value_1, key_2, value_2 ...)
+	 * @throws NullPointerException if provided peer address is {@code null}, or
+	 *             one of the attributes is {@code null}.
+	 * @throws IllegalArgumentException if provided attributes list has odd
+	 *             size or contains a duplicate key.
+	 */
+	public MapBasedEndpointContext(InetSocketAddress peerAddress, String virtualHost, Principal peerIdentity,
+			String... attributes) {
+
+		super(peerAddress, virtualHost, peerIdentity);
 
 		if ((attributes.length & 1) == 0) {
 			Map<String, String> newEntries = new HashMap<>();
@@ -85,7 +105,25 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 	 */
 	public MapBasedEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity,
 			Map<String, String> attributes) {
-		super(peerAddress, peerIdentity);
+
+		this(peerAddress, null, peerIdentity, attributes);
+	}
+
+	/**
+	 * Creates a new endpoint context with correlation context support.
+	 * 
+	 * @param peerAddress peer address of endpoint context
+	 * @param virtualHost the name of the virtual host at the peer
+	 * @param peerIdentity peer identity of endpoint context
+	 * @param attributes map of attributes
+	 * @throws NullPointerException if provided peer address, or attributes map
+	 *             is {@code null}.
+	 */
+	public MapBasedEndpointContext(InetSocketAddress peerAddress, String virtualHost, Principal peerIdentity,
+			Map<String, String> attributes) {
+
+		super(peerAddress, virtualHost, peerIdentity);
+
 		if (attributes == null) {
 			throw new NullPointerException("missing attributes map, must not be null!");
 		}


### PR DESCRIPTION
The virtual host property can be used to match contexts and/or set the
value of the SNI TLS extension.

In the next step the ClientHandshaker will then make use of this property to set the server name in an SNI extension during a DTLS handshake