### PR TITLE
Added cf-Android dtls example

### DIFF
--- a/demo-apps/cf-android/app/src/main/java/org/eclipse/californium/examples/ConfigureDtls.java
+++ b/demo-apps/cf-android/app/src/main/java/org/eclipse/californium/examples/ConfigureDtls.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Vikram and others.
+ * Contributors:
+ *    Vikram - Initial creation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - introduce configurable
+ *                                                    key store type and
+ *                                                    InputStreamFactory.
+ ******************************************************************************/
+package org.eclipse.californium.examples;
+
+import android.content.Context;
+
+import org.eclipse.californium.elements.util.SslContextUtil;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.dtls.pskstore.StaticPskStore;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.cert.Certificate;
+
+/**
+ * class ConfigureDTLS.<br>
+ * This class is used to configure dtls connector for both client and server side connections.
+ * It allows to configure dtls connector in three different modes.
+ * The class variables PSK, CERTIFICATE_MODE, and RPK_MODE define three different modes of dtls connector.
+ * <br>PSK_MODE: supports PSK mode if this variable is set to true and to false if not.
+ * <br>CERTIFICATE_MODE: supports certificate based authentication, if this variable is
+ * set to true and false if not.
+ * <br>RPK_MODE: alternatively supports RPK mode if this variable is set to true and to false if not.
+ * <br>An endpoint may either support all the three modes or must support atleast one mode.
+ */
+public class ConfigureDtls {
+
+    private static final boolean PSK_MODE = false;
+    private static final boolean CERTIFICATE_MODE = true;
+    private static final boolean RPK_MODE = false;
+    public static final String PSK_IDENTITY = "password";
+    public static final byte[] PSK_SECRET = "sesame".getBytes();
+    private static final String TRUST_NAME = null; // loads all the certificates
+    private static final String KEY_STORE_LOCATION = "certs/keyStore.p12";
+    private static final String TRUST_STORE_LOCATION = "certs/trustStore.p12";
+    private static final char[] TRUST_STORE_PASSWORD = "rootPass".toCharArray();
+    private static final char[] KEY_STORE_PASSWORD = "endPass".toCharArray();
+
+    public static void loadCredentials(DtlsConnectorConfig.Builder dtlsConfig, String alias){
+
+        SslContextUtil.Credentials endpointCredentials = null;
+        Certificate[] trustedCertificates = null;
+        try {
+            endpointCredentials = SslContextUtil.loadCredentials(
+                    SslContextUtil.CLASSPATH_SCHEME + KEY_STORE_LOCATION, alias, KEY_STORE_PASSWORD,
+                    KEY_STORE_PASSWORD);
+            trustedCertificates = SslContextUtil.loadTrustedCertificates(
+                    SslContextUtil.CLASSPATH_SCHEME + TRUST_STORE_LOCATION, TRUST_NAME, TRUST_STORE_PASSWORD);
+        } catch (GeneralSecurityException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        if (PSK_MODE) {
+            dtlsConfig.setPskStore(new StaticPskStore(PSK_IDENTITY, PSK_SECRET));
+        } else if (CERTIFICATE_MODE) {
+            dtlsConfig.setTrustStore(trustedCertificates);
+            dtlsConfig.setIdentity(endpointCredentials.getPrivateKey(),
+                    endpointCredentials.getCertificateChain(), false);
+        } else if (RPK_MODE) {
+            dtlsConfig.setIdentity(endpointCredentials.getPrivateKey(),
+                    endpointCredentials.getCertificateChain(), true);
+        }
+    }
+}

--- a/demo-apps/cf-android/app/src/main/java/org/eclipse/californium/examples/MainActivity.java
+++ b/demo-apps/cf-android/app/src/main/java/org/eclipse/californium/examples/MainActivity.java
@@ -12,6 +12,7 @@
  *
  * Contributors:
  *    Matthias Kovatsch - creator and main architect
+ *    Vikram - added dtls client
  ******************************************************************************/
 package org.eclipse.californium.examples;
 
@@ -25,16 +26,25 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
 
-import org.eclipse.californium.examples.R;
 import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.CoapResponse;
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.EndpointManager;
+import org.eclipse.californium.elements.UDPConnector;
+import org.eclipse.californium.scandium.DTLSConnector;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 
 public class MainActivity extends AppCompatActivity {
+
+    public static final String CLIENT_NAME = "client";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        initCoapEndpoint();
     }
 
     @Override
@@ -50,23 +60,26 @@ public class MainActivity extends AppCompatActivity {
         // automatically handle clicks on the Home/Up button, so long
         // as you specify a parent activity in AndroidManifest.xml.
         int id = item.getItemId();
-
         //noinspection SimplifiableIfStatement
-        if (id == R.id.action_sandbox) {
-            ((EditText)findViewById(R.id.editUri)).setText(R.string.uri_sandbox);
-            return true;
-        } else if (id == R.id.action_local) {
-            ((EditText)findViewById(R.id.editUri)).setText(R.string.uri_local);
-            return true;
-        } else if (id == R.id.action_start) {
-            if (!item.isChecked()) {
-                startService(new Intent(this, ServerService.class));
-                item.setChecked(true);
-            } else {
-                stopService(new Intent(this, ServerService.class));
-                item.setChecked(false);
-            }
-            return true;
+        switch(id){
+            case R.id.action_sandbox:
+                ((EditText)findViewById(R.id.editUri)).setText(R.string.uri_sandbox);
+                return true;
+            case R.id.action_local:
+                ((EditText)findViewById(R.id.editUri)).setText(R.string.uri_local);
+                return true;
+            case R.id.action_start:
+                if (!item.isChecked()) {
+                    startService(new Intent(this, ServerService.class));
+                    item.setChecked(true);
+                } else {
+                    stopService(new Intent(this, ServerService.class));
+                    item.setChecked(false);
+                }
+                return true;
+            case R.id.action_local_dtls:
+                ((EditText)findViewById(R.id.editUri)).setText(R.string.uri_dtls_local);
+                return true;
         }
 
         return super.onOptionsItemSelected(item);
@@ -75,6 +88,14 @@ public class MainActivity extends AppCompatActivity {
     public void clickGet(View view) {
         String uri = ((EditText)findViewById(R.id.editUri)).getText().toString();
         new CoapGetTask().execute(uri);
+    }
+
+
+    @Override
+    public void onDestroy() {
+
+        super.onDestroy();
+        stopService(new Intent(this,ServerService.class));
     }
 
     class CoapGetTask extends AsyncTask<String, String, CoapResponse> {
@@ -102,5 +123,26 @@ public class MainActivity extends AppCompatActivity {
                 ((TextView)findViewById(R.id.textCodeName)).setText("No response");
             }
         }
+    }
+
+    /**
+     * method initCoapEndpoint.
+     * This method is used to setup EndpointpointManager with both plain
+     * and dtls connector.
+     */
+    private void initCoapEndpoint(){
+        CoapEndpoint.CoapEndpointBuilder dtlsEndpointBuilder = new CoapEndpoint.CoapEndpointBuilder();
+        // setup coap EndpointManager to dtls connector
+        DtlsConnectorConfig.Builder dtlsConfig = new DtlsConnectorConfig.Builder();
+        dtlsConfig.setClientOnly();
+        ConfigureDtls.loadCredentials(dtlsConfig, CLIENT_NAME);
+        DTLSConnector dtlsConnector = new DTLSConnector(dtlsConfig.build());
+        dtlsEndpointBuilder.setConnector(dtlsConnector);
+        EndpointManager.getEndpointManager().setDefaultEndpoint(dtlsEndpointBuilder.build());
+        // setup coap EndpointManager to udp connector
+        CoapEndpoint.CoapEndpointBuilder udpEndpointBuilder = new CoapEndpoint.CoapEndpointBuilder();
+        UDPConnector udpConnector = new UDPConnector();
+        udpEndpointBuilder.setConnector(udpConnector);
+        EndpointManager.getEndpointManager().setDefaultEndpoint(udpEndpointBuilder.build());
     }
 }

--- a/demo-apps/cf-android/app/src/main/java/org/eclipse/californium/examples/ServerService.java
+++ b/demo-apps/cf-android/app/src/main/java/org/eclipse/californium/examples/ServerService.java
@@ -12,28 +12,40 @@
  *
  * Contributors:
  *    Matthias Kovatsch - creator and main architect
+ *    Vikram            - added Dtls server
  ******************************************************************************/
 package org.eclipse.californium.examples;
 
-import android.app.Notification;
-import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.app.Service;
-import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
 
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.scandium.DTLSConnector;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+
+import java.net.InetSocketAddress;
 
 public class ServerService extends Service {
 
     CoapServer server;
+    private static final int DTLS_PORT = 5684;
+    private static final int CoAP_PORT = 5683;
+    public static final String SERVER_NAME = "server";
 
     @Override
     public void onCreate() {
-        this.server = new CoapServer();
+        this.server = new CoapServer(CoAP_PORT);
+        DtlsConnectorConfig.Builder dtlsConfig = new DtlsConnectorConfig.Builder();
+        dtlsConfig.setAddress(new InetSocketAddress(DTLS_PORT));
+        ConfigureDtls.loadCredentials(dtlsConfig, SERVER_NAME);
+        DTLSConnector connector = new DTLSConnector(dtlsConfig.build());
+        CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+        builder.setConnector(connector);
+        server.addEndpoint(builder.build());
         server.add(new HelloWorldResource());
     }
 

--- a/demo-apps/cf-android/app/src/main/res/menu/menu_main.xml
+++ b/demo-apps/cf-android/app/src/main/res/menu/menu_main.xml
@@ -6,9 +6,11 @@
         android:orderInCategory="1" app:showAsAction="never" />
     <item android:id="@+id/action_local" android:title="@string/action_local"
         android:orderInCategory="2" app:showAsAction="never" />
+    <item android:id="@+id/action_local_dtls" android:title="@string/action_local_dtls"
+        android:orderInCategory="3" app:showAsAction="never" />
     </group>
     <group>
     <item android:id="@+id/action_start" android:title="@string/action_start"
-        android:orderInCategory="3" app:showAsAction="never" android:checkable="true" />
+        android:orderInCategory="4" app:showAsAction="never" android:checkable="true" />
 </group>
 </menu>

--- a/demo-apps/cf-android/app/src/main/res/values/strings.xml
+++ b/demo-apps/cf-android/app/src/main/res/values/strings.xml
@@ -6,9 +6,11 @@
 
     <string name="action_sandbox">californium.eclipse.org</string>
     <string name="action_local">localhost</string>
+    <string name="action_local_dtls">dtls localhost</string>
 
     <string name="action_start">Run Local Server</string>
 
     <string name="uri_sandbox">coap://californium.eclipse.org:5683/</string>
     <string name="uri_local">coap://localhost:5683/</string>
+    <string name="uri_dtls_local">coaps://localhost:5684/</string>
 </resources>


### PR DESCRIPTION
This pull request adds dtls example to existing cf-android app. It also address the activity life cycle of MainActivity "onDestroy" method which is missing in existing version. 
In current cf-Android example, when the app is destroyed without unchecking Local Server checkbox from menu options, the local server remain running in background. 