### PR TITLE
Add "evict on read access" as configurable mode for LRU cache.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageIdProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageIdProvider.java
@@ -98,6 +98,7 @@ public class InMemoryMessageIdProvider implements MessageIdProvider {
 		// 10 minutes
 		trackers = new LeastRecentlyUsedCache<>(config.getInt(NetworkConfig.Keys.MAX_ACTIVE_PEERS, 150000),
 				config.getLong(NetworkConfig.Keys.MAX_PEER_INACTIVITY_PERIOD, 10 * 60));
+		trackers.setEvictingOnReadAccess(false);
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/AnonymizedOriginTracer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/AnonymizedOriginTracer.java
@@ -94,6 +94,7 @@ public final class AnonymizedOriginTracer extends MessageInterceptorAdapter {
 		} catch (NoSuchAlgorithmException e) {
 		}
 		HMAC = mac;
+		CLIENT_CACHE.setEvictingOnReadAccess(true);
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -199,8 +199,10 @@ public class BlockwiseLayer extends AbstractLayer {
 				NetworkConfigDefaults.DEFAULT_MAX_RESOURCE_BODY_SIZE);
 		int maxActivePeers = config.getInt(NetworkConfig.Keys.MAX_ACTIVE_PEERS,
 				NetworkConfigDefaults.DEFAULT_MAX_ACTIVE_PEERS);
-		block1Transfers = new LeastRecentlyUsedCache<>(maxActivePeers, blockTimeout / 1000);
-		block2Transfers = new LeastRecentlyUsedCache<>(maxActivePeers, blockTimeout / 1000);
+		block1Transfers = new LeastRecentlyUsedCache<>(maxActivePeers, TimeUnit.MILLISECONDS.toSeconds(blockTimeout));
+		block1Transfers.setEvictingOnReadAccess(false);
+		block2Transfers = new LeastRecentlyUsedCache<>(maxActivePeers, TimeUnit.MILLISECONDS.toSeconds(blockTimeout));
+		block2Transfers.setEvictingOnReadAccess(false);
 
 		LOGGER.info(
 			"BlockwiseLayer uses MAX_MESSAGE_SIZE={}, PREFERRED_BLOCK_SIZE={}, BLOCKWISE_STATUS_LIFETIME={} and MAX_RESOURCE_BODY_SIZE={}",

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/RequestStatistic.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/RequestStatistic.java
@@ -126,7 +126,7 @@ public class RequestStatistic extends CoapResource {
 	private static final long START_TIME = System.currentTimeMillis();
 	private static final int MAX_HISTORY = 8;
 
-	private LeastRecentlyUsedCache<String, List<RequestInformation>> requests = new LeastRecentlyUsedCache<String, List<RequestInformation>>(
+	private final LeastRecentlyUsedCache<String, List<RequestInformation>> requests = new LeastRecentlyUsedCache<String, List<RequestInformation>>(
 			1024 * 16, 0);
 
 	public RequestStatistic() {
@@ -134,6 +134,7 @@ public class RequestStatistic extends CoapResource {
 		getAttributes().setTitle("Resource that collects requests for client staistics");
 		getAttributes().addContentType(TEXT_PLAIN);
 		getAttributes().addContentType(APPLICATION_JSON);
+		requests.setEvictingOnReadAccess(false);
 	}
 
 	@Override

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/LeastRecentlyUsedCache.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/LeastRecentlyUsedCache.java
@@ -17,6 +17,8 @@
  *                                                    from system time changes
  *    Achim Kraus (Bosch Software Innovations GmbH) - add save remove with value
  *                                                    parameter
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add parameter for 
+ *                                                    "evict on access"
  ******************************************************************************/
 package org.eclipse.californium.elements.util;
 
@@ -25,45 +27,48 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 
 /**
- * An in-memory cache with a maximum capacity
- * and support for evicting stale entries based on an LRU policy.
+ * An in-memory cache with a maximum capacity and support for evicting stale
+ * entries based on an LRU policy.
  * <p>
- * The cache keeps track of the values' last-access time automatically.
- * Every time a value is read from or put to the store, the access-time
- * is updated.
+ * The cache keeps track of the values' last-access time automatically. Every
+ * time a value is read from or put to the store, the access-time is updated.
  * </p>
  * <p>
- * A value can be successfully added to the cache if any of the
- * following conditions is met:
+ * A value can be successfully added to the cache if any of the following
+ * conditions is met:
  * </p>
  * <ul>
  * <li>The cache's remaining capacity is greater than zero.</li>
- * <li>The cache contains at least one <em>stale</em> entry, i.e. an
- * entry that has not been accessed for at least the cache's
- * <em>expiration threshold</em> period. In such a case the least-
- * recently accessed stale entry gets evicted from the cache to make
- * place for the new value to be added.</li>
+ * <li>The cache contains at least one <em>stale</em> entry, i.e. an entry that
+ * has not been accessed for at least the cache's <em>expiration threshold</em>
+ * period. In such a case the least-recently accessed stale entry gets evicted
+ * from the cache to make place for the new value to be added.</li>
  * </ul>
  * <p>
- * This implementation uses a <code>java.util.HashMap</code> as its backing store.
- * In addition to that the cache keeps a doubly-linked list of the
- * entries in access-time order.
+ * Depending on {@link #evictOnReadAccess} the read access may evict expired
+ * entries or returns them and updates the last-access time.
  * </p>
  * <p>
- * Access to the cache's entries (e.g. <em>put</em>, <em>get</em>, <em>remove</em>)
- * is <em>not</em> thread safe. Clients should explicitly serialize access to the cache
- * from multiple threads.
+ * This implementation uses a {@link java.util.HashMap} as its backing store. In
+ * addition to that the cache keeps a doubly-linked list of the entries in
+ * access-time order.
  * </p>
  * <p>
- * Insertion, lookup and removal of entries is done in
- * <em>O(log n)</em>.
+ * Access to the cache's entries (e.g. <em>put</em>, <em>get</em>,
+ * <em>remove</em>, <em>find</em>) is <em>not</em> thread safe. Clients should
+ * explicitly serialize access to the cache from multiple threads.
+ * </p>
+ * <p>
+ * Insertion, lookup and removal of entries is done in <em>O(log n)</em>.
  * </p>
  * 
  * Note: if the <em>expiration threshold</em> is {@code 0}, "stale" is not
- * applied in {@link #get(Object)} (otherwise that get would never return something).
+ * applied in {@link #get(Object)} (otherwise that get would never return
+ * something).
  * 
  * @param <K> The type of the keys used in the cache.
  * @param <V> The type of the values used in the cache.
@@ -87,12 +92,21 @@ public class LeastRecentlyUsedCache<K, V> {
 	private Map<K, CacheEntry<K, V>> cache;
 	private volatile int capacity;
 	private CacheEntry<K, V> header;
+	/**
+	 * Threshold for expiration in seconds.
+	 */
 	private volatile long expirationThreshold;
+	/**
+	 * Enables eviction on read access ({@link #get(Object)} and
+	 * {@link #find(Predicate)}). Default is {@code true}.
+	 */
+	private volatile boolean evictOnReadAccess = true;
 	private List<EvictionListener<V>> evictionListeners = new LinkedList<>();
 
 	/**
-	 * Creates a cache with an initial capacity of {@link #DEFAULT_INITIAL_CAPACITY}, a maximum
-	 * capacity of {@link #DEFAULT_CAPACITY} entries and an expiration threshold of
+	 * Creates a cache with an initial capacity of
+	 * {@link #DEFAULT_INITIAL_CAPACITY}, a maximum capacity of
+	 * {@link #DEFAULT_CAPACITY} entries and an expiration threshold of
 	 * {@link #DEFAULT_THRESHOLD_SECS} seconds.
 	 */
 	public LeastRecentlyUsedCache() {
@@ -102,13 +116,13 @@ public class LeastRecentlyUsedCache<K, V> {
 	/**
 	 * Creates a cache based on given configuration parameters.
 	 * <p>
-	 * The cache's initial capacity is set to the lesser of {@link #DEFAULT_INITIAL_CAPACITY}
-	 * and <em>capacity</em>.
+	 * The cache's initial capacity is set to the lesser of
+	 * {@link #DEFAULT_INITIAL_CAPACITY} and <em>capacity</em>.
 	 * 
 	 * @param capacity the maximum number of entries the cache can manage
-	 * @param threshold the period of time of inactivity (in seconds) after which an
-	 *            entry is considered stale and can be evicted from the cache if
-	 *            a new entry is to be added to the cache
+	 * @param threshold the period of time of inactivity (in seconds) after
+	 *            which an entry is considered stale and can be evicted from the
+	 *            cache if a new entry is to be added to the cache
 	 */
 	public LeastRecentlyUsedCache(final int capacity, final long threshold) {
 
@@ -118,13 +132,14 @@ public class LeastRecentlyUsedCache<K, V> {
 	/**
 	 * Creates a cache based on given configuration parameters.
 	 * 
-	 * @param initialCapacity The initial number of entries the cache will be initialized to support.
-	 *            The cache's capacity will be doubled dynamically every time 0.75 percent of its
-	 *            current capacity is used but it will never exceed <em>maxCapacity</em>.
+	 * @param initialCapacity The initial number of entries the cache will be
+	 *            initialized to support. The cache's capacity will be doubled
+	 *            dynamically every time 0.75 percent of its current capacity is
+	 *            used but it will never exceed <em>maxCapacity</em>.
 	 * @param maxCapacity The maximum number of entries the cache can manage
-	 * @param threshold The period of time of inactivity (in seconds) after which an
-	 *            entry is considered stale and can be evicted from the cache if
-	 *            a new entry is to be added to the cache
+	 * @param threshold The period of time of inactivity (in seconds) after
+	 *            which an entry is considered stale and can be evicted from the
+	 *            cache if a new entry is to be added to the cache
 	 */
 	public LeastRecentlyUsedCache(final int initialCapacity, final int maxCapacity, final long threshold) {
 
@@ -144,7 +159,8 @@ public class LeastRecentlyUsedCache<K, V> {
 	}
 
 	/**
-	 * Registers a listener to be notified about (stale) entries being evicted from the cache.
+	 * Registers a listener to be notified about (stale) entries being evicted
+	 * from the cache.
 	 * 
 	 * @param listener the listener
 	 */
@@ -155,7 +171,28 @@ public class LeastRecentlyUsedCache<K, V> {
 	}
 
 	/**
-	 * Gets the period of time after which an entry is considered <em>stale</em> if it hasn't be accessed.
+	 * Get evict mode on read access.
+	 * 
+	 * @return {@code true}, if entries are evicted on read access, when
+	 *         expired, {@code false}, if not.
+	 */
+	public boolean isEvictingOnReadAccess() {
+		return evictOnReadAccess;
+	}
+
+	/**
+	 * Set evict mode on read access.
+	 * 
+	 * @param evict {@code true}, if entries are evicted on read access, when
+	 *            expired, {@code false}, if not.
+	 */
+	public void setEvictingOnReadAccess(boolean evict) {
+		evictOnReadAccess = evict;
+	}
+
+	/**
+	 * Gets the period of time after which an entry is considered <em>stale</em>
+	 * if it hasn't be accessed.
 	 * 
 	 * @return the threshold in seconds
 	 */
@@ -164,16 +201,18 @@ public class LeastRecentlyUsedCache<K, V> {
 	}
 
 	/**
-	 * Sets the period of time after which an entry is to be considered
-	 * stale if it hasn't be accessed.
+	 * Sets the period of time after which an entry is to be considered stale if
+	 * it hasn't be accessed.
 	 * 
-	 * <em>NB</em>: invoking this method after creation of the cache does <em>not</em> have an
-	 * immediate effect, i.e. no (now stale) entries are purged from the cache.
-	 * This happens only when a new entry is put to the cache or a stale entry is read from the cache.
+	 * <em>NB</em>: invoking this method after creation of the cache does
+	 * <em>not</em> have an immediate effect, i.e. no (now stale) entries are
+	 * purged from the cache. This happens only when a new entry is put to the
+	 * cache or a stale entry is read from the cache.
 	 * 
 	 * @param newThreshold the threshold in seconds
 	 * @see #put(Object, Object)
 	 * @see #get(Object)
+	 * @see #find(Predicate)
 	 */
 	public final void setExpirationThreshold(long newThreshold) {
 		this.expirationThreshold = newThreshold;
@@ -191,9 +230,10 @@ public class LeastRecentlyUsedCache<K, V> {
 	/**
 	 * Sets the maximum number of entries this cache can manage.
 	 * 
-	 * <em>NB</em>: invoking this method after creation of the cache does <em>not</em> have an
-	 * immediate effect, i.e. no entries are purged from the cache.
-	 * This happens only when a new entry is put to the cache or a stale entry is read from the cache.
+	 * <em>NB</em>: invoking this method after creation of the cache does
+	 * <em>not</em> have an immediate effect, i.e. no entries are purged from
+	 * the cache. This happens only when a new entry is put to the cache or a
+	 * stale entry is read from the cache.
 	 * 
 	 * @param capacity the maximum number of entries the cache can manage
 	 * @see #put(Object, Object)
@@ -213,8 +253,8 @@ public class LeastRecentlyUsedCache<K, V> {
 	}
 
 	/**
-	 * Gets the number of entries that can be added to this cache without
-	 * the need for removing stale entries.
+	 * Gets the number of entries that can be added to this cache without the
+	 * need for removing stale entries.
 	 * 
 	 * @return The number of entries.
 	 */
@@ -233,25 +273,25 @@ public class LeastRecentlyUsedCache<K, V> {
 	/**
 	 * Puts an entry to the cache.
 	 * 
-	 * An entry can be successfully added to the cache if any of the
-	 * following conditions are met:
+	 * An entry can be successfully added to the cache if any of the following
+	 * conditions are met:
 	 * <ul>
 	 * <li>The cache's remaining capacity is greater than zero.</li>
-	 * <li>The cache contains at least one <em>stale</em> entry, i.e. an
-	 * entry that has not been accessed for at least the cache's <em>
-	 * expiration threshold</em> period. In such a case the least-
-	 * recently accessed stale entry gets evicted from the cache to make
-	 * place for the new entry to be added.</li>
+	 * <li>The cache contains at least one <em>stale</em> entry, i.e. an entry
+	 * that has not been accessed for at least the cache's <em> expiration
+	 * threshold</em> period. In such a case the least- recently accessed stale
+	 * entry gets evicted from the cache to make place for the new entry to be
+	 * added.</li>
 	 * </ul>
 	 * 
 	 * If an entry is evicted this method notifies all registered
-	 * <code>EvictionListeners</code>.
+	 * {@code EvictionListeners}.
 	 * 
 	 * @param key the key to store the value under
 	 * @param value the value to store
-	 * @return <code>true</code> if the entry could be added to the
-	 * cache, <code>false</code> otherwise, e.g. because the cache's
-	 * remaining capacity is zero and no stale entries can be evicted
+	 * @return {@code true} if the entry could be added to the cache,
+	 *         {@code false} otherwise, e.g. because the cache's remaining
+	 *         capacity is zero and no stale entries can be evicted
 	 * @see #addEvictionListener(EvictionListener)
 	 */
 	public final boolean put(K key, V value) {
@@ -306,12 +346,9 @@ public class LeastRecentlyUsedCache<K, V> {
 	/**
 	 * Gets a value from the cache.
 	 * 
-	 * If the cache contains the key but the value is <em>stale</em>
-	 * the entry is removed from the cache.
-	 * 
 	 * @param key the key to look up in the cache
 	 * @return the value if the key has been found in the cache and the value is
-	 *         not stale, <code>null</code> otherwise
+	 *         not stale, {@code null} otherwise
 	 */
 	public final V get(K key) {
 		if (key == null) {
@@ -320,9 +357,15 @@ public class LeastRecentlyUsedCache<K, V> {
 		CacheEntry<K, V> entry = cache.get(key);
 		if (entry == null) {
 			return null;
-		} else if (expirationThreshold > 0 && entry.isStale(expirationThreshold)) {
+		}
+		return access(entry);
+	}
+
+	private final V access(CacheEntry<K, V> entry) {
+		if (evictOnReadAccess && expirationThreshold > 0 && entry.isStale(expirationThreshold)) {
 			cache.remove(entry.getKey());
 			entry.remove();
+			notifyEvictionListeners(entry.getValue());
 			return null;
 		} else {
 			entry.recordAccess(header);
@@ -333,9 +376,11 @@ public class LeastRecentlyUsedCache<K, V> {
 	/**
 	 * Removes an entry from the cache.
 	 * 
+	 * Doesn't call {@code EvictionListeners}.
+	 * 
 	 * @param key the key of the entry to remove
-	 * @return the removed value or <code>null</code> if the cache does not
-	 *         contain the key
+	 * @return the removed value or {@code null}, if the cache does not contain
+	 *         the key
 	 */
 	public final V remove(K key) {
 		if (key == null) {
@@ -353,10 +398,12 @@ public class LeastRecentlyUsedCache<K, V> {
 	/**
 	 * Removes provided entry from the cache.
 	 * 
+	 * Doesn't call {@code EvictionListeners}.
+	 * 
 	 * @param key the key of the entry to remove
 	 * @param value value of the entry to remove
-	 * @return the removed value or <code>null</code> if the cache does not
-	 *         contain the key or entry
+	 * @return the removed value or {@code null}, if the cache does not contain
+	 *         the key or entry
 	 */
 	public final V remove(K key, V value) {
 		if (key == null) {
@@ -376,15 +423,35 @@ public class LeastRecentlyUsedCache<K, V> {
 	/**
 	 * Finds a value based on a predicate.
 	 * 
-	 * @param predicate the condition to match
-	 * @return the first value from the cache that matches according to the given
-	 *          predicate or <code>null</code> if no value matches
+	 * @param predicate the condition to match. Assumed to match entries in a
+	 *            unique manner.
+	 * @return the first value from the cache that matches according to the
+	 *         given predicate, or {@code null}, if no value matches
 	 */
 	public final V find(Predicate<V> predicate) {
+		return find(predicate, true);
+	}
+
+	/**
+	 * Finds a value based on a predicate.
+	 * 
+	 * Returns the first matching value applying the {@link #evictOnReadAccess}
+	 * setting.
+	 * 
+	 * @param predicate the condition to match
+	 * @param unique {@code true}, if the predicate matches entries in a unique
+	 *            manner, {@code false}, if more entries may be matched.
+	 * @return the first value from the cache that matches according to the
+	 *         given predicate, or {@code null}, if no value matches
+	 */
+	public final V find(Predicate<V> predicate, boolean unique) {
 		if (predicate != null) {
 			for (CacheEntry<K, V> entry : cache.values()) {
 				if (predicate.accept(entry.getValue())) {
-					return entry.getValue();
+					V value = access(entry);
+					if (unique || value != null) {
+						return value;
+					}
 				}
 			}
 		}
@@ -392,8 +459,8 @@ public class LeastRecentlyUsedCache<K, V> {
 	}
 
 	/**
-	 * A predicate to be applied to cache entries to determine the result set when searching for particular
-	 * values.
+	 * A predicate to be applied to cache entries to determine the result set
+	 * when searching for particular values.
 	 *
 	 * @param <V> The type of value the predicate can be evaluated on.
 	 */
@@ -403,13 +470,15 @@ public class LeastRecentlyUsedCache<K, V> {
 		 * Applies the predicate to a cache value.
 		 * 
 		 * @param value The value to evaluate the predicate for.
-		 * @return {@code true} if the cache entry containing the value is part of the result set.
+		 * @return {@code true} if the cache entry containing the value is part
+		 *         of the result set.
 		 */
 		public boolean accept(V value);
 	}
 
 	/**
-	 * A callback for getting notified about entries being evicted from the cache.
+	 * A callback for getting notified about entries being evicted from the
+	 * cache.
 	 *
 	 * @param <V> The type of entry being evicted.
 	 */
@@ -427,8 +496,8 @@ public class LeastRecentlyUsedCache<K, V> {
 	 * Gets all connections contained in this cache.
 	 * <p>
 	 * The iterator returned is directly backed by this cache's underlying map.
-	 * If the cache is modified while an iteration over the values is in progress,
-	 * the results of the iteration are undefined.
+	 * If the cache is modified while an iteration over the values is in
+	 * progress, the results of the iteration are undefined.
 	 * </p>
 	 * <p>
 	 * Removal of connections from the iterator is unsupported.
@@ -441,14 +510,27 @@ public class LeastRecentlyUsedCache<K, V> {
 
 		return new Iterator<V>() {
 
+			private CacheEntry<K, V> nextEntry;
+
 			@Override
 			public boolean hasNext() {
-				return iter.hasNext();
+				nextEntry = null;
+				while (iter.hasNext()) {
+					CacheEntry<K, V> entry = iter.next();
+					if (access(entry) != null) {
+						nextEntry = entry;
+						break;
+					}
+				}
+				return nextEntry != null;
 			}
 
 			@Override
 			public V next() {
-				return iter.next().value;
+				if (nextEntry == null) {
+					throw new NoSuchElementException();
+				}
+				return nextEntry.value;
 			}
 
 			@Override
@@ -510,9 +592,8 @@ public class LeastRecentlyUsedCache<K, V> {
 
 		@Override
 		public String toString() {
-			return new StringBuilder("CacheEntry [key: ").append(key)
-					.append(", last access: ").append(lastUpdate).append("]")
-					.toString();
+			return new StringBuilder("CacheEntry [key: ").append(key).append(", last access: ").append(lastUpdate)
+					.append("]").toString();
 		}
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -16,6 +16,9 @@
  *                                                    for handshakeFailed.
  *    Achim Kraus (Bosch Software Innovations GmbH) - use final for collections
  *    Bosch Software Innovations GmbH - migrate to SLF4J
+ *    Achim Kraus (Bosch Software Innovations GmbH) - configure LRU to return 
+ *                                                    expired entries on read access.
+ *                                                    See issue #707
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -112,6 +115,7 @@ public final class InMemoryConnectionStore implements ResumptionSupportingConnec
 	 */
 	public InMemoryConnectionStore(final int capacity, final long threshold, final SessionCache sessionCache) {
 		connections = new LeastRecentlyUsedCache<>(capacity, threshold);
+		connections.setEvictingOnReadAccess(false);
 		this.sessionCache = sessionCache;
 
 		if (sessionCache != null) {


### PR DESCRIPTION
Update find and iterator to "evict on read access" processing including
the update of the last-access time.
Setup the usage of the LRU cache to explicit defined "evict on read access"
mode.
Fix issue #707.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>