### PR TITLE
Cleanup CoapEndpoint.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
@@ -171,7 +171,7 @@ public class CoapServer implements ServerInterface {
 		this.endpoints = new ArrayList<>();
 		// create endpoint for each port
 		for (int port : ports) {
-			CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+			CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 			builder.setPort(port);
 			builder.setNetworkConfig(config);
 			addEndpoint(builder.build());
@@ -240,7 +240,7 @@ public class CoapServer implements ServerInterface {
 			// servers should bind to the configured port (while clients should use an ephemeral port through the default endpoint)
 			int port = config.getInt(NetworkConfig.Keys.COAP_PORT);
 			LOGGER.info("no endpoints have been defined for server, setting up server endpoint on default port {}", port);
-			CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+			CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 			builder.setPort(port);
 			builder.setNetworkConfig(config);
 			addEndpoint(builder.build());

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -258,136 +258,10 @@ public class CoapEndpoint implements Endpoint {
 	};
 
 	/**
-	 * Creates a new <em>coap</em> endpoint using default configuration.
-	 * <p>
-	 * The endpoint will bind to all network interfaces and listen on an ephemeral port.
-	 */
-	@Deprecated
-	public CoapEndpoint() {
-		this(0);
-	}
-
-	/**
-	 * Creates a new <em>coap</em> endpoint using default configuration.
-	 * <p>
-	 * The endpoint will bind to all network interfaces.
-	 *
-	 * @param port The port to listen on.
-	 */
-	@Deprecated
-	public CoapEndpoint(final int port) {
-		this(new InetSocketAddress(port));
-	}
-
-	/**
-	 * Creates a new <em>coap</em> endpoint using default configuration.
-	 *
-	 * @param address The IP address and port to bind to.
-	 */
-	@Deprecated
-	public CoapEndpoint(final InetSocketAddress address) {
-		this(address, NetworkConfig.getStandard());
-	}
-
-	/**
-	 * Creates a new <em>coap</em> endpoint for a configuration.
-	 * <p>
-	 * The endpoint will bind to all network interfaces and listen on an ephemeral port.
-	 * 
-	 * @param config The configuration values to use.
-	 */
-	@Deprecated
-	public CoapEndpoint(final NetworkConfig config) {
-		this(new InetSocketAddress(0), config);
-	}
-
-	/**
-	 * Creates a new <em>coap</em> endpoint for a port and configuration.
-	 * <p>
-	 * The endpoint will bind to all network interfaces and listen on an ephemeral port.
-	 *
-	 * @param port The port to listen on.
-	 * @param config The configuration values to use.
-	 */
-	@Deprecated
-	public CoapEndpoint(final int port, final NetworkConfig config) {
-		this(new InetSocketAddress(port), config);
-	}
-
-	/**
-	 * Creates a new <em>coap</em> endpoint for a configuration.
-	 *
-	 * @param address The IP address and port to bind to.
-	 * @param config The configuration values to use.
-	 */
-	@Deprecated
-	public CoapEndpoint(final InetSocketAddress address, final NetworkConfig config) {
-		this(new UDPConnector(address), true, config, null, null, null, null, null);
-	}
-
-	/**
-	 * Creates a new <em>coap</em> endpoint for a configuration and message exchange store.
-	 *
-	 * @param address The IP address and port to bind to.
-	 * @param config The configuration values to use.
-	 * @param exchangeStore The store to use for keeping track of message exchanges.
-	 */
-	@Deprecated
-	public CoapEndpoint(final InetSocketAddress address, final NetworkConfig config,
-			final MessageExchangeStore exchangeStore) {
-		this(new UDPConnector(address), true, config, null, null, exchangeStore, null, null);
-	}
-
-	/**
-	 * Creates a new endpoint for a connector and configuration.
-	 * <p>
-	 * The endpoint will support the connector's implemented scheme and will bind to
-	 * the IP address and port the connector is configured for.
-	 * 
-	 * @param connector The connector to use.
-	 * @param config The configuration values to use.
-	 */
-	@Deprecated
-	public CoapEndpoint(final Connector connector, final NetworkConfig config) {
-		this(connector, false, config, null, null, null, null, null);
-	}
-
-	/**
-	 * Creates a new <em>coap</em> endpoint for a configuration and observation store.
-	 * 
-	 * @param address The IP address and port to bind to.
-	 * @param config The configuration values to use.
-	 * @param store The store to use for keeping track of observations initiated by this
-	 *              endpoint.
-	 */
-	@Deprecated
-	public CoapEndpoint(final InetSocketAddress address, final NetworkConfig config, final ObservationStore store) {
-		this(new UDPConnector(address), true, config, null, store, null, null, null);
-	}
-
-	/**
-	 * Creates a new endpoint for a connector, configuration, message exchange and observation store.
-	 * <p>
-	 * The endpoint will support the connector's implemented scheme and will bind to
-	 * the IP address and port the connector is configured for.
-	 *
-	 * @param connector The connector to use.
-	 * @param config The configuration values to use.
-	 * @param store The store to use for keeping track of observations initiated by this
-	 *              endpoint.
-	 * @param exchangeStore The store to use for keeping track of message exchanges.
-	 */
-	@Deprecated
-	public CoapEndpoint(Connector connector, NetworkConfig config, ObservationStore store,
-			MessageExchangeStore exchangeStore) {
-		this(connector, false, config, null, store, exchangeStore, null, null);
-	}
-
-	/**
 	 * Creates a new endpoint for a connector, configuration, message exchange
 	 * and observation store.
 	 * <p>
-	 * Intended to be called either by the {@link CoapEndpointBuilder} or a
+	 * Intended to be called either by the {@link Builder} or a
 	 * subclass constructor. The endpoint will support the connector's
 	 * implemented scheme and will bind to the IP address and port the connector
 	 * is configured for.
@@ -1157,7 +1031,7 @@ public class CoapEndpoint implements Endpoint {
 	/**
 	 * Builder to create CoapEndpoints.
 	 */
-	public static class CoapEndpointBuilder {
+	public static class Builder {
 
 		/**
 		 * Network configuration to be applied.
@@ -1218,7 +1092,7 @@ public class CoapEndpoint implements Endpoint {
 		/**
 		 * Create new builder.
 		 */
-		public CoapEndpointBuilder() {
+		public Builder() {
 		}
 
 		/**
@@ -1231,7 +1105,7 @@ public class CoapEndpoint implements Endpoint {
 		 * @return this
 		 * @see #config
 		 */
-		public CoapEndpointBuilder setNetworkConfig(NetworkConfig config) {
+		public Builder setNetworkConfig(NetworkConfig config) {
 			this.config = config;
 			return this;
 		}
@@ -1258,7 +1132,7 @@ public class CoapEndpoint implements Endpoint {
 		 * @see #bindAddress
 		 * @see #connector
 		 */
-		public CoapEndpointBuilder setPort(int port) {
+		public Builder setPort(int port) {
 			if (this.bindAddress != null || this.connector != null) {
 				throw new IllegalArgumentException("bind address already defined!");
 			}
@@ -1286,7 +1160,7 @@ public class CoapEndpoint implements Endpoint {
 		 * @see #bindAddress
 		 * @see #connector
 		 */
-		public CoapEndpointBuilder setInetSocketAddress(InetSocketAddress address) {
+		public Builder setInetSocketAddress(InetSocketAddress address) {
 			if (this.bindAddress != null || this.connector != null) {
 				throw new IllegalArgumentException("bind address already defined!");
 			}
@@ -1314,7 +1188,7 @@ public class CoapEndpoint implements Endpoint {
 		 * @see #bindAddress
 		 * @see #connector
 		 */
-		public CoapEndpointBuilder setConnector(Connector connector) {
+		public Builder setConnector(Connector connector) {
 			if (this.bindAddress != null || this.connector != null) {
 				throw new IllegalArgumentException("bind address already defined!");
 			}
@@ -1346,7 +1220,7 @@ public class CoapEndpoint implements Endpoint {
 		 * @see #bindAddress
 		 * @see #connector
 		 */
-		public CoapEndpointBuilder setConnectorWithAutoConfiguration(UDPConnector connector) {
+		public Builder setConnectorWithAutoConfiguration(UDPConnector connector) {
 			if (this.bindAddress != null || this.connector != null) {
 				throw new IllegalArgumentException("bind address already defined!");
 			}
@@ -1364,7 +1238,7 @@ public class CoapEndpoint implements Endpoint {
 		 * @return this
 		 * @see #observationStore
 		 */
-		public CoapEndpointBuilder setObservationStore(ObservationStore store) {
+		public Builder setObservationStore(ObservationStore store) {
 			this.observationStore = store;
 			return this;
 		}
@@ -1378,7 +1252,7 @@ public class CoapEndpoint implements Endpoint {
 		 * @return this
 		 * @see #exchangeStore
 		 */
-		public CoapEndpointBuilder setMessageExchangeStore(MessageExchangeStore exchangeStore) {
+		public Builder setMessageExchangeStore(MessageExchangeStore exchangeStore) {
 			this.exchangeStore = exchangeStore;
 			return this;
 		}
@@ -1392,7 +1266,7 @@ public class CoapEndpoint implements Endpoint {
 		 * @return this
 		 * @see #endpointContextMatcher
 		 */
-		public CoapEndpointBuilder setEndpointContextMatcher(EndpointContextMatcher endpointContextMatcher) {
+		public Builder setEndpointContextMatcher(EndpointContextMatcher endpointContextMatcher) {
 			this.endpointContextMatcher = endpointContextMatcher;
 			return this;
 		}
@@ -1406,7 +1280,7 @@ public class CoapEndpoint implements Endpoint {
 		 * @return this
 		 * @see #tokenGenerator
 		 */
-		public CoapEndpointBuilder setTokenGenerator(TokenGenerator tokenGenerator) {
+		public Builder setTokenGenerator(TokenGenerator tokenGenerator) {
 			this.tokenGenerator = tokenGenerator;
 			return this;
 		}
@@ -1420,7 +1294,7 @@ public class CoapEndpoint implements Endpoint {
 		 * @return this
 		 * @see #coapStackFactory
 		 */
-		public CoapEndpointBuilder setCoapStackFactory(CoapStackFactory coapStackFactory) {
+		public Builder setCoapStackFactory(CoapStackFactory coapStackFactory) {
 			this.coapStackFactory = coapStackFactory;
 			return this;
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapStackFactory.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapStackFactory.java
@@ -22,7 +22,7 @@ import org.eclipse.californium.elements.Connector;
 /**
  * Factory for CoapStack.
  * 
- * Either provided to the {@link CoapEndpoint.CoapEndpointBuilder} or set as
+ * Either provided to the {@link CoapEndpoint.Builder} or set as
  * default {@link CoapEndpoint#setDefaultCoapStackFactory(CoapStackFactory)}.
  */
 public interface CoapStackFactory {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/EndpointManager.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/EndpointManager.java
@@ -133,7 +133,7 @@ public class EndpointManager {
 			} else if (CoAP.COAP_SECURE_TCP_URI_SCHEME.equalsIgnoreCase(uriScheme)) {
 				throw new IllegalStateException("URI scheme " + uriScheme + " requires a previous set connector!");
 			} else {
-				endpoint = new CoapEndpoint.CoapEndpointBuilder().build();
+				endpoint = new CoapEndpoint.Builder().build();
 			}
 			try {
 				endpoint.start();

--- a/californium-core/src/test/java/org/eclipse/californium/core/multicast/MulticastTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/multicast/MulticastTest.java
@@ -61,7 +61,7 @@ public class MulticastTest {
 		server1 = new CoapServer();
 		InetSocketAddress serverSocketAddress = new InetSocketAddress(CoAP.DEFAULT_COAP_PORT);
 		Connector connector = new UdpMulticastConnector(serverSocketAddress, CoAP.MULTICAST_IPV4);
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setNetworkConfig(config);
 		builder.setConnector(connector);
 		server1.addEndpoint(builder.build());
@@ -83,7 +83,7 @@ public class MulticastTest {
 
 		server2 = new CoapServer();
 		connector = new UdpMulticastConnector(serverSocketAddress, CoAP.MULTICAST_IPV4);
-		builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder = new CoapEndpoint.Builder();
 		builder.setNetworkConfig(config);
 		builder.setConnector(connector);
 		server2.addEndpoint(builder.build());
@@ -116,7 +116,7 @@ public class MulticastTest {
 		request.setURI("coap://" + CoAP.MULTICAST_IPV4.getHostAddress() + "/hello");
 		request.setType(Type.NON);
 		CoapClient client = new CoapClient();
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setNetworkConfig(config);
 		client.setEndpoint(builder.build());
 		client.advanced(handler, request);
@@ -135,7 +135,7 @@ public class MulticastTest {
 		request.setURI("coap://" + CoAP.MULTICAST_IPV4.getHostAddress() + "/no");
 		request.setType(Type.NON);
 		CoapClient client = new CoapClient();
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setNetworkConfig(config);
 		client.setEndpoint(builder.build());
 		client.advanced(handler, request);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
@@ -76,7 +76,7 @@ public class CoapEndpointTest {
 		establishedContext = new AddressEndpointContext(CONNECTOR_ADDRESS, null);
 		receivedRequests = new ArrayList<Request>();
 		connector = new SimpleConnector();
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setConnector(connector);
 		builder.setNetworkConfig(CONFIG);
 
@@ -161,7 +161,7 @@ public class CoapEndpointTest {
 	@Test
 	public void testSecureSchemeIsSetOnIncomingRequest() throws Exception {
 		SimpleConnector connector = new SimpleSecureConnector();
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setConnector(connector);
 		builder.setNetworkConfig(CONFIG);
 		Endpoint endpoint = builder.build();

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/EndpointManagerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/EndpointManagerTest.java
@@ -72,7 +72,7 @@ public class EndpointManagerTest {
 	public void testSetDefaultEndpoint() throws Exception {
 		// GIVEN a old and a new endpoint
 		Endpoint oldEndpoint = EndpointManager.getEndpointManager().getDefaultEndpoint();
-		Endpoint endpoint = new CoapEndpoint.CoapEndpointBuilder().build();
+		Endpoint endpoint = new CoapEndpoint.Builder().build();
 
 		// WHEN set the new default endpoint
 		EndpointManager.getEndpointManager().setDefaultEndpoint(endpoint);
@@ -149,7 +149,7 @@ public class EndpointManagerTest {
 	}
 
 	private static Endpoint createEndpoint(String protocol) {
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setConnector(new DummyConnector(protocol));
 		builder.setNetworkConfig(network.getStandardTestConfig());
 		return builder.build();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/BlockwiseTransferTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/BlockwiseTransferTest.java
@@ -98,7 +98,7 @@ public class BlockwiseTransferTest {
 
 	@Before
 	public void createClient() throws IOException {
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setNetworkConfig(config);
 		clientEndpoint = builder.build();
 		clientEndpoint.start();
@@ -274,7 +274,7 @@ public class BlockwiseTransferTest {
 
 		CoapServer result = new CoapServer();
 
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		builder.setNetworkConfig(config);
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ClientAsynchronousTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ClientAsynchronousTest.java
@@ -273,7 +273,7 @@ public class ClientAsynchronousTest {
 	}
 
 	private static void createServer() {
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		CoapEndpoint endpoint = builder.build();
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ClientSynchronousTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ClientSynchronousTest.java
@@ -177,7 +177,7 @@ public class ClientSynchronousTest {
 	@Test
 	public void testSynchronousPing() throws Exception {
 		final AtomicBoolean sent = new AtomicBoolean();
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		CoapEndpoint clientEndpoint = builder.build();
 		clientEndpoint.addInterceptor(new MessageInterceptorAdapter() {
@@ -244,7 +244,7 @@ public class ClientSynchronousTest {
 	}
 
 	private static void createServer() {
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		serverEndpoint = builder.build();
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
@@ -375,7 +375,7 @@ public class MemoryLeakingHashMapTest {
 
 		// Create the endpoint for the server and create surveillant
 		serverExchangeStore = new InMemoryMessageExchangeStore(config);	
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		builder.setNetworkConfig(config);
 		builder.setMessageExchangeStore(serverExchangeStore);
@@ -383,7 +383,7 @@ public class MemoryLeakingHashMapTest {
 		serverEndpoint.addInterceptor(new MessageTracer());
 
 		clientExchangeStore = new InMemoryMessageExchangeStore(config);
-		builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		builder.setNetworkConfig(config);
 		builder.setMessageExchangeStore(clientExchangeStore);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MessageTypeTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MessageTypeTest.java
@@ -65,7 +65,7 @@ public class MessageTypeTest {
 		System.out.println(System.lineSeparator() + "Start " + MessageTypeTest.class.getSimpleName());
 		EndpointManager.clear();
 
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		CoapEndpoint endpoint = builder.build();
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ObserveTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ObserveTest.java
@@ -374,7 +374,7 @@ public class ObserveTest {
 		NetworkConfig config = network.createTestConfig().setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200)
 				.setFloat(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1f).setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f);
 
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		builder.setNetworkConfig(config);
 		CoapEndpoint endpoint = builder.build();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/RandomAccessBlockTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/RandomAccessBlockTest.java
@@ -82,7 +82,7 @@ public class RandomAccessBlockTest {
 		NetworkConfig config = network.getStandardTestConfig()
 			.setInt(Keys.MAX_RESOURCE_BODY_SIZE, maxBodySize);
 
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		builder.setNetworkConfig(config);
 
@@ -93,7 +93,7 @@ public class RandomAccessBlockTest {
 		server.start();
 		serverAddress = endpoint.getAddress();
 
-		builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		builder.setNetworkConfig(config);
 		

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceTreeTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceTreeTest.java
@@ -108,7 +108,7 @@ public class ResourceTreeTest {
 	}
 	
 	private void createServer() {
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		CoapEndpoint endpoint = builder.build();
 		

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/SmallServerClientTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/SmallServerClientTest.java
@@ -95,7 +95,7 @@ public class SmallServerClientTest {
 	}
 
 	private void createSimpleServer() {
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		CoapEndpoint endpoint = builder.build();
 		server = new CoapServer();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ClusteringTest.java
@@ -87,7 +87,7 @@ public class ClusteringTest {
 		store = new InMemoryObservationStore(config);
 
 		notificationListener1 = new SynchronousNotificationListener();
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		builder.setNetworkConfig(config);
 		builder.setObservationStore(store);
@@ -100,7 +100,7 @@ public class ClusteringTest {
 		System.out.println("Client 1 binds to port " + clientPort1);
 
 		notificationListener2 = new SynchronousNotificationListener();
-		builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		builder.setNetworkConfig(config);
 		builder.setObservationStore(store);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/DeduplicationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/DeduplicationTest.java
@@ -69,7 +69,7 @@ public class DeduplicationTest {
 			.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 128)
 			.setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200) // client retransmits after 200 ms
 			.setInt(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1);
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		builder.setNetworkConfig(config);
 		client = builder.build();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ServerDeduplicationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ServerDeduplicationTest.java
@@ -88,7 +88,7 @@ public class ServerDeduplicationTest {
 		config.setInt(Keys.ACK_TIMEOUT, 1000);
 		config.setFloat(Keys.ACK_TIMEOUT_SCALE, 1.0F);
 		config.setFloat(Keys.ACK_RANDOM_FACTOR, 1.0F);
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		builder.setNetworkConfig(config);
 		Endpoint ep = builder.build();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/maninmiddle/LossyBlockwiseTransferTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/maninmiddle/LossyBlockwiseTransferTest.java
@@ -82,14 +82,14 @@ public class LossyBlockwiseTransferTest {
 			.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 32)
 			.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 32);
 
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		builder.setNetworkConfig(config);
 
 		clientEndpoint = builder.build();
 		clientEndpoint.start();
 
-		builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
 		builder.setNetworkConfig(config);
 

--- a/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureBlockwiseTest.java
+++ b/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureBlockwiseTest.java
@@ -136,7 +136,7 @@ public class SecureBlockwiseTest {
 				.setInt(Keys.PREFERRED_BLOCK_SIZE, DEFAULT_BLOCK_SIZE)
 				.setString(Keys.RESPONSE_MATCHING, mode.name());
 		serverConnector = new DTLSConnector(dtlsConfig);
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setConnector(serverConnector);
 		builder.setNetworkConfig(config);
 		serverEndpoint = builder.build();
@@ -156,7 +156,7 @@ public class SecureBlockwiseTest {
 				.setConnectionThreadCount(2)
 				.setPskStore(pskStore).build();
 		clientConnector = new DTLSConnector(clientdtlsConfig);
-		builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder = new CoapEndpoint.Builder();
 		builder.setConnector(clientConnector);
 		builder.setNetworkConfig(config);
 		clientEndpoint = builder.build();

--- a/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureObserveTest.java
+++ b/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureObserveTest.java
@@ -426,7 +426,7 @@ public class SecureObserveTest {
 																// 10s
 				.setString(Keys.RESPONSE_MATCHING, mode.name());
 		serverConnector = new DTLSConnector(dtlsConfig);
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setConnector(serverConnector);
 		builder.setNetworkConfig(config);
 		serverEndpoint = builder.build();
@@ -446,7 +446,7 @@ public class SecureObserveTest {
 				.setConnectionThreadCount(2)
 				.setPskStore(pskStore).build();
 		clientConnector = new DTLSConnector(clientdtlsConfig);
-		builder = new CoapEndpoint.CoapEndpointBuilder();
+		builder = new CoapEndpoint.Builder();
 		builder.setConnector(clientConnector);
 		builder.setNetworkConfig(config);
 		clientEndpoint = builder.build();

--- a/californium-osgi/src/main/java/org/eclipse/californium/osgi/SimpleServerEndpointFactory.java
+++ b/californium-osgi/src/main/java/org/eclipse/californium/osgi/SimpleServerEndpointFactory.java
@@ -53,7 +53,7 @@ public class SimpleServerEndpointFactory implements EndpointFactory {
 
 	@Override
 	public final Endpoint getEndpoint(NetworkConfig config, InetSocketAddress address) {
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setNetworkConfig(config);
 		builder.setInetSocketAddress(address);
 		return builder.build();
@@ -65,7 +65,7 @@ public class SimpleServerEndpointFactory implements EndpointFactory {
 		Endpoint endpoint = null;
 		if (secureConnectorFactory != null) {
 			Connector connector = secureConnectorFactory.newConnector(address);
-			CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+			CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 			builder.setNetworkConfig(config);
 			builder.setConnector(connector);
 			endpoint = builder.build();

--- a/demo-apps/cf-benchmark-observe/src/main/java/org/eclipse/californium/benchmark/observe/ObserveBenchmarkClient.java
+++ b/demo-apps/cf-benchmark-observe/src/main/java/org/eclipse/californium/benchmark/observe/ObserveBenchmarkClient.java
@@ -101,7 +101,7 @@ public class ObserveBenchmarkClient {
 			
 		server.add(new AnnounceResource("announce"));
 		
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(sockAddr);
 		server.addEndpoint(builder.build());
 		server.start();

--- a/demo-apps/cf-benchmark/src/main/java/org/eclipse/californium/benchmark/BenchmarkServer.java
+++ b/demo-apps/cf-benchmark/src/main/java/org/eclipse/californium/benchmark/BenchmarkServer.java
@@ -110,7 +110,7 @@ public class BenchmarkServer {
 		server.add(new FibonacciResource("fibonacci"));
 		server.add(new ShutDownResource("shutdown"));
 
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(sockAddr);
 		server.addEndpoint(builder.build());
 		server.start();

--- a/demo-apps/cf-benchmark/src/main/java/org/eclipse/californium/benchmark/TcpThroughputServer.java
+++ b/demo-apps/cf-benchmark/src/main/java/org/eclipse/californium/benchmark/TcpThroughputServer.java
@@ -20,7 +20,7 @@ public class TcpThroughputServer {
 				.setLong(NetworkConfig.Keys.EXCHANGE_LIFETIME, 10000);
 
 		Connector serverConnector = new TcpServerConnector(new InetSocketAddress(CoAP.DEFAULT_COAP_PORT), 1, 100);
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setConnector(serverConnector);
 		builder.setNetworkConfig(net);
 		CoapEndpoint endpoint = builder.build();

--- a/demo-apps/cf-cocoa/src/main/java/org/eclipse/californium/examples/CocoaClient.java
+++ b/demo-apps/cf-cocoa/src/main/java/org/eclipse/californium/examples/CocoaClient.java
@@ -56,7 +56,7 @@ public class CocoaClient {
 				.setInt(NetworkConfig.Keys.NSTART, 4);
 
 		// create an endpoint with this configuration
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setNetworkConfig(config);
 		CoapEndpoint cocoaEndpoint = builder.build();
 		// all CoapClients will use the default endpoint (unless

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
@@ -625,7 +625,7 @@ public class BenchmarkClient {
 
 		// Create & start clients
 		for (int index = 0; index < clients; ++index) {
-			CoapEndpoint.CoapEndpointBuilder endpointBuilder = new CoapEndpoint.CoapEndpointBuilder();
+			CoapEndpoint.Builder endpointBuilder = new CoapEndpoint.Builder();
 			endpointBuilder.setNetworkConfig(config);
 			Arguments connectionArgs = arguments;
 			if (secure) {

--- a/demo-apps/cf-helloworld-client/src/main/java/org/eclipse/californium/examples/MulticastTestClient.java
+++ b/demo-apps/cf-helloworld-client/src/main/java/org/eclipse/californium/examples/MulticastTestClient.java
@@ -58,7 +58,7 @@ public class MulticastTestClient {
 
 		NetworkConfig config = NetworkConfig.createWithFile(CONFIG_FILE, CONFIG_HEADER, DEFAULTS);
 
-		CoapEndpoint endpoint = new CoapEndpoint.CoapEndpointBuilder().setNetworkConfig(config).build();
+		CoapEndpoint endpoint = new CoapEndpoint.Builder().setNetworkConfig(config).build();
 		CoapClient client = new CoapClient();
 
 		client.setURI("coap://localhost:5683/helloWorld");

--- a/demo-apps/cf-helloworld-server/src/main/java/org/eclipse/californium/examples/HelloWorldServer.java
+++ b/demo-apps/cf-helloworld-server/src/main/java/org/eclipse/californium/examples/HelloWorldServer.java
@@ -70,14 +70,14 @@ public class HelloWorldServer extends CoapServer {
 		for (InetAddress addr : EndpointManager.getEndpointManager().getNetworkInterfaces()) {
 			InetSocketAddress bindToAddress = new InetSocketAddress(addr, COAP_PORT);
 			if (udp) {
-				CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+				CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 				builder.setInetSocketAddress(bindToAddress);
 				builder.setNetworkConfig(config);
 				addEndpoint(builder.build());
 			}
 			if (tcp) {
 				TcpServerConnector connector = new TcpServerConnector(bindToAddress, TCP_THREADS, TCP_IDLE_TIMEOUT);
-				CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+				CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 				builder.setConnector(connector);
 				builder.setNetworkConfig(config);
 				addEndpoint(builder.build());

--- a/demo-apps/cf-helloworld-server/src/main/java/org/eclipse/californium/examples/MulticastTestServer.java
+++ b/demo-apps/cf-helloworld-server/src/main/java/org/eclipse/californium/examples/MulticastTestServer.java
@@ -48,7 +48,7 @@ public class MulticastTestServer {
 		int port = config.getInt(Keys.COAP_PORT);
 		InetSocketAddress localAddress = new InetSocketAddress(port);
 		Connector connector = new UdpMulticastConnector(localAddress, CoAP.MULTICAST_IPV4);
-		return new CoapEndpoint.CoapEndpointBuilder().setNetworkConfig(config).setConnector(connector).build();
+		return new CoapEndpoint.Builder().setNetworkConfig(config).setConnector(connector).build();
 	}
 
 	private static class HelloWorldResource extends CoapResource {

--- a/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/ClientInitializer.java
+++ b/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/ClientInitializer.java
@@ -205,7 +205,7 @@ public class ClientInitializer {
 			connector = new UDPConnector();
 		}
 
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setConnector(connector);
 		builder.setNetworkConfig(config);
 		CoapEndpoint endpoint = builder.build();

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
@@ -155,14 +155,14 @@ public abstract class AbstractTestServer extends CoapServer {
 			if (protocols.contains(Protocol.UDP) || protocols.contains(Protocol.TCP)) {
 				InetSocketAddress bindToAddress = new InetSocketAddress(addr, coapPort);
 				if (protocols.contains(Protocol.UDP)) {
-					CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+					CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 					builder.setInetSocketAddress(bindToAddress);
 					builder.setNetworkConfig(config);
 					addEndpoint(builder.build());
 				}
 				if (protocols.contains(Protocol.TCP)) {
 					TcpServerConnector connector = new TcpServerConnector(bindToAddress, tcpThreads, tcpIdleTimeout);
-					CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+					CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 					builder.setConnector(connector);
 					builder.setNetworkConfig(config);
 					addEndpoint(builder.build());
@@ -185,7 +185,7 @@ public abstract class AbstractTestServer extends CoapServer {
 					dtlsConfig.setConnectionThreadCount(dtlsThreads);
 					dtlsConfig.setReceiverThreadCount(dtlsReceiverThreads);
 					DTLSConnector connector = new DTLSConnector(dtlsConfig.build());
-					CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+					CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 					builder.setConnector(connector);
 					builder.setNetworkConfig(config);
 
@@ -194,7 +194,7 @@ public abstract class AbstractTestServer extends CoapServer {
 				if (protocols.contains(Protocol.TLS)) {
 					TlsServerConnector connector = new TlsServerConnector(serverSslContext, ClientAuthMode.WANTED,
 							bindToAddress, tcpThreads, tlsHandshakeTimeout, tcpIdleTimeout);
-					CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+					CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 					builder.setConnector(connector);
 					builder.setNetworkConfig(config);
 					addEndpoint(builder.build());

--- a/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/SecureClient.java
+++ b/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/SecureClient.java
@@ -49,7 +49,7 @@ public class SecureClient {
 		try {
 			URI uri = new URI(SERVER_URI);
 			CoapClient client = new CoapClient(uri);
-			CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+			CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 			builder.setConnector(dtlsConnector);
 			
 			client.setEndpoint(builder.build());

--- a/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/SecureServer.java
+++ b/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/SecureServer.java
@@ -66,7 +66,7 @@ public class SecureServer {
 		List<Mode> modes = CredentialsUtil.parse(args, CredentialsUtil.DEFAULT_MODES, SUPPORTED_MODES);
 		CredentialsUtil.setupCredentials(config, CredentialsUtil.SERVER_NAME, modes);
 		DTLSConnector connector = new DTLSConnector(config.build());
-		CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setConnector(connector);
 		server.addEndpoint(builder.build());
 		server.start();

--- a/demo-apps/cf-simplefile-server/src/main/java/org/eclipse/californium/examples/SimpleFileServer.java
+++ b/demo-apps/cf-simplefile-server/src/main/java/org/eclipse/californium/examples/SimpleFileServer.java
@@ -101,7 +101,7 @@ public class SimpleFileServer extends CoapServer {
 	 */
 	private void addEndpoints() {
 		for (InetAddress addr : EndpointManager.getEndpointManager().getNetworkInterfaces()) {
-			CoapEndpoint.CoapEndpointBuilder builder = new CoapEndpoint.CoapEndpointBuilder();
+			CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 			builder.setInetSocketAddress(new InetSocketAddress(addr, COAP_PORT));
 			addEndpoint(builder.build());
 		}


### PR DESCRIPTION
Rename CoapEndpointBuilder into Builder.
Remove deprecated constructors.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>