### PR TITLE
Respond overload

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
@@ -16,6 +16,7 @@
  *    Dominique Im Obersteg - parsers and initial implementation
  *    Daniel Pauli - parsers and initial implementation
  *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - apply source formatter
  ******************************************************************************/
 package org.eclipse.californium.core.server.resources;
 
@@ -37,14 +38,14 @@ import org.eclipse.californium.core.network.Exchange;
  * responding to requests.
  */
 public class CoapExchange {
-	
+
 	/* The internal (advanced) exchange. */
 	private final Exchange exchange;
 	private final Map<String, String> queryParameters;
 
 	/* The destination resource. */
 	private final CoapResource resource;
-	
+
 	/* Response option values. */
 	private String locationPath = null;
 	private String locationQuery = null;
@@ -93,7 +94,7 @@ public class CoapExchange {
 	public InetAddress getSourceAddress() {
 		return exchange.getRequest().getSourceContext().getPeerAddress().getAddress();
 	}
-	
+
 	/**
 	 * Gets the source port of the request.
 	 *
@@ -102,7 +103,7 @@ public class CoapExchange {
 	public int getSourcePort() {
 		return exchange.getRequest().getSourceContext().getPeerAddress().getPort();
 	}
-	
+
 	/**
 	 * Gets the request code: <tt>GET</tt>, <tt>POST</tt>, <tt>PUT</tt> or
 	 * <tt>DELETE</tt>.
@@ -112,7 +113,7 @@ public class CoapExchange {
 	public Code getRequestCode() {
 		return exchange.getRequest().getCode();
 	}
-	
+
 	/**
 	 * Gets the request's options.
 	 *
@@ -126,8 +127,8 @@ public class CoapExchange {
 	 * Gets the value of a URI query parameter.
 	 * 
 	 * @param name The name of the query parameter.
-	 * @return The value of the parameter or {@code null} if the request did not include
-	 *         a query parameter with the given name.
+	 * @return The value of the parameter or {@code null} if the request did not
+	 *         include a query parameter with the given name.
 	 */
 	public String getQueryParameter(final String name) {
 
@@ -137,6 +138,7 @@ public class CoapExchange {
 			return null;
 		}
 	}
+
 	/**
 	 * Gets the request payload as byte array.
 	 *
@@ -145,7 +147,7 @@ public class CoapExchange {
 	public byte[] getRequestPayload() {
 		return exchange.getRequest().getPayload();
 	}
-	
+
 	/**
 	 * Gets the request payload as string.
 	 *
@@ -154,7 +156,7 @@ public class CoapExchange {
 	public String getRequestText() {
 		return exchange.getRequest().getPayloadString();
 	}
-	
+
 	/**
 	 * Accept the exchange, i.e. send an acknowledgment to the client that the
 	 * exchange has arrived and a separate message is being computed and sent
@@ -164,7 +166,7 @@ public class CoapExchange {
 	public void accept() {
 		exchange.sendAccept();
 	}
-	
+
 	/**
 	 * Reject the exchange if it is impossible to be processed, e.g. if it
 	 * carries an unknown critical option. In most cases, it is better to
@@ -173,25 +175,28 @@ public class CoapExchange {
 	public void reject() {
 		exchange.sendReject();
 	}
-	
+
 	/**
 	 * Set the Location-Path for the response.
+	 * 
 	 * @param path the Location-Path value
 	 */
 	public void setLocationPath(String path) {
 		locationPath = path;
 	}
-	
+
 	/**
 	 * Set the Location-Query for the response.
+	 * 
 	 * @param query the Location-Query value
 	 */
 	public void setLocationQuery(String query) {
 		locationQuery = query;
 	}
-	
+
 	/**
 	 * Set the Max-Age for the response body.
+	 * 
 	 * @param age the Max-Age value
 	 */
 	public void setMaxAge(long age) {
@@ -200,45 +205,56 @@ public class CoapExchange {
 
 	/**
 	 * Set the ETag for the response.
+	 * 
 	 * @param tag the ETag of the current response
 	 */
 	public void setETag(byte[] tag) {
 		eTag = tag;
 	}
-	
+
 	/**
-	 * Respond the specified response code and no payload. Allowed response codes are:
+	 * Respond the specified response code and no payload. Allowed response
+	 * codes are:
 	 * <ul>
-	 *   <li>GET: Content (2.05), Valid (2.03)</li>
-	 *   <li>POST: Created (2.01), Changed (2.04), Deleted (2.02) </li>
-	 *   <li>PUT: Created (2.01), Changed (2.04)</li>
-	 *   <li>DELETE: Deleted (2.02)</li>
+	 * <li>GET: Content (2.05), Valid (2.03)</li>
+	 * <li>POST: Created (2.01), Changed (2.04), Deleted (2.02)</li>
+	 * <li>PUT: Created (2.01), Changed (2.04)</li>
+	 * <li>DELETE: Deleted (2.02)</li>
 	 * </ul>
+	 * 
+	 * Fills in {@link #locationPath}, {@link #locationQuery}, {@link #maxAge},
+	 * and/or {@link #eTag}, if set before.
 	 *
 	 * @param code the response code
 	 */
 	public void respond(ResponseCode code) {
 		respond(new Response(code));
 	}
-	
+
 	/**
 	 * Respond with response code 2.05 (Content) and the specified payload.
 	 *
+	 * Fills in {@link #locationPath}, {@link #locationQuery}, {@link #maxAge},
+	 * and/or {@link #eTag}, if set before.
+	 * 
 	 * @param payload the payload as string
 	 */
 	public void respond(String payload) {
 		respond(ResponseCode.CONTENT, payload);
 	}
-	
+
 	/**
 	 * Respond with the specified response code and the specified payload.
 	 * <ul>
-	 *   <li>GET: Content (2.05), Valid (2.03)</li>
-	 *   <li>POST: Created (2.01), Changed (2.04), Deleted (2.02) </li>
-	 *   <li>PUT: Created (2.01), Changed (2.04)</li>
-	 *   <li>DELETE: Deleted (2.02)</li>
+	 * <li>GET: Content (2.05), Valid (2.03)</li>
+	 * <li>POST: Created (2.01), Changed (2.04), Deleted (2.02)</li>
+	 * <li>PUT: Created (2.01), Changed (2.04)</li>
+	 * <li>DELETE: Deleted (2.02)</li>
 	 * </ul>
 	 *
+	 * Fills in {@link #locationPath}, {@link #locationQuery}, {@link #maxAge},
+	 * and/or {@link #eTag}, if set before.
+	 * 
 	 * @param code the response code
 	 * @param payload the payload
 	 */
@@ -248,15 +264,18 @@ public class CoapExchange {
 		response.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
 		respond(response);
 	}
-	
+
 	/**
 	 * Respond with the specified response code and the specified payload.
 	 * <ul>
-	 *   <li>GET: Content (2.05), Valid (2.03)</li>
-	 *   <li>POST: Created (2.01), Changed (2.04), Deleted (2.02) </li>
-	 *   <li>PUT: Created (2.01), Changed (2.04)</li>
-	 *   <li>DELETE: Deleted (2.02)</li>
+	 * <li>GET: Content (2.05), Valid (2.03)</li>
+	 * <li>POST: Created (2.01), Changed (2.04), Deleted (2.02)</li>
+	 * <li>PUT: Created (2.01), Changed (2.04)</li>
+	 * <li>DELETE: Deleted (2.02)</li>
 	 * </ul>
+	 *
+	 * Fills in {@link #locationPath}, {@link #locationQuery}, {@link #maxAge},
+	 * and/or {@link #eTag}, if set before.
 	 *
 	 * @param code the response code
 	 * @param payload the payload
@@ -270,12 +289,15 @@ public class CoapExchange {
 	/**
 	 * Respond with the specified response code and the specified payload.
 	 * <ul>
-	 *   <li>GET: Content (2.05), Valid (2.03)</li>
-	 *   <li>POST: Created (2.01), Changed (2.04), Deleted (2.02) </li>
-	 *   <li>PUT: Created (2.01), Changed (2.04)</li>
-	 *   <li>DELETE: Deleted (2.02)</li>
+	 * <li>GET: Content (2.05), Valid (2.03)</li>
+	 * <li>POST: Created (2.01), Changed (2.04), Deleted (2.02)</li>
+	 * <li>PUT: Created (2.01), Changed (2.04)</li>
+	 * <li>DELETE: Deleted (2.02)</li>
 	 * </ul>
 	 *
+	 * Fills in {@link #locationPath}, {@link #locationQuery}, {@link #maxAge},
+	 * and/or {@link #eTag}, if set before.
+	 * 
 	 * @param code the response code
 	 * @param payload the payload
 	 * @param contentFormat the Content-Format of the payload
@@ -286,15 +308,18 @@ public class CoapExchange {
 		response.getOptions().setContentFormat(contentFormat);
 		respond(response);
 	}
-	
+
 	/**
 	 * Respond with the specified response code and the specified payload.
 	 * <ul>
-	 *   <li>GET: Content (2.05), Valid (2.03)</li>
-	 *   <li>POST: Created (2.01), Changed (2.04), Deleted (2.02) </li>
-	 *   <li>PUT: Created (2.01), Changed (2.04)</li>
-	 *   <li>DELETE: Deleted (2.02)</li>
+	 * <li>GET: Content (2.05), Valid (2.03)</li>
+	 * <li>POST: Created (2.01), Changed (2.04), Deleted (2.02)</li>
+	 * <li>PUT: Created (2.01), Changed (2.04)</li>
+	 * <li>DELETE: Deleted (2.02)</li>
 	 * </ul>
+	 * 
+	 * Fills in {@link #locationPath}, {@link #locationQuery}, {@link #maxAge},
+	 * and/or {@link #eTag}, if set before.
 	 *
 	 * @param code the response code
 	 * @param payload the payload
@@ -306,30 +331,39 @@ public class CoapExchange {
 		response.getOptions().setContentFormat(contentFormat);
 		respond(response);
 	}
-	
+
 	/**
 	 * Respond with the specified response.
+	 * 
+	 * Fills in {@link #locationPath}, {@link #locationQuery}, {@link #maxAge},
+	 * and/or {@link #eTag}, if set before.
+	 * 
 	 * @param response the response
 	 */
 	public void respond(Response response) {
-		if (response == null) throw new NullPointerException();
-		
+		if (response == null)
+			throw new NullPointerException();
+
 		// set the response options configured through the CoapExchange API
-		if (locationPath != null) response.getOptions().setLocationPath(locationPath);
-		if (locationQuery != null) response.getOptions().setLocationQuery(locationQuery);
-		if (maxAge != 60) response.getOptions().setMaxAge(maxAge);
+		if (locationPath != null)
+			response.getOptions().setLocationPath(locationPath);
+		if (locationQuery != null)
+			response.getOptions().setLocationQuery(locationQuery);
+		if (maxAge != 60)
+			response.getOptions().setMaxAge(maxAge);
 		if (eTag != null) {
 			response.getOptions().clearETags();
 			response.getOptions().addETag(eTag);
 		}
-		
+
 		resource.checkObserveRelation(exchange, response);
-		
+
 		exchange.sendResponse(response);
 	}
-	
+
 	/**
 	 * Provides access to the internal Exchange object.
+	 * 
 	 * @return the Exchange object
 	 */
 	public Exchange advanced() {

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
@@ -213,6 +213,20 @@ public class CoapExchange {
 	}
 
 	/**
+	 * Respond a overload.
+	 * 
+	 * Current implementation use 5.03. May be changed, if RFC
+	 * "https://draft-ietf-core-too-many-reqs" gets adopted.
+	 *
+	 * @param seconds estimated time in seconds after which the client may retry
+	 *            to send requests.
+	 */
+	public void respondOverload(int seconds) {
+		setMaxAge(seconds);
+		respond(ResponseCode.SERVICE_UNAVAILABLE);
+	}
+
+	/**
 	 * Respond the specified response code and no payload. Allowed response
 	 * codes are:
 	 * <ul>


### PR DESCRIPTION
Add convenient method for overload response to indicate a "long term"
overload to the client along with an estimated time the retry to send
request.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>
