### PR TITLE
Cleanup (de-)serialization.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/OptionSet.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/OptionSet.java
@@ -144,7 +144,9 @@ public final class OptionSet {
 	 * @param origin the origin to be copied
 	 */
 	public OptionSet(OptionSet origin) {
-		if (origin == null) throw new NullPointerException();
+		if (origin == null) {
+			throw new NullPointerException("option set must not be null!");
+		}
 		if_match_list       = copyList(origin.if_match_list);
 		uri_host            = origin.uri_host;
 		etag_list           = copyList(origin.etag_list);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataParser.java
@@ -22,6 +22,7 @@
  *                                                 to MessageFormatException
  * Achim Kraus (Bosch Software Innovations GmbH) - add EndpointContext when parsing
  *                                                 RawData. 
+ * Achim Kraus (Bosch Software Innovations GmbH) - expose parseOptionsAndPayload
  ******************************************************************************/
 package org.eclipse.californium.core.network.serialization;
 
@@ -30,6 +31,8 @@ import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.util.DatagramReader;
 
 import static org.eclipse.californium.core.coap.CoAP.MessageFormat.PAYLOAD_MARKER;
+
+import java.io.ByteArrayInputStream;
 
 /**
  * A base class for parsing CoAP messages from a byte array.
@@ -41,9 +44,14 @@ public abstract class DataParser {
 	 * 
 	 * @param raw contains the byte array to parse.
 	 * @return the message.
-	 * @throws MessageFormatException if the array cannot be parsed into a message.
+	 * @throws MessageFormatException if the raw-data byte array cannot be
+	 *             parsed into a message.
+	 * @throws NullPointerException if the raw-data is {@code null}.
 	 */
 	public final Message parseMessage(final RawData raw) {
+		if (raw == null) {
+			throw new NullPointerException("raw-data must not be null!");
+		}
 		Message message = parseMessage(raw.getBytes());
 		message.setSourceContext(raw.getEndpointContext());
 		return message;
@@ -59,7 +67,7 @@ public abstract class DataParser {
 	public final Message parseMessage(final byte[] msg) {
 
 		String errorMsg = "illegal message code";
-		DatagramReader reader = new DatagramReader(msg);
+		DatagramReader reader = new DatagramReader(new ByteArrayInputStream(msg));
 		MessageHeader header = parseHeader(reader);
 		try {
 			Message message = null;
@@ -94,18 +102,6 @@ public abstract class DataParser {
 
 	/**
 	 * Parses a byte array into a CoAP message header.
-	 * 
-	 * @param raw contains the byte array to parse.
-	 * @return the message header the array has been parsed into.
-	 * @throws MessageFormatException if the array cannot be parsed into a message header.
-	 */
-	public final MessageHeader parseHeader(RawData raw) {
-		DatagramReader reader = new DatagramReader(raw.getBytes());
-		return parseHeader(reader);
-	}
-
-	/**
-	 * Parses a byte array into a CoAP message header.
 	 * <p>
 	 * Subclasses need to override this method according to the concrete type of message
 	 * encoding to support.
@@ -130,7 +126,21 @@ public abstract class DataParser {
 		}
 	}
 
-	private static void parseOptionsAndPayload(DatagramReader reader, Message message) {
+	/**
+	 * Parse options and payload from reader.
+	 * 
+	 * @param reader reader that contains the bytes to parse
+	 * @param message message to set parsed options and payload
+	 * @throws NullPointerException if one of the provided parameters is
+	 *             {@code null}
+	 */
+	public static void parseOptionsAndPayload(DatagramReader reader, Message message) {
+		if (reader == null) {
+			throw new NullPointerException("reader must not be null!");
+		}
+		if (message == null) {
+			throw new NullPointerException("message must not be null!");
+		}
 		int currentOptionNumber = 0;
 		byte nextByte = 0;
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataParser.java
@@ -37,8 +37,7 @@ import static org.eclipse.californium.core.coap.CoAP.MessageFormat.*;
 public final class TcpDataParser extends DataParser {
 
 	@Override
-	public MessageHeader parseHeader(final DatagramReader reader) {
-
+	protected MessageHeader parseHeader(final DatagramReader reader) {
 		int len = reader.read(LENGTH_NIBBLE_BITS);
 		int tokenLength = reader.read(TOKEN_LENGTH_BITS);
 		int lengthSize = 0;

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataSerializerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataSerializerTest.java
@@ -45,7 +45,6 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-
 /**
  * Verifies behavior of the common functionality of data serializers.
  */
@@ -68,7 +67,7 @@ public class DataSerializerTest {
 	 */
 	@Parameters
 	public static DataSerializer[] getSerializers() {
-		return new DataSerializer[]{new UdpDataSerializer(), new TcpDataSerializer()};
+		return new DataSerializer[] { new UdpDataSerializer(), new TcpDataSerializer() };
 	}
 
 	/**
@@ -79,7 +78,7 @@ public class DataSerializerTest {
 
 		// GIVEN a CoAP request
 		Request req = Request.newGet();
-		req.setToken(new byte[]{0x00});
+		req.setToken(new byte[] { 0x00 });
 		req.getOptions().setObserve(0);
 
 		// WHEN serializing the request to a byte array
@@ -97,7 +96,7 @@ public class DataSerializerTest {
 
 		// GIVEN a CoAP request
 		Request req = Request.newGet();
-		req.setToken(new byte[]{0x00});
+		req.setToken(new byte[] { 0x00 });
 		req.getOptions().setObserve(0);
 		req.setDestinationContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramReader.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramReader.java
@@ -14,6 +14,8 @@
  *    Matthias Kovatsch - creator and main architect
  *    Stefan Jucker - DTLS implementation
  *    Achim Kraus (Bosch Software Innovations GmbH) - add "mark" and "reset"
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add constructor without 
+ *                                                    cloning of the provided data.
  ******************************************************************************/
 package org.eclipse.californium.elements.util;
 
@@ -50,9 +52,21 @@ public final class DatagramReader {
 	 * @param byteArray The byte array to read from.
 	 */
 	public DatagramReader(final byte[] byteArray) {
+		this(new ByteArrayInputStream(Arrays.copyOf(byteArray, byteArray.length)));
+	}
 
+	/**
+	 * Creates a new reader for an bytes stream.
+	 * 
+	 * @param byteStream The byte stream to read from.
+	 * @throws NullPointerException, if byte stream is {@code null}
+	 */
+	public DatagramReader(final ByteArrayInputStream byteStream) {
+		if (byteStream == null) {
+			throw new NullPointerException("byte stream must not be null!");
+		}
 		// initialize underlying byte stream
-		byteStream = new ByteArrayInputStream(Arrays.copyOf(byteArray, byteArray.length));
+		this.byteStream = byteStream;
 
 		// initialize bit buffer
 		currentByte = 0;

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramWriter.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramWriter.java
@@ -13,10 +13,13 @@
  * Contributors:
  *    Matthias Kovatsch - creator and main architect
  *    Stefan Jucker - DTLS implementation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add methods to reduce
+ *                                                    required clones.
  ******************************************************************************/
 package org.eclipse.californium.elements.util;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 /**
  * This class describes the functionality to write raw network-ordered datagrams
@@ -175,12 +178,21 @@ public final class DatagramWriter {
 		return byteArray;
 	}
 
-	// Utilities ///////////////////////////////////////////////////////////////
+	public void write(DatagramWriter data) {
+		try {
+			data.byteStream.writeTo(byteStream);
+		} catch (IOException e) {
+		}
+	}
+
+	public int size() {
+		return byteStream.size();
+	}
 
 	/**
 	 * Writes pending bits to the stream.
 	 */
-	private void writeCurrentByte() {
+	public void writeCurrentByte() {
 
 		if (currentBitIndex < Byte.SIZE - 1) {
 
@@ -190,6 +202,8 @@ public final class DatagramWriter {
 			currentBitIndex = Byte.SIZE - 1;
 		}
 	}
+
+	// Utilities ///////////////////////////////////////////////////////////////
 
 	@Override
 	public String toString() {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -1220,7 +1220,7 @@ public class DTLSConnector implements Connector {
 			throw new NullPointerException("Message must not be null");
 		} else if (!running.get()) {
 			throw new IllegalStateException("connector must be started before sending messages is possible");
-		} else if (msg.getBytes().length > MAX_PLAINTEXT_FRAGMENT_LENGTH) {
+		} else if (msg.getSize() > MAX_PLAINTEXT_FRAGMENT_LENGTH) {
 			throw new IllegalArgumentException("Message data must not exceed "
 					+ MAX_PLAINTEXT_FRAGMENT_LENGTH + " bytes");
 		} else {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ApplicationMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ApplicationMessage.java
@@ -15,11 +15,11 @@
  *    Stefan Jucker - DTLS implementation
  *    Kai Hudalla (Bosch Software Innovations GmbH) - add accessor for message type
  *    Kai Hudalla (Bosch Software Innovations GmbH) - add accessor for peer address
+ *    Achim Kraus (Bosch Software Innovations GmbH) - remove cloning of byte array
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
 import java.net.InetSocketAddress;
-import java.util.Arrays;
 
 import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.util.ByteArrayUtils;
@@ -41,16 +41,18 @@ public final class ApplicationMessage extends AbstractMessage {
 
 	/**
 	 * Creates a new <em>APPLICATION_DATA</em> message containing specific data.
+	 * <p>
+	 * The given byte array will not be cloned/copied, i.e. any changes made to
+	 * the byte array after this method has been invoked will be exposed in the
+	 * message's payload.
 	 * 
-	 * @param data
-	 *            the application data.
-	 * @param peerAddress
-	 *            the IP address and port the message is to be sent to or has been
-	 *            received from
+	 * @param data byte array with the application data.
+	 * @param peerAddress the IP address and port the message is to be sent to
+	 *            or has been received from
 	 */
 	public ApplicationMessage(byte[] data, InetSocketAddress peerAddress) {
 		super(peerAddress);
-		this.data = Arrays.copyOf(data, data.length);
+		this.data = data;
 	}
 
 	// Methods ////////////////////////////////////////////////////////
@@ -74,6 +76,18 @@ public final class ApplicationMessage extends AbstractMessage {
 		return data;
 	}
 
+	/**
+	 * Create message from byte array.
+	 * <p>
+	 * The given byte array will not be cloned/copied, i.e. any changes made to
+	 * the byte array after this method has been invoked will be exposed in the
+	 * message's payload.
+	 * 
+	 * @param byteArray byte array with the application data.
+	 * @param peerAddress peer's address
+	 * @return created message
+	 * @see #ApplicationMessage(byte[], InetSocketAddress)
+	 */
 	public static DTLSMessage fromByteArray(byte[] byteArray, InetSocketAddress peerAddress) {
 		return new ApplicationMessage(byteArray, peerAddress);
 	}


### PR DESCRIPTION
Expose (de-)serialization of options and payload.
Reduce clones of payload byte arrays.
Mainly intended to make serializers reusable for oscore.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>