### PR TITLE
Add deliver duplicate to exchange.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -43,6 +43,7 @@
  *                                                    Issue #487
  *    Achim Kraus (Bosch Software Innovations GmbH) - add checkMID to support
  *                                                    rejection of previous notifications
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add deliver duplicate
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -69,6 +70,7 @@ import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.stack.BlockwiseLayer;
 import org.eclipse.californium.core.network.stack.CoapStack;
 import org.eclipse.californium.core.observe.ObserveRelation;
+import org.eclipse.californium.core.server.MessageDeliverer;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.elements.EndpointContext;
 import org.slf4j.Logger;
@@ -91,7 +93,8 @@ import org.slf4j.LoggerFactory;
  * {@link #execute(StripedExchangeJob)}. For convenience the
  * {@link #executeComplete()} is provided to execute {@link #setComplete()}
  * accordingly. Methods, which are documented to throw a
- * {@link ConcurrentModificationException}MUST comply to this execution pattern!
+ * {@link ConcurrentModificationException} MUST comply to this execution
+ * pattern!
  * <p>
  * If the exchange represents a "blockwise" transfer and if the transparent mode
  * is used, the exchange keeps also the (original) request and use the current
@@ -252,6 +255,21 @@ public class Exchange {
 	// The relation that the target resource has established with the source
 	private volatile ObserveRelation relation;
 
+	/**
+	 * Indicates, that the current request is already answered. Access is
+	 * synchronized in scope of {@link #deliverDuplicatesCounter}.
+	 */
+	private boolean currentRequestAnswered;
+	/**
+	 * Indicates, that a duplicate request without answer should be passed to
+	 * the {@link MessageDeliverer}.
+	 */
+	private boolean deliverDuplicate;
+	/**
+	 * Counter for delivered duplicate requests.
+	 */
+	private final AtomicInteger deliverDuplicatesCounter = new AtomicInteger();
+
 	private final AtomicReference<EndpointContext> endpointContext = new AtomicReference<EndpointContext>();
 
 	//If object security option is used, the Cryptographic context identifier is stored here
@@ -341,9 +359,20 @@ public class Exchange {
 	 * Accept this exchange and therefore the request. Only if the request's
 	 * type was a <code>CON</code> and the request has not been acknowledged
 	 * yet, it sends an ACK to the client.
+	 * 
+	 * @throws IllegalStateException if {@link #setupDeliverDuplicate(int)} was
+	 *             called before, but {@link #checkCurrentResponse(Response)}
+	 *             wasn't called to indicate the intended request
+	 *             retransmission.
 	 */
 	public void sendAccept() {
 		assert (origin == Origin.REMOTE);
+		synchronized (deliverDuplicatesCounter) {
+			if (deliverDuplicate) {
+				throw new IllegalStateException("Accept not allowed while waiting for request retransmission!");
+			}
+			currentRequestAnswered = true;
+		}
 		Request current = currentRequest;
 		if (current.getType() == Type.CON && !current.isAcknowledged()) {
 			current.setAcknowledged(true);
@@ -355,9 +384,20 @@ public class Exchange {
 	/**
 	 * Reject this exchange and therefore the request. Sends an RST back to the
 	 * client.
+	 * 
+	 * @throws IllegalStateException if {@link #setupDeliverDuplicate(int)} was
+	 *             called before, but {@link #checkCurrentResponse(Response)}
+	 *             wasn't called to indicate the intended request
+	 *             retransmission.
 	 */
 	public void sendReject() {
 		assert (origin == Origin.REMOTE);
+		synchronized (deliverDuplicatesCounter) {
+			if (deliverDuplicate) {
+				throw new IllegalStateException("Reject not allowed while waiting for request retransmission!");
+			}
+			currentRequestAnswered = true;
+		}
 		Request current = currentRequest;
 		current.setRejected(true);
 		EmptyMessage rst = EmptyMessage.newRST(current);
@@ -371,6 +411,10 @@ public class Exchange {
 	 * @param response the response
 	 */
 	public void sendResponse(Response response) {
+		synchronized (deliverDuplicatesCounter) {
+			deliverDuplicate = false;
+			currentRequestAnswered = true;
+		}
 		Request current = currentRequest;
 		response.setDestinationContext(current.getSourceContext());
 		endpoint.sendResponse(this, response);
@@ -464,23 +508,32 @@ public class Exchange {
 		if (currentRequest != newCurrentRequest) {
 			setRetransmissionHandle(null);
 			failedTransmissionCount = 0;
-			Token token = currentRequest.getToken();
-			if (token != null) {
-				if (token.equals(newCurrentRequest.getToken())) {
-					token = null;
-				} else if (keepRequestInStore && token.equals(request.getToken())) {
-					token = null;
+			if (origin == Origin.LOCAL) {
+				Token token = currentRequest.getToken();
+
+				if (token != null) {
+					if (token.equals(newCurrentRequest.getToken())) {
+						token = null;
+					} else if (keepRequestInStore && token.equals(request.getToken())) {
+						token = null;
+					}
 				}
-			}
-			KeyMID key = null;
-			if (currentRequest.hasMID() && currentRequest.getMID() != newCurrentRequest.getMID()) {
-				key = KeyMID.fromOutboundMessage(currentRequest);
-			}
-			if (token != null || key != null) {
-				LOGGER.info("{} replace {} by {}", this, currentRequest, newCurrentRequest);
-				RemoveHandler obs = this.removeHandler;
-				if (obs != null) {
-					obs.remove(this, token, key);
+				KeyMID key = null;
+				if (currentRequest.hasMID() && currentRequest.getMID() != newCurrentRequest.getMID()) {
+					key = KeyMID.fromOutboundMessage(currentRequest);
+				}
+				if (token != null || key != null) {
+					LOGGER.info("{} replace {} by {}", this, currentRequest, newCurrentRequest);
+					RemoveHandler obs = this.removeHandler;
+					if (obs != null) {
+						obs.remove(this, token, key);
+					}
+				}
+			} else if (!newCurrentRequest.isDuplicate()) {
+				synchronized (deliverDuplicatesCounter) {
+					deliverDuplicate = false;
+					currentRequestAnswered = false;
+					deliverDuplicatesCounter.set(0);
 				}
 			}
 			currentRequest = newCurrentRequest;
@@ -533,11 +586,13 @@ public class Exchange {
 	public void setCurrentResponse(Response newCurrentResponse) {
 		assertOwner();
 		if (currentResponse != newCurrentResponse) {
-			if (currentResponse != null && currentResponse.getType() == Type.CON && currentResponse.hasMID()) {
-				RemoveHandler handler = this.removeHandler;
-				if (handler != null) {
-					KeyMID key = KeyMID.fromOutboundMessage(currentResponse);
-					handler.remove(this, null, key);
+			if (origin == Origin.REMOTE) {
+				if (currentResponse != null && currentResponse.getType() == Type.CON && currentResponse.hasMID()) {
+					RemoveHandler handler = this.removeHandler;
+					if (handler != null) {
+						KeyMID key = KeyMID.fromOutboundMessage(currentResponse);
+						handler.remove(this, null, key);
+					}
 				}
 			}
 			currentResponse = newCurrentResponse;
@@ -659,6 +714,60 @@ public class Exchange {
 	 */
 	public void setEndpoint(Endpoint endpoint) {
 		this.endpoint = endpoint;
+	}
+
+	/**
+	 * Check, if the duplicated request should be delivered.
+	 * 
+	 * A duplicated request should be delivered, if
+	 * {@link #setupDeliverNextDuplicate(int)} was called successfully before.
+	 * Duplicate request for an already answered request should not be delivered
+	 * again and will return {@code false}. Successive calls to this method
+	 * without successful calls to {@link #setupDeliverDuplicate(int)} will also
+	 * return {@code false}.
+	 * 
+	 * Intended to be used for "short term" congestion control.
+	 * 
+	 * @return {@code true} if duplicate should be delivered, {@code false} if
+	 *         duplicate should be ignored.
+	 */
+	public boolean checkDeliverDuplicate() {
+		synchronized (deliverDuplicatesCounter) {
+			if (deliverDuplicate) {
+				deliverDuplicate = false;
+				deliverDuplicatesCounter.incrementAndGet();
+				return true;
+			} else {
+				return false;
+			}
+		}
+	}
+
+	/**
+	 * Setup exchange to deliver the next duplicate request.
+	 * 
+	 * The provided threshold limits the number of delivered duplicate
+	 * requests, not the number of calls of this method.
+	 * 
+	 * Intended to be used for "short term" congestion control. If the threshold
+	 * is reached, the congestion last longer and a response with 5.03 will be
+	 * more appreciated.
+	 * 
+	 * @param threshold threshold for delivered duplicate requests.
+	 * @return {@code true} if duplicate would be delivered, {@code false}, if
+	 *         threshold of delivered duplicates is reached, the request was
+	 *         already answered, or it's not a CON request.
+	 */
+	public boolean setupDeliverDuplicate(int threshold) {
+		if (!currentRequest.isConfirmable()) {
+			return false;
+		}
+		synchronized (deliverDuplicatesCounter) {
+			if (!currentRequestAnswered && !deliverDuplicate && deliverDuplicatesCounter.get() < threshold) {
+				deliverDuplicate = true;
+			}
+			return deliverDuplicate;
+		}
 	}
 
 	/**

--- a/californium-core/src/test/java/org/eclipse/californium/core/DummyEndpoint.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/DummyEndpoint.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH               - initial creation
+ *                                                    moved from ResourceAttributesTest
+ ******************************************************************************/
+package org.eclipse.californium.core;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.Token;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.EndpointObserver;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
+import org.eclipse.californium.core.observe.NotificationListener;
+import org.eclipse.californium.core.server.MessageDeliverer;
+
+public class DummyEndpoint implements Endpoint {
+
+	@Override
+	public void start() throws IOException {
+	}
+
+	@Override
+	public void stop() {
+	}
+
+	@Override
+	public void destroy() {
+	}
+
+	@Override
+	public void clear() {
+	}
+
+	@Override
+	public boolean isStarted() {
+		return false;
+	}
+
+	@Override
+	public void setExecutor(ScheduledExecutorService executor) {
+	}
+
+	@Override
+	public void addObserver(EndpointObserver obs) {
+	}
+
+	@Override
+	public void removeObserver(EndpointObserver obs) {
+	}
+
+	@Override
+	public void addNotificationListener(NotificationListener lis) {
+	}
+
+	@Override
+	public void removeNotificationListener(NotificationListener lis) {
+	}
+
+	@Override
+	public void addInterceptor(MessageInterceptor interceptor) {
+	}
+
+	@Override
+	public void removeInterceptor(MessageInterceptor interceptor) {
+	}
+
+	@Override
+	public List<MessageInterceptor> getInterceptors() {
+		return null;
+	}
+
+	@Override
+	public void sendRequest(Request request) {
+	}
+
+	@Override
+	public void sendResponse(Exchange exchange, Response response) {
+		exchange.setResponse(response);
+	}
+
+	@Override
+	public void sendEmptyMessage(Exchange exchange, EmptyMessage message) {
+	}
+
+	@Override
+	public void setMessageDeliverer(MessageDeliverer deliverer) {
+	}
+
+	@Override
+	public InetSocketAddress getAddress() {
+		return null;
+	}
+
+	@Override
+	public URI getUri() {
+		return null;
+	}
+
+	@Override
+	public NetworkConfig getConfig() {
+		return null;
+	}
+
+	@Override
+	public void cancelObservation(Token token) {
+	}
+	
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/ExchangeTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/ExchangeTest.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH               - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetAddress;
+
+import org.eclipse.californium.category.Small;
+import org.eclipse.californium.core.DummyEndpoint;
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange.Origin;
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Small.class)
+public class ExchangeTest {
+
+	private Exchange exchange;
+
+	@Before
+	public void setUp() {
+		Request request = Request.newGet();
+		request.setMID(1);
+		request.setSourceContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
+		exchange = new Exchange(request, Origin.REMOTE, null);
+		exchange.setEndpoint(new DummyEndpoint());
+	}
+
+	@Test
+	public void testSetupDeliverDuplicate() {
+		// setup to deliver one duplicate request
+		assertTrue("could not setup deliver next duplicate", exchange.setupDeliverDuplicate(1));
+		// setup to deliver one duplicate request,
+		// but still haven't received that duplicate
+		assertTrue("could not setup deliver next duplicate twice", exchange.setupDeliverDuplicate(1));
+		// received duplicate, check delivery
+		assertTrue("deliver next duplicate is disabled", exchange.checkDeliverDuplicate());
+		// setup to deliver one duplicate request fails,
+		// because this duplicate has already been received
+		assertFalse("setup deliver next duplicate, should fail with threshold",
+				exchange.setupDeliverDuplicate(1));
+		// but setup to deliver a second duplicate request succeeds
+		assertTrue("could not setup deliver second duplicate", exchange.setupDeliverDuplicate(2));
+	}
+
+	@Test
+	public void testCheckDeliverDuplicate() {
+		// check deliver duplicate default
+		assertFalse("deliver duplicate should be disabled by default", exchange.checkDeliverDuplicate());
+		// setup to deliver one duplicate request
+		assertTrue("could not setup deliver next duplicate", exchange.setupDeliverDuplicate(1));
+		// check deliver duplicate after setup
+		assertTrue("deliver next duplicate is disabled", exchange.checkDeliverDuplicate());
+		// check deliver next duplicate
+		assertFalse("deliver second duplicate without setup is endabled", exchange.checkDeliverDuplicate());
+		// setup to deliver second duplicate request
+		assertTrue("could not setup deliver second duplicate", exchange.setupDeliverDuplicate(2));
+		// check deliver duplicate after setup
+		assertTrue("deliver second duplicate is disabled", exchange.checkDeliverDuplicate());
+		// check deliver duplicate after setup
+		assertFalse("deliver second duplicate without setup is enabled", exchange.checkDeliverDuplicate());
+	}
+
+	@Test
+	public void testSetupDeliverDuplicateAfterAccept() {
+		// setup to deliver one duplicate request
+		assertTrue("could not setup deliver next duplicate", exchange.setupDeliverDuplicate(1));
+		assertTrue("deliver next duplicate is disabled", exchange.checkDeliverDuplicate());
+		exchange.sendAccept();
+		assertFalse("could setup deliver next duplicate after accept the request", exchange.setupDeliverDuplicate(2));
+	}
+
+	@Test
+	public void testSetupDeliverDuplicateAfterReject() {
+		// setup to deliver one duplicate request
+		assertTrue("could not setup deliver next duplicate", exchange.setupDeliverDuplicate(1));
+		assertTrue("deliver next duplicate is disabled", exchange.checkDeliverDuplicate());
+		exchange.sendReject();
+		assertFalse("could setup deliver next duplicate after reject the request", exchange.setupDeliverDuplicate(2));
+	}
+
+	@Test
+	public void testDeliverDuplicateAfterResponse() {
+		// setup to deliver one duplicate request
+		assertTrue("could not setup deliver next duplicate", exchange.setupDeliverDuplicate(1));
+		Response response = Response.createResponse(exchange.getCurrentRequest(), CoAP.ResponseCode.CONTENT);
+		exchange.sendResponse(response);
+		assertFalse("could setup deliver next duplicate after response", exchange.setupDeliverDuplicate(1));
+		assertFalse("deliver duplicate after response is enabled", exchange.checkDeliverDuplicate());
+	}
+
+	@Test
+	public void testDeliverDuplicateNewResponse() {
+		// setup to deliver one duplicate request
+		assertTrue("could not setup deliver next duplicate", exchange.setupDeliverDuplicate(1));
+		assertTrue("deliver next duplicate is disabled", exchange.checkDeliverDuplicate());
+		assertFalse("setup deliver next duplicate, should fail with threshold",
+				exchange.setupDeliverDuplicate(1));
+		Request newRequest = Request.newGet();
+		newRequest.setMID(exchange.getCurrentRequest().getMID() + 1);
+		exchange.setCurrentRequest(newRequest);
+		assertTrue("could not setup deliver next duplicate after new request", exchange.setupDeliverDuplicate(1));
+		assertTrue("deliver next duplicate is disabled", exchange.checkDeliverDuplicate());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testAcceptAfterSetupDeliverDuplicate() {
+		// setup to deliver one duplicate request
+		assertTrue("could not setup deliver next duplicate", exchange.setupDeliverDuplicate(1));
+		exchange.sendAccept();
+		assertFalse("could setup deliver next duplicate after accept the request", exchange.setupDeliverDuplicate(1));
+		assertFalse("deliver duplicate after accept is enabled", exchange.checkDeliverDuplicate());
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testRejectAfterSetupDeliverDuplicate() {
+		// setup to deliver one duplicate request
+		assertTrue("could not setup deliver next duplicate", exchange.setupDeliverDuplicate(1));
+		exchange.sendReject();
+		assertFalse("could setup deliver next duplicate after reject the request", exchange.setupDeliverDuplicate(1));
+		assertFalse("deliver duplicate after reject is enabled", exchange.checkDeliverDuplicate());
+	}
+
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceAttributesTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceAttributesTest.java
@@ -20,30 +20,17 @@
  ******************************************************************************/
 package org.eclipse.californium.core.test;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.URI;
 import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.DummyEndpoint;
 import org.eclipse.californium.core.coap.Request;
-import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
-import org.eclipse.californium.core.coap.EmptyMessage;
-import org.eclipse.californium.core.coap.Token;
-import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.EndpointManager;
-import org.eclipse.californium.core.network.EndpointObserver;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.MatcherTestUtils;
 import org.eclipse.californium.core.network.Exchange.Origin;
-import org.eclipse.californium.core.network.config.NetworkConfig;
-import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
-import org.eclipse.californium.core.observe.NotificationListener;
-import org.eclipse.californium.core.server.MessageDeliverer;
 import org.eclipse.californium.core.server.resources.DiscoveryResource;
 import org.eclipse.californium.core.server.resources.Resource;
 import org.junit.Assert;
@@ -124,99 +111,5 @@ public class ResourceAttributesTest {
 		discovery.handleRequest(exchange);
 		System.out.println(exchange.getResponse().getPayloadString());
 		Assert.assertEquals(ResponseCode.BAD_OPTION, exchange.getResponse().getCode());
-	}
-	
-	private static class DummyEndpoint implements Endpoint {
-
-		@Override
-		public void start() throws IOException {
-		}
-
-		@Override
-		public void stop() {
-		}
-
-		@Override
-		public void destroy() {
-		}
-
-		@Override
-		public void clear() {
-		}
-
-		@Override
-		public boolean isStarted() {
-			return false;
-		}
-
-		@Override
-		public void setExecutor(ScheduledExecutorService executor) {
-		}
-
-		@Override
-		public void addObserver(EndpointObserver obs) {
-		}
-
-		@Override
-		public void removeObserver(EndpointObserver obs) {
-		}
-
-		@Override
-		public void addNotificationListener(NotificationListener lis) {
-		}
-
-		@Override
-		public void removeNotificationListener(NotificationListener lis) {
-		}
-
-		@Override
-		public void addInterceptor(MessageInterceptor interceptor) {
-		}
-
-		@Override
-		public void removeInterceptor(MessageInterceptor interceptor) {
-		}
-
-		@Override
-		public List<MessageInterceptor> getInterceptors() {
-			return null;
-		}
-
-		@Override
-		public void sendRequest(Request request) {
-		}
-
-		@Override
-		public void sendResponse(Exchange exchange, Response response) {
-			exchange.setResponse(response);
-		}
-
-		@Override
-		public void sendEmptyMessage(Exchange exchange, EmptyMessage message) {
-		}
-
-		@Override
-		public void setMessageDeliverer(MessageDeliverer deliverer) {
-		}
-
-		@Override
-		public InetSocketAddress getAddress() {
-			return null;
-		}
-
-		@Override
-		public URI getUri() {
-			return null;
-		}
-
-		@Override
-		public NetworkConfig getConfig() {
-			return null;
-		}
-
-		@Override
-		public void cancelObservation(Token token) {
-		}
-		
 	}
 }


### PR DESCRIPTION
If coap requests are forwarded into a "back pressure" mechanism, this extension enables the coap stack to explicit wait for a retransmission of a request to overcome a short time overload of the system. Overloads with longer duration may still be answered by 5.03 to indicate such a longer overload to the client.
This extension is intended to be used for the hono coap-adapter.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>