### PR TITLE
Add more flexibility to auto resumption.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/AddressEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/AddressEndpointContext.java
@@ -112,7 +112,7 @@ public class AddressEndpointContext implements EndpointContext {
 	}
 
 	@Override
-	public boolean inhibitNewConnection() {
+	public boolean hasCriticalEntries() {
 		return false;
 	}
 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
@@ -43,6 +43,13 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 	 * the DTLS session.
 	 */
 	public static final String KEY_CIPHER = "DTLS_CIPHER";
+	/**
+	 * The name of the attribute that contains a auto session resumption timeout
+	 * in milliseconds. {@code "0"}, force a session resumption, {@code ""},
+	 * disable auto session resumption. None critical attribute, not considered
+	 * for matching.
+	 */
+	public static final String KEY_RESUMPTION_TIMEOUT = KEY_PREFIX_NONE_CRITICAL + "DTLS_RESUMPTION_TIMEOUT";
 
 	/**
 	 * Creates a context for DTLS session parameters.

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContext.java
@@ -74,14 +74,16 @@ public interface EndpointContext {
 	Map<String, String> entries();
 
 	/**
-	 * Check, if the correlation information contained, will inhibit a new
-	 * connection.
+	 * Check, if the correlation information contained, contains critical
+	 * entries relevant for matching. A context with critical entries will
+	 * inhibit a new connection.
 	 * 
-	 * @return {@code true}, if no new connection could match the correlation
-	 *         context provided in this instance. {@code false}, if a new
-	 *         connection may match this correlation context.
+	 * @return {@code true}, if critical entries contained, and no new
+	 *         connection could match the correlation context provided in this
+	 *         instance. {@code false}, if a new connection may match this
+	 *         correlation context.
 	 */
-	boolean inhibitNewConnection();
+	boolean hasCriticalEntries();
 
 	/**
 	 * Gets the identity of the peer that the message is for or from.

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContextUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContextUtil.java
@@ -52,10 +52,10 @@ public class EndpointContextUtil {
 			}
 			if (!match) {
 				/* logging differences with warning level */
-				LOGGER.warn("{}, {}: \"{}\" != \"{}\"", new Object[] { name, key, value1, value2 });
+				LOGGER.warn("{}, {}: \"{}\" != \"{}\"",  name, key, value1, value2);
 			} else if (trace) {
 				/* logging matches with finest level */
-				LOGGER.trace("{}, {}: \"{}\" == \"{}\"", new Object[] { name, key, value1, value2 });
+				LOGGER.trace("{}, {}: \"{}\" == \"{}\"", name, key, value1, value2);
 			}
 			matchAll = matchAll && match;
 		}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/KeySetEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/KeySetEndpointContextMatcher.java
@@ -87,14 +87,14 @@ public class KeySetEndpointContextMatcher implements EndpointContextMatcher {
 	@Override
 	public boolean isToBeSent(EndpointContext messageContext, EndpointContext connectionContext) {
 		if (null == connectionContext) {
-			return !messageContext.inhibitNewConnection();
+			return !messageContext.hasCriticalEntries();
 		}
 		boolean result = compareHostname ? isSameVirtualHost(messageContext, connectionContext) : true;
 		return result && internalMatch(messageContext, connectionContext);
 	}
 
 	private final boolean internalMatch(EndpointContext requestedContext, EndpointContext availableContext) {
-		if (!requestedContext.inhibitNewConnection()) {
+		if (!requestedContext.hasCriticalEntries()) {
 			return true;
 		}
 		return EndpointContextUtil.match(getName(), keys, requestedContext, availableContext);

--- a/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
@@ -33,20 +33,28 @@ import java.util.Map;
  */
 public class MapBasedEndpointContext extends AddressEndpointContext {
 
+	/**
+	 * Prefix for none critical attributes. These attributes are not considered
+	 * for context matching nor {@link #hasCriticalEntries()}.
+	 */
+	public static final String KEY_PREFIX_NONE_CRITICAL = "*";
+
+	private final boolean hasCriticalEntries;
 	private final Map<String, String> entries;
 
 	/**
-	 * Creates a context for a socket address, authenticated identity and arbitrary
-	 * key/value pairs.
+	 * Creates a context for a socket address, authenticated identity and
+	 * arbitrary key/value pairs.
 	 * 
 	 * @param peerAddress peer address of endpoint context
 	 * @param peerIdentity peer identity of endpoint context
 	 * @param attributes list of attributes (key/value pairs, e.g. key_1,
 	 *            value_1, key_2, value_2 ...)
-	 * @throws NullPointerException if provided peer address is {@code null}, or
-	 *             one of the attributes is {@code null}.
-	 * @throws IllegalArgumentException if provided attributes list has odd
-	 *             size or contains a duplicate key.
+	 * @throws NullPointerException if provided peer address is {@code null},
+	 *             the provided attributes is {@code null}, or one of the
+	 *             attributes is {@code null}.
+	 * @throws IllegalArgumentException if provided attributes list has odd size
+	 *             or contains a duplicate key.
 	 */
 	public MapBasedEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity, String... attributes) {
 
@@ -54,44 +62,23 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 	}
 
 	/**
-	 * Creates a context for a socket address, authenticated identity and arbitrary
-	 * key/value pairs.
+	 * Creates a context for a socket address, authenticated identity and
+	 * arbitrary key/value pairs.
 	 * 
 	 * @param peerAddress peer address of endpoint context
 	 * @param virtualHost the name of the virtual host at the peer
 	 * @param peerIdentity peer identity of endpoint context
 	 * @param attributes list of attributes (key/value pairs, e.g. key_1,
 	 *            value_1, key_2, value_2 ...)
-	 * @throws NullPointerException if provided peer address is {@code null}, or
-	 *             one of the attributes is {@code null}.
-	 * @throws IllegalArgumentException if provided attributes list has odd
-	 *             size or contains a duplicate key.
+	 * @throws NullPointerException if provided peer address is {@code null},
+	 *             the provided attributes is {@code null}, or one of the
+	 *             attributes is {@code null}.
+	 * @throws IllegalArgumentException if provided attributes list has odd size
+	 *             or contains a duplicate key.
 	 */
 	public MapBasedEndpointContext(InetSocketAddress peerAddress, String virtualHost, Principal peerIdentity,
 			String... attributes) {
-
-		super(peerAddress, virtualHost, peerIdentity);
-
-		if ((attributes.length & 1) == 0) {
-			Map<String, String> newEntries = new HashMap<>();
-			for (int index = 0; index < attributes.length; ++index) {
-				String key = attributes[index];
-				String value = attributes[++index];
-				if (null == key) {
-					throw new NullPointerException((index / 2) + ". key is null");
-				}
-				if (null == value) {
-					throw new NullPointerException((index / 2) + ". value is null");
-				}
-				String old = newEntries.put(key, value);
-				if (null != old) {
-					throw new IllegalArgumentException((index / 2) + ". key '" + key + "' is provided twice");
-				}
-			}
-			this.entries = Collections.unmodifiableMap(newEntries);
-		} else {
-			throw new IllegalArgumentException("number of attributes must be even, not " + attributes.length + "!");
-		}
+		this(peerAddress, virtualHost, peerIdentity, createMap(attributes));
 	}
 
 	/**
@@ -128,6 +115,62 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 			throw new NullPointerException("missing attributes map, must not be null!");
 		}
 		this.entries = Collections.unmodifiableMap(new HashMap<>(attributes));
+		this.hasCriticalEntries = findCriticalEntries(entries);
+	}
+
+	/**
+	 * Create map of attributes.
+	 * 
+	 * @param attributes list of attributes (key/value pairs, e.g. key_1,
+	 *            value_1, key_2, value_2 ...)
+	 * @return create map
+	 * @throws NullPointerException if the provided attributes is {@code null},
+	 *             or one of the attributes is {@code null}.
+	 * @throws IllegalArgumentException if provided attributes list has odd size
+	 *             or contains a duplicate key.
+	 */
+	private static final Map<String, String> createMap(String... attributes) {
+		if (attributes == null) {
+			throw new NullPointerException("attributes must not null!");
+		}
+		if ((attributes.length & 1) != 0) {
+			throw new IllegalArgumentException("number of attributes must be even, not " + attributes.length + "!");
+		}
+		Map<String, String> entries = new HashMap<>();
+		for (int index = 0; index < attributes.length; ++index) {
+			String key = attributes[index];
+			String value = attributes[++index];
+			if (null == key) {
+				throw new NullPointerException((index / 2) + ". key is null");
+			}
+			if (null == value) {
+				throw new NullPointerException((index / 2) + ". value is null");
+			}
+			String old = entries.put(key, value);
+			if (null != old) {
+				throw new IllegalArgumentException((index / 2) + ". key '" + key + "' is provided twice");
+			}
+		}
+		return entries;
+	}
+
+	/**
+	 * Check, if at least one critical attribute is contained in the provided
+	 * map.
+	 * 
+	 * Use {@link #KEY_PREFIX_NONE_CRITICAL} to distinguish the critical from
+	 * the none critical attributes.
+	 * 
+	 * @param attributes map of attributes
+	 * @return {@code true}, if at least one critical attribute is contained.
+	 */
+	private static final boolean findCriticalEntries(Map<String, String> attributes) {
+		for (String key : attributes.keySet()) {
+			if (!key.startsWith(KEY_PREFIX_NONE_CRITICAL)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override
@@ -141,8 +184,8 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 	}
 
 	@Override
-	public boolean inhibitNewConnection() {
-		return !entries.isEmpty();
+	public boolean hasCriticalEntries() {
+		return hasCriticalEntries;
 	}
 
 	@Override
@@ -150,4 +193,23 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 		return String.format("MAP(%s)", getPeerAddressAsString());
 	}
 
+	/**
+	 * Add entries to endpoint context.
+	 * 
+	 * @param context original endpoint context.
+	 * @param attributes list of attributes (key/value pairs, e.g. key_1,
+	 *            value_1, key_2, value_2 ...)
+	 * @return new endpoint context with additional attributes.
+	 * @throws NullPointerException if the provided attributes is {@code null},
+	 *             or one of the attributes is {@code null}.
+	 * @throws IllegalArgumentException if provided attributes list has odd size
+	 *             or contains a duplicate key.
+	 */
+	public static MapBasedEndpointContext addEntries(EndpointContext context, String... attributes) {
+		Map<String, String> additionalAttributes = createMap(attributes);
+		Map<String, String> entries = new HashMap<>(context.entries());
+		entries.putAll(additionalAttributes);
+		return new MapBasedEndpointContext(context.getPeerAddress(), context.getVirtualHost(),
+				context.getPeerIdentity(), entries);
+	}
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/DtlsEndpointContextMatcherTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/DtlsEndpointContextMatcherTest.java
@@ -17,6 +17,7 @@ package org.eclipse.californium.elements;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.eclipse.californium.elements.DtlsEndpointContext.*;
 
 import java.net.InetSocketAddress;
 
@@ -31,6 +32,7 @@ import org.junit.Test;
 public class DtlsEndpointContextMatcherTest {
 
 	private static final InetSocketAddress ADDRESS = new InetSocketAddress(0);
+	private static final String SCOPE = "californium.eclipse.org";
 
 	private EndpointContext connectorContext;
 	private EndpointContext scopedConnectorContext;
@@ -38,6 +40,10 @@ public class DtlsEndpointContextMatcherTest {
 	private EndpointContext scopedRelaxedMessageContext;
 	private EndpointContext strictMessageContext;
 	private EndpointContext scopedStrictMessageContext;
+	private EndpointContext noneCriticalMessageContext;
+	private EndpointContext scopedNoneCriticalMessageContext;
+	private EndpointContext strictNoneCriticalMessageContext;
+	private EndpointContext scopedStrictNoneCriticalMessageContext;
 	private EndpointContext differentMessageContext;
 	private EndpointContext scopedDifferentMessageContext;
 	private EndpointContext unsecureMessageContext;
@@ -51,18 +57,24 @@ public class DtlsEndpointContextMatcherTest {
 		strictMatcher = new StrictDtlsEndpointContextMatcher();
 
 		connectorContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
-		scopedConnectorContext = new DtlsEndpointContext(ADDRESS, "iot.eclipse.org", null, "session", "1", "CIPHER");
+		scopedConnectorContext = new DtlsEndpointContext(ADDRESS, SCOPE, null, "session", "1", "CIPHER");
 
 		relaxedMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "2", "CIPHER");
-		scopedRelaxedMessageContext = new DtlsEndpointContext(ADDRESS, "iot.eclipse.org", null, "session", "2", "CIPHER");
+		scopedRelaxedMessageContext = new DtlsEndpointContext(ADDRESS, SCOPE, null, "session", "2", "CIPHER");
 
 		strictMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
-		scopedStrictMessageContext = new DtlsEndpointContext(ADDRESS, "iot.eclipse.org", null, "session", "1", "CIPHER");
+		scopedStrictMessageContext = new DtlsEndpointContext(ADDRESS, SCOPE, null, "session", "1", "CIPHER");
 
 		differentMessageContext = new DtlsEndpointContext(ADDRESS, null,"new session", "1", "CIPHER");
-		scopedDifferentMessageContext = new DtlsEndpointContext(ADDRESS, "iot.eclipse.org", null,"new session", "1", "CIPHER");
+		scopedDifferentMessageContext = new DtlsEndpointContext(ADDRESS, SCOPE, null,"new session", "1", "CIPHER");
 
 		unsecureMessageContext = new UdpEndpointContext(ADDRESS);
+		
+		noneCriticalMessageContext = new MapBasedEndpointContext(ADDRESS, null, KEY_RESUMPTION_TIMEOUT, "30000");
+		scopedNoneCriticalMessageContext = new MapBasedEndpointContext(ADDRESS, SCOPE, null, KEY_RESUMPTION_TIMEOUT, "30000");
+
+		strictNoneCriticalMessageContext = new MapBasedEndpointContext(ADDRESS, null, KEY_SESSION_ID, "session", KEY_EPOCH, "1", KEY_CIPHER, "CIPHER", KEY_RESUMPTION_TIMEOUT, "30000");
+		scopedStrictNoneCriticalMessageContext = new MapBasedEndpointContext(ADDRESS, SCOPE, null, KEY_SESSION_ID, "session", KEY_EPOCH, "1", KEY_CIPHER, "CIPHER", KEY_RESUMPTION_TIMEOUT, "30000");
 	}
 
 	@Test
@@ -73,6 +85,10 @@ public class DtlsEndpointContextMatcherTest {
 		assertThat(relaxedMatcher.isToBeSent(differentMessageContext, connectorContext), is(false));
 		assertThat(relaxedMatcher.isToBeSent(scopedDifferentMessageContext, connectorContext), is(false));
 		assertThat(relaxedMatcher.isToBeSent(unsecureMessageContext, connectorContext), is(false));
+		assertThat(relaxedMatcher.isToBeSent(noneCriticalMessageContext, connectorContext), is(true));
+		assertThat(relaxedMatcher.isToBeSent(scopedNoneCriticalMessageContext, connectorContext), is(false));
+		assertThat(relaxedMatcher.isToBeSent(strictNoneCriticalMessageContext, connectorContext), is(true));
+		assertThat(relaxedMatcher.isToBeSent(scopedStrictNoneCriticalMessageContext, connectorContext), is(false));
 	}
 
 	@Test
@@ -85,6 +101,10 @@ public class DtlsEndpointContextMatcherTest {
 		assertThat(relaxedMatcher.isToBeSent(differentMessageContext, scopedConnectorContext), is(false));
 		assertThat(relaxedMatcher.isToBeSent(scopedDifferentMessageContext, scopedConnectorContext), is(false));
 		assertThat(relaxedMatcher.isToBeSent(unsecureMessageContext, scopedConnectorContext), is(false));
+		assertThat(relaxedMatcher.isToBeSent(noneCriticalMessageContext, scopedConnectorContext), is(false));
+		assertThat(relaxedMatcher.isToBeSent(scopedNoneCriticalMessageContext, scopedConnectorContext), is(true));
+		assertThat(relaxedMatcher.isToBeSent(strictNoneCriticalMessageContext, scopedConnectorContext), is(false));
+		assertThat(relaxedMatcher.isToBeSent(scopedStrictNoneCriticalMessageContext, scopedConnectorContext), is(true));
 	}
 
 	@Test
@@ -94,6 +114,10 @@ public class DtlsEndpointContextMatcherTest {
 		assertThat(strictMatcher.isToBeSent(relaxedMessageContext, connectorContext), is(false));
 		assertThat(strictMatcher.isToBeSent(scopedRelaxedMessageContext, connectorContext), is(false));
 		assertThat(strictMatcher.isToBeSent(unsecureMessageContext, connectorContext), is(false));
+		assertThat(strictMatcher.isToBeSent(noneCriticalMessageContext, connectorContext), is(true));
+		assertThat(strictMatcher.isToBeSent(scopedNoneCriticalMessageContext, connectorContext), is(false));
+		assertThat(strictMatcher.isToBeSent(strictNoneCriticalMessageContext, connectorContext), is(true));
+		assertThat(strictMatcher.isToBeSent(scopedStrictNoneCriticalMessageContext, connectorContext), is(false));
 	}
 
 	@Test
@@ -106,6 +130,10 @@ public class DtlsEndpointContextMatcherTest {
 		assertThat(strictMatcher.isToBeSent(differentMessageContext, scopedConnectorContext), is(false));
 		assertThat(strictMatcher.isToBeSent(scopedDifferentMessageContext, scopedConnectorContext), is(false));
 		assertThat(strictMatcher.isToBeSent(unsecureMessageContext, scopedConnectorContext), is(false));
+		assertThat(strictMatcher.isToBeSent(noneCriticalMessageContext, scopedConnectorContext), is(false));
+		assertThat(strictMatcher.isToBeSent(scopedNoneCriticalMessageContext, scopedConnectorContext), is(true));
+		assertThat(strictMatcher.isToBeSent(strictNoneCriticalMessageContext, scopedConnectorContext), is(false));
+		assertThat(strictMatcher.isToBeSent(scopedStrictNoneCriticalMessageContext, scopedConnectorContext), is(true));
 	}
 
 	@Test
@@ -116,6 +144,10 @@ public class DtlsEndpointContextMatcherTest {
 		assertThat(relaxedMatcher.isToBeSent(differentMessageContext, null), is(false));
 		assertThat(relaxedMatcher.isToBeSent(scopedDifferentMessageContext, null), is(false));
 		assertThat(relaxedMatcher.isToBeSent(unsecureMessageContext, null), is(false));
+		assertThat(relaxedMatcher.isToBeSent(noneCriticalMessageContext, null), is(true));
+		assertThat(relaxedMatcher.isToBeSent(scopedNoneCriticalMessageContext, null), is(true));
+		assertThat(relaxedMatcher.isToBeSent(strictNoneCriticalMessageContext, null), is(false));
+		assertThat(relaxedMatcher.isToBeSent(scopedStrictNoneCriticalMessageContext, null), is(false));
 	}
 
 	@Test
@@ -126,6 +158,34 @@ public class DtlsEndpointContextMatcherTest {
 		assertThat(strictMatcher.isToBeSent(relaxedMessageContext, null), is(false));
 		assertThat(strictMatcher.isToBeSent(scopedRelaxedMessageContext, null), is(false));
 		assertThat(strictMatcher.isToBeSent(unsecureMessageContext, null), is(false));
+		assertThat(strictMatcher.isToBeSent(noneCriticalMessageContext, null), is(true));
+		assertThat(strictMatcher.isToBeSent(scopedNoneCriticalMessageContext, null), is(true));
+		assertThat(strictMatcher.isToBeSent(strictNoneCriticalMessageContext, null), is(false));
+		assertThat(strictMatcher.isToBeSent(scopedStrictNoneCriticalMessageContext, null), is(false));
+	}
+
+	@Test
+	public void testAddNewEntries() {
+		EndpointContext context = MapBasedEndpointContext.addEntries(strictMessageContext, KEY_RESUMPTION_TIMEOUT, "30000");
+		assertThat(context.getPeerAddress(), is(strictMessageContext.getPeerAddress()));
+		assertThat(context.getVirtualHost(), is(strictMessageContext.getVirtualHost()));
+		assertThat(context.getPeerIdentity(), is(strictMessageContext.getPeerIdentity()));
+		assertThat(context.get(KEY_RESUMPTION_TIMEOUT), is("30000"));
+
+		context = MapBasedEndpointContext.addEntries(scopedStrictMessageContext, KEY_RESUMPTION_TIMEOUT, "30000");
+		assertThat(context.getPeerAddress(), is(scopedStrictMessageContext.getPeerAddress()));
+		assertThat(context.getVirtualHost(), is(scopedStrictMessageContext.getVirtualHost()));
+		assertThat(context.getPeerIdentity(), is(scopedStrictMessageContext.getPeerIdentity()));
+		assertThat(context.get(KEY_RESUMPTION_TIMEOUT), is("30000"));
+	}
+
+	@Test
+	public void testAddContainedEntries() {
+		EndpointContext	context = MapBasedEndpointContext.addEntries(noneCriticalMessageContext, KEY_RESUMPTION_TIMEOUT, "60000");
+		assertThat(context.getPeerAddress(), is(noneCriticalMessageContext.getPeerAddress()));
+		assertThat(context.getVirtualHost(), is(noneCriticalMessageContext.getVirtualHost()));
+		assertThat(context.getPeerIdentity(), is(noneCriticalMessageContext.getPeerIdentity()));
+		assertThat(context.get(KEY_RESUMPTION_TIMEOUT), is("60000"));
 	}
 
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.eclipse.californium.elements.DtlsEndpointContext;
 import org.eclipse.californium.scandium.dtls.CertificateType;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
@@ -535,10 +536,11 @@ public final class DtlsConnectorConfig {
 	 * 
 	 * If no messages are exchanged for this timeout, the next message will
 	 * trigger a session resumption automatically. Intended to be used, if
-	 * traffic is routed over a NAT.
+	 * traffic is routed over a NAT. The value may be overridden by the endpoint
+	 * context attribute {@link DtlsEndpointContext#KEY_RESUMPTION_TIMEOUT}.
 	 * 
-	 * @return timeout in milliseconds, or {@code null}, if no automatic resumption
-	 *         is intended.
+	 * @return timeout in milliseconds, or {@code null}, if no automatic
+	 *         resumption is intended.
 	 */
 	public Long getAutoResumptionTimeoutMillis() {
 		return autoResumptionTimeoutMillis;
@@ -1308,12 +1310,23 @@ public final class DtlsConnectorConfig {
 		/**
 		 * Set the timeout of automatic session resumption in milliseconds.
 		 * <p>
-		 * The default value is {@code null}, no automatic session resumption.
+		 * The default value is {@code null}, for no automatic session
+		 * resumption. The configured value may be overridden by the endpoint
+		 * context attribute {@link DtlsEndpointContext#KEY_RESUMPTION_TIMEOUT}.
 		 * 
-		 * @param timeoutInMillis the number of milliseconds.
+		 * @param timeoutInMillis the number of milliseconds. Usually values
+		 *            around 30000 milliseconds are useful, depending on the
+		 *            setup of NATS on the path. Smaller timeouts are only
+		 *            useful for unit test, they would trigger too many
+		 *            resumption handshakes.
 		 * @return this builder for command chaining.
+		 * @throws IllegalArgumentException if the timeout is below 1
+		 *             millisecond
 		 */
 		public Builder setAutoResumptionTimeoutMillis(long timeoutInMillis) {
+			if (timeoutInMillis < 1) {
+				throw new IllegalArgumentException("auto resumption timeout must not below 1!");
+			}
 			config.autoResumptionTimeoutMillis = timeoutInMillis;
 			return this;
 		}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStoreTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStoreTest.java
@@ -124,7 +124,7 @@ public class InMemoryConnectionStoreTest {
 	private Connection newConnection(long ip) throws HandshakeException, UnknownHostException {
 		InetAddress addr = InetAddress.getByAddress(longToIp(ip));
 		InetSocketAddress peerAddress = new InetSocketAddress(addr, 0);
-		Connection con = new Connection(peerAddress, null);
+		Connection con = new Connection(peerAddress);
 		con.getSessionListener().sessionEstablished(null, newSession(peerAddress));
 		return con;
 	}


### PR DESCRIPTION
Introduce none critical context attributes.
Rename inhibitNewConnection in hasCriticalEntries.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>