### PR TITLE
Add tests to check there is no leak when error occurred before sending.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -889,6 +889,9 @@ public class BlockwiseLayer extends AbstractLayer {
 					 */
 					if (!response.isNotification()) {
 						block.setToken(response.getToken());
+					} else if (exchange.isNotification()) {
+						// Recreate cleanup message observer 
+						request.addMessageObserver(new CleanupMessageObserver(exchange));
 					}
 
 					// copy options
@@ -904,6 +907,7 @@ public class BlockwiseLayer extends AbstractLayer {
 					// add an observer that cleans up the block2 transfer tracker if the
 					// block request fails
 					addBlock2CleanUpObserver(block, key, status);
+					
 
 					status.setCurrentNum(nextNum);
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CleanupMessageObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CleanupMessageObserver.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ *                                      extracted from ExchangeCleanupLayer
+ ******************************************************************************/
+package org.eclipse.californium.core.network.stack;
+
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Cleanup exchange when user cancelled outgoing requests or messages which
+ * failed to be send.
+ */
+class CleanupMessageObserver extends MessageObserverAdapter {
+
+	static final Logger LOGGER = LoggerFactory.getLogger(CleanupMessageObserver.class.getName());
+
+	private final Exchange exchange;
+
+	CleanupMessageObserver(final Exchange exchange) {
+		this.exchange = exchange;
+	}
+
+	@Override
+	public void onCancel() {
+		complete("canceled");
+	}
+
+	@Override
+	public void failed() {
+		complete("failed");
+	}
+
+	private void complete(final String action) {
+		if (exchange.executeComplete()) {
+			if (exchange.isOfLocalOrigin()) {
+				Request request = exchange.getCurrentRequest();
+				LOGGER.debug("{}, {} request [MID={}, {}]", action, exchange, request.getMID(), request.getToken());
+			} else {
+				Response response = exchange.getCurrentResponse();
+				LOGGER.debug("{}, {} response [MID={}, {}]", action, exchange, response.getMID(), response.getToken());
+			}
+		}
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/CountingHandler.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/CountingHandler.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.californium.core.CoapHandler;
+import org.eclipse.californium.core.CoapResponse;
+
+public class CountingHandler implements CoapHandler {
+
+	public AtomicInteger loadCalls = new AtomicInteger();
+	public AtomicInteger errorCalls = new AtomicInteger();
+
+	@Override
+	public void onLoad(CoapResponse response) {
+		int counter;
+		synchronized (this) {
+			counter = loadCalls.incrementAndGet();
+			notifyAll();
+		}
+		System.out.println("Received " + counter + ". Notification: " + response.advanced());
+	}
+
+	@Override
+	public void onError() {
+		int counter;
+		synchronized (this) {
+			counter = errorCalls.incrementAndGet();
+			notifyAll();
+		}
+		System.out.println(counter + " Errors!");
+	}
+
+	public boolean waitForLoadCalls(final int counter, final long timeout, final TimeUnit unit)
+			throws InterruptedException {
+		return waitForCalls(counter, timeout, unit, loadCalls);
+	}
+
+	public boolean waitForErrorCalls(final int counter, final long timeout, final TimeUnit unit)
+			throws InterruptedException {
+		return waitForCalls(counter, timeout, unit, errorCalls);
+	}
+
+	private synchronized boolean waitForCalls(final int counter, final long timeout, final TimeUnit unit,
+			AtomicInteger calls) throws InterruptedException {
+		if (0 < timeout) {
+			long end = System.nanoTime() + unit.toNanos(timeout);
+			while (calls.get() < counter) {
+				long left = TimeUnit.NANOSECONDS.toMillis(end - System.nanoTime());
+				if (0 < left) {
+					wait(left);
+				} else {
+					break;
+				}
+			}
+		}
+		return calls.get() >= counter;
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/CountingMessageObserver.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/CountingMessageObserver.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Sierra Wireless - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
+import org.eclipse.californium.core.coap.Response;
+
+public class CountingMessageObserver extends MessageObserverAdapter {
+
+	public AtomicInteger loadCalls = new AtomicInteger();
+	public AtomicInteger errorCalls = new AtomicInteger();
+
+	@Override
+	public void onRetransmission() {
+	}
+
+	@Override
+	public void onResponse(Response response) {
+		int counter;
+		synchronized (this) {
+			counter = loadCalls.incrementAndGet();
+			notifyAll();
+		}
+		System.out.println("Received " + counter + ". Notification: " + response);
+	}
+	
+	@Override
+	public void onSendError(Throwable error) {
+		int counter;
+		synchronized (this) {
+			counter = errorCalls.incrementAndGet();
+			notifyAll();
+		}
+		System.out.println(counter + " Errors!");
+	}
+
+	public boolean waitForLoadCalls(final int counter, final long timeout, final TimeUnit unit)
+			throws InterruptedException {
+		return waitForCalls(counter, timeout, unit, loadCalls);
+	}
+
+	public boolean waitForErrorCalls(final int counter, final long timeout, final TimeUnit unit)
+			throws InterruptedException {
+		return waitForCalls(counter, timeout, unit, errorCalls);
+	}
+
+	private synchronized boolean waitForCalls(final int counter, final long timeout, final TimeUnit unit,
+			AtomicInteger calls) throws InterruptedException {
+		if (0 < timeout) {
+			long end = System.nanoTime() + unit.toNanos(timeout);
+			while (calls.get() < counter) {
+				long left = TimeUnit.NANOSECONDS.toMillis(end - System.nanoTime());
+				if (0 < left) {
+					wait(left);
+				} else {
+					break;
+				}
+			}
+		}
+		return calls.get() >= counter;
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ErrorInjector.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ErrorInjector.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Sierra Wireless - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.interceptors.MessageInterceptorAdapter;
+import org.eclipse.californium.elements.EndpointContext;
+
+public class ErrorInjector extends MessageInterceptorAdapter {
+
+	private AtomicBoolean errorOnEstablishedContext = new AtomicBoolean(false);
+	private AtomicBoolean errorOnSent = new AtomicBoolean(false);
+	private AtomicBoolean errorOnReadyToSend = new AtomicBoolean(false);
+
+	public void setErrorOnEstablishedContext() {
+		errorOnEstablishedContext.set(true);
+	}
+
+	public void setErrorOnSent() {
+		errorOnSent.set(true);
+	}
+
+	public void setErrorOnReadyToSend() {
+		errorOnReadyToSend.set(true);
+	}
+
+	@Override
+	public void sendRequest(final Request request) {
+		request.addMessageObserver(new ErrorInjectorMessageObserver(request));
+	}
+
+	@Override
+	public void sendResponse(final Response response) {
+		response.addMessageObserver(new ErrorInjectorMessageObserver(response));
+	}
+
+	private class ErrorInjectorMessageObserver extends MessageObserverAdapter {
+
+		private Message message;
+
+		public ErrorInjectorMessageObserver(Message message) {
+			this.message = message;
+		}
+
+		@Override
+		public void onReadyToSend() {
+			if (errorOnReadyToSend.getAndSet(false)) {
+				RuntimeException exception = new IllegalStateException("Simulate error before to sent");
+				message.setSendError(exception);
+				throw exception;
+			}
+		}
+
+		@Override
+		public void onSent() {
+			if (errorOnReadyToSend.getAndSet(false)) {
+				RuntimeException exception = new IllegalStateException("Simulate error on sent");
+				message.setSendError(exception);
+				throw exception;
+			}
+		}
+
+		@Override
+		public void onContextEstablished(EndpointContext endpointContext) {
+			if (errorOnEstablishedContext.getAndSet(false)) {
+				RuntimeException exception = new IllegalStateException("Simulate error on context established");
+				message.setSendError(exception);
+				throw exception;
+			}
+		}
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MessageExchangeStoreTool.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MessageExchangeStoreTool.java
@@ -43,6 +43,8 @@ import org.eclipse.californium.core.network.stack.CoapStack;
 import org.eclipse.californium.core.network.stack.CoapUdpStack;
 import org.eclipse.californium.core.network.stack.Layer;
 import org.eclipse.californium.core.observe.InMemoryObservationStore;
+import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.EndpointContextMatcher;
 import org.eclipse.californium.elements.UDPConnector;
 import org.eclipse.californium.elements.UdpEndpointContextMatcher;
 
@@ -186,23 +188,28 @@ public class MessageExchangeStoreTool {
 		private final InMemoryObservationStore observationStore;
 		private RequestEventChecker requestChecker;
 
-		private CoapTestEndpoint(InetSocketAddress bind, NetworkConfig config,
+		private CoapTestEndpoint(Connector connector, boolean applyConfiguration, NetworkConfig config,
 				InMemoryObservationStore observationStore, InMemoryMessageExchangeStore exchangeStore,
-				boolean checkAddress) {
-			super(new UDPConnector(bind), true, config, new RandomTokenGenerator(config), observationStore,
-					exchangeStore, new UdpEndpointContextMatcher(checkAddress), COAP_STACK_TEST_FACTORY);
+				EndpointContextMatcher matcher) {
+			super(connector, applyConfiguration, config, new RandomTokenGenerator(config), observationStore,
+					exchangeStore, matcher, COAP_STACK_TEST_FACTORY);
 			this.exchangeStore = exchangeStore;
 			this.observationStore = observationStore;
 			this.requestChecker = new RequestEventChecker();
 		}
 
 		public CoapTestEndpoint(InetSocketAddress bind, NetworkConfig config, boolean checkAddress) {
-			this(bind, config, new InMemoryObservationStore(config), new InMemoryMessageExchangeStore(config),
-					checkAddress);
+			this(new UDPConnector(bind), true, config, new InMemoryObservationStore(config),
+					new InMemoryMessageExchangeStore(config), new UdpEndpointContextMatcher(checkAddress));
 		}
 
 		public CoapTestEndpoint(InetSocketAddress bind, NetworkConfig config) {
 			this(bind, config, true);
+		}
+
+		public CoapTestEndpoint(Connector connector, NetworkConfig config, EndpointContextMatcher matcher) {
+			this(connector, false, config, new InMemoryObservationStore(config),
+					new InMemoryMessageExchangeStore(config), matcher);
 		}
 
 		public InMemoryMessageExchangeStore getExchangeStore() {

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveServerSideTest.java
@@ -38,7 +38,7 @@ import static org.eclipse.californium.core.coap.CoAP.Type.ACK;
 import static org.eclipse.californium.core.coap.CoAP.Type.CON;
 import static org.eclipse.californium.core.coap.CoAP.Type.NON;
 import static org.eclipse.californium.core.coap.CoAP.Type.RST;
-import static org.eclipse.californium.core.test.MessageExchangeStoreTool.*;
+import static org.eclipse.californium.core.test.MessageExchangeStoreTool.assertAllExchangesAreCompleted;
 import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.createLockstepEndpoint;
 import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.generateNextToken;
 import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.printServerLog;
@@ -48,8 +48,11 @@ import static org.junit.Assert.assertThat;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.californium.CheckCondition;
+import org.eclipse.californium.TestTools;
 import org.eclipse.californium.category.Medium;
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapServer;
@@ -58,6 +61,8 @@ import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.core.test.ErrorInjector;
+import org.eclipse.californium.core.test.MessageExchangeStoreTool.CoapTestEndpoint;
 import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -138,7 +143,6 @@ public class ObserveServerSideTest {
 			assertAllExchangesAreCompleted(serverEndpoint);
 		} finally {
 			printServerLog(serverInterceptor);
-			
 			System.out.println();
 			client.destroy();
 		}
@@ -198,10 +202,7 @@ public class ObserveServerSideTest {
 		client.expectResponse().type(respType).code(CONTENT).token(tok).sameMID("MID").loadObserve("E").payload(respPayload).go();
 		serverInterceptor.log(" // lost");
 
-		Thread.sleep(ACK_TIMEOUT + 100);
-
-		Assert.assertEquals("Resource should have removed observe relation after timeout", 0, testObsResource.getObserverCount());
-
+		Assert.assertEquals("Resource should have removed observe relation after timeout", 0, waitForObservers(ACK_TIMEOUT + 100, 0));
 	}
 
 	@Test
@@ -239,8 +240,7 @@ public class ObserveServerSideTest {
 		client.expectResponse().type(CON).code(CONTENT).token(tok).sameMID("MID").loadObserve("D").payload(respPayload).go();
 		serverInterceptor.log("// lost (4. retransmission)");
 
-		Thread.sleep(ACK_TIMEOUT + 100);
-		Assert.assertEquals("Resource has not removed relation:", 0, testObsResource.getObserverCount());
+		Assert.assertEquals("Resource has not removed relation after timeout:", 0, waitForObservers(ACK_TIMEOUT + 100, 0));
 	}
 
 	@Test
@@ -262,11 +262,10 @@ public class ObserveServerSideTest {
 		serverInterceptor.log("// lost ");
 		client.expectResponse().type(respType).code(CONTENT).token(tok).sameMID("MID").loadObserve("B").payload(respPayload).go();
 
-		System.out.println("Reject notification");
+		serverInterceptor.log("// Reject notification (cancel observe)");
 		client.sendEmpty(RST).loadMID("MID").go();
 
-		Thread.sleep(100);
-		Assert.assertEquals("Resource has not removed relation:", 0, testObsResource.getObserverCount());
+		Assert.assertEquals("Resource has not removed observe relation:", 0, waitForObservers(ACK_TIMEOUT + 100, 0));
 	}
 
 	@Test
@@ -288,15 +287,14 @@ public class ObserveServerSideTest {
 		client.sendRequest(CON, GET, tok2, ++mid).path(RESOURCE_PATH).loadETag("tag").block2(1, false, 32).go();
 		client.expectResponse(ACK, CONTENT, tok2, mid).block2(1, true, 32).payload(respPayload, 32, 64).go();
 		client.sendRequest(CON, GET, tok2, ++mid).path(RESOURCE_PATH).loadETag("tag").block2(2, false, 32).go();
-		client.expectResponse(ACK, CONTENT, tok2, mid).block2(2, false, 32).payload(respPayload, 64, 80).go(); 
+		client.expectResponse(ACK, CONTENT, tok2, mid).block2(2, false, 32).payload(respPayload, 64, 80).go();
 
 		// First notification
-		Thread.sleep(50);
 		respType = CON;
 		testObsResource.change(generateRandomPayload(80));
 		serverInterceptor.log(System.lineSeparator() + "   === changed ===");
 		client.expectResponse().type(CON).code(CONTENT).token(tok).storeMID("MID").checkObs("A", "B").storeETag("tag")
-			.block2(0, true, 32).size2(respPayload.length()).payload(respPayload, 0, 32).go();
+				.block2(0, true, 32).size2(respPayload.length()).payload(respPayload, 0, 32).go();
 		client.sendEmpty(ACK).loadMID("MID").go();
 
 		// Get remaining blocks
@@ -307,16 +305,15 @@ public class ObserveServerSideTest {
 		client.expectResponse(ACK, CONTENT, tok3, mid).block2(2, false, 32).payload(respPayload, 64, 80).go();
 
 		// Second notification
-		Thread.sleep(50);
 		respType = CON;
 		testObsResource.change(generateRandomPayload(80));
 		serverInterceptor.log(System.lineSeparator() + "   === changed ===");
 		client.expectResponse().type(respType).code(CONTENT).token(tok).storeMID("MID").checkObs("A", "B").block2(0, true, 32).payload(respPayload, 0, 32).go();
+		
+		serverInterceptor.log("// Reject notification (cancel observe)");
 		client.sendEmpty(RST).loadMID("MID").go(); // client cancels observation
 
-
-		Thread.sleep(ACK_TIMEOUT + 100);
-		Assert.assertEquals("Resource has not removed relation:", 0, testObsResource.getObserverCount());
+		Assert.assertEquals("Resource has not removed observe relation:", 0, waitForObservers(ACK_TIMEOUT + 100, 0));
 	}
 
 	@Test
@@ -332,27 +329,26 @@ public class ObserveServerSideTest {
 		Assert.assertEquals("Resource has not added relation:", 1, testObsResource.getObserverCount());
 		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
 
-		Thread.sleep(100);
 		// First notification
 		testObsResource.change("First notification " + generateRandomPayload(10));
 		client.expectResponse().type(NON).code(CONTENT).token(tok).storeMID("MID").checkObs("A", "B").payload(respPayload).go();
 
-		Thread.sleep(100);
 		respType = CON;
 		testObsResource.change("Second notification " + generateRandomPayload(10));
 		client.expectResponse().type(respType).code(CONTENT).token(tok).storeMID("MID").checkObs("B", "C").payload(respPayload).go();
 		client.sendEmpty(ACK).loadMID("MID").go();
 
+		// wait, hopefully the ACK is processed before the next notification is send.
 		Thread.sleep(100);
 		respType = NON;
 		testObsResource.change("Third notification " + generateRandomPayload(10));
-		client.expectResponse().type(respType).code(CONTENT).token(tok).storeMID("MID").checkObs("C", "D").payload(respPayload).go();
+		// NON, or CON, if ACK is not processed yet.
+		client.expectResponse().type(NON, CON).code(CONTENT).token(tok).storeMID("MID").checkObs("C", "D").payload(respPayload).go();
 
-		System.out.println("Reject notification");
+		serverInterceptor.log("// Reject notification (cancel observe)");
 		client.sendEmpty(RST).loadMID("MID").go();
 
-		Thread.sleep(100);
-		Assert.assertEquals("Resource has not removed relation:", 0, testObsResource.getObserverCount());
+		Assert.assertEquals("Resource has not removed observe relation:", 0, waitForObservers(ACK_TIMEOUT + 100, 0));
 	}
 
 	@Test
@@ -368,24 +364,20 @@ public class ObserveServerSideTest {
 		Assert.assertEquals("Resource has not added relation:", 1, testObsResource.getObserverCount());
 		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
 
-		Thread.sleep(100);
 		// First notification
 		testObsResource.change("First notification " + generateRandomPayload(10));
 		client.expectResponse().type(NON).code(CONTENT).token(tok).storeMID("MID1").checkObs("A", "B").payload(respPayload).go();
 
-		Thread.sleep(100);
 		testObsResource.change("Second notification " + generateRandomPayload(10));
 		client.expectResponse().type(NON).code(CONTENT).token(tok).storeMID("MID2").checkObs("B", "C").payload(respPayload).go();
 
-		Thread.sleep(100);
 		testObsResource.change("Third notification " + generateRandomPayload(10));
 		client.expectResponse().type(NON).code(CONTENT).token(tok).storeMID("MID3").checkObs("C", "D").payload(respPayload).go();
 
-		System.out.println("Reject 1. notification");
+		serverInterceptor.log("// Reject 1. notification (cancel observe)");
 		client.sendEmpty(RST).loadMID("MID1").go();
 
-		Thread.sleep(100);
-		Assert.assertEquals("Resource has not removed relation:", 0, testObsResource.getObserverCount());
+		Assert.assertEquals("Resource has not removed observe relation:", 0, waitForObservers(ACK_TIMEOUT + 100, 0));
 	}
 
 	@Test
@@ -425,11 +417,10 @@ public class ObserveServerSideTest {
 		client.expectResponse().type(respType).code(CONTENT).token(tok).storeMID("MID").checkObs("C", "D")
 			.size2(respPayload.length()).block2(0, true, 16).payload(respPayload, 0, 16).go();
 
-		System.out.println("Reject notification");
+		serverInterceptor.log("// Reject notification (cancel observe)");
 		client.sendEmpty(RST).loadMID("MID").go();
 
-		Thread.sleep(100);
-		Assert.assertEquals("Resource has not removed relation:", 0, testObsResource.getObserverCount());
+		Assert.assertEquals("Resource has not removed relation:", 0, waitForObservers(ACK_TIMEOUT + 100, 0));
 	}
 
 	@Test
@@ -474,10 +465,9 @@ public class ObserveServerSideTest {
 		// after 4 retransmission attempts the server cancels the observation
 		serverInterceptor.log(System.lineSeparator() + "   server cancels observe relation");
 
-		Thread.sleep(ACK_TIMEOUT + 100);
-		assertThat("Resource has not removed observe relation", testObsResource.getObserverCount(), is(0));
+		Assert.assertEquals("Resource has not removed observe relation after timeout:", 0, waitForObservers(ACK_TIMEOUT + 100, 0));
 	}
-	
+
 	/**
 	 * Test incomplete block2 notification (missing request)
 	 * 
@@ -512,21 +502,108 @@ public class ObserveServerSideTest {
 		// no leak.
 	}
 
+	@Test
+	public void testFailedToSendNonNotification() throws Exception {
+
+		System.out.println("Establish an observe relation and failed to send NON notification");
+		respPayload = generateRandomPayload(30);
+		Token tok = generateNextToken();
+
+		ErrorInjector errorInjector = new ErrorInjector();
+		serverEndpoint.addInterceptor(errorInjector);
+
+		respType = null;
+		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
+		client.expectResponse().type(ACK).code(CONTENT).token(tok).storeObserve("A").payload(respPayload).go();
+		Assert.assertEquals("Resource has not added relation:", 1, testObsResource.getObserverCount());
+		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
+
+		// First notification
+		testObsResource.change("First notification " + generateRandomPayload(10));
+		client.expectResponse().type(NON).code(CONTENT).token(tok).storeMID("MID1").checkObs("A", "B").payload(respPayload).go();
+
+		// Simulate error when we send response
+		errorInjector.setErrorOnReadyToSend();
+		testObsResource.change("Second notification " + generateRandomPayload(10));
+
+		Thread.sleep(100);
+		Assert.assertEquals("Resource has still its observe relation:", 1, testObsResource.getObserverCount());
+
+		// Ensure we get the third notification
+		testObsResource.change("Third notification " + generateRandomPayload(10));
+		client.expectResponse().type(NON).code(CONTENT).token(tok).storeMID("MID3").checkObs("B", "C").payload(respPayload).go();
+
+		// Cancel observe relation
+		serverInterceptor.log("// Reject 1. notification (cancel observe)");
+		client.sendEmpty(RST).loadMID("MID1").go();
+
+		Assert.assertEquals("Resource has not removed observe relation:", 0, waitForObservers(ACK_TIMEOUT + 100, 0));
+	}
+
+	@Test
+	public void testRejectAfterFailedToSendNonNotification() throws Exception {
+
+		System.out.println("Establish an observe relation and failed to send NON notification");
+		respPayload = generateRandomPayload(30);
+		Token tok = generateNextToken();
+
+		ErrorInjector errorInjector = new ErrorInjector();
+		serverEndpoint.addInterceptor(errorInjector);
+
+		respType = null;
+		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
+		client.expectResponse().type(ACK).code(CONTENT).token(tok).storeObserve("A").payload(respPayload).go();
+		Assert.assertEquals("Resource has not added relation:", 1, testObsResource.getObserverCount());
+		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
+
+		// First notification
+		testObsResource.change("First notification " + generateRandomPayload(10));
+		client.expectResponse().type(NON).code(CONTENT).token(tok).storeMID("MID1").checkObs("A", "B")
+				.payload(respPayload).go();
+
+		// Simulate error when we send response
+		errorInjector.setErrorOnReadyToSend();
+		testObsResource.change("Second notification " + generateRandomPayload(10));
+
+		Thread.sleep(100);
+
+		serverInterceptor.log("// Reject 1. notification (cancel observe)");
+		client.sendEmpty(RST).loadMID("MID1").go();
+
+		Assert.assertEquals("Resource has not removed observe relation:", 0, waitForObservers(ACK_TIMEOUT + 100, 0));
+	}
+
+	private int waitForObservers(long timeoutMillis, final int count) throws InterruptedException {
+
+		TestTools.waitForCondition(timeoutMillis, 50, TimeUnit.MILLISECONDS, new CheckCondition() {
+
+			@Override
+			public boolean isFulFilled() throws IllegalStateException {
+				return testObsResource.getObserverCount() == count;
+			}
+		});
+
+		return testObsResource.getObserverCount();
+	}
+
 	// All tests are made with this resource
 	private static class TestObserveResource extends CoapResource {
 
 		private AtomicInteger etagSequence = new AtomicInteger(1);
 
-		public TestObserveResource(String name) { 
+		public TestObserveResource(String name) {
 			super(name);
 			setObservable(true);
 		}
 
 		public void handleGET(CoapExchange exchange) {
 			Response response = new Response(CONTENT);
-			response.setType(respType); // respType is altered throughout the test cases
-			response.setPayload(respPayload); // payload is altered throughout the test cases
+			response.setType(respType); // respType is altered throughout the
+										// test cases
+			response.setPayload(respPayload); // payload is altered throughout
+												// the test cases
 			addEtag(response);
+
 			exchange.respond(response);
 		}
 

--- a/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureObserveTest.java
+++ b/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureObserveTest.java
@@ -41,7 +41,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.californium.category.Medium;
 import org.eclipse.californium.core.CoapClient;
-import org.eclipse.californium.core.CoapHandler;
 import org.eclipse.californium.core.CoapObserveRelation;
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapResponse;
@@ -54,6 +53,7 @@ import org.eclipse.californium.core.network.EndpointManager;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.core.test.CountingHandler;
 import org.eclipse.californium.elements.EndpointMismatchException;
 import org.eclipse.californium.examples.NatUtil;
 import org.eclipse.californium.integration.test.util.CoapsNetworkRule;
@@ -502,53 +502,6 @@ public class SecureObserveTest {
 
 		public Response getCurrentResponse() {
 			return currentResponse;
-		}
-	}
-
-	private class CountingHandler implements CoapHandler {
-
-		public AtomicInteger loadCalls = new AtomicInteger();
-		public AtomicInteger errorCalls = new AtomicInteger();
-
-		@Override
-		public void onLoad(CoapResponse response) {
-			int counter;
-			synchronized (this) {
-				counter = loadCalls.incrementAndGet();
-				notifyAll();
-			}
-			System.out.println("Received " + counter + ". Notification: " + response.advanced());
-		}
-
-		@Override
-		public void onError() {
-			int counter;
-			synchronized (this) {
-				counter = errorCalls.incrementAndGet();
-				notifyAll();
-			}
-			System.out.println(counter + " Errors!");
-		}
-
-		public boolean waitForLoadCalls(final int counter, final long timeout, final TimeUnit unit)
-				throws InterruptedException {
-			return waitForCalls(counter, timeout, unit, loadCalls);
-		}
-
-		private synchronized boolean waitForCalls(final int counter, final long timeout, final TimeUnit unit,
-				AtomicInteger calls) throws InterruptedException {
-			if (0 < timeout) {
-				long end = System.nanoTime() + unit.toNanos(timeout);
-				while (calls.get() < counter) {
-					long left = TimeUnit.NANOSECONDS.toMillis(end - System.nanoTime());
-					if (0 < left) {
-						wait(left);
-					} else {
-						break;
-					}
-				}
-			}
-			return calls.get() >= counter;
 		}
 	}
 }

--- a/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureTest.java
+++ b/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureTest.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Sierra wirelss and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Simon Bernard (Sierra Wireless) - initial implementation.
+ ******************************************************************************/
+package org.eclipse.californium.integration.test;
+
+import static org.eclipse.californium.core.test.MessageExchangeStoreTool.assertAllExchangesAreCompleted;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.californium.category.Medium;
+import org.eclipse.californium.core.CoapClient;
+import org.eclipse.californium.core.network.EndpointManager;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
+import org.eclipse.californium.core.test.CountingHandler;
+import org.eclipse.californium.core.test.MessageExchangeStoreTool.CoapTestEndpoint;
+import org.eclipse.californium.elements.StrictDtlsEndpointContextMatcher;
+import org.eclipse.californium.integration.test.util.CoapsNetworkRule;
+import org.eclipse.californium.scandium.DTLSConnector;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Medium.class)
+public class SecureTest {
+
+	@ClassRule
+	public static CoapsNetworkRule network = new CoapsNetworkRule(CoapsNetworkRule.Mode.DIRECT,
+			CoapsNetworkRule.Mode.NATIVE);
+
+	// CoAP config constants
+	private static final int TEST_EXCHANGE_LIFETIME = 247; // milliseconds
+	private static final int TEST_SWEEP_DEDUPLICATOR_INTERVAL = 100; // milliseconds
+
+	// DTLS config constants
+	private static final String PSK_IDENITITY = "client1";
+	private static final String PSK_KEY = "key1";
+	private static final int NB_RETRANSMISSION = 2;
+	private static final int RETRANSMISSION_TIMEOUT = 100; // milliseconds
+
+	private CoapTestEndpoint coapTestEndpoint;
+
+	@Before
+	public void startupServer() {
+		System.out.println(System.lineSeparator() + "Start " + getClass().getSimpleName());
+	}
+
+	@After
+	public void shutdownServer() {
+		System.out.println("End " + getClass().getSimpleName());
+	}
+
+	/**
+	 * Ensure there is no leak when we try to send a request to an absent peer
+	 */
+	@Test
+	public void testSecureGetHandshakeTimeout() throws Exception {
+		// Get a free port to be sure we send request to an absent port
+		try (DatagramSocket datagramSocket = new DatagramSocket(0)) {
+			int freePort = datagramSocket.getLocalPort();
+
+			// Create an endpoint
+			createEndpoint();
+
+			// Send a request to an absent peer
+			CoapClient client = new CoapClient("coaps", InetAddress.getLoopbackAddress().getHostAddress(), freePort);
+			CountingHandler handler = new CountingHandler();
+			client.get(handler);
+
+			// Wait for error
+			handler.waitForErrorCalls(1, 1000, TimeUnit.MILLISECONDS);
+
+			// We should get a handshake timeout error and so exchange store is empty
+			Assert.assertEquals("An error is expected", 1, handler.errorCalls.get());
+
+			// Ensure there is no leak : all exchanges are completed
+			assertAllExchangesAreCompleted(coapTestEndpoint);
+		}
+	}
+
+	private void createEndpoint() {
+		// setup DTLS Config
+		Builder builder = new DtlsConnectorConfig.Builder();
+		builder.setAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		builder.setPskStore(new TestUtilPskStore(PSK_IDENITITY, PSK_KEY.getBytes()));
+		builder.setMaxRetransmissions(NB_RETRANSMISSION);
+		builder.setRetransmissionTimeout(RETRANSMISSION_TIMEOUT);
+		DtlsConnectorConfig dtlsConfig = builder.build();
+
+		// setup CoAP config
+		NetworkConfig config = network.createTestConfig().setInt(Keys.ACK_TIMEOUT, 200)
+				.setFloat(Keys.ACK_RANDOM_FACTOR, 1f).setFloat(Keys.ACK_TIMEOUT_SCALE, 1f)
+				.setLong(Keys.EXCHANGE_LIFETIME, TEST_EXCHANGE_LIFETIME)
+				.setLong(Keys.MARK_AND_SWEEP_INTERVAL, TEST_SWEEP_DEDUPLICATOR_INTERVAL);
+
+		// create endpoint for tests
+		DTLSConnector clientConnector = new DTLSConnector(dtlsConfig);
+		coapTestEndpoint = new CoapTestEndpoint(clientConnector, config, new StrictDtlsEndpointContextMatcher());
+		EndpointManager.getEndpointManager().setDefaultEndpoint(coapTestEndpoint);
+	}
+}


### PR DESCRIPTION
Cleanup observe test, temove not required sleeps there.
Extract CleanupMessageObserver from ExchangeCleanupLayer and add CON
response to cleanup into it. Add also a CleanupMessageObserver to
blockwise notifies in BlockwiseLayer.

Signed-off-by: Simon Bernard <sbernard@sierrawireless.com>
Also-by: Achim Kraus <achim.kraus@bosch-si.com>