### PR TITLE
Replace getLocalHost() by getLoopbackAddress().

### DIFF
--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/config/DtlsConnectorConfigTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/config/DtlsConnectorConfigTest.java
@@ -15,6 +15,8 @@
  *    Kai Hudalla (Bosch Software Innovations GmbH) - add support for anonymous client-only
  *                                                    configuration
  *    Kai Hudalla (Bosch Software Innovations GmbH) - fix bug 483559
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Replace getLocalHost() by
+ *                                                    getLoopbackAddress()
  ******************************************************************************/
 package org.eclipse.californium.scandium.config;
 
@@ -46,7 +48,7 @@ public class DtlsConnectorConfigTest {
 
 	@Before
 	public void setUp() throws Exception {
-		endpoint =  new InetSocketAddress(InetAddress.getLocalHost(), 10000);
+		endpoint =  new InetSocketAddress(InetAddress.getLoopbackAddress(), 10000);
 		builder = new DtlsConnectorConfig.Builder().setAddress(endpoint);
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
@@ -21,6 +21,8 @@
  *                                                    add testServerCertExtPrefersX509WithEmptyTrustStore
  *                                                    trustStore := null, disable x.509
  *                                                    trustStore := [], enable x.509, trust all
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Replace getLocalHost() by
+ *                                                    getLoopbackAddress()
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -187,7 +189,7 @@ public class ClientHandshakerTest {
 
 		DtlsConnectorConfig.Builder builder = 
 				new DtlsConnectorConfig.Builder()
-					.setAddress(new InetSocketAddress(InetAddress.getLocalHost(), 0))
+					.setAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0))
 					.setIdentity(
 						DtlsTestTools.getClientPrivateKey(),
 						DtlsTestTools.getClientCertificateChain(),

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HelloExtensionsTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HelloExtensionsTest.java
@@ -13,6 +13,8 @@
  * Contributors:
  *    Kai Hudalla, Bosch Software Innovations GmbH
  *    Kai Hudalla (Bosch Software Innovations GmbH) - adapt to HelloExtensions changes
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Replace getLocalHost() by
+ *                                                    getLoopbackAddress()
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -43,7 +45,7 @@ public class HelloExtensionsTest {
 
 	@Before
 	public void setUp() throws UnknownHostException {
-		peerAddress = new InetSocketAddress(InetAddress.getLocalHost(), 5684);
+		peerAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), 5684);
 	}
 
 	@Test

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordTest.java
@@ -14,6 +14,8 @@
  *    Matthias Kovatsch - creator and main architect
  *    Stefan Jucker - DTLS implementation
  *    Kai Hudalla (Bosch Software Innovations GmbH) - add test cases for verifying sequence number handling
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Replace getLocalHost() by
+ *                                                    getLoopbackAddress()
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -68,7 +70,7 @@ public class RecordTest {
 		for ( int i = 0; i < payloadLength; i++) {
 			payloadData[i] = 0x34;
 		}
-		session = new DTLSSession(new InetSocketAddress(InetAddress.getLocalHost(), 7000), true);
+		session = new DTLSSession(new InetSocketAddress(InetAddress.getLoopbackAddress(), 7000), true);
 		DTLSConnectionState readState = new DTLSConnectionState(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
 				CompressionMethod.NULL, key, new IvParameterSpec(client_iv), null);
 		session.setReadState(readState);


### PR DESCRIPTION
In rare case the test may fail cause by DNS issues, which are not part of the test.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>