### PR TITLE
Remove HELLO_VERIFY_REQUEST from resumption handshakes.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -169,6 +169,11 @@ public final class DtlsConnectorConfig {
 
 	private Boolean sniEnabled;
 
+	/**
+	 * Use HELLO_VERIFY_REQUEST for session resumption.
+	 */
+	private Boolean verifyRequestOnResumptionEnabled;
+
 	private DtlsConnectorConfig() {
 		// empty
 	}
@@ -253,6 +258,19 @@ public final class DtlsConnectorConfig {
 	 */
 	public Boolean isSniEnabled() {
 		return sniEnabled;
+	}
+
+	/**
+	 * Checks whether a HELLO_VERIFY_REQUEST should be used also for session
+	 * resumption. Though a CLIENT_HELLO with an session id is used for session
+	 * resumption, that session ID could be used to check, if this is a valid
+	 * CLIENT_HELLO request.
+	 * 
+	 * @return {@code true} if a HELLO_VERIFY_REQUEST should be used also for
+	 *         session resumption
+	 */
+	public Boolean isVerifyRequestOnResumptionEnabled() {
+		return verifyRequestOnResumptionEnabled;
 	}
 
 	/**
@@ -478,6 +496,7 @@ public final class DtlsConnectorConfig {
 		cloned.connectionThreadCount = connectionThreadCount;
 		cloned.autoResumptionTimeoutMillis = autoResumptionTimeoutMillis;
 		cloned.sniEnabled = sniEnabled;
+		cloned.verifyRequestOnResumptionEnabled = verifyRequestOnResumptionEnabled;
 		return cloned;
 	}
 
@@ -1018,6 +1037,26 @@ public final class DtlsConnectorConfig {
 			return this;
 		}
 
+		/**
+		 * Sets whether a HELLO_VERIFY_REQUEST should be used also for session
+		 * resumption. If a CLIENT_HELLO with an session ID is used for session
+		 * resumption, that session ID could be used to check, if this is a
+		 * valid CLIENT_HELLO request. Though HELLO_VERIFY_REQUEST requires one
+		 * message exchange more, it slows down a bit the handshake. If your
+		 * system is expect to be attacked by spoofed IP message with valid
+		 * session IDs, enable the use of verify requests as protection against
+		 * that. The default is disabled (assuming that spoof attack with valid
+		 * session IDs are negligible).
+		 * 
+		 * @param flag {@code true} if a HELLO_VERIFY_REQUEST should be used
+		 *            also for session resumption
+		 * @return this builder for command chaining.
+		 */
+		public Builder setVerifyRequestOnResumptionEnabled(boolean flag) {
+			config.verifyRequestOnResumptionEnabled = flag;
+			return this;
+		}
+
 		private boolean isConfiguredWithKeyPair() {
 			return config.privateKey != null && config.publicKey != null;
 		}
@@ -1106,6 +1145,9 @@ public final class DtlsConnectorConfig {
 			}
 			if (config.sniEnabled == null) {
 				config.sniEnabled = Boolean.TRUE;
+			}
+			if (config.verifyRequestOnResumptionEnabled == null) {
+				config.verifyRequestOnResumptionEnabled = Boolean.FALSE;
 			}
 
 			// check cipher consistency

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -353,8 +353,9 @@ public class ClientHandshaker extends Handshaker {
 		clientHello.setCookie(message.getCookie());
 		// update the length (cookie added)
 		clientHello.setFragmentLength(clientHello.getMessageLength());
-
-		DTLSFlight flight = new DTLSFlight(getSession(), 3);
+		
+		flightNumber = 3;
+		DTLSFlight flight = new DTLSFlight(getSession(), flightNumber);
 		flight.addMessage(wrapMessage(clientHello));
 		recordLayer.sendFlight(flight);
 	}
@@ -500,7 +501,8 @@ public class ClientHandshaker extends Handshaker {
 			return;
 		}
 		serverHelloDone = message;
-		DTLSFlight flight = new DTLSFlight(getSession(), 5);
+		flightNumber += 2;
+		DTLSFlight flight = new DTLSFlight(getSession(), flightNumber);
 
 		createCertificateMessage(flight);
 
@@ -725,8 +727,9 @@ public class ClientHandshaker extends Handshaker {
 		state = startMessage.getMessageType().getCode();
 
 		// store for later calculations
+		flightNumber = 1;
 		clientHello = startMessage;
-		DTLSFlight flight = new DTLSFlight(session, 1);
+		DTLSFlight flight = new DTLSFlight(session, flightNumber);
 		flight.addMessage(wrapMessage(startMessage));
 
 		recordLayer.sendFlight(flight);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
@@ -31,6 +31,8 @@
  *    Achim Kraus (Bosch Software Innovations GmbH) - reset master secret, when
  *                                                    session resumption is refused.
  *    Achim Kraus (Bosch Software Innovations GmbH) - add dtls flight number
+ *    Achim Kraus (Bosch Software Innovations GmbH) - adjust dtls flight number
+ *                                                    for short resumption
 ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -223,7 +225,8 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 			// this last flight
 			return;
 		}
-		DTLSFlight flight = new DTLSFlight(getSession(), 5);
+		flightNumber += 2;
+		DTLSFlight flight = new DTLSFlight(getSession(), flightNumber);
 
 		// update the handshake hash
 		md.update(clientHello.toByteArray());
@@ -285,8 +288,9 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 
 		state = message.getMessageType().getCode();
 		clientHello = message;
-
-		DTLSFlight flight = new DTLSFlight(getSession(), 1);
+		
+		flightNumber = 1;
+		DTLSFlight flight = new DTLSFlight(getSession(), flightNumber);
 		flight.addMessage(wrapMessage(message));
 
 		recordLayer.sendFlight(flight);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingServerHandshaker.java
@@ -24,6 +24,8 @@
  *                                                    APPLICATION messages
  *    Bosch Software Innovations GmbH - migrate to SLF4J
  *    Achim Kraus (Bosch Software Innovations GmbH) - add dtls flight number
+ *    Achim Kraus (Bosch Software Innovations GmbH) - adjust dtls flight number
+ *                                                    for short resumption
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -147,7 +149,8 @@ public class ResumingServerHandshaker extends ServerHandshaker {
 							AlertDescription.ILLEGAL_PARAMETER,
 							clientHello.getPeer()));
 		} else {
-			DTLSFlight flight = new DTLSFlight(getSession(), 4);
+			flightNumber += 2;
+			DTLSFlight flight = new DTLSFlight(getSession(), flightNumber);
 			md.update(clientHello.getRawMessage());
 
 			clientRandom = clientHello.getRandom();
@@ -201,11 +204,4 @@ public class ResumingServerHandshaker extends ServerHandshaker {
 		sessionEstablished();
 		handshakeCompleted();
 	}
-
-//	@Override
-//	protected boolean isChangeCipherSpecMessageDue() {
-//
-//		// in an abbreviated handshake we immediately expect the client's ChangeCipherSpec message
-//		return true;
-//	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumptionSupportingConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumptionSupportingConnectionStore.java
@@ -14,6 +14,8 @@
  *    Simon Bernard (Sierra Wireless) - Initial creation
  *    Achim Kraus (Bosch Software Innovations GmbH) - fix session resumption with 
  *                                                    session cache. issue #712
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add putEstablishedSession
+ *                                                    for faster find
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
@@ -44,6 +46,14 @@ public interface ResumptionSupportingConnectionStore {
 	 * @return <code>true</code>, if updated, <code>false</code>, otherwise.
 	 */
 	boolean update(Connection connection);
+
+	/**
+	 * Put connection associated with the session id into the store.
+	 * 
+	 * @param session established session.
+	 * @param connection connection of established session
+	 */
+	void putEstablishedSession(final DTLSSession session, final Connection connection);
 
 	/**
 	 * Gets the number of additional connection this store can manage.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -436,7 +436,8 @@ public class ServerHandshaker extends Handshaker {
 			throw new HandshakeException("Client did not send required authentication messages.", alert);
 		}
 
-		DTLSFlight flight = new DTLSFlight(getSession(), 6);
+		flightNumber += 2;
+		DTLSFlight flight = new DTLSFlight(getSession(), flightNumber);
 
 		// create handshake hash
 		if (clientCertificate != null) { // optional
@@ -507,7 +508,11 @@ public class ServerHandshaker extends Handshaker {
 	private void receivedClientHello(final ClientHello clientHello) throws HandshakeException {
 
 		handshakeStarted();
-		DTLSFlight flight = new DTLSFlight(getSession(), 4);
+
+		byte[] cookie = clientHello.getCookie();
+		flightNumber = (cookie != null && cookie.length > 0) ? 4 : 2;
+
+		DTLSFlight flight = new DTLSFlight(getSession(), flightNumber);
 
 		// update the handshake hash
 		md.update(clientHello.getRawMessage());

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorStartStopTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorStartStopTest.java
@@ -108,7 +108,7 @@ public class DTLSConnectorStartStopTest {
 		clientConnectionStore.setTag("client");
 		InetSocketAddress clientEndpoint = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 		clientConfig = ConnectorHelper.newStandardClientConfig(clientEndpoint);
-		client = new DTLSConnector(clientConfig, clientConnectionStore, clientSessionCache);
+		client = new DTLSConnector(clientConfig, clientConnectionStore);
 		clientChannel = serverHelper.new LatchDecrementingRawDataChannel();
 		client.setRawDataReceiver(clientChannel);
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStoreTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStoreTest.java
@@ -62,7 +62,7 @@ public class InMemoryConnectionStoreTest {
 	public void testFindRetrievesLocalConnection() {
 		// given a connection store containing a connection with a peer
 		store.put(con);
-
+		store.putEstablishedSession(con.getEstablishedSession(), con);
 		// when retrieving the connection for the given peer
 		Connection connectionWithPeer = store.find(sessionId);
 		assertThat(connectionWithPeer, is(con));
@@ -95,6 +95,7 @@ public class InMemoryConnectionStoreTest {
 		sessionCache.put(con.getEstablishedSession());
 		store = new InMemoryConnectionStore(INITIAL_CAPACITY, 1000, sessionCache);
 		store.put(con);
+		store.putEstablishedSession(con.getEstablishedSession(), con);
 
 		// WHEN the session is removed from the cache (e.g. because it became stale)
 		sessionCache.remove(con.getEstablishedSession().getSessionIdentifier());


### PR DESCRIPTION
Only use HELLO_VERIFY_REQUEST, if session id is unknown.
Make find connection by session id faster using map instead of iterative
search.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>