### PR TITLE
Add time to tests log

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ErrorInjector.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ErrorInjector.java
@@ -53,7 +53,7 @@ public class ErrorInjector extends MessageInterceptorAdapter {
 		response.addMessageObserver(new ErrorInjectorMessageObserver(response));
 	}
 
-	private class ErrorInjectorMessageObserver extends MessageObserverAdapter {
+	public class ErrorInjectorMessageObserver extends MessageObserverAdapter {
 
 		private Message message;
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -1211,11 +1211,6 @@ public class BlockwiseClientSideTest {
 		reqtPayload = generateRandomPayload(300);
 		String path = "test";
 
-		// Add error injector to client endpoint to be able to simulate error
-		// before we really send a message.
-		ErrorInjector errorInjector = new ErrorInjector();
-		client.addInterceptor(errorInjector);
-
 		// Start block 1 transfer
 		Request request = createRequest(PUT, path, server);
 		request.setPayload(reqtPayload);
@@ -1229,7 +1224,9 @@ public class BlockwiseClientSideTest {
 				.payload(reqtPayload.substring(128, 256)).go();
 
 		// Simulate error before we send the next block1 request
+		ErrorInjector errorInjector = new ErrorInjector();
 		errorInjector.setErrorOnReadyToSend();
+		clientInterceptor.setErrorInjector(errorInjector);
 		server.sendResponse(ACK, CONTINUE).loadBoth("B").block1(1, true, 128).go();
 
 		// Wait for error
@@ -1250,11 +1247,6 @@ public class BlockwiseClientSideTest {
 		respPayload = generateRandomPayload(300);
 		String path = "test";
 
-		// Add error injector to client endpoint to be able to simulate error
-		// before we really send a message.
-		ErrorInjector errorInjector = new ErrorInjector();
-		client.addInterceptor(errorInjector);
-
 		// Start block 2 transfer
 		Request request = createRequest(GET, path, server);
 		CountingMessageObserver counter = new CountingMessageObserver();
@@ -1266,7 +1258,9 @@ public class BlockwiseClientSideTest {
 		server.expectRequest(CON, GET, path).storeBoth("B").block2(1, false, 128).go();
 
 		// Simulate error before we send the next block2 request
+		ErrorInjector errorInjector = new ErrorInjector();
 		errorInjector.setErrorOnReadyToSend();
+		clientInterceptor.setErrorInjector(errorInjector);
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 128).payload(respPayload.substring(128, 256))
 				.go();
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -262,7 +262,7 @@ public class BlockwiseClientSideTest {
 		request.waitForResponse();
 		assertTrue("BlockwiseLayer should be empty", client.getStack().getBlockwiseLayer().isEmpty());
 
-		clientInterceptor.log(System.lineSeparator() + "// next transfer");
+		clientInterceptor.logNewLine("// next transfer");
 		request = createRequest(GET, path, server);
 		client.sendRequest(request);
 		server.expectRequest(CON, GET, path).storeBoth("A").go();
@@ -823,7 +823,7 @@ public class BlockwiseClientSideTest {
 		notificationListener.resetNotificationCount();
 
 		System.out.println("Server sends first notification...");
-		clientInterceptor.log(System.lineSeparator() + "... time passes ...");
+		clientInterceptor.logNewLine("... time passes ...");
 		respPayload = generateRandomPayload(280);
 
 		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(62354).block2(0, true, 128).size2(respPayload.length())
@@ -843,7 +843,7 @@ public class BlockwiseClientSideTest {
 		assertNumberOfReceivedNotifications(notificationListener, 1, true);
 
 		System.out.println("Server sends second notification...");
-		clientInterceptor.log(System.lineSeparator() + "... time passes ...");
+		clientInterceptor.logNewLine("... time passes ...");
 		respPayload = generateRandomPayload(290);
 
 		server.sendResponse(CON, CONTENT).loadToken("At").mid(++mid).observe(17).block2(0, true, 128).size2(respPayload.length())

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseInterceptor.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseInterceptor.java
@@ -17,14 +17,21 @@
  ******************************************************************************/
 package org.eclipse.californium.core.test.lockstep;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.coap.MessageObserver;
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.test.ErrorInjector;
+import org.eclipse.californium.elements.EndpointContext;
+import org.eclipse.californium.elements.util.IntendedTestException;
 import org.eclipse.californium.elements.util.StringUtil;
 
 /**
@@ -35,10 +42,32 @@ public abstract class BlockwiseInterceptor {
 
 	private final long startNano = System.nanoTime();
 
+	protected ErrorInjector errorInjector;
+	protected CountDownLatch expectedErrors;
+
 	protected final StringBuilder buffer = new StringBuilder();
 
 	protected BlockwiseInterceptor() {
 		// do nothing
+	}
+
+	public final synchronized void setErrorInjector(ErrorInjector errorInjector) {
+		this.errorInjector = errorInjector;
+	}
+
+	public final synchronized void setExpectedErrors(int expectedErrors) {
+		this.expectedErrors = new CountDownLatch(expectedErrors);
+	}
+
+	public final boolean awaitErrors(long timeout, TimeUnit unit) throws InterruptedException {
+		final CountDownLatch expectedErrors;
+		synchronized (this) {
+			expectedErrors = this.expectedErrors;
+		}
+		if (expectedErrors != null) {
+			return expectedErrors.await(timeout, unit);
+		}
+		return false;
 	}
 
 	/**
@@ -71,8 +100,8 @@ public abstract class BlockwiseInterceptor {
 
 	protected final void appendBlockOption(final int nbr, final BlockOption option) {
 		if (option != null) {
-			buffer.append(", ").append(nbr).append(":")
-				.append(option.getNum()).append("/").append(option.isM() ? 1 : 0).append("/").append(option.getSize());
+			buffer.append(", ").append(nbr).append(":").append(option.getNum()).append("/").append(option.isM() ? 1 : 0)
+					.append("/").append(option.getSize());
 		}
 	}
 
@@ -112,9 +141,9 @@ public abstract class BlockwiseInterceptor {
 		if (request.isCanceled()) {
 			buffer.append("CANCELED ");
 		}
-		buffer.append(request.getType()).append(" [MID=").append(request.getMID())
-			.append(", T=").append(request.getTokenString()).append("], ")
-			.append(request.getCode()).append(", /").append(request.getOptions().getUriPathString());
+		buffer.append(request.getType()).append(" [MID=").append(request.getMID()).append(", T=")
+				.append(request.getTokenString()).append("], ").append(request.getCode()).append(", /")
+				.append(request.getOptions().getUriPathString());
 		appendBlockOption(1, request.getOptions().getBlock1());
 		appendBlockOption(2, request.getOptions().getBlock2());
 		appendObserveOption(request.getOptions());
@@ -126,9 +155,8 @@ public abstract class BlockwiseInterceptor {
 		if (response.isCanceled()) {
 			buffer.append("CANCELED ");
 		}
-		buffer.append(response.getType()).append(" [MID=").append(response.getMID())
-			.append(", T=").append(response.getTokenString()).append("], ")
-			.append(response.getCode());
+		buffer.append(response.getType()).append(" [MID=").append(response.getMID()).append(", T=")
+				.append(response.getTokenString()).append("], ").append(response.getCode());
 		appendBlockOption(1, response.getOptions().getBlock1());
 		appendBlockOption(2, response.getOptions().getBlock2());
 		appendObserveOption(response.getOptions());
@@ -152,8 +180,65 @@ public abstract class BlockwiseInterceptor {
 	/**
 	 * Clears the buffer.
 	 */
-	public final void clear() {
+	public synchronized final void clear() {
 		buffer.setLength(0);
+		errorInjector = null;
+	}
+
+	protected abstract class LoggingMessageObserver extends MessageObserverAdapter {
+
+		private final MessageObserver errorInjectorObserver;
+
+		protected LoggingMessageObserver(final ErrorInjector errorInjector, final Message message) {
+			this.errorInjectorObserver = errorInjector.new ErrorInjectorMessageObserver(message);
+		}
+
+		private void countDown() {
+			final CountDownLatch latch;
+			synchronized (this) {
+				latch = expectedErrors;
+			}
+			if (latch != null) {
+				latch.countDown();
+			}
+		}
+
+		@Override
+		public void onReadyToSend() {
+			try {
+				errorInjectorObserver.onReadyToSend();
+			} catch (IntendedTestException exception) {
+				log(exception);
+				countDown();
+				throw exception;
+			}
+		}
+
+		@Override
+		public void onSent() {
+			try {
+				errorInjectorObserver.onSent();
+				log(null);
+				countDown();
+			} catch (IntendedTestException exception) {
+				log(exception);
+				countDown();
+				throw exception;
+			}
+		}
+
+		@Override
+		public void onContextEstablished(EndpointContext endpointContext) {
+			try {
+				errorInjectorObserver.onContextEstablished(endpointContext);
+			} catch (IntendedTestException exception) {
+				log(exception);
+				countDown();
+				throw exception;
+			}
+		}
+
+		public abstract void log(IntendedTestException exception);
 	}
 
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
@@ -345,7 +345,7 @@ public class BlockwiseServerSideTest {
 		Thread.sleep((long) (TEST_BLOCKWISE_STATUS_LIFETIME * 0.75));
 		
 		assertTrue(!serverEndpoint.getStack().getBlockwiseLayer().isEmpty());
-		serverInterceptor.log(System.lineSeparator() + "//////// Missing last GET ////////");
+		serverInterceptor.logNewLine("//////// Missing last GET ////////");
 	}
 
 	/**
@@ -384,7 +384,7 @@ public class BlockwiseServerSideTest {
 		Thread.sleep((long) (TEST_BLOCKWISE_STATUS_LIFETIME * 0.75));
 
 		assertTrue(!serverEndpoint.getStack().getBlockwiseLayer().isEmpty());
-		serverInterceptor.log(System.lineSeparator() + "//////// Missing last PUT ////////");
+		serverInterceptor.logNewLine("//////// Missing last PUT ////////");
 	}
 
 	/**
@@ -440,7 +440,7 @@ public class BlockwiseServerSideTest {
 
 		// Try another BlockwiseLayer transfer from same peer, same URL, same
 		// option.
-		serverInterceptor.log(System.lineSeparator() + "// next transfer");
+		serverInterceptor.logNewLine("// next transfer");
 		reqtPayload = generateRandomPayload(300);
 		tok = generateNextToken();
 		client.sendRequest(CON, PUT, tok, ++mid).path(RESOURCE_PATH).block1(0, true, 128).size1(reqtPayload.length())
@@ -541,7 +541,7 @@ public class BlockwiseServerSideTest {
 		client.sendRequest(CON, PUT, tok, ++mid).path(RESOURCE_PATH).block1(1, true, 128).payload(reqtPayload.substring(128, 256)).go();
 		client.expectResponse(ACK, CONTINUE, tok, mid).block1(1, true, 128).payload("").go();
 
-		serverInterceptor.log(System.lineSeparator() + "... client crashes or whatever and restarts transfer");
+		serverInterceptor.logNewLine("... client crashes or whatever and restarts transfer");
 
 		client.sendRequest(CON, PUT, tok, ++mid).path(RESOURCE_PATH).block1(0, true, 128).size1(reqtPayload.length()).payload(reqtPayload.substring(0, 128)).go();
 		client.expectResponse(ACK, CONTINUE, tok, mid).block1(0, true, 128).payload("").go();
@@ -851,7 +851,7 @@ public class BlockwiseServerSideTest {
 		client.sendRequest(CON, GET, tok1, ++mid).path(RESOURCE_PATH).block2(2, false, 128).go();
 		client.expectResponse(ACK, CONTENT, tok1, mid).block2(2, false, 128).noOption(OBSERVE).payload(respPayload.substring(256, 300)).go();
 
-		serverInterceptor.log(System.lineSeparator() + "... time passes ...");
+		serverInterceptor.logNewLine("... time passes ...");
 		System.out.println("Send first notification");
 		respPayload = generateRandomPayload(280);
 		testResource.changed();
@@ -868,7 +868,7 @@ public class BlockwiseServerSideTest {
 		client.expectResponse(ACK, CONTENT, tok2, mid).block2(2, false, 128).noOption(OBSERVE).payload(respPayload.substring(256, 280)).go();
 
 		System.out.println("Send second notification");
-		serverInterceptor.log(System.lineSeparator() + "... time passes ...");
+		serverInterceptor.logNewLine("... time passes ...");
 		respPayload = generateRandomPayload(290);
 		testResource.changed();
 
@@ -903,7 +903,7 @@ public class BlockwiseServerSideTest {
 		client.expectResponse(ACK, CONTENT, tok, mid).block2(2, false, 64).noOption(OBSERVE).payload(respPayload.substring(128, 150)).go();
 
 		System.out.println("Send first notification");
-		serverInterceptor.log(System.lineSeparator() + "... time passes ...");
+		serverInterceptor.logNewLine("... time passes ...");
 		respPayload = generateRandomPayload(140);
 		testResource.changed(); // First notification
 
@@ -919,7 +919,7 @@ public class BlockwiseServerSideTest {
 		client.expectResponse(ACK, CONTENT, tok2, mid).block2(2, false, 64).noOption(OBSERVE).payload(respPayload.substring(128, 140)).go();
 
 		System.out.println("Send second notification");
-		serverInterceptor.log(System.lineSeparator() + "... time passes ...");
+		serverInterceptor.logNewLine("... time passes ...");
 		respPayload = generateRandomPayload(145);
 		testResource.changed(); // Second notification
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClientBlockwiseInterceptor.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClientBlockwiseInterceptor.java
@@ -23,9 +23,11 @@ import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
+import org.eclipse.californium.elements.util.IntendedTestException;
 
 /**
- * A message interceptor for tracing messages from the viewpoint of a CoAP client.
+ * A message interceptor for tracing messages from the viewpoint of a CoAP
+ * client.
  *
  */
 public final class ClientBlockwiseInterceptor extends BlockwiseInterceptor implements MessageInterceptor {
@@ -34,7 +36,26 @@ public final class ClientBlockwiseInterceptor extends BlockwiseInterceptor imple
 	public synchronized void sendRequest(final Request request) {
 		logNewLine();
 		appendRequestDetails(request);
-		buffer.append("    ----->");
+		if (errorInjector != null) {
+			buffer.append("    (should be dropped by error)");
+			request.addMessageObserver(new LoggingMessageObserver(errorInjector, request) {
+
+				@Override
+				public void log(IntendedTestException exception) {
+					logNewLine();
+					appendRequestDetails(request);
+					if (exception == null) {
+						buffer.append("    -----> (sent!)");
+					}
+					else {
+						buffer.append("    -----> (dropped)");
+					}
+				};
+			});
+		}
+		else {
+			buffer.append("    ----->");
+		}
 	}
 
 	@Override

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClientBlockwiseInterceptor.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClientBlockwiseInterceptor.java
@@ -32,37 +32,39 @@ public final class ClientBlockwiseInterceptor extends BlockwiseInterceptor imple
 
 	@Override
 	public synchronized void sendRequest(final Request request) {
-		buffer.append(System.lineSeparator());
+		logNewLine();
 		appendRequestDetails(request);
 		buffer.append("    ----->");
 	}
 
 	@Override
 	public synchronized void sendResponse(final Response response) {
-		buffer.append("ERROR: Server received ").append(response).append(System.lineSeparator());
+		logNewLine();
+		buffer.append("ERROR: Server received ").append(response);
 	}
 
 	@Override
 	public synchronized void sendEmptyMessage(final EmptyMessage message) {
-		buffer.append(System.lineSeparator());
+		logNewLine();
 		appendEmptyMessageDetails(message);
 		buffer.append("   ----->");
 	}
 
 	@Override
 	public synchronized void receiveRequest(final Request request) {
-		buffer.append(System.lineSeparator()).append("ERROR: Server sent ").append(request).append(System.lineSeparator());
+		logNewLine();
+		buffer.append("ERROR: Server sent ").append(request);
 	}
 
 	@Override
 	public synchronized void receiveResponse(Response response) {
-		buffer.append(System.lineSeparator()).append("<-----   ");
+		logNewLine("<-----   ");
 		appendResponseDetails(response);
 	}
 
 	@Override
 	public synchronized void receiveEmptyMessage(final EmptyMessage message) {
-		buffer.append(System.lineSeparator()).append("<-----   ");
+		logNewLine("<-----   ");
 		appendEmptyMessageDetails(message);
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/IntegrationTestTools.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/IntegrationTestTools.java
@@ -91,6 +91,7 @@ public final class IntegrationTestTools {
 
 	public static void printServerLog(ClientBlockwiseInterceptor interceptor) {
 		System.out.println(interceptor.toString());
+		System.out.println();
 		interceptor.clear();
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -232,7 +232,7 @@ public class ObserveClientSideTest {
 		server.sendResponse(ACK, CONTENT).loadBoth("B").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
 		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 16).go();
 
-		clientInterceptor.log(System.lineSeparator() + "//////// Overriding notification ////////");
+		clientInterceptor.logNewLine("//////// Overriding notification ////////");
 		String respPayload3 = "abcdefghijklmnopqrstuvwxyzabcdefghijklmn";
 
 		//
@@ -272,7 +272,7 @@ public class ObserveClientSideTest {
 		server.expectRequest(CON, GET, path).storeBoth("F").block2(1, false, 16).go();
 		server.goMultiExpectation();
 
-		clientInterceptor.log(System.lineSeparator() + "//////// Overriding notification (4) ////////");
+		clientInterceptor.logNewLine("//////// Overriding notification (4) ////////");
 		String respPayload4 = "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMN";
 
 		// start new block
@@ -286,7 +286,7 @@ public class ObserveClientSideTest {
 		server.goMultiExpectation();
 
 		// old block from notification 4 transfer
-		clientInterceptor.log(System.lineSeparator() + "//////// Conflicting notification block ////////");
+		clientInterceptor.logNewLine("//////// Conflicting notification block ////////");
 		// this block should be discarded by client
 		server.sendResponse(ACK, CONTENT).loadBoth("F").block2(1, true, 16).payload(respPayload.substring(16, 32)).go();
 
@@ -303,7 +303,7 @@ public class ObserveClientSideTest {
 		assertNumberOfReceivedNotifications(notificationListener, 1, true);
 
 		// cancel
-		clientInterceptor.log(System.lineSeparator() + "//////// Notification after cancellation ////////");
+		clientInterceptor.logNewLine("//////// Notification after cancellation ////////");
 		respPayload = generateRandomPayload(34);
 		server.sendResponse(CON, CONTENT).loadToken("T").mid(++mid).observe(6).block2(0, true, 16).size2(respPayload.length()).payload(respPayload.substring(0, 16)).go();
 		server.startMultiExpectation();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveServerSideTest.java
@@ -166,7 +166,7 @@ public class ObserveServerSideTest {
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
 		client.expectResponse(ACK, CONTENT, tok, mid).storeObserve("Z").payload(respPayload).go();
 		Assert.assertEquals("Resource has not added relation:", 1, testObsResource.getObserverCount());
-		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
+		serverInterceptor.logNewLine("Observe relation established");
 
 		// First notification
 		respType = NON;
@@ -215,7 +215,7 @@ public class ObserveServerSideTest {
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
 		client.expectResponse(ACK, CONTENT, tok, mid).storeObserve("A").payload(respPayload).go();
 		Assert.assertEquals("Resource has not added relation:", 1, testObsResource.getObserverCount());
-		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
+		serverInterceptor.logNewLine("Observe relation established");
 
 		// First notification
 		respType = CON;
@@ -253,7 +253,7 @@ public class ObserveServerSideTest {
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
 		client.expectResponse(ACK, CONTENT, tok, mid).storeObserve("A").payload(respPayload).go();
 		Assert.assertEquals("Resource has not added relation:", 1, testObsResource.getObserverCount());
-		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
+		serverInterceptor.logNewLine("Observe relation established");
 
 		// First notification
 		respType = CON;
@@ -280,7 +280,7 @@ public class ObserveServerSideTest {
 		client.expectResponse(ACK, CONTENT, tok, mid).storeObserve("A").storeETag("tag")
 			.block2(0, true, 32).size2(respPayload.length()).payload(respPayload, 0, 32).go();
 		Assert.assertEquals("Resource has not added relation:", 1, testObsResource.getObserverCount());
-		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
+		serverInterceptor.logNewLine("Observe relation established");
 
 		// Get remaining blocks
 		Token tok2 = generateNextToken();
@@ -292,7 +292,7 @@ public class ObserveServerSideTest {
 		// First notification
 		respType = CON;
 		testObsResource.change(generateRandomPayload(80));
-		serverInterceptor.log(System.lineSeparator() + "   === changed ===");
+		serverInterceptor.logNewLine("   === changed ===");
 		client.expectResponse().type(CON).code(CONTENT).token(tok).storeMID("MID").checkObs("A", "B").storeETag("tag")
 				.block2(0, true, 32).size2(respPayload.length()).payload(respPayload, 0, 32).go();
 		client.sendEmpty(ACK).loadMID("MID").go();
@@ -307,7 +307,7 @@ public class ObserveServerSideTest {
 		// Second notification
 		respType = CON;
 		testObsResource.change(generateRandomPayload(80));
-		serverInterceptor.log(System.lineSeparator() + "   === changed ===");
+		serverInterceptor.logNewLine("   === changed ===");
 		client.expectResponse().type(respType).code(CONTENT).token(tok).storeMID("MID").checkObs("A", "B").block2(0, true, 32).payload(respPayload, 0, 32).go();
 		
 		serverInterceptor.log("// Reject notification (cancel observe)");
@@ -327,7 +327,7 @@ public class ObserveServerSideTest {
 		client.sendRequest(NON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
 		client.expectResponse().type(NON).code(CONTENT).token(tok).storeObserve("A").payload(respPayload).go();
 		Assert.assertEquals("Resource has not added relation:", 1, testObsResource.getObserverCount());
-		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
+		serverInterceptor.logNewLine("Observe relation established");
 
 		// First notification
 		testObsResource.change("First notification " + generateRandomPayload(10));
@@ -362,7 +362,7 @@ public class ObserveServerSideTest {
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
 		client.expectResponse().type(ACK).code(CONTENT).token(tok).storeObserve("A").payload(respPayload).go();
 		Assert.assertEquals("Resource has not added relation:", 1, testObsResource.getObserverCount());
-		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
+		serverInterceptor.logNewLine("Observe relation established");
 
 		// First notification
 		testObsResource.change("First notification " + generateRandomPayload(10));
@@ -395,7 +395,7 @@ public class ObserveServerSideTest {
 		client.expectResponse().type(NON).code(CONTENT).token(tok).payload(respPayload, 16, 30).go();
 
 		assertThat("Resource has not added relation", testObsResource.getObserverCount(), is(1));
-		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
+		serverInterceptor.logNewLine("Observe relation established");
 
 		// First notification
 		testObsResource.change("First notification " + generateRandomPayload(10));
@@ -433,7 +433,7 @@ public class ObserveServerSideTest {
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
 		client.expectResponse(ACK, CONTENT, tok, mid).storeObserve("A").payload(respPayload).go();
 		Assert.assertEquals("Resource has not added relation:", 1, testObsResource.getObserverCount());
-		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
+		serverInterceptor.logNewLine("Observe relation established");
 
 		// First notification
 		testObsResource.change("First notification " + generateRandomPayload(10));
@@ -463,7 +463,7 @@ public class ObserveServerSideTest {
 		client.expectResponse().type(CON).code(CONTENT).token(tok).newMID("MID").checkObs("B", "B").payload(respPayload).go();
 
 		// after 4 retransmission attempts the server cancels the observation
-		serverInterceptor.log(System.lineSeparator() + "   server cancels observe relation");
+		serverInterceptor.logNewLine("   server cancels observe relation");
 
 		Assert.assertEquals("Resource has not removed observe relation after timeout:", 0, waitForObservers(ACK_TIMEOUT + 100, 0));
 	}
@@ -484,12 +484,12 @@ public class ObserveServerSideTest {
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
 		client.expectResponse(ACK, CONTENT, tok, mid).storeObserve("A").storeETag("tag").payload(respPayload).go();
 		Assert.assertEquals("Resource has not added relation:", 1, testObsResource.getObserverCount());
-		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
+		serverInterceptor.logNewLine("Observe relation established");
 
 		// First notification
 		respType = CON;
 		testObsResource.change(generateRandomPayload(80));
-		serverInterceptor.log(System.lineSeparator() + "   === changed ===");
+		serverInterceptor.logNewLine("   === changed ===");
 		client.expectResponse().type(CON).code(CONTENT).token(tok).storeMID("MID").checkObs("A", "B").storeETag("tag")
 				.block2(0, true, 32).size2(respPayload.length()).payload(respPayload, 0, 32).go();
 		client.sendEmpty(ACK).loadMID("MID").go();
@@ -516,7 +516,7 @@ public class ObserveServerSideTest {
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
 		client.expectResponse().type(ACK).code(CONTENT).token(tok).storeObserve("A").payload(respPayload).go();
 		Assert.assertEquals("Resource has not added relation:", 1, testObsResource.getObserverCount());
-		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
+		serverInterceptor.logNewLine("Observe relation established");
 
 		// First notification
 		testObsResource.change("First notification " + generateRandomPayload(10));
@@ -554,7 +554,7 @@ public class ObserveServerSideTest {
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
 		client.expectResponse().type(ACK).code(CONTENT).token(tok).storeObserve("A").payload(respPayload).go();
 		Assert.assertEquals("Resource has not added relation:", 1, testObsResource.getObserverCount());
-		serverInterceptor.log(System.lineSeparator() + "Observe relation established");
+		serverInterceptor.logNewLine("Observe relation established");
 
 		// First notification
 		testObsResource.change("First notification " + generateRandomPayload(10));

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ServerBlockwiseInterceptor.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ServerBlockwiseInterceptor.java
@@ -34,29 +34,27 @@ public final class ServerBlockwiseInterceptor extends BlockwiseInterceptor imple
 
 	@Override
 	public synchronized void sendRequest(final Request request) {
-		buffer.append(System.lineSeparator()).append("ERROR: Server sent ").append(request).append(System.lineSeparator());
+		logNewLine();
+		buffer.append("ERROR: Server sent ").append(request);
 	}
 
 	@Override
 	public synchronized void sendResponse(final Response response) {
-
-		buffer.append(System.lineSeparator()).append("<-----   ");
+		logNewLine("<-----   ");
 		appendResponseDetails(response);
 	}
 
 	@Override
 	public synchronized void sendEmptyMessage(final EmptyMessage message) {
-		buffer.append(System.lineSeparator()).append("<-----   ");
+		logNewLine("<-----   ");
 		appendEmptyMessageDetails(message);
 	}
 
 	@Override
 	public synchronized void receiveRequest(final Request request) {
-
-		buffer.append(System.lineSeparator());
+		logNewLine();
 		appendRequestDetails(request);
 		buffer.append("    ----->");
-
 		if (null != handler) {
 			handler.receiveRequest(request);
 		}
@@ -64,12 +62,13 @@ public final class ServerBlockwiseInterceptor extends BlockwiseInterceptor imple
 
 	@Override
 	public synchronized void receiveResponse(final Response response) {
-		buffer.append(System.lineSeparator()).append("ERROR: Server received ").append(response).append(System.lineSeparator());
+		logNewLine();
+		buffer.append("ERROR: Server received ").append(response);
 	}
 
 	@Override
 	public synchronized void receiveEmptyMessage(final EmptyMessage message) {
-		buffer.append(System.lineSeparator());
+		logNewLine();
 		appendEmptyMessageDetails(message);
 		buffer.append("    ----->");
 	}


### PR DESCRIPTION
Add time to the special blockwise interceptor logging.
Also add the error drops in the log.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>