### PR TITLE
Add handshake timestamp to DtlsEndpointContext.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
@@ -180,7 +180,7 @@ public class CoapEndpointTest {
 		endpoint.setMessageDeliverer(deliverer);
 		endpoint.start();
 		
-		EndpointContext secureCtx = new DtlsEndpointContext(SOURCE_ADDRESS, null, "session", "1", "CIPHER");
+		EndpointContext secureCtx = new DtlsEndpointContext(SOURCE_ADDRESS, null, "session", "1", "CIPHER", "100");
 		RawData inboundRequest = RawData.inbound(getSerializedRequest(), secureCtx, false);
 		connector.receiveMessage(inboundRequest);
 		assertTrue(latch.await(2, TimeUnit.SECONDS));

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataSerializerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataSerializerTest.java
@@ -52,7 +52,7 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class DataSerializerTest {
 
-	private static final EndpointContext ENDPOINT_CONTEXT = new DtlsEndpointContext(new InetSocketAddress(0), null, "session", "1", "CIPHER");
+	private static final EndpointContext ENDPOINT_CONTEXT = new DtlsEndpointContext(new InetSocketAddress(0), null, "session", "1", "CIPHER", "100");
 
 	/**
 	 * The concrete serializer to run the test cases with.

--- a/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
@@ -44,6 +44,11 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 	 */
 	public static final String KEY_CIPHER = "DTLS_CIPHER";
 	/**
+	 * The name of the attribute that contains the timestamp of the last
+	 * handshake of the DTLS session.
+	 */
+	public static final String KEY_HANDSHAKE_TIMESTAMP = "KEY_HANDSHAKE_TIMESTAMP";
+	/**
 	 * The name of the attribute that contains a auto session resumption timeout
 	 * in milliseconds. {@code "0"}, force a session resumption, {@code ""},
 	 * disable auto session resumption. None critical attribute, not considered
@@ -59,13 +64,14 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 	 * @param sessionId the session's ID.
 	 * @param epoch the session's current read/write epoch.
 	 * @param cipher the cipher suite of the session's current read/write state.
+	 * @param timestamp the timestamp of the last handshake.
 	 * @throws NullPointerException if any of the parameters other than peerIdentity
 	 *             are {@code null}.
 	 */
 	public DtlsEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity,
-			String sessionId, String epoch, String cipher) {
+			String sessionId, String epoch, String cipher, String timestamp) {
 
-		this(peerAddress, null, peerIdentity, sessionId, epoch, cipher);
+		this(peerAddress, null, peerIdentity, sessionId, epoch, cipher, timestamp);
 	}
 
 	/**
@@ -77,13 +83,15 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 	 * @param sessionId the session's ID.
 	 * @param epoch the session's current read/write epoch.
 	 * @param cipher the cipher suite of the session's current read/write state.
+	 * @param timestamp the timestamp of the last handshake.
 	 * @throws NullPointerException if any of the parameters other than peerIdentity
 	 *             are {@code null}.
 	 */
 	public DtlsEndpointContext(InetSocketAddress peerAddress, String virtualHost, Principal peerIdentity,
-			String sessionId, String epoch, String cipher) {
+			String sessionId, String epoch, String cipher, String timestamp) {
 
-		super(peerAddress, virtualHost, peerIdentity, KEY_SESSION_ID, sessionId, KEY_CIPHER, cipher, KEY_EPOCH, epoch);
+		super(peerAddress, virtualHost, peerIdentity, KEY_SESSION_ID, sessionId, KEY_CIPHER, cipher, KEY_EPOCH, epoch,
+				KEY_HANDSHAKE_TIMESTAMP, timestamp);
 	}
 
 	/**

--- a/element-connector/src/test/java/org/eclipse/californium/elements/DtlsEndpointContextMatcherTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/DtlsEndpointContextMatcherTest.java
@@ -56,17 +56,17 @@ public class DtlsEndpointContextMatcherTest {
 		relaxedMatcher = new RelaxedDtlsEndpointContextMatcher();
 		strictMatcher = new StrictDtlsEndpointContextMatcher();
 
-		connectorContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
-		scopedConnectorContext = new DtlsEndpointContext(ADDRESS, SCOPE, null, "session", "1", "CIPHER");
+		connectorContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER", "100");
+		scopedConnectorContext = new DtlsEndpointContext(ADDRESS, SCOPE, null, "session", "1", "CIPHER", "100");
 
-		relaxedMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "2", "CIPHER");
-		scopedRelaxedMessageContext = new DtlsEndpointContext(ADDRESS, SCOPE, null, "session", "2", "CIPHER");
+		relaxedMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "2", "CIPHER", "200");
+		scopedRelaxedMessageContext = new DtlsEndpointContext(ADDRESS, SCOPE, null, "session", "2", "CIPHER", "200");
 
-		strictMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
-		scopedStrictMessageContext = new DtlsEndpointContext(ADDRESS, SCOPE, null, "session", "1", "CIPHER");
+		strictMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER", "100");
+		scopedStrictMessageContext = new DtlsEndpointContext(ADDRESS, SCOPE, null, "session", "1", "CIPHER", "100");
 
-		differentMessageContext = new DtlsEndpointContext(ADDRESS, null,"new session", "1", "CIPHER");
-		scopedDifferentMessageContext = new DtlsEndpointContext(ADDRESS, SCOPE, null,"new session", "1", "CIPHER");
+		differentMessageContext = new DtlsEndpointContext(ADDRESS, null,"new session", "1", "CIPHER", "100");
+		scopedDifferentMessageContext = new DtlsEndpointContext(ADDRESS, SCOPE, null,"new session", "1", "CIPHER", "100");
 
 		unsecureMessageContext = new UdpEndpointContext(ADDRESS);
 		

--- a/element-connector/src/test/java/org/eclipse/californium/elements/EndpointContextUtilTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/EndpointContextUtilTest.java
@@ -37,10 +37,10 @@ public class EndpointContextUtilTest {
 
 	@Before
 	public void setup() {
-		connectorContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
-		relaxedMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "2", "CIPHER");
-		strictMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
-		differentMessageContext = new DtlsEndpointContext(ADDRESS, null, "new session", "1", "CIPHER");
+		connectorContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER", "100");
+		relaxedMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "2", "CIPHER", "200");
+		strictMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER", "100");
+		differentMessageContext = new DtlsEndpointContext(ADDRESS, null, "new session", "1", "CIPHER", "100");
 		MapBasedEndpointContext mapBasedContext = new MapBasedEndpointContext(ADDRESS, null, "ID", "session", "UNKNOWN", "secret");
 		unsecureMessageContext = mapBasedContext;
 		mapBasedContext = new MapBasedEndpointContext(ADDRESS, null, "ID", "session", "UNKNOWN", "topsecret");

--- a/element-connector/src/test/java/org/eclipse/californium/elements/PrincipalEndpointContextMatcherTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/PrincipalEndpointContextMatcherTest.java
@@ -43,7 +43,7 @@ public class PrincipalEndpointContextMatcherTest {
 		principal2 = new TestPrincipal("P1"); // intended to have the same name as principal1
 		principal3 = new TestPrincipal("P3");
 		
-		connectionContext = new DtlsEndpointContext(ADDRESS, principal1, "session", "1", "CIPHER");
+		connectionContext = new DtlsEndpointContext(ADDRESS, principal1, "session", "1", "CIPHER", "100");
 		messageContext = new AddressEndpointContext(ADDRESS, principal2);
 		differentMessageContext = new AddressEndpointContext(ADDRESS, principal3);
 		unsecureMessageContext = new AddressEndpointContext(ADDRESS, null);

--- a/element-connector/src/test/java/org/eclipse/californium/elements/UdpEndpointContextMatcherTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/UdpEndpointContextMatcherTest.java
@@ -44,7 +44,7 @@ public class UdpEndpointContextMatcherTest {
 		messageContext = new UdpEndpointContext(ADDRESS);
 		multicastContext = new UdpEndpointContext(MULTICAST_ADDRESS);
 		changedAddressContext = new UdpEndpointContext(CHANGED_ADDRESS);
-		secureMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER");
+		secureMessageContext = new DtlsEndpointContext(ADDRESS, null, "session", "1", "CIPHER", "100");
 		matcher = new UdpEndpointContextMatcher(true);
 	}
 

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/LeastRecentlyUsedCacheTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/LeastRecentlyUsedCacheTest.java
@@ -286,7 +286,7 @@ public class LeastRecentlyUsedCacheTest {
 		cache = new LeastRecentlyUsedCache<>(capacity, 0);
 		cache.setExpirationThreshold(expirationThresholdMillis, TimeUnit.MILLISECONDS);
 		for (int i = 0; i < noOfEntries; i++) {
-			cache.put(i, String.valueOf(i));
+			cache.put(i, Integer.toString(i));
 		}
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -1405,7 +1405,7 @@ public class DTLSConnector implements Connector, RecordLayer {
 
 		// use the record sequence number from CLIENT_HELLO as initial sequence number
 		// for records sent to the client (see section 4.2.1 of RFC 6347 (DTLS 1.2))
-		DTLSSession newSession = new DTLSSession(record.getPeerAddress(), false, record.getSequenceNumber());
+		DTLSSession newSession = new DTLSSession(record.getPeerAddress(), record.getSequenceNumber());
 		// initialize handshaker based on CLIENT_HELLO (this accounts
 		// for the case that multiple cookie exchanges have taken place)
 		Handshaker handshaker = new ServerHandshaker(clientHello.getMessageSeq(), newSession,

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
@@ -153,7 +153,7 @@ public class DTLSConnectorAdvancedTest {
 			// Create handshaker with ReverseRecordLayer
 			// to send message in bad order.
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ClientHandshaker clientHandshaker = new ClientHandshaker(new DTLSSession(serverHelper.serverEndpoint, true),
+			ClientHandshaker clientHandshaker = new ClientHandshaker(new DTLSSession(serverHelper.serverEndpoint),
 					new ReverseRecordLayer(rawClient), sessionListener, clientConfig, 1280);
 
 			// Start handshake (Send CLIENT HELLO)
@@ -206,7 +206,7 @@ public class DTLSConnectorAdvancedTest {
 
 			// Create server handshaker
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ServerHandshaker serverHandshaker = new ServerHandshaker(new DTLSSession(client.getAddress(), false, 1),
+			ServerHandshaker serverHandshaker = new ServerHandshaker(new DTLSSession(client.getAddress(), 1),
 					new ReverseRecordLayer(rawServer), sessionListener, serverHelper.serverConfig, 1280);
 
 			// Wait to receive response (should be CLIENT HELLO, flight 3)
@@ -244,7 +244,7 @@ public class DTLSConnectorAdvancedTest {
 			rawClient.start();
 
 			// Create handshaker
-			DTLSSession clientSession = new DTLSSession(serverHelper.serverEndpoint, true);
+			DTLSSession clientSession = new DTLSSession(serverHelper.serverEndpoint);
 			LatchSessionListener sessionListener = new LatchSessionListener();
 			ClientHandshaker clientHandshaker = new ClientHandshaker(clientSession, clientRecordLayer, sessionListener,
 					clientConfig, 1280);
@@ -331,7 +331,7 @@ public class DTLSConnectorAdvancedTest {
 			client.send(data);
 
 			// Create server handshaker
-			DTLSSession serverSession = new DTLSSession(client.getAddress(), false, 1);
+			DTLSSession serverSession = new DTLSSession(client.getAddress(), 1);
 			LatchSessionListener sessionListener = new LatchSessionListener();
 			ServerHandshaker serverHandshaker = new ServerHandshaker(serverSession, serverRecordLayer, sessionListener,
 					serverHelper.serverConfig, 1280);
@@ -425,7 +425,7 @@ public class DTLSConnectorAdvancedTest {
 
 			// Create handshaker
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ClientHandshaker clientHandshaker = new ClientHandshaker(new DTLSSession(serverHelper.serverEndpoint, true),
+			ClientHandshaker clientHandshaker = new ClientHandshaker(new DTLSSession(serverHelper.serverEndpoint),
 					clientRecordLayer, sessionListener, clientConfig, 1280);
 
 			// Start handshake (Send CLIENT HELLO, flight 1)
@@ -499,7 +499,7 @@ public class DTLSConnectorAdvancedTest {
 			client.send(data);
 
 			// Create server handshaker
-			DTLSSession serverSession = new DTLSSession(client.getAddress(), false, 1);
+			DTLSSession serverSession = new DTLSSession(client.getAddress(), 1);
 			LatchSessionListener sessionListener = new LatchSessionListener();
 			ServerHandshaker serverHandshaker = new ServerHandshaker(serverSession, serverRecordLayer, sessionListener,
 					serverHelper.serverConfig, 1280);
@@ -596,7 +596,7 @@ public class DTLSConnectorAdvancedTest {
 
 			// Create server handshaker
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ServerHandshaker serverHandshaker = new ServerHandshaker(new DTLSSession(client.getAddress(), false, 1),
+			ServerHandshaker serverHandshaker = new ServerHandshaker(new DTLSSession(client.getAddress(), 1),
 					new BasicRecordLayer(rawServer), sessionListener, serverHelper.serverConfig, 1280);
 
 			// Wait to receive response (should be CLIENT HELLO, flight 3)
@@ -649,7 +649,7 @@ public class DTLSConnectorAdvancedTest {
 			rawClient.start();
 
 			// Create handshaker
-			DTLSSession clientSession = new DTLSSession(serverHelper.serverEndpoint, true);
+			DTLSSession clientSession = new DTLSSession(serverHelper.serverEndpoint);
 			LatchSessionListener sessionListener = new LatchSessionListener();
 			ClientHandshaker clientHandshaker = new ClientHandshaker(clientSession, clientRecordLayer, sessionListener,
 					clientConfig, 1280);
@@ -737,7 +737,7 @@ public class DTLSConnectorAdvancedTest {
 			rawClient.start();
 
 			// Create handshaker
-			DTLSSession clientSession = new DTLSSession(serverHelper.serverEndpoint, true);
+			DTLSSession clientSession = new DTLSSession(serverHelper.serverEndpoint);
 			LatchSessionListener sessionListener = new LatchSessionListener();
 			ClientHandshaker clientHandshaker = new ClientHandshaker(clientSession, clientRecordLayer, sessionListener,
 					clientConfig, 1280);
@@ -824,7 +824,7 @@ public class DTLSConnectorAdvancedTest {
 			rawClient.start();
 
 			// Create handshaker
-			DTLSSession clientSession = new DTLSSession(serverHelper.serverEndpoint, true);
+			DTLSSession clientSession = new DTLSSession(serverHelper.serverEndpoint);
 			LatchSessionListener sessionListener = new LatchSessionListener();
 			ClientHandshaker clientHandshaker = new ClientHandshaker(clientSession, clientRecordLayer, sessionListener,
 					clientConfig, 1280);
@@ -880,7 +880,7 @@ public class DTLSConnectorAdvancedTest {
 			client.send(data);
 
 			// Create server handshaker
-			DTLSSession serverSession = new DTLSSession(client.getAddress(), false, 1);
+			DTLSSession serverSession = new DTLSSession(client.getAddress(), 1);
 			LatchSessionListener sessionListener = new LatchSessionListener();
 			ServerHandshaker serverHandshaker = new ServerHandshaker(serverSession, serverRecordLayer, sessionListener,
 					serverHelper.serverConfig, 1280);
@@ -958,7 +958,7 @@ public class DTLSConnectorAdvancedTest {
 			// Create server handshaker
 			BasicRecordLayer serverRecordLayer = new BasicRecordLayer(rawServer);
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ServerHandshaker serverHandshaker = new ServerHandshaker(new DTLSSession(client.getAddress(), false, 1),
+			ServerHandshaker serverHandshaker = new ServerHandshaker(new DTLSSession(client.getAddress(), 1),
 					serverRecordLayer, sessionListener, serverHelper.serverConfig, 1280);
 
 			// Wait to receive response (should be CLIENT HELLO, flight 3)
@@ -1003,7 +1003,7 @@ public class DTLSConnectorAdvancedTest {
 		RecordCollectorDataHandler alt2Collector = new RecordCollectorDataHandler();
 		UdpConnector rawAlt2Client = new UdpConnector(0, alt2Collector);
 
-		DTLSSession clientSession = new DTLSSession(serverHelper.serverEndpoint, true);
+		DTLSSession clientSession = new DTLSSession(serverHelper.serverEndpoint);
 		try {
 			// Start connector
 			rawClient.start();

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
@@ -264,7 +264,7 @@ public class DTLSEndpointContextTest {
 				.getLatestInboundMessage().getEndpointContext();
 		assertThat(context, is(notNullValue()));
 		assertThat(context.getSessionId(), is(establishedClientSession.getSessionIdentifier().toString()));
-		assertThat(context.getEpoch(), is(String.valueOf(establishedClientSession.getReadEpoch())));
+		assertThat(context.getEpoch(), is(Integer.toString(establishedClientSession.getReadEpoch())));
 		assertThat(context.getCipher(), is(establishedClientSession.getReadStateCipher()));
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DTLSSessionTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DTLSSessionTest.java
@@ -53,7 +53,7 @@ public class DTLSSessionTest {
 	@Test
 	public void testDefaultMaxFragmentLengthCompliesWithSpec() {
 		// when instantiating a default server session
-		session = new DTLSSession(PEER_ADDRESS, false);
+		session = new DTLSSession(PEER_ADDRESS);
 
 		// then the max fragment size is as specified in DTLS spec
 		assertThat(session.getMaxFragmentLength(), is(DEFAULT_MAX_FRAGMENT_LENGTH));
@@ -146,9 +146,9 @@ public class DTLSSessionTest {
 
 	@Test
 	public void testConstructorEnforcesMaxSequenceNo() {
-		session = new DTLSSession(PEER_ADDRESS, false, DtlsTestTools.MAX_SEQUENCE_NO); // should succeed
+		session = new DTLSSession(PEER_ADDRESS, DtlsTestTools.MAX_SEQUENCE_NO); // should succeed
 		try {
-			session = new DTLSSession(PEER_ADDRESS, false, DtlsTestTools.MAX_SEQUENCE_NO + 1); // should fail
+			session = new DTLSSession(PEER_ADDRESS, DtlsTestTools.MAX_SEQUENCE_NO + 1); // should fail
 			fail("DTLSSession constructor should have refused initial sequence number > 2^48 - 1");
 		} catch (IllegalArgumentException e) {
 			// ok
@@ -157,7 +157,7 @@ public class DTLSSessionTest {
 
 	@Test(expected = IllegalStateException.class)
 	public void testGetSequenceNumberEnforcesMaxSequenceNo() {
-		session = new DTLSSession(PEER_ADDRESS, false, DtlsTestTools.MAX_SEQUENCE_NO);
+		session = new DTLSSession(PEER_ADDRESS, DtlsTestTools.MAX_SEQUENCE_NO);
 		session.getSequenceNumber(); // should throw exception
 	}
 
@@ -183,7 +183,7 @@ public class DTLSSessionTest {
 	}
 
 	public static DTLSSession newEstablishedServerSession(InetSocketAddress peerAddress, CipherSuite cipherSuite, boolean useRawPublicKeys) {
-		DTLSSession session = new DTLSSession(peerAddress, false);
+		DTLSSession session = new DTLSSession(peerAddress);
 		DTLSConnectionState currentState = newConnectionState(cipherSuite);
 		session.setSessionIdentifier(new SessionId());
 		session.setReadState(currentState);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
@@ -103,7 +103,7 @@ public class HandshakerTest {
 			receivedMessages[i++] = 0;
 		}
 
-		session = new DTLSSession(endpoint, false);
+		session = new DTLSSession(endpoint);
 		session.setReceiveRawPublicKey(false);
 		session.setParameterAvailable();
 		certificateChain = DtlsTestTools.getServerCertificateChain();

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordTest.java
@@ -70,7 +70,7 @@ public class RecordTest {
 		for ( int i = 0; i < payloadLength; i++) {
 			payloadData[i] = 0x34;
 		}
-		session = new DTLSSession(new InetSocketAddress(InetAddress.getLoopbackAddress(), 7000), true);
+		session = new DTLSSession(new InetSocketAddress(InetAddress.getLoopbackAddress(), 7000));
 		DTLSConnectionState readState = new DTLSConnectionState(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
 				CompressionMethod.NULL, key, new IvParameterSpec(client_iv), null);
 		session.setReadState(readState);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
@@ -83,7 +83,7 @@ public class ServerHandshakerTest {
 	@Before
 	public void setup() throws Exception {
 		endpoint = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
-		session = new DTLSSession(endpoint, false);
+		session = new DTLSSession(endpoint);
 		recordLayer = new SimpleRecordLayer();
 		config = new DtlsConnectorConfig.Builder()
 				.setAddress(endpoint)


### PR DESCRIPTION
I guess, one comment will be: "now we can make strict matching really strict" 

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>