### PR TITLE
Add some tests about proactive cancel

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
@@ -203,9 +203,8 @@ public class CoapObserveRelation {
 	 * GET with Observe=1.
 	 */
 	public void proactiveCancel() {
-		sendCancelObserve();
-		// cancel observe relation
 		cancel();
+		sendCancelObserve();
 	}
 
 	/**


### PR DESCRIPTION
I added some tests relative to #688.

I think "a test about pro active cancel (ed40c69)" makes sense to be added.
The second one, "test that response with observe option is for simple GET (8fcf2cb)", maybe a little less, but I used it to check #689.