### PR TITLE
[#511] Include virtual host in DtlsEndpointContext matching.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/KeySetEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/KeySetEndpointContextMatcher.java
@@ -89,4 +89,28 @@ public class KeySetEndpointContextMatcher implements EndpointContextMatcher {
 		return Collections.unmodifiableSet(new CopyOnWriteArraySet<String>(Arrays.asList(keys)));
 	}
 
+
+	/**
+	 * Checks if two endpoint contexts have the same virtual host property value.
+	 * 
+	 * @param firstContext The first context.
+	 * @param secondContext The second context.
+	 * @return {@code true} if the second context is {@code null} of if both contexts'
+	 *         virtualHost properties have the same value.
+	 * @throws NullPointerException if the first context is {@code null}.
+	 */
+	public static final boolean isSameVirtualHost(EndpointContext firstContext, EndpointContext secondContext) {
+
+		if (firstContext == null) {
+			throw new NullPointerException("first context must not be null");
+		} else if (secondContext == null) {
+			return true;
+		} else {
+			String firstVirtualHost = firstContext.getVirtualHost();
+			String otherVirtualHost = secondContext.getVirtualHost();
+
+			return firstVirtualHost == otherVirtualHost ||
+					(firstVirtualHost != null && firstVirtualHost.equals(otherVirtualHost));
+		}
+	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/RelaxedDtlsEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/RelaxedDtlsEndpointContextMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -26,8 +26,41 @@ public class RelaxedDtlsEndpointContextMatcher extends KeySetEndpointContextMatc
 
 	private static final String KEYS[] = { DtlsEndpointContext.KEY_SESSION_ID, DtlsEndpointContext.KEY_CIPHER };
 
+	/**
+	 * Creates a new matcher.
+	 */
 	public RelaxedDtlsEndpointContextMatcher() {
 		super("relaxed context", KEYS);
 	}
 
+	/**
+	 * @return {@code true} if both contexts have the same value for properties
+	 *          <ul>
+	 *            <li>{@link DtlsEndpointContext#KEY_SESSION_ID}</li>
+	 *            <li>{@link DtlsEndpointContext#KEY_CIPHER}</li>
+	 *          </ul>
+	 *          and have a matching virtualHost property according to
+	 *          {@link KeySetEndpointContextMatcher#isSameVirtualHost(EndpointContext, EndpointContext)}.
+	 * @throws NullPointerException if the first context is {@code null}.
+	 */
+	@Override
+	public boolean isResponseRelatedToRequest(EndpointContext requestContext, EndpointContext responseContext) {
+
+		return isSameVirtualHost(requestContext, responseContext) && super.isResponseRelatedToRequest(requestContext, responseContext);
+	}
+
+	/**
+	 * @return {@code true} if both contexts have the same value for properties
+	 *          <ul>
+	 *            <li>{@link DtlsEndpointContext#KEY_SESSION_ID}</li>
+	 *            <li>{@link DtlsEndpointContext#KEY_CIPHER}</li>
+	 *          </ul>
+	 *          and have a matching virtualHost property according to
+	 *          {@link KeySetEndpointContextMatcher#isSameVirtualHost(EndpointContext, EndpointContext)}.
+	 * @throws NullPointerException if the first context is {@code null}.
+	 */
+	@Override
+	public boolean isToBeSent(EndpointContext messageContext, EndpointContext connectionContext) {
+		return isSameVirtualHost(messageContext, connectionContext) && super.isToBeSent(messageContext, connectionContext);
+	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/RelaxedDtlsEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/RelaxedDtlsEndpointContextMatcher.java
@@ -28,39 +28,17 @@ public class RelaxedDtlsEndpointContextMatcher extends KeySetEndpointContextMatc
 
 	/**
 	 * Creates a new matcher.
+	 * <p>
+	 * Two contexts will be considered <em>matching</em> if they have the same value
+	 * for properties
+	 * <ul>
+	 *   <li>{@link DtlsEndpointContext#KEY_SESSION_ID}</li>
+	 *   <li>{@link DtlsEndpointContext#KEY_CIPHER}</li>
+	 * </ul>
+	 * and have a matching virtualHost property according to
+	 * {@link KeySetEndpointContextMatcher#isSameVirtualHost(EndpointContext, EndpointContext)}.
 	 */
 	public RelaxedDtlsEndpointContextMatcher() {
-		super("relaxed context", KEYS);
-	}
-
-	/**
-	 * @return {@code true} if both contexts have the same value for properties
-	 *          <ul>
-	 *            <li>{@link DtlsEndpointContext#KEY_SESSION_ID}</li>
-	 *            <li>{@link DtlsEndpointContext#KEY_CIPHER}</li>
-	 *          </ul>
-	 *          and have a matching virtualHost property according to
-	 *          {@link KeySetEndpointContextMatcher#isSameVirtualHost(EndpointContext, EndpointContext)}.
-	 * @throws NullPointerException if the first context is {@code null}.
-	 */
-	@Override
-	public boolean isResponseRelatedToRequest(EndpointContext requestContext, EndpointContext responseContext) {
-
-		return isSameVirtualHost(requestContext, responseContext) && super.isResponseRelatedToRequest(requestContext, responseContext);
-	}
-
-	/**
-	 * @return {@code true} if both contexts have the same value for properties
-	 *          <ul>
-	 *            <li>{@link DtlsEndpointContext#KEY_SESSION_ID}</li>
-	 *            <li>{@link DtlsEndpointContext#KEY_CIPHER}</li>
-	 *          </ul>
-	 *          and have a matching virtualHost property according to
-	 *          {@link KeySetEndpointContextMatcher#isSameVirtualHost(EndpointContext, EndpointContext)}.
-	 * @throws NullPointerException if the first context is {@code null}.
-	 */
-	@Override
-	public boolean isToBeSent(EndpointContext messageContext, EndpointContext connectionContext) {
-		return isSameVirtualHost(messageContext, connectionContext) && super.isToBeSent(messageContext, connectionContext);
+		super("relaxed context", KEYS, true);
 	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/StrictDtlsEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/StrictDtlsEndpointContextMatcher.java
@@ -27,41 +27,18 @@ public class StrictDtlsEndpointContextMatcher extends KeySetEndpointContextMatch
 
 	/**
 	 * Creates a new matcher.
+	 * <p>
+	 * Two contexts will be considered <em>matching</em> if they have the same value
+	 * for properties
+	 * <ul>
+	 *   <li>{@link DtlsEndpointContext#KEY_SESSION_ID}</li>
+	 *   <li>{@link DtlsEndpointContext#KEY_EPOCH}</li>
+	 *   <li>{@link DtlsEndpointContext#KEY_CIPHER}</li>
+	 * </ul>
+	 * and have a matching virtualHost property according to
+	 * {@link KeySetEndpointContextMatcher#isSameVirtualHost(EndpointContext, EndpointContext)}.
 	 */
 	public StrictDtlsEndpointContextMatcher() {
-		super("strict context", KEYS);
-	}
-
-	/**
-	 * @return {@code true} if both contexts have the same value for properties
-	 *          <ul>
-	 *            <li>{@link DtlsEndpointContext#KEY_SESSION_ID}</li>
-	 *            <li>{@link DtlsEndpointContext#KEY_EPOCH}</li>
-	 *            <li>{@link DtlsEndpointContext#KEY_CIPHER}</li>
-	 *          </ul>
-	 *          and have a matching virtualHost property according to
-	 *          {@link KeySetEndpointContextMatcher#isSameVirtualHost(EndpointContext, EndpointContext)}.
-	 * @throws NullPointerException if the first context is {@code null}.
-	 */
-	@Override
-	public boolean isResponseRelatedToRequest(EndpointContext requestContext, EndpointContext responseContext) {
-
-		return isSameVirtualHost(requestContext, responseContext) && super.isResponseRelatedToRequest(requestContext, responseContext);
-	}
-
-	/**
-	 * @return {@code true} if both contexts have the same value for properties
-	 *          <ul>
-	 *            <li>{@link DtlsEndpointContext#KEY_SESSION_ID}</li>
-	 *            <li>{@link DtlsEndpointContext#KEY_EPOCH}</li>
-	 *            <li>{@link DtlsEndpointContext#KEY_CIPHER}</li>
-	 *          </ul>
-	 *          and have a matching virtualHost property according to
-	 *          {@link KeySetEndpointContextMatcher#isSameVirtualHost(EndpointContext, EndpointContext)}.
-	 * @throws NullPointerException if the first context is {@code null}.
-	 */
-	@Override
-	public boolean isToBeSent(EndpointContext messageContext, EndpointContext connectionContext) {
-		return isSameVirtualHost(messageContext, connectionContext) && super.isToBeSent(messageContext, connectionContext);
+		super("strict context", KEYS, true);
 	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/StrictDtlsEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/StrictDtlsEndpointContextMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -25,7 +25,43 @@ public class StrictDtlsEndpointContextMatcher extends KeySetEndpointContextMatch
 	private static final String KEYS[] = { DtlsEndpointContext.KEY_SESSION_ID, DtlsEndpointContext.KEY_EPOCH,
 			DtlsEndpointContext.KEY_CIPHER };
 
+	/**
+	 * Creates a new matcher.
+	 */
 	public StrictDtlsEndpointContextMatcher() {
 		super("strict context", KEYS);
+	}
+
+	/**
+	 * @return {@code true} if both contexts have the same value for properties
+	 *          <ul>
+	 *            <li>{@link DtlsEndpointContext#KEY_SESSION_ID}</li>
+	 *            <li>{@link DtlsEndpointContext#KEY_EPOCH}</li>
+	 *            <li>{@link DtlsEndpointContext#KEY_CIPHER}</li>
+	 *          </ul>
+	 *          and have a matching virtualHost property according to
+	 *          {@link KeySetEndpointContextMatcher#isSameVirtualHost(EndpointContext, EndpointContext)}.
+	 * @throws NullPointerException if the first context is {@code null}.
+	 */
+	@Override
+	public boolean isResponseRelatedToRequest(EndpointContext requestContext, EndpointContext responseContext) {
+
+		return isSameVirtualHost(requestContext, responseContext) && super.isResponseRelatedToRequest(requestContext, responseContext);
+	}
+
+	/**
+	 * @return {@code true} if both contexts have the same value for properties
+	 *          <ul>
+	 *            <li>{@link DtlsEndpointContext#KEY_SESSION_ID}</li>
+	 *            <li>{@link DtlsEndpointContext#KEY_EPOCH}</li>
+	 *            <li>{@link DtlsEndpointContext#KEY_CIPHER}</li>
+	 *          </ul>
+	 *          and have a matching virtualHost property according to
+	 *          {@link KeySetEndpointContextMatcher#isSameVirtualHost(EndpointContext, EndpointContext)}.
+	 * @throws NullPointerException if the first context is {@code null}.
+	 */
+	@Override
+	public boolean isToBeSent(EndpointContext messageContext, EndpointContext connectionContext) {
+		return isSameVirtualHost(messageContext, connectionContext) && super.isToBeSent(messageContext, connectionContext);
 	}
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/DtlsEndpointContextMatcherTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/DtlsEndpointContextMatcherTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -23,54 +23,108 @@ import java.net.InetSocketAddress;
 import org.junit.Before;
 import org.junit.Test;
 
+/**
+ * Verifies behavior of the {@link StrictDtlsEndpointContextMatcher} and
+ * {@link RelaxedDtlsEndpointContextMatcher}.
+ *
+ */
 public class DtlsEndpointContextMatcherTest {
 
 	private static final InetSocketAddress ADDRESS = new InetSocketAddress(0);
-	
+
 	private EndpointContext connectorContext;
+	private EndpointContext scopedConnectorContext;
 	private EndpointContext relaxedMessageContext;
+	private EndpointContext scopedRelaxedMessageContext;
 	private EndpointContext strictMessageContext;
+	private EndpointContext scopedStrictMessageContext;
 	private EndpointContext differentMessageContext;
+	private EndpointContext scopedDifferentMessageContext;
 	private EndpointContext unsecureMessageContext;
 	private EndpointContextMatcher relaxedMatcher;
 	private EndpointContextMatcher strictMatcher;
 
 	@Before
 	public void setup() {
-		connectorContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
-		relaxedMessageContext = new DtlsEndpointContext(ADDRESS, null,"session", "2", "CIPHER");
-		strictMessageContext = new DtlsEndpointContext(ADDRESS, null,"session", "1", "CIPHER");
-		differentMessageContext = new DtlsEndpointContext(ADDRESS, null,"new session", "1", "CIPHER");
-		unsecureMessageContext = new UdpEndpointContext(ADDRESS);
+
 		relaxedMatcher = new RelaxedDtlsEndpointContextMatcher();
 		strictMatcher = new StrictDtlsEndpointContextMatcher();
+
+		connectorContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
+		scopedConnectorContext = new DtlsEndpointContext(ADDRESS, "iot.eclipse.org", null, "session", "1", "CIPHER");
+
+		relaxedMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "2", "CIPHER");
+		scopedRelaxedMessageContext = new DtlsEndpointContext(ADDRESS, "iot.eclipse.org", null, "session", "2", "CIPHER");
+
+		strictMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
+		scopedStrictMessageContext = new DtlsEndpointContext(ADDRESS, "iot.eclipse.org", null, "session", "1", "CIPHER");
+
+		differentMessageContext = new DtlsEndpointContext(ADDRESS, null,"new session", "1", "CIPHER");
+		scopedDifferentMessageContext = new DtlsEndpointContext(ADDRESS, "iot.eclipse.org", null,"new session", "1", "CIPHER");
+
+		unsecureMessageContext = new UdpEndpointContext(ADDRESS);
 	}
 
 	@Test
 	public void testRelaxedWithConnectionEndpointContext() {
+
 		assertThat(relaxedMatcher.isToBeSent(relaxedMessageContext, connectorContext), is(true));
+		assertThat(relaxedMatcher.isToBeSent(scopedRelaxedMessageContext, connectorContext), is(false));
 		assertThat(relaxedMatcher.isToBeSent(differentMessageContext, connectorContext), is(false));
+		assertThat(relaxedMatcher.isToBeSent(scopedDifferentMessageContext, connectorContext), is(false));
 		assertThat(relaxedMatcher.isToBeSent(unsecureMessageContext, connectorContext), is(false));
+	}
+
+	@Test
+	public void testRelaxedWithScopedConnectionEndpointContext() {
+
+		assertThat(relaxedMatcher.isToBeSent(relaxedMessageContext, scopedConnectorContext), is(false));
+		assertThat(relaxedMatcher.isToBeSent(scopedRelaxedMessageContext, scopedConnectorContext), is(true));
+		assertThat(relaxedMatcher.isToBeSent(strictMessageContext, scopedConnectorContext), is(false));
+		assertThat(relaxedMatcher.isToBeSent(scopedStrictMessageContext, scopedConnectorContext), is(true));
+		assertThat(relaxedMatcher.isToBeSent(differentMessageContext, scopedConnectorContext), is(false));
+		assertThat(relaxedMatcher.isToBeSent(scopedDifferentMessageContext, scopedConnectorContext), is(false));
+		assertThat(relaxedMatcher.isToBeSent(unsecureMessageContext, scopedConnectorContext), is(false));
 	}
 
 	@Test
 	public void testStrictWithConnectionEndpointContext() {
 		assertThat(strictMatcher.isToBeSent(strictMessageContext, connectorContext), is(true));
+		assertThat(strictMatcher.isToBeSent(scopedStrictMessageContext, connectorContext), is(false));
 		assertThat(strictMatcher.isToBeSent(relaxedMessageContext, connectorContext), is(false));
+		assertThat(strictMatcher.isToBeSent(scopedRelaxedMessageContext, connectorContext), is(false));
 		assertThat(strictMatcher.isToBeSent(unsecureMessageContext, connectorContext), is(false));
 	}
 
 	@Test
+	public void testStrictWithScopedConnectionEndpointContext() {
+
+		assertThat(strictMatcher.isToBeSent(strictMessageContext, scopedConnectorContext), is(false));
+		assertThat(strictMatcher.isToBeSent(scopedStrictMessageContext, scopedConnectorContext), is(true));
+		assertThat(strictMatcher.isToBeSent(relaxedMessageContext, scopedConnectorContext), is(false));
+		assertThat(strictMatcher.isToBeSent(scopedRelaxedMessageContext, scopedConnectorContext), is(false));
+		assertThat(strictMatcher.isToBeSent(differentMessageContext, scopedConnectorContext), is(false));
+		assertThat(strictMatcher.isToBeSent(scopedDifferentMessageContext, scopedConnectorContext), is(false));
+		assertThat(strictMatcher.isToBeSent(unsecureMessageContext, scopedConnectorContext), is(false));
+	}
+
+	@Test
 	public void testRelaxedWithoutConnectionEndpointContext() {
+
 		assertThat(relaxedMatcher.isToBeSent(relaxedMessageContext, null), is(false));
+		assertThat(relaxedMatcher.isToBeSent(scopedRelaxedMessageContext, null), is(false));
 		assertThat(relaxedMatcher.isToBeSent(differentMessageContext, null), is(false));
+		assertThat(relaxedMatcher.isToBeSent(scopedDifferentMessageContext, null), is(false));
 		assertThat(relaxedMatcher.isToBeSent(unsecureMessageContext, null), is(false));
 	}
 
 	@Test
 	public void testStrictWithoutConnectionEndpointContext() {
+
 		assertThat(strictMatcher.isToBeSent(strictMessageContext, null), is(false));
+		assertThat(strictMatcher.isToBeSent(scopedStrictMessageContext, null), is(false));
 		assertThat(strictMatcher.isToBeSent(relaxedMessageContext, null), is(false));
+		assertThat(strictMatcher.isToBeSent(scopedRelaxedMessageContext, null), is(false));
 		assertThat(strictMatcher.isToBeSent(unsecureMessageContext, null), is(false));
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -294,13 +294,15 @@ public final class DTLSSession {
 	}
 
 	public DtlsEndpointContext getConnectionWriteContext() {
-		return new DtlsEndpointContext(peer, peerIdentity, sessionIdentifier.toString(),
-					String.valueOf(writeEpoch), cipherSuite.name());
+
+		return new DtlsEndpointContext(peer, virtualHost, peerIdentity, sessionIdentifier.toString(),
+				String.valueOf(writeEpoch), cipherSuite.name());
 	}
 
 	public DtlsEndpointContext getConnectionReadContext() {
-		return new DtlsEndpointContext(peer, peerIdentity, sessionIdentifier.toString(),
-					String.valueOf(readEpoch), cipherSuite.name());
+
+		return new DtlsEndpointContext(peer, virtualHost, peerIdentity, sessionIdentifier.toString(),
+				String.valueOf(readEpoch), cipherSuite.name());
 	}
 
 	/**


### PR DESCRIPTION
Make sure that messages destined for host X are not sent over a DTLS
session established with host Y.