### PR TITLE
Lru no update on read

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -219,7 +219,7 @@ public class BlockwiseLayer extends AbstractLayer {
 					if (enableStatus) {
 						{
 							HEALTH_LOGGER.debug("{} block1 transfers", block1Transfers.size());
-							Iterator<Block1BlockwiseStatus> iterator = block1Transfers.values();
+							Iterator<Block1BlockwiseStatus> iterator = block1Transfers.valuesIterator();
 							int max = 5;
 							while (iterator.hasNext()) {
 								HEALTH_LOGGER.debug("   block1 {}", iterator.next());
@@ -231,7 +231,7 @@ public class BlockwiseLayer extends AbstractLayer {
 						}
 						{
 							HEALTH_LOGGER.debug("{} block2 transfers", block2Transfers.size());
-							Iterator<Block2BlockwiseStatus> iterator = block2Transfers.values();
+							Iterator<Block2BlockwiseStatus> iterator = block2Transfers.valuesIterator();
 							int max = 5;
 							while (iterator.hasNext()) {
 								HEALTH_LOGGER.debug("   block2 {}", iterator.next());

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/LeastRecentlyUsedCacheTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/LeastRecentlyUsedCacheTest.java
@@ -14,6 +14,8 @@
  *    Kai Hudalla (Bosch Software Innovations GmbH) - initial creation
  *    Achim Kraus (Bosch Software Innovations GmbH) - add test for find and 
  *                                                    evict on access
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add test for iterator 
+ *                                                    and update last-access time
  ******************************************************************************/
 package org.eclipse.californium.elements.util;
 
@@ -24,6 +26,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.californium.elements.util.LeastRecentlyUsedCache.EvictionListener;
@@ -36,45 +40,99 @@ import org.junit.Test;
  */
 public class LeastRecentlyUsedCacheTest {
 
+	private static final long THRESHOLD_MILLIS = 300;
+
 	LeastRecentlyUsedCache<Integer, String> cache;
 
 	@Test
 	public void testGetFailsWhenExpired() throws InterruptedException {
-		long threshold = 1; // second
 		int capacity = 5;
 		int numberOfSessions = 1;
 
-		givenACacheWithEntries(capacity, threshold, numberOfSessions);
+		givenACacheWithEntries(capacity, THRESHOLD_MILLIS, numberOfSessions);
 		cache.setEvictingOnReadAccess(true);
 		String eldest = cache.getEldest();
 		Integer key = Integer.valueOf(eldest);
 		assertNotNull(cache.get(key));
-		Thread.sleep(threshold * 1100);
+		Thread.sleep(THRESHOLD_MILLIS + 100);
 		assertNull(cache.get(key));
 	}
 
 	@Test
 	public void testGetSucceedsEvenExpired() throws InterruptedException {
-		long threshold = 1; // second
 		int capacity = 5;
 		int numberOfSessions = 1;
 
-		givenACacheWithEntries(capacity, threshold, numberOfSessions);
+		givenACacheWithEntries(capacity, THRESHOLD_MILLIS, numberOfSessions);
 		cache.setEvictingOnReadAccess(false);
 		String eldest = cache.getEldest();
 		Integer key = Integer.valueOf(eldest);
 		assertNotNull(cache.get(key));
-		Thread.sleep(threshold * 1100);
+		Thread.sleep(THRESHOLD_MILLIS + 100);
 		assertNotNull(cache.get(key));
 	}
 
 	@Test
+	public void testUpdate() throws InterruptedException {
+		int capacity = 5;
+		int numberOfSessions = 1;
+
+		givenACacheWithEntries(capacity, THRESHOLD_MILLIS, numberOfSessions);
+		cache.setEvictingOnReadAccess(true);
+		cache.setUpdatingOnReadAccess(false);
+		String eldest = cache.getEldest();
+		Integer key = Integer.valueOf(eldest);
+		Thread.sleep(THRESHOLD_MILLIS / 2);
+		assertNotNull(cache.get(key));
+		assertTrue(cache.update(key)); // update last-access time
+		Thread.sleep((THRESHOLD_MILLIS / 2) + 100);
+		assertNotNull(cache.get(key)); // not expired
+		assertTrue(cache.update(key));
+		Thread.sleep(THRESHOLD_MILLIS / 2);
+		assertNotNull(cache.get(key)); // no update last-access time
+		Thread.sleep((THRESHOLD_MILLIS / 2) + 100);
+		assertNull(cache.get(key)); // expired!
+	}
+
+	@Test
+	public void testIteratorWhenExpired() throws InterruptedException {
+		int capacity = 5;
+		int numberOfSessions = 5;
+
+		givenACacheWithEntries(capacity, THRESHOLD_MILLIS, numberOfSessions);
+		cache.setEvictingOnReadAccess(true);
+		Thread.sleep(THRESHOLD_MILLIS / 2);
+		Iterator<String> valuesIterator = cache.valuesIterator();
+		cache.setUpdatingOnReadAccess(true);
+		assertNext(valuesIterator);
+		cache.setUpdatingOnReadAccess(false);
+		assertNext(valuesIterator);
+		cache.setUpdatingOnReadAccess(true);
+		assertNext(valuesIterator);
+		cache.setUpdatingOnReadAccess(false);
+		assertNext(valuesIterator);
+		cache.setUpdatingOnReadAccess(true);
+		assertNext(valuesIterator);
+		Thread.sleep((THRESHOLD_MILLIS / 2) + 100);
+
+		valuesIterator = cache.valuesIterator();
+		assertNext(valuesIterator);
+		assertNext(valuesIterator);
+		assertNext(valuesIterator);
+		assertFalse(valuesIterator.hasNext());
+	}
+
+	private void assertNext(Iterator<String> iterator) {
+		String value = iterator.next();
+		assertNotNull(value);
+	}
+
+	@Test
 	public void testFindUniqueFailsWhenExpired() throws InterruptedException {
-		long threshold = 1; // second
 		int capacity = 5;
 		int numberOfSessions = 3;
 
-		givenACacheWithEntries(capacity, threshold, numberOfSessions);
+		givenACacheWithEntries(capacity, THRESHOLD_MILLIS, numberOfSessions);
 		cache.setEvictingOnReadAccess(true);
 		final String eldest = cache.getEldest();
 		Predicate<String> predicate = new Predicate<String>() {
@@ -86,17 +144,16 @@ public class LeastRecentlyUsedCacheTest {
 
 		};
 		assertNotNull(cache.find(predicate));
-		Thread.sleep(threshold * 1100);
+		Thread.sleep(THRESHOLD_MILLIS + 100);
 		assertNull(cache.find(predicate));
 	}
 
 	@Test
 	public void testFindUniqueSucceedsEvenExpired() throws InterruptedException {
-		long threshold = 1; // second
 		int capacity = 5;
 		int numberOfSessions = 3;
 
-		givenACacheWithEntries(capacity, threshold, numberOfSessions);
+		givenACacheWithEntries(capacity, THRESHOLD_MILLIS, numberOfSessions);
 		cache.setEvictingOnReadAccess(false);
 		final String eldest = cache.getEldest();
 		Predicate<String> predicate = new Predicate<String>() {
@@ -108,23 +165,34 @@ public class LeastRecentlyUsedCacheTest {
 
 		};
 		assertNotNull(cache.find(predicate));
-		Thread.sleep(threshold * 1100);
+		Thread.sleep(THRESHOLD_MILLIS + 100);
 		assertNotNull(cache.find(predicate));
 	}
 
 	@Test
 	public void testFindNoneUniqueSucceedsEvenFirstEvicted() throws InterruptedException {
-		long threshold = 1; // second
 		int capacity = 5;
 		int numberOfSessions = 3;
 
-		givenACacheWithEntries(capacity, threshold, numberOfSessions);
-		cache.setEvictingOnReadAccess(false);
-		SimplePredicate predicate = new SimplePredicate(2);
-		assertNotNull(cache.find(predicate));
-		Thread.sleep(threshold * 1100);
-		predicate = new SimplePredicate(2);
-		assertNotNull(cache.find(predicate));
+		givenACacheWithEntries(capacity, THRESHOLD_MILLIS, numberOfSessions);
+		cache.setEvictingOnReadAccess(true);
+
+		Thread.sleep(THRESHOLD_MILLIS / 2);
+
+		// skip 1., update 2. by read
+		SkipFirsts predicate = new SkipFirsts(1);
+		String value;
+		assertNotNull((value = cache.find(predicate, false)));
+
+		// expires 1.
+		Thread.sleep((THRESHOLD_MILLIS / 2) + 100);
+
+		EvictionCounter counter = new EvictionCounter();
+		cache.addEvictionListener(counter);
+		// evict 1., select the 2.
+		predicate = new SkipFirsts(0);
+		assertThat(cache.find(predicate, false), is(value));
+		assertThat(counter.count, is(1));
 	}
 
 	@Test
@@ -156,11 +224,10 @@ public class LeastRecentlyUsedCacheTest {
 
 	@Test
 	public void testStoreFailsIfCapacityReached() {
-		long threshold = 10; // seconds
 		int capacity = 10;
 		int numberOfSessions = 10;
 
-		givenACacheWithEntries(capacity, threshold, numberOfSessions);
+		givenACacheWithEntries(capacity, THRESHOLD_MILLIS * 100, numberOfSessions);
 		assertThat(cache.remainingCapacity(), is(0));
 		String eldest = cache.getEldest();
 
@@ -200,29 +267,38 @@ public class LeastRecentlyUsedCacheTest {
 	/**
 	 * 
 	 * @param capacity
-	 * @param expirationThreshold
+	 * @param expirationThresholdMillis
 	 * @param noOfEntries
 	 */
-	private void givenACacheWithEntries(int capacity, long expirationThreshold, int noOfEntries) {
-		cache = new LeastRecentlyUsedCache<>(capacity, expirationThreshold);
-
+	private void givenACacheWithEntries(int capacity, long expirationThresholdMillis, int noOfEntries) {
+		cache = new LeastRecentlyUsedCache<>(capacity, 0);
+		cache.setExpirationThreshold(expirationThresholdMillis, TimeUnit.MILLISECONDS);
 		for (int i = 0; i < noOfEntries; i++) {
 			cache.put(i, String.valueOf(i));
 		}
 	}
 
-	private static class SimplePredicate implements Predicate<String> {
+	private static class SkipFirsts implements Predicate<String> {
 
-		int count = 2;
+		private int skipCount;
 
-		private SimplePredicate(int count) {
-			this.count = count;
+		private SkipFirsts(int skipCount) {
+			this.skipCount = skipCount;
 		}
 
 		@Override
 		public boolean accept(String value) {
-			--count;
-			return count <= 0;
+			return skipCount-- <= 0;
+		}
+	};
+
+	private static class EvictionCounter implements EvictionListener<String> {
+
+		private int count;
+
+		@Override
+		public void onEviction(String value) {
+			++count;
 		}
 	};
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -23,12 +23,11 @@
 package org.eclipse.californium.scandium.dtls;
 
 import java.net.InetSocketAddress;
-import java.util.Iterator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.eclipse.californium.elements.util.LeastRecentlyUsedCache;
 import org.eclipse.californium.elements.util.LeastRecentlyUsedCache.Predicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An in-memory <code>ConnectionStore</code> with a configurable maximum capacity
@@ -217,11 +216,8 @@ public final class InMemoryConnectionStore implements ResumptionSupportingConnec
 
 	@Override
 	public synchronized void markAllAsResumptionRequired() {
-		for (Iterator<Connection> iterator = connections.values(); iterator.hasNext(); ) {
-			Connection c = iterator.next();
-			if (c != null){
-				c.setResumptionRequired(true);
-			}
+		for (Connection connection : connections.values()) {
+			connection.setResumptionRequired(true);
 		}
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumptionSupportingConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumptionSupportingConnectionStore.java
@@ -19,6 +19,16 @@ public interface ResumptionSupportingConnectionStore {
 	boolean put(Connection connection);
 
 	/**
+	 * Update a connection in the store.
+	 * 
+	 * Update the last-access time to prevent connection from being evicted.
+	 * 
+	 * @param connection the connection to update.
+	 * @return <code>true</code>, if updated, <code>false</code>, otherwise.
+	 */
+	boolean update(Connection connection);
+
+	/**
 	 * Gets the number of additional connection this store can manage.
 	 * 
 	 * @return the remaining capacity
@@ -62,5 +72,5 @@ public interface ResumptionSupportingConnectionStore {
 	 * 
 	 */
 	void markAllAsResumptionRequired();
-	
+
 }


### PR DESCRIPTION
Update LRU last-access time conditionally. 
Use that to update DTLS session timestamp only on valid MAC.

Additional changes and fixes:
Change values() to return a Collection instead of an Iterator. Enables
use in for-loops. Use nanoseconds for threshold to speedup tests.
Fixes ConcurrentModificationException, when eviction occurs during
iteration over entries.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>