### PR TITLE
Add IntendedTestException to omit stacktrace.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ErrorInjector.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ErrorInjector.java
@@ -23,6 +23,7 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.interceptors.MessageInterceptorAdapter;
 import org.eclipse.californium.elements.EndpointContext;
+import org.eclipse.californium.elements.util.IntendedTestException;
 
 public class ErrorInjector extends MessageInterceptorAdapter {
 
@@ -63,7 +64,7 @@ public class ErrorInjector extends MessageInterceptorAdapter {
 		@Override
 		public void onReadyToSend() {
 			if (errorOnReadyToSend.getAndSet(false)) {
-				RuntimeException exception = new IllegalStateException("Simulate error before to sent");
+				RuntimeException exception = new IntendedTestException("Simulate error before to sent");
 				message.setSendError(exception);
 				throw exception;
 			}
@@ -72,7 +73,7 @@ public class ErrorInjector extends MessageInterceptorAdapter {
 		@Override
 		public void onSent() {
 			if (errorOnReadyToSend.getAndSet(false)) {
-				RuntimeException exception = new IllegalStateException("Simulate error on sent");
+				RuntimeException exception = new IntendedTestException("Simulate error on sent");
 				message.setSendError(exception);
 				throw exception;
 			}
@@ -81,7 +82,7 @@ public class ErrorInjector extends MessageInterceptorAdapter {
 		@Override
 		public void onContextEstablished(EndpointContext endpointContext) {
 			if (errorOnEstablishedContext.getAndSet(false)) {
-				RuntimeException exception = new IllegalStateException("Simulate error on context established");
+				RuntimeException exception = new IntendedTestException("Simulate error on context established");
 				message.setSendError(exception);
 				throw exception;
 			}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/IntendedTestException.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/IntendedTestException.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
+/**
+ * Intended exception during test.
+ * 
+ * Should be logged without stacktrace.
+ */
+public class IntendedTestException extends RuntimeException {
+
+	private static final StackTraceElement[] EMPTY = new StackTraceElement[0];
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Create new intended exception during tests.
+	 * 
+	 * @param message exception message
+	 */
+	public IntendedTestException(String message) {
+		super(message);
+	}
+
+	@Override
+	public Throwable fillInStackTrace() {
+		return this;
+	}
+
+	@Override
+	public void setStackTrace(StackTraceElement[] stackTrace) {
+		// ignored
+	}
+
+	@Override
+	public StackTraceElement[] getStackTrace() {
+		return EMPTY;
+	}
+
+	@Override
+	public void printStackTrace() {
+		// ignored
+	}
+
+	@Override
+	public void printStackTrace(PrintStream s) {
+		// ignored
+	}
+
+	@Override
+	public void printStackTrace(PrintWriter s) {
+		// ignored
+	}
+}


### PR DESCRIPTION
Reduce information overflow in logs during tests.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>