### PR TITLE
More proactive cancel

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -634,7 +634,7 @@ public class Request extends Message {
 	 *         0.
 	 */
 	public final boolean isObserve() {
-		return getOptions().hasObserve() && getOptions().getObserve() == 0;
+		return isObserveOption(0);
 	}
 
 	/**
@@ -649,6 +649,28 @@ public class Request extends Message {
 		}
 		getOptions().setObserve(1);
 		return this;
+	}
+
+	/**
+	 * Checks if this request is used to cancel an observe relation.
+	 * 
+	 * @return {@code true} if this request's <em>observe</em> option is set to
+	 *         1.
+	 */
+	public final boolean isObserveCancel() {
+		return isObserveOption(1);
+	}
+
+	/**
+	 * Checks if this request is used to manage an observe relation.
+	 * 
+	 * @param observe value for observe option
+	 * @return {@code true} if this request's <em>observe</em> option matches
+	 *         the observe parameter, {@code false}, otherwise.
+	 */
+	private final boolean isObserveOption(int observe) {
+		Integer optionObserver = getOptions().getObserve();
+		return optionObserver != null && optionObserver.intValue() == observe;
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -287,10 +287,10 @@ public final class UdpMatcher extends BaseMatcher {
 					LOGGER.trace("received duplicate response for open {}: {}", exchange, response);
 					response.setDuplicate(true);
 				} else if (!exchange.isNotification()) {
-					if (response.isNotification() && response.getType() != Type.ACK && !exchange.getRequest().isObserve()) {
-						// notification for none observe request
-						// including observation cancel request
-						LOGGER.debug("ignoring notify {}!", response);
+					if (response.isNotification() && response.getType() != Type.ACK
+							&& currentRequest.isObserveCancel()) {
+						// overlapping notification for observation cancel request
+						LOGGER.debug("ignoring notify for pending cancel {}!", response);
 						return null;
 					}
 					// we have received the expected response for the
@@ -322,8 +322,7 @@ public final class UdpMatcher extends BaseMatcher {
 		Exchange exchange = exchangeStore.remove(idByMID, null);
 
 		if (exchange == null) {
-			LOGGER.debug("ignoring unmatchable empty message from {}: {}",
-					new Object[] { message.getSourceContext(), message });
+			LOGGER.debug("ignoring unmatchable empty message from {}: {}", message.getSourceContext(), message);
 			return null;
 		}
 		try {

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
@@ -150,7 +150,7 @@ public class ServerMessageDeliverer implements MessageDeliverer {
 
 			InetSocketAddress source = request.getSourceContext().getPeerAddress();
 
-			if (request.getOptions().getObserve() == 0) {
+			if (request.isObserve()) {
 				// Requests wants to observe and resource allows it :-)
 				LOGGER.debug("initiating an observe relation between {} and resource {}", source, resource.getURI());
 				ObservingEndpoint remote = observeManager.findObservingEndpoint(source);
@@ -160,7 +160,7 @@ public class ServerMessageDeliverer implements MessageDeliverer {
 				// all that's left is to add the relation to the resource which
 				// the resource must do itself if the response is successful
 
-			} else if (request.getOptions().getObserve() == 1) {
+			} else if (request.isObserveCancel()) {
 				// Observe defines 1 for canceling
 				ObserveRelation relation = observeManager.getRelation(source, request.getToken());
 				if (relation != null) {

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/PlugtestChecker.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/PlugtestChecker.java
@@ -999,7 +999,7 @@ public class PlugtestChecker {
 			} else if (!invert) {
 				System.out.printf("PASS: Observe (%d)\n",
 						// response.getFirstOption(OptionNumberRegistry.OBSERVE).getIntValue());
-						response.getOptions().getObserve().intValue());
+						response.getOptions().getObserve());
 			} else {
 				System.out.println("PASS: No Observe");
 			}


### PR DESCRIPTION
Add one test for notifications after simple successful cancel observe request.
Just for discussion, not to be merged!