### PR TITLE
Added support for ECDHE_PSK mode

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -26,6 +26,7 @@
  *                                                    trustStore := null, disable x.509
  *                                                    trustStore := [], enable x.509, trust all
  *    Bosch Software Innovations GmbH - remove serverNameResolver property
+ *    Vikram (University of Rostock) - added CipherSuite TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256                        
  *******************************************************************************/
 
 package org.eclipse.californium.scandium.config;
@@ -113,10 +114,10 @@ public final class DtlsConnectorConfig {
 	/** store of the PSK */
 	private PskStore pskStore;
 
-	/** the private key for RPK and X509 mode */
+	/** the private key for RPK and X509 mode, right now only EC type is supported */
 	private PrivateKey privateKey;
 
-	/** the public key for both RPK and X.509 mode */
+	/** the public key for RPK and X.509 mode, right now only EC type is supported */
 	private PublicKey publicKey;
 
 	/** the certificate for RPK and X509 mode */
@@ -999,6 +1000,7 @@ public final class DtlsConnectorConfig {
 				switch (suite) {
 				case TLS_PSK_WITH_AES_128_CCM_8:
 				case TLS_PSK_WITH_AES_128_CBC_SHA256:
+				case TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256:
 					verifyPskBasedCipherConfig();
 					break;
 				case TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8:
@@ -1050,6 +1052,7 @@ public final class DtlsConnectorConfig {
 			if (config.pskStore != null) {
 				ciphers.add(CipherSuite.TLS_PSK_WITH_AES_128_CCM_8);
 				ciphers.add(CipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA256);
+				ciphers.add(CipherSuite.TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256);
 			}
 
 			config.supportedCipherSuites = ciphers.toArray(new CipherSuite[0]);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchange.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Copyright 2018 University of Rostock, Institute of Applied Microelectronics and Computer Engineering
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Vikram (University of Rostock)- Initial creation, adapted from ECDHClientKeyExchange
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import static org.eclipse.californium.elements.util.StandardCharsets.UTF_8;
+
+import java.net.InetSocketAddress;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.util.Arrays;
+
+import org.eclipse.californium.elements.util.DatagramReader;
+import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
+import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
+import org.eclipse.californium.scandium.util.ByteArrayUtils;
+
+/**
+ * Generates client ephemeral ECDH keys for Dtls ECDH_PSK mode.
+ * 
+ * @see <a href="https://tools.ietf.org/html/rfc5489#section-2">RFC 5489</a> for details.
+ */
+public final class EcdhPskClientKeyExchange extends ClientKeyExchange {
+
+
+	protected static final int LENGTH_BITS = 8; // opaque point <1..2^8-1>
+	private static final int IDENTITY_LENGTH_BITS = 16; // opaque <0..2^16-1>;
+
+	/**
+	 *See <a href="https://tools.ietf.org/html/rfc5489#section-2">RFC 5489</a>.
+	 */
+	private final byte[] identityEncoded;
+	/**
+	 *See <a href="https://tools.ietf.org/html/rfc5489#section-2">RFC 5489</a>.
+	 */
+	private final String identity;
+	private final byte[] pointEncoded;
+	
+	/**
+	 * Creates a new key exchange message for an identity hint and a public key.
+	 * 
+	 * @param hint - PSK identity as clear text
+	 * @param clientPublicKey - ephemeral public key of client
+	 * @param peerAddress
+	 * @throws NullPointerException if either hint or clietPublicKey are {@code null}
+	 */
+	public EcdhPskClientKeyExchange(String hint, PublicKey clientPublicKey, InetSocketAddress peerAddress) {
+		super(peerAddress);
+		if (hint == null) {
+			throw new NullPointerException("identity cannot be null");
+		}
+		if (clientPublicKey == null) {
+			throw new NullPointerException("ephemeral public key cannot be null");
+		}
+		this.identity = hint;
+		this.identityEncoded = hint.getBytes(UTF_8);
+		ECPublicKey publicKey = (ECPublicKey) clientPublicKey;
+		ECPoint point = publicKey.getW();
+		ECParameterSpec params = publicKey.getParams();
+			
+		this.pointEncoded = ECDHECryptography.encodePoint(point, params.getCurve());
+	}
+	
+	/**
+	 * Creates a new key exchange message for an identity hint and a public key.
+	 * 
+	 * @param hintEncoded - opaque encoded PSK identity hint for server
+	 * @param pointEncoded - ephemeral public key of client (encoded point)
+	 * @param peerAddress
+	 * @throws NullPointerException if either hintEncoded or pointEncoded are {@code null}
+	 */
+	public EcdhPskClientKeyExchange(byte[] hintEncoded, byte[] pointEncoded, InetSocketAddress peerAddress) {
+		super(peerAddress);
+		if (hintEncoded ==null) {
+			throw new NullPointerException("identity cannot be null");
+		}
+		if (pointEncoded == null) {
+			throw new NullPointerException("epehemeral public key cannot be null");
+		}
+		this.identityEncoded = Arrays.copyOf(hintEncoded, hintEncoded.length);
+		this.identity = new String(this.identityEncoded,UTF_8);
+		this.pointEncoded = Arrays.copyOf(pointEncoded, pointEncoded.length);
+	}
+
+	@Override
+	public byte[] fragmentToByteArray() {
+		DatagramWriter writer = new DatagramWriter();
+		writer.write(identityEncoded.length, IDENTITY_LENGTH_BITS);
+		writer.writeBytes(identityEncoded);
+		writer.write(pointEncoded.length, LENGTH_BITS);
+		writer.writeBytes(pointEncoded);
+		return writer.toByteArray();
+	}
+	
+	/**
+	 * Deserialize byte array to key exchange message.
+	 * 
+	 * @param byteArray
+	 * @param peerAddress
+	 * @return {@code EcdhPskClientKeyExchange}
+	 * @throws NullPointerException if either byteArray or peerAddress is {@code null}
+	 */
+	public static HandshakeMessage fromByteArray(byte[] byteArray, InetSocketAddress peerAddress) {
+		if (byteArray == null) {
+			throw new NullPointerException("byte array cannot be null");
+		}
+		if (peerAddress == null) {
+			throw new NullPointerException("peer address cannot be null");
+		}
+		DatagramReader reader = new DatagramReader(byteArray);
+		int identityLength = reader.read(IDENTITY_LENGTH_BITS);
+		byte[] identityEncoded = reader.readBytes(identityLength);	
+		int length = reader.read(LENGTH_BITS);
+		byte[] pointEncoded = reader.readBytes(length);
+		return new EcdhPskClientKeyExchange(identityEncoded, pointEncoded, peerAddress);
+	}
+		
+
+	@Override
+	public int getMessageLength() {
+		return 3 + identityEncoded.length + pointEncoded.length;
+	}
+
+	/**
+	 * This method returns the ephemeral public key (encoded point) from {@link ClientKeyExchange}.
+	 * 
+	 * @return encoded point in byte array
+	 */
+	public byte[] getEncodedPoint() {
+		return Arrays.copyOf(pointEncoded, pointEncoded.length);
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(super.toString());
+		sb.append("\t\t Encoded identity value: ");
+		sb.append(ByteArrayUtils.toHex(identityEncoded)).append(StringUtil.lineSeparator());;
+		sb.append("\t\tEC Diffie-Hellman public value: ");		
+		sb.append(ByteArrayUtils.toHexString(pointEncoded));
+		sb.append(StringUtil.lineSeparator());
+		return sb.toString();
+	}		
+	
+	/**
+	 * This method returns the PSK identity as clear text.
+	 * 
+	 * @return psk identity
+	 */
+	public String getIdentity() {
+		return identity;
+	}
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchange.java
@@ -1,0 +1,305 @@
+/*******************************************************************************
+ * Copyright 2018 University of Rostock, Institute of Applied Microelectronics and Computer Engineering
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Vikram (University of Rostock)- Initial creation, adapted from ECDHServerKeyExchange
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import static org.eclipse.californium.elements.util.StandardCharsets.UTF_8;
+
+import java.net.InetSocketAddress;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
+import java.util.Arrays;
+
+import org.eclipse.californium.elements.util.DatagramReader;
+import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.StringUtil;
+import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
+import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
+import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
+import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Generates server ephemeral ECDH keys for Dtls PSK mode.
+ * <p>
+ * Server must send the {@code ServerKeyExchange} message even if the PSK identity hint is not provided.
+ * 
+ * @see <a href="https://tools.ietf.org/html/rfc5489#section-2">RFC 5489</a>
+ */
+public final class EcdhPskServerKeyExchange extends ServerKeyExchange {
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(EcdhPskServerKeyExchange.class.getCanonicalName());
+	
+	private static final int IDENTITY_HINT_LENGTH_BITS = 16;
+	private static final String MSG_UNKNOWN_CURVE_TYPE = "Unknown curve type [{}]";
+	private static final int CURVE_TYPE_BITS = 8;
+	private static final int NAMED_CURVE_BITS = 16;
+	private static final int PUBLIC_LENGTH_BITS = 8;
+	
+	/**
+	 * The algorithm name to generate elliptic curve keypairs. See also <a href=
+	 * "http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#KeyPairGenerator"
+	 * >KeyPairGenerator Algorithms</a>.
+	 */
+	private static final String KEYPAIR_GENERATOR_INSTANCE = "EC";
+
+	/**
+	 * The PSK identity MUST be first converted to a character string, and then
+	 * encoded to octets using UTF-8. See <a
+	 * href="http://tools.ietf.org/html/rfc4279#section-5.1">RFC 4279</a>.
+	 */
+	private byte[] hintEncoded;
+	
+	/** The hint in cleartext. */
+	private String hint;
+	
+	/** The ECCurveType */
+	
+	/** parameters are conveyed verbosely; underlying finite field is a prime 
+	 * field
+	*/ 
+	private static final int EXPLICIT_PRIME = 1;
+	
+	/** parameters are conveyed verbosely; underlying finite field is a 
+	 * characteristic-2 field
+	*/ 
+	private static final int EXPLICIT_CHAR2 = 2;
+	
+	/** a named curve is used */
+	private static final int NAMED_CURVE = 3;
+
+	/** ephemeral public key */
+	private ECPublicKey publicKey = null;
+
+	private ECPoint point = null;
+	private byte[] pointEncoded = null;
+
+	private final int curveId;
+	
+	// TODO right now only named curve is supported
+	private int curveType = NAMED_CURVE;
+	
+	/**
+	 * Creates a new key exchange message with psk hint as clear text and ServerDHParams.
+	 * 
+	 * @see <a href="http://tools.ietf.org/html/rfc4279#section-3">RFC 4279</a>
+	 * @param pskHint - preshared key hint in clear text
+	 * @param ecdhe - {@code ECDHECryptography}
+	 * @param clientRandom - nonce
+	 * @param serverRandom - nonce
+	 * @param namedCurveId - ec curve used 
+	 * @param peerAddress
+	 * @throws NullPointerException if any of the arguments ecdhe, 
+	 * clientRandom and serverRandom are {@code null}
+	 */
+	public EcdhPskServerKeyExchange(String pskHint, ECDHECryptography ecdhe, Random clientRandom, Random serverRandom, 
+			int namedCurveId, InetSocketAddress peerAddress) {	
+		super(peerAddress);	
+		if (ecdhe == null) {
+			throw new NullPointerException("ECDHECryptography class object cannot be null");
+		}
+		if (clientRandom == null || serverRandom == null) {
+			throw new NullPointerException("nonce cannot be null");
+		}
+		if (pskHint != null) {
+			this.hint = pskHint;		
+		} else {
+			this.hint = "";
+		}
+		this.hintEncoded = hint.getBytes(UTF_8);
+		this.curveId = namedCurveId;
+		publicKey = ecdhe.getPublicKey();
+		ECParameterSpec parameters = publicKey.getParams();
+		point = publicKey.getW();
+		pointEncoded = ECDHECryptography.encodePoint(point, parameters.getCurve());
+	}
+	
+	/**
+	 * Creates a new key exchange message with ServerDHParams.
+	 * 
+	 * @see <a href="http://tools.ietf.org/html/rfc4279#section-3">RFC 4279</a>
+	 * @param ecdhe - {@code ECDHECryptography}
+	 * @param clientRandom - nonce
+	 * @param serverRandom - nonce
+	 * @param namedCurveId - ec curve used 
+	 * @param peerAddress
+	 * @throws NullPointerException if any of arguments ecdhe, 
+	 * clientRandom and serverRandom are {@code null}
+	 */
+	public EcdhPskServerKeyExchange(ECDHECryptography ecdhe, Random clientRandom, Random serverRandom, 
+			int namedCurveId, InetSocketAddress peerAddress) {
+		this(null, ecdhe, clientRandom, serverRandom, namedCurveId, peerAddress);
+	}
+	
+	private EcdhPskServerKeyExchange(byte[] hintEncoded, int curveId, byte[] pointEncoded, InetSocketAddress peerAddress) throws HandshakeException {		
+		super(peerAddress);
+		this.curveId = curveId;
+		this.hintEncoded = hintEncoded;
+		this.hint = new String(this.hintEncoded, UTF_8);
+		if (pointEncoded == null) {
+			throw new NullPointerException("ephemeral public key cannot be null");
+		}
+		this.pointEncoded = Arrays.copyOf(pointEncoded, pointEncoded.length);
+		// re-create public key from params
+		SupportedGroup group = SupportedGroup.fromId(curveId);
+		if (group == null || !group.isUsable()) {
+			throw new HandshakeException(
+				String.format("Server used unsupported elliptic curve (%d) for ECDH", curveId),
+				new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, peerAddress));
+		} else {
+			try {
+				point = ECDHECryptography.decodePoint(pointEncoded, group.getEcParams().getCurve());
+				KeyFactory keyFactory = KeyFactory.getInstance(KEYPAIR_GENERATOR_INSTANCE);
+				publicKey = (ECPublicKey) keyFactory.generatePublic(new ECPublicKeySpec(point, group.getEcParams()));
+			} catch (GeneralSecurityException e) {
+				LOGGER.debug("Cannot re-create server's public key from params", e);
+				throw new HandshakeException(
+					String.format("Cannot re-create server's public key from params: %s", e.getMessage()),
+					new AlertMessage(AlertLevel.FATAL, AlertDescription.INTERNAL_ERROR, peerAddress));
+			}
+		}
+	}
+
+	// TODO this is called 4 times for Flight 4
+	@Override
+	public byte[] fragmentToByteArray() {
+		DatagramWriter writer = new DatagramWriter();
+		writer.write(hintEncoded.length, IDENTITY_HINT_LENGTH_BITS);
+		writer.writeBytes(hintEncoded);
+		switch (curveType) {
+		// TODO add support for other curve types
+		case EXPLICIT_PRIME:
+		case EXPLICIT_CHAR2:
+			break;
+		case NAMED_CURVE:
+			writeNamedCurve(writer);
+			break;
+		default:
+			LOGGER.warn(MSG_UNKNOWN_CURVE_TYPE, curveType);
+			break;
+		}
+		return writer.toByteArray();
+	}
+	
+	
+	private void writeNamedCurve(DatagramWriter writer) {
+		writer.write(NAMED_CURVE, CURVE_TYPE_BITS);
+		writer.write(curveId, NAMED_CURVE_BITS);
+		writer.write(pointEncoded.length, PUBLIC_LENGTH_BITS);
+		writer.writeBytes(pointEncoded);
+	}
+	
+	/**
+	 * Deserialize byte array to key exchange message.
+	 * 
+	 * @param byteArray
+	 * @param peerAddress
+	 * @return {@code EcdhPskServerKeyExchange}
+	 * @throws HandshakeException - if the byte array includes unsupported curve
+	 * @throws NullPointerException if either byteArray or peerAddress is {@code null}
+	 */
+	public static HandshakeMessage fromByteArray(byte[] byteArray, InetSocketAddress peerAddress) throws HandshakeException {
+		if (byteArray == null) {
+			throw new NullPointerException("byte array cannot be null");
+		}
+		if (peerAddress == null) {
+			throw new NullPointerException("peer address cannot be null");
+		}
+		DatagramReader reader = new DatagramReader(byteArray);
+		int hintLength = reader.read(IDENTITY_HINT_LENGTH_BITS);
+		byte[] hintEncoded = reader.readBytes(hintLength);
+		int curveType = reader.read(CURVE_TYPE_BITS);
+		switch (curveType) {
+		// TODO right now only named curve supported
+		case NAMED_CURVE:
+			int curveId = reader.read(NAMED_CURVE_BITS);
+			int length = reader.read(PUBLIC_LENGTH_BITS);
+			byte[] pointEncoded = reader.readBytes(length);
+			return new EcdhPskServerKeyExchange(hintEncoded, curveId, pointEncoded, peerAddress);
+		default:
+			throw new HandshakeException(
+					String.format("Curve type [%s] received in ServerKeyExchange message from peer [%s] is unsupported",
+							curveType, peerAddress),
+					new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, peerAddress));
+		}
+	}
+
+	@Override
+	public int getMessageLength() {
+		int length = 0;
+		switch (curveType) {
+		case EXPLICIT_PRIME:
+		case EXPLICIT_CHAR2:
+			break;		
+		case NAMED_CURVE:
+			length = 6 + hintEncoded.length + pointEncoded.length;
+			break;
+		default:
+			LOGGER.warn(MSG_UNKNOWN_CURVE_TYPE, curveType);
+			break;
+		}		
+		return length;
+	}
+	
+	/**
+	 * This method returns the ephemeral (EC) Public key from {@code EcdhPskServerKeyExchange}.
+	 * 
+	 * @return - EC Public key 
+	 */
+	public ECPublicKey getPublicKey() {
+		return publicKey;
+	}
+	
+	/**
+	 * This method returns the EC curve Id used for generating the ephemeral DH key.
+	 * 
+	 * @return - int curve id
+	 */
+	public int getCurveId() {
+		return curveId;
+	}
+	
+	/**
+	 * This method returns the preshared key hint used by server in {@code ServerKeyExchange}
+	 * message. If psk hint not present this will return an empty string.
+	 * 
+	 * @return preshared key hint as clear text.
+	 */
+	public String getHint() {
+		return hint;
+	}
+	
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(super.toString());
+		if (hint.equals("")) {
+			sb.append("\t\tPSK Identity Hint: ").append("psk hint not present");
+		} else {
+			sb.append("\t\tPSK Identity Hint: ").append(hint);
+		}
+		sb.append("\t\tEC Diffie-Hellman public key: ");
+		sb.append(getPublicKey().toString());
+		// bug in ECPublicKey.toString() gives object pointer
+		sb.append(StringUtil.lineSeparator());
+
+		return sb.toString();
+	}
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeMessage.java
@@ -16,6 +16,7 @@
  *    Kai Hudalla (Bosch Software Innovations GmbH) - add accessor for message type
  *    Kai Hudalla (Bosch Software Innovations GmbH) - add accessor for peer address
  *    Bosch Software Innovations GmbH - migrate to SLF4J
+ *    Vikram (University of Rostock) - added ECDHE_PSK mode
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -267,6 +268,8 @@ public abstract class HandshakeMessage extends AbstractMessage {
 			return ECDHServerKeyExchange.fromByteArray(bytesLeft, peerAddress);
 		case PSK:
 			return PSKServerKeyExchange.fromByteArray(bytesLeft, peerAddress);
+		case ECDHE_PSK:
+			return EcdhPskServerKeyExchange.fromByteArray(bytesLeft, peerAddress);
 		default:
 			throw new HandshakeException(
 					"Unsupported key exchange algorithm",
@@ -282,6 +285,8 @@ public abstract class HandshakeMessage extends AbstractMessage {
 			return ECDHClientKeyExchange.fromByteArray(bytesLeft, peerAddress);
 		case PSK:
 			return PSKClientKeyExchange.fromByteArray(bytesLeft, peerAddress);
+		case ECDHE_PSK:
+			return EcdhPskClientKeyExchange.fromByteArray(bytesLeft, peerAddress);
 		case NULL:
 			return NULLClientKeyExchange.fromByteArray(bytesLeft, peerAddress);
 		default:

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
@@ -25,6 +25,7 @@
  *                                                    support for certificate-based,
  *                                                    none ECC-based cipher suites is
  *                                                    still missing!
+ *    Vikram (University of Rostock) - added CipherSuite TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256 
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls.cipher;
 
@@ -53,6 +54,8 @@ public enum CipherSuite {
 
 	TLS_NULL_WITH_NULL_NULL(0x0000, KeyExchangeAlgorithm.NULL, Cipher.NULL, MACAlgorithm.NULL),
 	TLS_PSK_WITH_AES_128_CBC_SHA256(0x00AE, KeyExchangeAlgorithm.PSK, Cipher.AES_128_CBC, MACAlgorithm.HMAC_SHA256),
+	/**See <a href="https://tools.ietf.org/html/rfc5489#section-3.2">RFC 5489</a> for details*/
+	TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256(0xC037, KeyExchangeAlgorithm.ECDHE_PSK, Cipher.AES_128_CBC, MACAlgorithm.HMAC_SHA256),
 	TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256(0xC023, KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN, Cipher.AES_128_CBC, MACAlgorithm.HMAC_SHA256),
 	TLS_PSK_WITH_AES_128_CCM_8(0xC0A8, KeyExchangeAlgorithm.PSK, Cipher.AES_128_CCM_8, MACAlgorithm.NULL),
 	TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8(0xC0AE, KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN, Cipher.AES_128_CCM_8, MACAlgorithm.NULL);
@@ -160,6 +163,7 @@ public enum CipherSuite {
 	public boolean requiresServerCertificateMessage() {
 		return !(KeyExchangeAlgorithm.DH_ANON.equals(keyExchange) ||
 				KeyExchangeAlgorithm.PSK.equals(keyExchange) ||
+				KeyExchangeAlgorithm.ECDHE_PSK.equals(keyExchange)||
 				KeyExchangeAlgorithm.NULL.equals(keyExchange));
 	}
 
@@ -169,7 +173,8 @@ public enum CipherSuite {
 	 * @return <code>true</code> if ECC is used
 	 */
 	public boolean isEccBased() {
-		return KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN.equals(keyExchange);
+		return KeyExchangeAlgorithm.ECDHE_PSK.equals(keyExchange)|| 
+				KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN.equals(keyExchange);
 	}
 
 	/**
@@ -515,7 +520,7 @@ public enum CipherSuite {
 	 *
 	 */
 	public enum KeyExchangeAlgorithm {
-		NULL, DHE_DSS, DHE_RSA, DH_ANON, RSA, DH_DSS, DH_RSA, PSK, EC_DIFFIE_HELLMAN;
+		NULL, DHE_DSS, DHE_RSA, DH_ANON, RSA, DH_DSS, DH_RSA, PSK, ECDHE_PSK, EC_DIFFIE_HELLMAN;
 	}
 
 	private enum PRFAlgorithm {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/util/PskUtil.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/util/PskUtil.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright 2018 University of Rostock, Institute of Applied Microelectronics and Computer Engineering
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Vikram (University of Rostock)- Initial creation, adapted from ClientHandshaker
+ ******************************************************************************/
+package org.eclipse.californium.scandium.util;
+
+import org.eclipse.californium.elements.auth.PreSharedKeyIdentity;
+import org.eclipse.californium.scandium.dtls.AlertMessage;
+import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
+import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
+import org.eclipse.californium.scandium.dtls.DTLSSession;
+import org.eclipse.californium.scandium.dtls.HandshakeException;
+import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Extracts psk credentials from the current {@code DTLSSession}.
+ */
+public class PskUtil {
+	
+	private static final Logger LOGGER = LoggerFactory.getLogger(PskUtil.class.getName());
+	
+	private byte[] psk;
+	
+	private PreSharedKeyIdentity pskIdentity;
+	
+	/**
+	 * Retrieves preshared key identity and preshared key for the given dtls session and psk store.
+	 * 
+	 * @param sniEnabled - {@code true} if SNI should be enabled for negotiating the given session
+	 * @param session - {@code DTLSSession}
+	 * @param pskStore - {@code PskStore}
+	 * @throws HandshakeException
+	 * @throws NullPointerException if either session or pskStore is {@code null}
+	 */
+	public PskUtil(boolean sniEnabled, DTLSSession session, PskStore pskStore) throws HandshakeException {
+		if (session == null) {
+			throw new NullPointerException("Dtls session cannot be null");
+		}
+		if (pskStore == null) {
+			throw new NullPointerException("psk store cannot be null");
+		}
+		String virtualHostName = session.getVirtualHost();
+		String identity = null;
+		if (sniEnabled && virtualHostName != null) {
+			ServerNames virtualHost = ServerNames.newInstance().add(ServerName.fromHostName(virtualHostName));
+			if (!session.isSniSupported()) {
+				LOGGER.warn("client is configured to use SNI but server does not support it, PSK authentication is likely to fail");
+			}
+			// look up identity in scope of virtual host
+			identity = pskStore.getIdentity(session.getPeer(), virtualHost);
+			if (identity == null) {
+				AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, session.getPeer());
+				throw new HandshakeException(
+						String.format(
+								"No Identity found for peer [address: %s, virtual host: %s]",
+								session.getPeer(), virtualHostName),
+						alert);
+			} else {
+				this.psk = pskStore.getKey(virtualHost, identity);
+				if (psk == null) {
+					AlertMessage alert = new AlertMessage(AlertLevel.FATAL,	AlertDescription.HANDSHAKE_FAILURE, session.getPeer());
+					throw new HandshakeException(
+							String.format("No pre-shared key found for [virtual host: %s, identity: %s]",
+									virtualHostName, identity),
+							alert);
+				} else {
+					this.pskIdentity = new PreSharedKeyIdentity(virtualHostName, identity);
+				}
+			}
+		} else {
+			identity = pskStore.getIdentity(session.getPeer());
+			if (identity == null) {
+				AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, session.getPeer());
+				throw new HandshakeException(
+						String.format("No Identity found for peer [address: %s]", session.getPeer()), alert);
+			} else {
+				this.psk = pskStore.getKey(identity);
+				if (psk == null) {
+					AlertMessage alert = new AlertMessage(AlertLevel.FATAL,	AlertDescription.HANDSHAKE_FAILURE, session.getPeer());
+					throw new HandshakeException(
+							String.format("No pre-shared key found for [identity: %s]", identity), alert);
+				} else {
+					this.pskIdentity = new PreSharedKeyIdentity(identity);
+				}
+			}
+		}		
+	}
+	
+	/**
+	 * This method returns the psk identity either for the virtual host hosted on session's peer 
+	 * or for the session's peer itself.
+	 * 
+	 * @return {@code PreSharedKeyIdentity}
+	 */
+	public PreSharedKeyIdentity getPskIdentity() {
+		return this.pskIdentity;
+	}
+	
+	/**
+	 * This method returns the pre shared key for the current 
+	 * {@code DTLSSession} and {@code PskStore}.
+	 * 
+	 * @return byte array
+	 */
+	public byte[] getPreSharedKey(){
+		return this.psk;
+	}
+}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -38,6 +38,7 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - move correlation tests to
  *                                                    DTLSCorrelationTest.
  *    Achim Kraus (Bosch Software Innovations GmbH) - add tests for automatic resumption
+ *    Vikram (University of Rostock) - add tests to check ECDHE_PSK CipherSuite   
  ******************************************************************************/
 package org.eclipse.californium.scandium;
 
@@ -191,7 +192,8 @@ public class DTLSConnectorTest {
 						CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
 						CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
 						CipherSuite.TLS_PSK_WITH_AES_128_CCM_8,
-						CipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA256})
+						CipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA256,
+						CipherSuite.TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256})
 			.setIdentity(DtlsTestTools.getPrivateKey(), DtlsTestTools.getServerCertificateChain(), true)
 			.setTrustStore(DtlsTestTools.getTrustedCertificates())
 			.setPskStore(pskStore)
@@ -1523,7 +1525,18 @@ public class DTLSConnectorTest {
 		assertFalse(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
 		assertThat(alert.get(), is(nullValue()));
 	}
-
+	
+	@Test
+	public void testConnectorEstablishSessionWithEcdhPskCBCSuite() throws Exception {
+		clientConfig = new DtlsConnectorConfig.Builder()
+				.setAddress(clientEndpoint)
+				.setPskStore(new StaticPskStore(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()))
+				.setSupportedCipherSuites(new CipherSuite[] {CipherSuite.TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256})
+				.build();
+			client = new DTLSConnector(clientConfig, clientConnectionStore);
+			givenAnEstablishedSession();
+	}
+	
 	/**
 	 * Verifies that the connector can successfully establish a session using a CBC based cipher suite.
 	 */

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/config/DtlsConnectorConfigTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/config/DtlsConnectorConfigTest.java
@@ -17,6 +17,7 @@
  *    Kai Hudalla (Bosch Software Innovations GmbH) - fix bug 483559
  *    Achim Kraus (Bosch Software Innovations GmbH) - Replace getLocalHost() by
  *                                                    getLoopbackAddress()
+ *    Vikram (University of Rostock) - add test to check ECDHE_PSK CipherSuite 
  ******************************************************************************/
 package org.eclipse.californium.scandium.config;
 
@@ -72,7 +73,7 @@ public class DtlsConnectorConfigTest {
 		DtlsConnectorConfig config = builder.setPskStore(new StaticPskStore("ID", "KEY".getBytes())).build();
 		assertTrue(config.getSupportedCipherSuites().length > 0);
 		for (CipherSuite suite : config.getSupportedCipherSuites()) {
-			assertThat(suite.getKeyExchange(), is(KeyExchangeAlgorithm.PSK));
+			assertThat(suite.getKeyExchange(), either(is(KeyExchangeAlgorithm.PSK)).or(is(KeyExchangeAlgorithm.ECDHE_PSK)));
 		}
 	}
 
@@ -94,15 +95,19 @@ public class DtlsConnectorConfigTest {
 				.build();
 		int ecDhSuitesCount = 0;
 		int pskSuitesCount = 0;
+		int dhPskSuitesCount = 0;
 		for (CipherSuite suite : config.getSupportedCipherSuites()) {
 			if (KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN.equals(suite.getKeyExchange())) {
 				ecDhSuitesCount++;
 			} else if (KeyExchangeAlgorithm.PSK.equals(suite.getKeyExchange())) {
 				pskSuitesCount++;
+			} else if (KeyExchangeAlgorithm.ECDHE_PSK.equals(suite.getKeyExchange())) {
+				dhPskSuitesCount++;
 			}
 		}
 		assertTrue(ecDhSuitesCount > 0);
 		assertTrue(pskSuitesCount > 0);
+		assertTrue(dhPskSuitesCount > 0);
 	}
 
 	@Test(expected = IllegalStateException.class)

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchangeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchangeTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright 2018 University of Rostock, Institute of Applied Microelectronics and Computer Engineering
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Vikram (University of Rostock)- Initial creation, adapted from ECDHServerKeyExchangeTest
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+
+import org.eclipse.californium.scandium.category.Small;
+import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
+import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
+import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedGroup;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Small.class)
+public class EcdhPskClientKeyExchangeTest {
+
+	EcdhPskClientKeyExchange msg;
+	InetSocketAddress peerAddress = new InetSocketAddress(5000);
+	byte[] ephemeralKeyPointEncoded;
+	String identity;
+	
+	@Before
+	public void setUp() throws Exception {
+
+		SupportedGroup usableGroup = SupportedGroup.secp256r1;
+		ECDHECryptography ecdhe = ECDHECryptography.fromNamedCurveId(usableGroup.getId());
+		msg = new EcdhPskClientKeyExchange("ID", ecdhe.getPublicKey(), peerAddress);
+		ephemeralKeyPointEncoded = msg.getEncodedPoint();
+		identity = msg.getIdentity();
+	}
+	
+	@Test
+	public void testInstanceToString() {
+		String toString = msg.toString();
+		assertNotNull(toString);
+	}
+
+	@Test
+	public void testDeserializedMsg() throws HandshakeException {
+		byte[] serializedMsg = msg.toByteArray();
+		HandshakeMessage handshakeMsg = HandshakeMessage.fromByteArray(
+				serializedMsg, KeyExchangeAlgorithm.ECDHE_PSK, false, peerAddress);
+		assertTrue(((EcdhPskClientKeyExchange)handshakeMsg).getIdentity().equals(identity));
+		assertNotNull(ephemeralKeyPointEncoded);
+		assertTrue((Arrays.equals(((EcdhPskClientKeyExchange)handshakeMsg).getEncodedPoint(), ephemeralKeyPointEncoded)));
+	}
+}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchangeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchangeTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright 2018 University of Rostock, Institute of Applied Microelectronics and Computer Engineering
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Vikram (University of Rostock)- Initial creation, adapted from ECDHServerKeyExchangeTest
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetSocketAddress;
+import java.security.interfaces.ECPublicKey;
+
+import org.eclipse.californium.scandium.category.Small;
+import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
+import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
+import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedGroup;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Small.class)
+public class EcdhPskServerKeyExchangeTest {
+	
+	EcdhPskServerKeyExchange msg;
+	InetSocketAddress peerAddress = new InetSocketAddress(5000);
+	ECPublicKey ephemeralPubKey;
+	
+	@Before
+	public void setUp() throws Exception {
+
+		SupportedGroup usableGroup = SupportedGroup.secp256r1;
+		msg = new EcdhPskServerKeyExchange(ECDHECryptography.fromNamedCurveId(usableGroup.getId()),
+				new Random(),
+				new Random(),
+				usableGroup.getId(),
+				peerAddress);
+		ephemeralPubKey = msg.getPublicKey();
+	}
+	
+	@Test
+	public void testInstanceToString() {
+		String toString = msg.toString();
+		assertNotNull(toString);
+	}
+
+	@Test
+	public void testDeserializedMsg() throws HandshakeException {
+		byte[] serializedMsg = msg.toByteArray();
+		HandshakeMessage handshakeMsg = HandshakeMessage.fromByteArray(
+				serializedMsg, KeyExchangeAlgorithm.ECDHE_PSK, false, peerAddress);		
+		assertTrue(((EcdhPskServerKeyExchange)handshakeMsg).getCurveId() == SupportedGroup.secp256r1.getId());
+		assertNotNull(ephemeralPubKey);
+		assertTrue(((EcdhPskServerKeyExchange)handshakeMsg).getPublicKey().equals(ephemeralPubKey));
+	}
+}


### PR DESCRIPTION
This pull request as per https://tools.ietf.org/html/rfc5489#section-2, adds an additional cipher suite that use a PSK to authenticate a ECDH exchange. This cipher suite protects from dictionary attacks and provides Perfect Forward Secrecy (PFS) while using pre shared keys.
https://github.com/eclipse/californium/issues/656