### PR TITLE
Fix test race condition in async client test

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
@@ -232,7 +232,7 @@ public class ObserveRelation {
 	
 	public void addNotification(Response notification) {
 		notifications.add(notification);
-		LOGGER.trace("{} add notification {} (size {}).", resource.getURI(), notification.getMID(), notifications.size());
+		LOGGER.trace("{} add notification MID {} (size {}).", resource.getURI(), notification.getMID(), notifications.size());
 	}
 	
 	public Iterator<Response> getNotificationIterator() {


### PR DESCRIPTION
Also cleanup RepeatingTestRunner (used to analyse the sporadic failing test).

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>