### PR TITLE
Update tcp implementation to netty-4.1.27.Final.

### DIFF
--- a/element-connector-tcp/pom.xml
+++ b/element-connector-tcp/pom.xml
@@ -16,7 +16,7 @@
 	<description>Element connector implementation for TCP/TLS</description>
 	
 	<properties>
-		<netty.version>4.1.25.Final</netty.version>
+		<netty.version>4.1.27.Final</netty.version>
 		<netty.version.lowerbound>4.1</netty.version.lowerbound>
 		<netty.version.upperbound>5</netty.version.upperbound>
 	</properties>

--- a/element-connector-tcp/src/main/java/org/eclipse/californium/elements/tcp/TcpClientConnector.java
+++ b/element-connector-tcp/src/main/java/org/eclipse/californium/elements/tcp/TcpClientConnector.java
@@ -134,7 +134,7 @@ public class TcpClientConnector implements Connector {
 	@Override
 	public synchronized void stop() {
 		if (workerGroup != null) {
-			workerGroup.shutdownGracefully(0, 1, TimeUnit.SECONDS).syncUninterruptibly();
+			workerGroup.shutdownGracefully(1, 1000, TimeUnit.MILLISECONDS).syncUninterruptibly();
 			workerGroup = null;
 		}
 	}

--- a/element-connector-tcp/src/main/java/org/eclipse/californium/elements/tcp/TcpServerConnector.java
+++ b/element-connector-tcp/src/main/java/org/eclipse/californium/elements/tcp/TcpServerConnector.java
@@ -129,11 +129,11 @@ public class TcpServerConnector implements Connector {
 	@Override
 	public synchronized void stop() {
 		if (null != bossGroup) {
-			bossGroup.shutdownGracefully(0, 1, TimeUnit.SECONDS).syncUninterruptibly();
+			bossGroup.shutdownGracefully(1, 1000, TimeUnit.MILLISECONDS).syncUninterruptibly();
 			bossGroup = null;
 		}
 		if (null != workerGroup) {
-			workerGroup.shutdownGracefully(0, 1, TimeUnit.SECONDS).syncUninterruptibly();
+			workerGroup.shutdownGracefully(1, 1000, TimeUnit.MILLISECONDS).syncUninterruptibly();
 			workerGroup = null;
 		}
 	}


### PR DESCRIPTION
Use none-zero quiet-period on shutdown, 0 seems to block the shutdown
sometimes.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>