### PR TITLE
Redesign connection/session listener function.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -47,6 +47,9 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - issue 744: use handshaker as
  *                                                    parameter for session listener.
  *    Achim Kraus (Bosch Software Innovations GmbH) - add handshakeFlightRetransmitted
+ *    Achim Kraus (Bosch Software Innovations GmbH) - redesign connection session listener to
+ *                                                    ensure, that the session listener methods
+ *                                                    are called via the handshaker.
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStoreTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStoreTest.java
@@ -12,6 +12,9 @@
  * 
  * Contributors:
  *    Kai Hudalla (Bosch Software Innovations GmbH) - initial creation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - redesign connection session listener to
+ *                                                    ensure, that the session listener methods
+ *                                                    are called via the handshaker.
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -121,7 +124,7 @@ public class InMemoryConnectionStoreTest {
 		InetAddress addr = InetAddress.getByAddress(longToIp(ip));
 		InetSocketAddress peerAddress = new InetSocketAddress(addr, 0);
 		Connection con = new Connection(peerAddress, null);
-		con.sessionEstablished(null, newSession(peerAddress));
+		con.getSessionListener().sessionEstablished(null, newSession(peerAddress));
 		return con;
 	}
 


### PR DESCRIPTION
Currently `onHandshakeComplete` will not be called for all listener, when called in application date received.
Also, if the handshaker is replaced, pending `newDeferredMessageSender` will not be called.
This PR is not intended to be merged for 2.0.0-M12, it may change the behaviour too much.
But It should go into scandium after the M12.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>