### PR TITLE
[#511] Extend PreSharedKeyIdentity with virtual host property.

### DIFF
--- a/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/TestUtilPskStore.java
+++ b/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/TestUtilPskStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -64,7 +64,7 @@ public class TestUtilPskStore implements PskStore {
 
 	@Override
 	public synchronized byte[] getKey(ServerNames serverNames, String identity) {
-		return key;
+		return getKey(identity);
 	}
 
 	@Override
@@ -72,4 +72,8 @@ public class TestUtilPskStore implements PskStore {
 		return identity;
 	}
 
+	@Override
+	public synchronized String getIdentity(InetSocketAddress peerAddress, ServerNames virtualHost) {
+		return getIdentity(peerAddress);
+	}
 }

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/PlugtestChecker.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/PlugtestChecker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Institute for Pervasive Computing, ETH Zurich and others.
+ * Copyright (c) 2015, 2018 Institute for Pervasive Computing, ETH Zurich and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -1245,6 +1245,10 @@ public class PlugtestChecker {
 			return identity;
 		}
 
+		@Override
+		public String getIdentity(InetSocketAddress peerAddress, ServerNames virtualHost) {
+			return identity;
+		}
 	}
 
 	private static boolean ping(String address) {

--- a/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/ClientInitializer.java
+++ b/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/ClientInitializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -229,6 +229,10 @@ public class ClientInitializer {
 			return identity;
 		}
 
+		@Override
+		public String getIdentity(InetSocketAddress peerAddress, ServerNames virtualHost) {
+			return getIdentity(peerAddress);
+		}
 	}
 
 	public static class Arguments {

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2017, 2018 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -222,5 +222,9 @@ public abstract class AbstractTestServer extends CoapServer {
 			return PSK_IDENTITY_PREFIX + "sandbox";
 		}
 
+		@Override
+		public String getIdentity(InetSocketAddress peerAddress, ServerNames virtualHost) {
+			return getIdentity(peerAddress);
+		}
 	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentity.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
+ * Copyright (c) 2015, 2018 Institute for Pervasive Computing, ETH Zurich and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,36 +17,88 @@ package org.eclipse.californium.elements.auth;
 
 import java.security.Principal;
 
+import org.eclipse.californium.elements.util.StringUtil;
+
 /**
  * A principal representing an authenticated peer's identity as used in a
  * <em>pre-shared key</em> handshake.
  */
-public class PreSharedKeyIdentity implements Principal {
+public final class PreSharedKeyIdentity implements Principal {
 
+	private final String virtualHost;
 	private final String identity;
+	private final String name;
 
 	/**
-	 * Creates a new instance for a given identity.
+	 * Creates a new instance for an identity.
 	 * 
 	 * @param identity the identity
 	 * @throws NullPointerException if the identity is <code>null</code>
 	 */
 	public PreSharedKeyIdentity(String identity) {
+		this(null, identity);
+	}
+
+	/**
+	 * Creates a new instance for an identity scoped to a virtual host.
+	 * 
+	 * @param virtualHost The virtual host name that the identity is scoped to.
+	 *                    The host name will be converted to lower case.
+	 * @param identity the identity.
+	 * @throws NullPointerException if the identity is <code>null</code>
+	 * @throws IllegalArgumentException if virtual host is not a valid host name
+	 *             as per <a href="http://tools.ietf.org/html/rfc1123">RFC 1123</a>.
+	 */
+	public PreSharedKeyIdentity(String virtualHost, String identity) {
 		if (identity == null) {
 			throw new NullPointerException("Identity must not be null");
 		} else {
+			StringBuilder b = new StringBuilder();
+			if (virtualHost == null) {
+				this.virtualHost = null;
+			} else if (StringUtil.isValidHostName(virtualHost)) {
+				this.virtualHost = virtualHost.toLowerCase();
+				b.append(this.virtualHost);
+			} else {
+				throw new IllegalArgumentException("virtual host is not a valid hostname");
+			}
 			this.identity = identity;
+
+			b.append(":").append(identity);
+			this.name = b.toString();
 		}
+	}
+
+	/**
+	 * Gets the virtual host name that the identity is scoped to.
+	 * 
+	 * @return The name or {@code null} if not set.
+	 */
+	public String getVirtualHost() {
+		return virtualHost;
 	}
 
 	/**
 	 * Gets the identity.
 	 * 
-	 * @return the identity
+	 * @return The identity.
+	 */
+	public String getIdentity() {
+		return identity;
+	}
+
+	/**
+	 * Gets the name of this principal.
+	 * <p>
+	 * The name consists of the server name and the identity,
+	 * separated by a colon character. If not server name has been
+	 * provided, then the name only consists of the identity.
+	 * 
+	 * @return the name
 	 */
 	@Override
 	public String getName() {
-		return identity;
+		return name;
 	}
 
 	/**
@@ -59,18 +111,23 @@ public class PreSharedKeyIdentity implements Principal {
 	 */
 	@Override
 	public String toString() {
-		return new StringBuilder("PreSharedKey Identity [").append(identity).append("]").toString();
+		return new StringBuilder("PreSharedKey Identity [")
+				.append("virtual host: ").append(virtualHost)
+				.append(", identity: ").append(identity)
+				.append("]").toString();
 	}
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result
-				+ ((identity == null) ? 0 : identity.hashCode());
-		return result;
+		return name.hashCode();
 	}
 
+	/**
+	 * Compares another object to this identity.
+	 * 
+	 * @return {@code true} if the other object is a {@code PreSharedKeyIdentity} and
+	 *         its name property has the same value as this instance.
+	 */
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) {
@@ -79,15 +136,15 @@ public class PreSharedKeyIdentity implements Principal {
 		if (obj == null) {
 			return false;
 		}
-		if (!(obj instanceof PreSharedKeyIdentity)) {
+		if (getClass() != obj.getClass()) {
 			return false;
 		}
 		PreSharedKeyIdentity other = (PreSharedKeyIdentity) obj;
-		if (identity == null) {
-			if (other.identity != null) {
+		if (name == null) {
+			if (other.name != null) {
 				return false;
 			}
-		} else if (!identity.equals(other.identity)) {
+		} else if (!name.equals(other.name)) {
 			return false;
 		}
 		return true;

--- a/element-connector/src/test/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentityTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentityTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements.auth;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+
+/**
+ * Verifies behavior of {@link PreSharedKeyIdentity}.
+ *
+ */
+public class PreSharedKeyIdentityTest {
+
+	/**
+	 * Verifies that the constructor rejects a host name containing
+	 * a colon character.
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testConstructorRejectsIllegalHostName() {
+		new PreSharedKeyIdentity("illegal.host:name", "acme");
+	}
+
+	/**
+	 * Verifies that two instances with the same identity but different
+	 * virtual host names are not considered equal.
+	 */
+	@Test
+	public void testEqualsDetectsNonMatchingVirtualHost() {
+		PreSharedKeyIdentity idOne = new PreSharedKeyIdentity("iot.eclipse.org", "device-1");
+		PreSharedKeyIdentity idTwo = new PreSharedKeyIdentity("coap.eclipse.org", "device-1");
+		assertFalse(idOne.equals(idTwo));
+	}
+
+	/**
+	 * Verifies that two instances with the same identity and virtual host
+	 * are considered equal.
+	 */
+	@Test
+	public void testEqualsSucceeds() {
+		PreSharedKeyIdentity idOne = new PreSharedKeyIdentity("iot.eclipse.org", "device-1");
+		PreSharedKeyIdentity idTwo = new PreSharedKeyIdentity("iot.eclipse.org", "device-1");
+		assertTrue(idOne.equals(idTwo));
+	}
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/auth/PrincipalSerializer.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/auth/PrincipalSerializer.java
@@ -35,6 +35,7 @@ import org.eclipse.californium.elements.util.StandardCharsets;
 public final class PrincipalSerializer {
 
 	private static final int PSK_LENGTH_BITS = 16;
+	private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 
 	private PrincipalSerializer() {
 	}
@@ -91,7 +92,7 @@ public final class PrincipalSerializer {
 
 	private static void serializeIdentity(final PreSharedKeyIdentity principal, final DatagramWriter writer) {
 		writer.writeByte(ClientAuthenticationType.PSK.code);
-		byte[] virtualHost = principal.getVirtualHost() == null ? new byte[0] :
+		byte[] virtualHost = principal.getVirtualHost() == null ? EMPTY_BYTE_ARRAY :
 			principal.getVirtualHost().getBytes(StandardCharsets.UTF_8);
 		writeBytesWithLength(PSK_LENGTH_BITS, virtualHost, writer);
 		writeBytesWithLength(PSK_LENGTH_BITS, principal.getIdentity().getBytes(StandardCharsets.UTF_8), writer);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/auth/PrincipalSerializer.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/auth/PrincipalSerializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 - 2018 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2016, 2018 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -91,7 +91,10 @@ public final class PrincipalSerializer {
 
 	private static void serializeIdentity(final PreSharedKeyIdentity principal, final DatagramWriter writer) {
 		writer.writeByte(ClientAuthenticationType.PSK.code);
-		writeBytesWithLength(PSK_LENGTH_BITS, principal.getName().getBytes(StandardCharsets.UTF_8), writer);
+		byte[] virtualHost = principal.getVirtualHost() == null ? new byte[0] :
+			principal.getVirtualHost().getBytes(StandardCharsets.UTF_8);
+		writeBytesWithLength(PSK_LENGTH_BITS, virtualHost, writer);
+		writeBytesWithLength(PSK_LENGTH_BITS, principal.getIdentity().getBytes(StandardCharsets.UTF_8), writer);
 	}
 
 	private static void serializeSubjectInfo(final RawPublicKeyIdentity principal, final DatagramWriter writer) {
@@ -123,7 +126,7 @@ public final class PrincipalSerializer {
 		}
 		int code = reader.read(8);
 		ClientAuthenticationType type = ClientAuthenticationType.fromCode((byte) code);
-		switch (type) {
+		switch(type) {
 		case CERT:
 			return deserializeCertChain(reader);
 		case PSK:
@@ -142,7 +145,10 @@ public final class PrincipalSerializer {
 	}
 
 	private static PreSharedKeyIdentity deserializeIdentity(final DatagramReader reader) {
-		return new PreSharedKeyIdentity(new String(readBytesWithLength(PSK_LENGTH_BITS, reader)));
+		byte[] bytes = readBytesWithLength(PSK_LENGTH_BITS, reader);
+		String virtualHost = bytes.length == 0 ? null : new String(bytes, StandardCharsets.UTF_8);
+		bytes = readBytesWithLength(PSK_LENGTH_BITS, reader);
+		return new PreSharedKeyIdentity(virtualHost, new String(bytes, StandardCharsets.UTF_8));
 	}
 
 	private static RawPublicKeyIdentity deserializeSubjectInfo(final DatagramReader reader)

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -157,6 +157,11 @@ public abstract class Handshaker {
 	/** The chain of certificates asserting this handshaker's identity */
 	protected X509Certificate[] certificateChain;
 
+	/**
+	 * Support Server Name Indication TLS extension.
+	 */
+	protected boolean sniEnabled = true;
+
 	private Set<SessionListener> sessionListeners = new LinkedHashSet<>();
 
 	private boolean changeCipherSuiteMessageExpected = false;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/pskstore/InMemoryPskStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/pskstore/InMemoryPskStore.java
@@ -24,24 +24,26 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.californium.scandium.util.ServerName;
 import org.eclipse.californium.scandium.util.ServerNames;
+import org.eclipse.californium.scandium.util.ServerName.NameType;
 
 /**
- * An in-memory pre-shared-key storage. 
+ * An in-memory pre-shared key storage.
+ * <p>
  * If you don't need to initiate connection,
  * you could just add identity/key with {@link #setKey(String, byte[])}.
  * If you need to initiate connection, 
  * you should add known peers with {@link #addKnownPeer(InetSocketAddress, String, byte[])}.
- * 
+ * <p>
  * To be used only for testing and evaluation. 
- * You are supposed to store your key in a secure way: 
+ * You are supposed to store your key in a secure way:
  * keeping them in-memory is not a good idea.
  */
 public class InMemoryPskStore implements PskStore {
 
+	private static final ServerName GLOBAL_SCOPE = ServerName.from(NameType.UNDEFINED, new byte[0]);
+
 	private final Map<ServerName, Map<String, byte[]>> scopedKeys = new ConcurrentHashMap<>();
-	private final Map<String, byte[]> keys = new ConcurrentHashMap<>();
-	private final Map<InetSocketAddress, String> identitiesByAddress = new ConcurrentHashMap<>();
-	private final Map<InetSocketAddress, ServerNames> serverNamesByAddress = new ConcurrentHashMap<>();
+	private final Map<InetSocketAddress, Map<ServerName, String>> scopedIdentities = new ConcurrentHashMap<>();
 
 	@Override
 	public byte[] getKey(final String identity) {
@@ -49,7 +51,29 @@ public class InMemoryPskStore implements PskStore {
 		if (identity == null) {
 			throw new NullPointerException("identity must not be null");
 		} else {
-			return getKeyFromMap(identity, keys);
+			synchronized (scopedKeys) {
+				return getKeyFromMap(identity, scopedKeys.get(GLOBAL_SCOPE));
+			}
+		}
+	}
+
+	@Override
+	public byte[] getKey(final ServerNames serverNames, final String identity) {
+
+		if (serverNames == null) {
+			return getKey(identity);
+		} else if (identity == null) {
+			throw new NullPointerException("identity must not be null");
+		} else {
+			synchronized (scopedKeys) {
+				for (ServerName serverName : serverNames) {
+					byte[] key = getKeyFromMap(identity, scopedKeys.get(serverName));
+					if (key != null) {
+						return key;
+					}
+				}
+				return null;
+			}
 		}
 	}
 
@@ -66,28 +90,10 @@ public class InMemoryPskStore implements PskStore {
 		return result;
 	}
 
-	@Override
-	public byte[] getKey(final ServerNames serverNames, final String identity) {
-
-		if (serverNames == null) {
-			throw new NullPointerException("server names must not be null");
-		} else if (identity == null) {
-			throw new NullPointerException("identity must not be null");
-		} else {
-			synchronized (scopedKeys) {
-				for (ServerName serverName : serverNames) {
-					byte[] key = getKeyFromMap(identity, scopedKeys.get(serverName));
-					if (key != null) {
-						return key;
-					}
-				}
-				return null;
-			}
-		}
-	}
-
 	/**
-	 * Set a key value for a given identity.
+	 * Sets a key value for a given identity.
+	 * <p>
+	 * If the key already exists, it will be replaced.
 	 * 
 	 * @param identity
 	 *            the identity associated with the key
@@ -96,30 +102,45 @@ public class InMemoryPskStore implements PskStore {
 	 */
 	public void setKey(final String identity, final byte[] key) {
 
-		keys.put(identity, Arrays.copyOf(key, key.length));
+		setKey(identity, key, GLOBAL_SCOPE);
 	}
 
 	/**
-	 * Sets a key for an identity scoped to a server name.
+	 * Sets a key for an identity scoped to a virtual host.
+	 * <p>
+	 * If the key already exists, it will be replaced.
 	 * 
 	 * @param identity The identity to set the key for.
 	 * @param key The key to set for the identity.
-	 * @param serverName The server name to associate the identity and key with.
+	 * @param virtualHost The virtual host to associate the identity and key with.
 	 */
-	public void setKey(final String identity, final byte[] key, final ServerName serverName) {
+	public void setKey(final String identity, final byte[] key, final String virtualHost) {
+		setKey(identity, key, ServerName.fromHostName(virtualHost));
+	}
+
+	/**
+	 * Sets a key for an identity scoped to a virtual host.
+	 * <p>
+	 * If the key already exists, it will be replaced.
+	 * 
+	 * @param identity The identity to set the key for.
+	 * @param key The key to set for the identity.
+	 * @param virtualHost The virtual host to associate the identity and key with.
+	 */
+	public void setKey(final String identity, final byte[] key, final ServerName virtualHost) {
 
 		if (identity == null) {
 			throw new NullPointerException("identity must not be null");
 		} else if (key == null) {
 			throw new NullPointerException("key must not be null");
-		} else if (serverName == null) {
+		} else if (virtualHost == null) {
 			throw new NullPointerException("serverName must not be null");
 		} else {
 			synchronized (scopedKeys) {
-				Map<String, byte[]> keysForServerName = scopedKeys.get(serverName);
+				Map<String, byte[]> keysForServerName = scopedKeys.get(virtualHost);
 				if (keysForServerName == null) {
 					keysForServerName = new ConcurrentHashMap<>();
-					scopedKeys.put(serverName, keysForServerName);
+					scopedKeys.put(virtualHost, keysForServerName);
 				}
 				keysForServerName.put(identity, Arrays.copyOf(key, key.length));
 			}
@@ -127,43 +148,98 @@ public class InMemoryPskStore implements PskStore {
 	}
 
 	/**
-	 * Add a known peer. Used when we need to initiate a connection.
+	 * Adds a shared key for a peer.
+	 * <p>
+	 * If the key already exists, it will be replaced.
 	 * 
-	 * @param peerAddress
-	 *            address of known peer we need to connect to
-	 * @param identity
-	 *            identity used for this peer
-	 * @param key
-	 *            the key used for this the peer
+	 * @param peerAddress the IP address and port to use the key for
+	 * @param identity the PSK identity
+	 * @param key the shared key
+	 * @throws NullPointerException if any of the parameters are {@code null}.
 	 */
 	public void addKnownPeer(final InetSocketAddress peerAddress, final String identity, final byte[] key) {
 
-		identitiesByAddress.put(peerAddress, identity);
-		setKey(identity, key);
+		addKnownPeer(peerAddress, GLOBAL_SCOPE, identity, key);
 	}
 
 	/**
-	 * Adds server names for a given peer.
+	 * Adds a shared key for a virtual host on a peer.
 	 * <p>
-	 * This method replaces any existing mapping for the peer address.
-	 * 
-	 * @param peerAddress The IP address of the peer.
-	 * @param serverNames The server names to include in the SNI extension.
+	 * If the key already exists, it will be replaced.
+	 * serverNames
+	 * @param peerAddress the IP address and port to use the key for
+	 * @param virtualHost the virtual host to use the key for
+	 * @param identity the PSK identity
+	 * @param key the shared key
+	 * @throws NullPointerException if any of the parameters are {@code null}.
 	 */
-	public void addServerNames(final InetSocketAddress peerAddress, final ServerNames serverNames) {
+	public void addKnownPeer(final InetSocketAddress peerAddress, final String virtualHost, final String identity, final byte[] key) {
 
-		if (peerAddress != null && serverNames != null) {
-			this.serverNamesByAddress.put(peerAddress, serverNames);
+		addKnownPeer(peerAddress, ServerName.fromHostName(virtualHost), identity, key);
+	}
+
+	private void addKnownPeer(final InetSocketAddress peerAddress, final ServerName virtualHost,
+			final String identity, final byte[] key) {
+
+		if (peerAddress == null) {
+			throw new NullPointerException("peer address must not be null");
+		} else if (virtualHost == null) {
+			throw new NullPointerException("virtual host must not be null");
+		} else if (identity == null) {
+			throw new NullPointerException("identity must not be null");
+		} else if (key == null) {
+			throw new NullPointerException("key must not be null");
+		} else {
+			synchronized (scopedKeys) {
+				Map<ServerName, String> identities = scopedIdentities.get(peerAddress);
+				if (identities == null) {
+					identities = new ConcurrentHashMap<>();
+					scopedIdentities.put(peerAddress, identities);
+				}
+				identities.put(virtualHost, identity);
+				setKey(identity, key, virtualHost);
+			}
 		}
 	}
 
 	@Override
-	public String getIdentity(final InetSocketAddress inetAddress) {
+	public String getIdentity(final InetSocketAddress peerAddress) {
 
-		if (inetAddress == null) {
+		if (peerAddress == null) {
 			throw new NullPointerException("address must not be null");
 		} else {
-			return identitiesByAddress.get(inetAddress);
+			synchronized (scopedKeys) {
+				return getIdentityFromMap(GLOBAL_SCOPE, scopedIdentities.get(peerAddress));
+			}
+		}
+	}
+
+	@Override
+	public String getIdentity(final InetSocketAddress peerAddress, final ServerNames virtualHost) {
+
+		if (virtualHost == null) {
+			return getIdentity(peerAddress);
+		} else if (peerAddress == null) {
+			throw new NullPointerException("address must not be null");
+		} else {
+			synchronized (scopedKeys) {
+				for (ServerName serverName : virtualHost) {
+					String identity = getIdentityFromMap(serverName, scopedIdentities.get(peerAddress));
+					if (identity != null) {
+						return identity;
+					}
+				}
+				return null;
+			}
+		}
+	}
+
+	private static String getIdentityFromMap(final ServerName virtualHost, final Map<ServerName, String> identities) {
+
+		if (identities != null) {
+			return identities.get(virtualHost);
+		} else {
+			return null;
 		}
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/pskstore/PskStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/pskstore/PskStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
+ * Copyright (c) 2015, 2018 Institute for Pervasive Computing, ETH Zurich and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  * Julien Vermillard - Sierra Wireless
+ * Bosch Software Innovations GmbH - add SNI support
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls.pskstore;
 
@@ -20,14 +21,15 @@ import java.net.InetSocketAddress;
 import org.eclipse.californium.scandium.util.ServerNames;
 
 /**
- * A storage for pre-shared-key identity.
+ * A service for resolving pre-shared key identities.
  */
 public interface PskStore {
 
 	/**
 	 * Gets the shared key for a given identity.
 	 * <p>
-	 * The key is used for mutual authentication during a DTLS handshake.
+	 * A DTLS server can use this method to look up the pre-shared key
+	 * for an identity provided by the client as part of a PSK key exchange.
 	 * 
 	 * @param identity The identity to look up the key for.
 	 * @return The key or <code>null</code> if the given identity is unknown.
@@ -36,22 +38,30 @@ public interface PskStore {
 	byte[] getKey(String identity);
 
 	/**
-	 * Gets the shared key for a given identity.
+	 * Gets the shared key for a given identity in the scope of a
+	 * server name.
 	 * <p>
-	 * The key is used for mutual authentication during a DTLS handshake.
+	 * A DTLS server can use this method to look up the pre-shared key
+	 * for an identity provided by the client as part of a PSK key exchange.
+	 * <p>
+	 * The key is looked up in the context of the <em>virtual host</em> that
+	 * the client has provided in the <em>Server Name Indication</em> extension
+	 * contained in its <em>CLIENT_HELLO</em> message.
 	 * 
-	 * @param serverNames The names of servers the client provided as part of
-	 *            the <em>Server Name Indication</em> hello extension during the
-	 *            DTLS handshake. The key returned for the given identity is
-	 *            being looked up in the context of these server names.
+	 * @param serverName The name of the host that the client wants to connect
+	 *            to as provided in the <em>Server Name Indication</em> HELLO
+	 *            extension during the DTLS handshake.
+	 *            The key returned for the given identity is being looked up
+	 *            in the context of this host name.
 	 * @param identity The identity to look up the key for.
-	 * @return The key or <code>null</code> if the given identity is unknown.
+	 * @return The key or <code>null</code> if no matching identity has been
+	 *         registered for any of the server name types.
 	 * @throws NullPointerException if any of the parameters is {@code null}.
 	 */
-	byte[] getKey(ServerNames serverNames, String identity);
+	byte[] getKey(ServerNames serverName, String identity);
 
 	/**
-	 * Gets the Identity to use for a PSK based handshake with a given peer.
+	 * Gets the <em>identity</em> to use for a PSK based handshake with a given peer.
 	 * <p>
 	 * A DTLS client uses this method to determine the identity to include in
 	 * its <em>CLIENT_KEY_EXCHANGE</em> message during a PSK based DTLS
@@ -64,4 +74,23 @@ public interface PskStore {
 	 * @throws NullPointerException if address is {@code null}.
 	 */
 	String getIdentity(InetSocketAddress inetAddress);
+
+	/**
+	 * Gets the <em>identity</em> to use for a PSK based handshake with a given peer.
+	 * <p>
+	 * A DTLS client uses this method to determine the identity to include in
+	 * its <em>CLIENT_KEY_EXCHANGE</em> message during a PSK based DTLS
+	 * handshake with the peer.
+	 * 
+	 * @param peerAddress The IP address and port of the peer to perform the
+	 *                    handshake with.
+	 * @param virtualHost The virtual host at the peer to connect to.
+	 *                    If {@code null}, the identity will be looked up in the
+	 *                    <em>global</em> scope, yielding the same result as
+	 *                    {@link #getIdentity(InetSocketAddress)}.
+	 * @return The identity to use or <code>null</code> if no peer with the
+	 *         given address and virtual host is registered.
+	 * @throws NullPointerException if address or host are {@code null}.
+	 */
+	String getIdentity(InetSocketAddress peerAddress, ServerNames virtualHost);
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/pskstore/StaticPskStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/pskstore/StaticPskStore.java
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2018 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ * Julien Vermillard - Sierra Wireless
+ * Bosch Software Innovations GmbH - add SNI support
+ ******************************************************************************/
 package org.eclipse.californium.scandium.dtls.pskstore;
 
 import java.net.InetSocketAddress;
@@ -36,12 +52,17 @@ public class StaticPskStore implements PskStore {
 	}
 
 	@Override
+	public String getIdentity(InetSocketAddress peerAddress, ServerNames virtualHost) {
+		return getIdentity(peerAddress);
+	}
+
+	@Override
 	public byte[] getKey(final String identity) {
 		return key;
 	}
 
 	@Override
 	public byte[] getKey(final ServerNames serverNames, final String identity) {
-		return key;
+		return getKey(identity);
 	}
 }


### PR DESCRIPTION
PSK identities can now be scoped to a virtual host in order to prevent
identity clashes when SNI is used.