### PR TITLE
Fix reordered handshake

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -26,7 +26,7 @@
  *    Kai Hudalla (Bosch Software Innovations GmbH) - derive max fragment length from network MTU
  *    Kai Hudalla (Bosch Software Innovations GmbH) - use SessionListener to trigger sending of pending
  *                                                    APPLICATION messages
- *    Achim Kraus (Bosch Software Innovations GmbH) - use isSendRawKey also for 
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use isSendRawKey also for
  *                                                    supportedServerCertificateTypes
  *    Ludwig Seitz (RISE SICS) - Updated calls to verifyCertificate() after refactoring
  *    Bosch Software Innovations GmbH - migrate to SLF4J
@@ -35,9 +35,11 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - issue #549
  *                                                    trustStore := null, disable x.509
  *                                                    trustStore := [], enable x.509, trust all
- *    Achim Kraus (Bosch Software Innovations GmbH) - fix usage of literal address 
+ *    Achim Kraus (Bosch Software Innovations GmbH) - fix usage of literal address
  *                                                    with enabled sni
- *    Vikram (University of Rostock) - added ECDHE_PSK mode                                                
+ *    Vikram (University of Rostock) - added ECDHE_PSK mode
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add handshake parameter available to
+ *                                                    process reordered handshake messages
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -394,6 +396,7 @@ public class ClientHandshaker extends Handshaker {
 		session.setSendRawPublicKey(CertificateType.RAW_PUBLIC_KEY.equals(serverHello.getClientCertificateType()));
 		session.setReceiveRawPublicKey(CertificateType.RAW_PUBLIC_KEY.equals(serverHello.getServerCertificateType()));
 		session.setSniSupported(serverHello.hasServerNameExtension());
+		session.setParameterAvailable();
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -33,6 +33,9 @@
  *    Bosch Software Innovations GmbH - migrate to SLF4J
  *    Achim Kraus (Bosch Software Innovations GmbH) - preserve creation time of session.
  *                                                    update time on set master secret.
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add handshake parameter and
+ *                                                    handshake parameter available to
+ *                                                    process reordered handshake messages
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -153,6 +156,12 @@ public final class DTLSSession {
 	 * If <code>true</code> expect a RawPublicKey, a full X.509 certificate chain otherwise.
 	 */
 	private boolean receiveRawPublicKey = false;
+
+	/**
+	 * Indicates, that the handshake parameters are available.
+	 * @see HandshakeParameter
+	 */
+	private boolean parameterAvailable = false;
 
 	private volatile long receiveWindowUpperBoundary = RECEIVE_WINDOW_SIZE - 1;
 	private volatile long receiveWindowLowerBoundary = 0;
@@ -585,6 +594,27 @@ public final class DTLSSession {
 	 */
 	synchronized public String getWriteStateCipher() {
 		return writeState.getCipherSuite().name();
+	}
+
+	/**
+	 * Set parameter available. Enables {@link #getParameter()} to return the
+	 * handshake parameter.
+	 */
+	public void setParameterAvailable() {
+		parameterAvailable = true;
+	}
+
+	/**
+	 * Return the handshake parameter, if set available.
+	 * 
+	 * @return the handshake parameter, or {@code null}, if
+	 *         {@link #setParameterAvailable()} wasn't called before.
+	 */
+	public HandshakeParameter getParameter() {
+		if (parameterAvailable) {
+			return new HandshakeParameter(cipherSuite.getKeyExchange(), receiveRawPublicKey);
+		}
+		return null;
 	}
 
 	final KeyExchangeAlgorithm getKeyExchange() {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/GenericHandshakeMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/GenericHandshakeMessage.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+
+/**
+ * Generic handshake message.
+ * 
+ * Use to partially process handshake messages, if they are received out of
+ * order an the full processing requires the {@link HandshakeParameter}. Offers
+ * later creation of specific handshake messages, if the handshake parameters
+ * are available.
+ */
+public class GenericHandshakeMessage extends HandshakeMessage {
+
+	/**
+	 * Handshake type of message
+	 */
+	private final HandshakeType type;
+	/**
+	 * Fragment bytes.
+	 */
+	private final byte[] byteArray;
+
+	/**
+	 * Create generic handshake message.
+	 * 
+	 * @param type handshake type
+	 * @param byteArray fragment bytes
+	 * @param peerAddress address of peer
+	 */
+	private GenericHandshakeMessage(HandshakeType type, byte[] byteArray, InetSocketAddress peerAddress) {
+		super(peerAddress);
+		this.byteArray = Arrays.copyOf(byteArray, byteArray.length);
+		this.type = type;
+	}
+
+	@Override
+	public HandshakeType getMessageType() {
+		return type;
+	}
+
+	@Override
+	public int getMessageLength() {
+		return byteArray.length;
+	}
+
+	@Override
+	public byte[] fragmentToByteArray() {
+		return byteArray;
+	}
+
+	/**
+	 * Get specific handshake message.
+	 * 
+	 * @param parameter handshake parameter
+	 * @return specific handshake message
+	 * @throws NullPointerException if handshake parameter is {@code null}
+	 * @throws HandshakeException if specific handshake message could not be
+	 *             created
+	 */
+	public HandshakeMessage getSpecificHandshakeMessage(HandshakeParameter parameter) throws HandshakeException {
+		if (parameter == null) {
+			throw new NullPointerException("HandshakeParameter must not be null!");
+		}
+		return HandshakeMessage.fromByteArray(getRawMessage(), parameter, getPeer());
+	}
+
+	/**
+	 * Read generic generic handshake message from bytes.
+	 * 
+	 * @param type handshake type
+	 * @param byteArray fragment bytes
+	 * @param peerAddress address of peer
+	 * @return generic handshake message
+	 */
+	public static GenericHandshakeMessage fromByteArray(HandshakeType type, byte[] byteArray,
+			InetSocketAddress peerAddress) {
+		return new GenericHandshakeMessage(type, byteArray, peerAddress);
+	}
+
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeParameter.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeParameter.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
+
+/**
+ * Handshake parameter.
+ * 
+ * Parameter which are defined by exchanged handshake messages and are used to
+ * decode other handshake messages.
+ */
+public class HandshakeParameter {
+
+	/**
+	 * Key exchange algorithm.
+	 */
+	private final KeyExchangeAlgorithm keyExchange;
+	/**
+	 * Indicate to use raw public keys certificates.
+	 */
+	private final boolean useRawPublicKey;
+
+	/**
+	 * Create handshake parameter.
+	 * 
+	 * @param keyExchange the key exchange algorithm
+	 * @param useRawPublicKey {@code true} to use raw public keys certificates,
+	 *            {@cod false}, otherwise.
+	 * @throws NullPointerException if key exchange is {@link null}
+	 */
+	public HandshakeParameter(KeyExchangeAlgorithm keyExchange, boolean useRawPublicKey) {
+		if (keyExchange == null) {
+			throw new NullPointerException("key exchange must not be null!");
+		}
+		this.keyExchange = keyExchange;
+		this.useRawPublicKey = useRawPublicKey;
+	}
+
+	/**
+	 * Get key exchange algorithm.
+	 * 
+	 * @return key exchange algorithm
+	 */
+	public KeyExchangeAlgorithm getKeyExchangeAlgorithm() {
+		return keyExchange;
+	}
+
+	/**
+	 * Indicate to use raw public key certificates.
+	 * 
+	 * @return {@code true} to use use raw public key certificates,
+	 *         {@code false} otherwise.
+	 */
+	public boolean useRawPublicKey() {
+		return useRawPublicKey;
+	}
+
+	public String toString() {
+		return "KeyExgAl=" + keyExchange + ", " + (useRawPublicKey ? "RPK" : "x.509");
+	}
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -45,6 +45,8 @@
  *                                                    trustStore := null, disable x.509
  *                                                    trustStore := [], enable x.509, trust all
  *    Vikram (University of Rostock) - added ECDHE_PSK mode
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add handshake parameter available to
+ *                                                    process reordered handshake messages
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -821,8 +823,9 @@ public class ServerHandshaker extends Handshaker {
 					negotiatedSupportedGroup = group;
 					session.setCipherSuite(cipherSuite);
 					addServerHelloExtensions(cipherSuite, clientHello, serverHelloExtensions);
+					session.setParameterAvailable();
 					LOGGER.debug("Negotiated cipher suite [{}] with peer [{}]",
-							new Object[]{cipherSuite.name(), getPeerAddress()});
+							cipherSuite.name(), getPeerAddress());
 					return;
 				}
 			}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/CertificateMessageTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/CertificateMessageTest.java
@@ -136,22 +136,23 @@ public class CertificateMessageTest {
 	@Test
 	public void testSerializationUsingRawPublicKey() throws IOException, GeneralSecurityException, HandshakeException {
 		givenACertificateMessage(DtlsTestTools.getServerCertificateChain(), true);
+		HandshakeParameter parameter = new HandshakeParameter(KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN, true);
 		PublicKey pk = message.getPublicKey();
 		assertNotNull(pk);
 		serializedMessage = message.toByteArray();
 		CertificateMessage msg = (CertificateMessage) HandshakeMessage.fromByteArray(
-				serializedMessage, KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN, true, peerAddress);
+				serializedMessage, parameter, peerAddress);
 		assertThat(msg.getPublicKey(), is(pk));
 	}
 
 	@Test
 	public void testSerializationUsingX509() throws IOException, GeneralSecurityException, HandshakeException {
 		givenACertificateMessage(DtlsTestTools.getServerCertificateChain(), false);
+		HandshakeParameter parameter = new HandshakeParameter(KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN, false);
 		PublicKey pk = message.getPublicKey();
 		assertNotNull(pk);
 		serializedMessage = message.toByteArray();
-		message = (CertificateMessage) HandshakeMessage.fromByteArray(
-				serializedMessage, KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN, false, peerAddress);
+		message = (CertificateMessage) HandshakeMessage.fromByteArray(serializedMessage, parameter, peerAddress);
 		assertThat(message.getPublicKey(), is(pk));
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchangeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchangeTest.java
@@ -58,8 +58,8 @@ public class ECDHServerKeyExchangeTest {
 	@Test
 	public void testDeserializedInstanceToString() throws HandshakeException {
 		byte[] serializedMsg = msg.toByteArray();
-		HandshakeMessage handshakeMsg = HandshakeMessage.fromByteArray(
-				serializedMsg, KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN, true, peerAddress);
+		HandshakeParameter parameter = new HandshakeParameter(KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN, true);
+		HandshakeMessage handshakeMsg = HandshakeMessage.fromByteArray(serializedMsg, parameter, peerAddress);
 		assertNotNull(handshakeMsg.toString());
 	}
 }

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchangeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchangeTest.java
@@ -56,8 +56,8 @@ public class EcdhPskClientKeyExchangeTest {
 	@Test
 	public void testDeserializedMsg() throws HandshakeException {
 		byte[] serializedMsg = msg.toByteArray();
-		HandshakeMessage handshakeMsg = HandshakeMessage.fromByteArray(
-				serializedMsg, KeyExchangeAlgorithm.ECDHE_PSK, false, peerAddress);
+		HandshakeParameter parameter = new HandshakeParameter(KeyExchangeAlgorithm.ECDHE_PSK, false);
+		HandshakeMessage handshakeMsg = HandshakeMessage.fromByteArray(serializedMsg, parameter, peerAddress);
 		assertTrue(((EcdhPskClientKeyExchange)handshakeMsg).getIdentity().equals(identity));
 		assertNotNull(ephemeralKeyPointEncoded);
 		assertTrue((Arrays.equals(((EcdhPskClientKeyExchange)handshakeMsg).getEncodedPoint(), ephemeralKeyPointEncoded)));

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchangeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchangeTest.java
@@ -57,8 +57,8 @@ public class EcdhPskServerKeyExchangeTest {
 	@Test
 	public void testDeserializedMsg() throws HandshakeException {
 		byte[] serializedMsg = msg.toByteArray();
-		HandshakeMessage handshakeMsg = HandshakeMessage.fromByteArray(
-				serializedMsg, KeyExchangeAlgorithm.ECDHE_PSK, false, peerAddress);		
+		HandshakeParameter parameter = new HandshakeParameter(KeyExchangeAlgorithm.ECDHE_PSK, false);
+		HandshakeMessage handshakeMsg = HandshakeMessage.fromByteArray(serializedMsg, parameter, peerAddress);
 		assertTrue(((EcdhPskServerKeyExchange)handshakeMsg).getCurveId() == SupportedGroup.secp256r1.getId());
 		assertNotNull(ephemeralPubKey);
 		assertTrue(((EcdhPskServerKeyExchange)handshakeMsg).getPublicKey().equals(ephemeralPubKey));

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
@@ -102,6 +102,7 @@ public class HandshakerTest {
 
 		session = new DTLSSession(endpoint, false);
 		session.setReceiveRawPublicKey(false);
+		session.setParameterAvailable();
 		certificateChain = DtlsTestTools.getServerCertificateChain();
 		trustAnchor = DtlsTestTools.getTrustedCertificates();
 		certificateMessage = createCertificateMessage(1);


### PR DESCRIPTION
Add uni test with reordered messages during a handshake. 
Introduced handshake parameter and signal their availability.
Use generic handshake message to partially process a handshake
message, when the handshake parameters are not already available.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>
