### PR TITLE
Fix SNI issues #649 and #644

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/RawData.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/RawData.java
@@ -215,8 +215,7 @@ public final class RawData {
 	 * Gets additional information regarding the context this message has been
 	 * received in or should be sent in.
 	 * 
-	 * @return the messageContext the endpoint information or <code>null</code>
-	 *         if no additional endpoint information is available
+	 * @return the message context including the endpoint information
 	 */
 	public EndpointContext getEndpointContext() {
 		return peerEndpointContext;

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentity.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentity.java
@@ -12,6 +12,8 @@
  * 
  * Contributors:
  *    Kai Hudalla (Bosch Software Innovations GmbH) - initial creation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add scoped identity indicator
+ *                                                    issue #649
  ******************************************************************************/
 package org.eclipse.californium.elements.auth;
 
@@ -25,6 +27,7 @@ import org.eclipse.californium.elements.util.StringUtil;
  */
 public final class PreSharedKeyIdentity implements Principal {
 
+	private final boolean scopedIdentity;
 	private final String virtualHost;
 	private final String identity;
 	private final String name;
@@ -36,7 +39,7 @@ public final class PreSharedKeyIdentity implements Principal {
 	 * @throws NullPointerException if the identity is <code>null</code>
 	 */
 	public PreSharedKeyIdentity(String identity) {
-		this(null, identity);
+		this(false, null, identity);
 	}
 
 	/**
@@ -50,23 +53,57 @@ public final class PreSharedKeyIdentity implements Principal {
 	 *             as per <a href="http://tools.ietf.org/html/rfc1123">RFC 1123</a>.
 	 */
 	public PreSharedKeyIdentity(String virtualHost, String identity) {
+		this(true, virtualHost, identity);
+	}
+
+	/**
+	 * Creates a new instance for an identity optional scoped to a virtual host.
+	 * 
+	 * @param sni enable scope to a virtual host
+	 * @param virtualHost The virtual host name that the identity is scoped to.
+	 *            The host name will be converted to lower case.
+	 * @param identity the identity.
+	 * @throws NullPointerException if the identity is <code>null</code>
+	 * @throws IllegalArgumentException if virtual host is not a valid host name
+	 *             as per <a href="http://tools.ietf.org/html/rfc1123">RFC
+	 *             1123</a>.
+	 */
+	private PreSharedKeyIdentity(boolean sni, String virtualHost, String identity) {
 		if (identity == null) {
 			throw new NullPointerException("Identity must not be null");
 		} else {
+			scopedIdentity = sni;
 			StringBuilder b = new StringBuilder();
-			if (virtualHost == null) {
-				this.virtualHost = null;
-			} else if (StringUtil.isValidHostName(virtualHost)) {
-				this.virtualHost = virtualHost.toLowerCase();
-				b.append(this.virtualHost);
+			if (sni) {
+				if (virtualHost == null) {
+					this.virtualHost = null;
+				} else if (StringUtil.isValidHostName(virtualHost)) {
+					this.virtualHost = virtualHost.toLowerCase();
+					b.append(this.virtualHost);
+				} else {
+					throw new IllegalArgumentException("virtual host is not a valid hostname");
+				}
+				b.append(":");
 			} else {
-				throw new IllegalArgumentException("virtual host is not a valid hostname");
+				if (virtualHost != null) {
+					throw new IllegalArgumentException("virtual host is not supported, if sni is disabled");
+				}
+				this.virtualHost = null;
 			}
 			this.identity = identity;
 
-			b.append(":").append(identity);
+			b.append(identity);
 			this.name = b.toString();
 		}
+	}
+
+	/**
+	 * Checks, if the identity is scoped by the virtual host name.
+	 * 
+	 * @return {@code true}, if the identity is scoped by the virtual host name.
+	 */
+	public boolean isScopedIdentity() {
+		return scopedIdentity;
 	}
 
 	/**
@@ -90,9 +127,11 @@ public final class PreSharedKeyIdentity implements Principal {
 	/**
 	 * Gets the name of this principal.
 	 * <p>
-	 * The name consists of the server name and the identity,
-	 * separated by a colon character. If not server name has been
-	 * provided, then the name only consists of the identity.
+	 * If the identity is not scoped by the server name, the
+	 * {@link #getIdentity()} is returned. If the identity is scoped by the
+	 * server name, the name consists of that server name and the identity,
+	 * separated by a colon character. If no server name has been provided, then
+	 * the name consists of a colon character followed by the identity.
 	 * 
 	 * @return the name
 	 */
@@ -106,15 +145,18 @@ public final class PreSharedKeyIdentity implements Principal {
 	 * 
 	 * Clients should not assume any particular format of the returned string
 	 * since it may change over time.
-	 *  
+	 * 
 	 * @return the string representation
 	 */
 	@Override
 	public String toString() {
-		return new StringBuilder("PreSharedKey Identity [")
-				.append("virtual host: ").append(virtualHost)
-				.append(", identity: ").append(identity)
-				.append("]").toString();
+		if (scopedIdentity) {
+			return new StringBuilder("PreSharedKey Identity [").append("virtual host: ").append(virtualHost)
+					.append(", identity: ").append(identity).append("]").toString();
+		} else {
+			return new StringBuilder("PreSharedKey Identity [").append("identity: ").append(identity).append("]")
+					.toString();
+		}
 	}
 
 	@Override

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
@@ -610,7 +610,7 @@ public class SslContextUtil {
 	 * @throws IllegalArgumentException if null, a empty array is provided or a
 	 *             none x509 certificate was found or a array entry was null.
 	 */
-	private static X509Certificate[] asX509Certificates(Certificate[] certificates) {
+	public static X509Certificate[] asX509Certificates(Certificate[] certificates) {
 		if (null == certificates || 0 == certificates.length) {
 			throw new IllegalArgumentException("certificates missing!");
 		}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentityTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentityTest.java
@@ -44,6 +44,7 @@ public class PreSharedKeyIdentityTest {
 		PreSharedKeyIdentity idOne = new PreSharedKeyIdentity("iot.eclipse.org", "device-1");
 		PreSharedKeyIdentity idTwo = new PreSharedKeyIdentity("coap.eclipse.org", "device-1");
 		assertFalse(idOne.equals(idTwo));
+		assertTrue(idOne.isScopedIdentity());
 	}
 
 	/**
@@ -55,5 +56,19 @@ public class PreSharedKeyIdentityTest {
 		PreSharedKeyIdentity idOne = new PreSharedKeyIdentity("iot.eclipse.org", "device-1");
 		PreSharedKeyIdentity idTwo = new PreSharedKeyIdentity("iot.eclipse.org", "device-1");
 		assertTrue(idOne.equals(idTwo));
+		assertTrue(idOne.isScopedIdentity());
+	}
+
+	/**
+	 * Verifies that two instances with the same identity but one with virtual host
+	 * and one without are not considered equal.
+	 */
+	@Test
+	public void testEqualsFails() {
+		PreSharedKeyIdentity idOne = new PreSharedKeyIdentity("device-1");
+		PreSharedKeyIdentity idTwo = new PreSharedKeyIdentity(null, "device-1");
+		assertFalse(idOne.equals(idTwo));
+		assertFalse(idOne.isScopedIdentity());
+		assertTrue(idTwo.isScopedIdentity());
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtension.java
@@ -52,7 +52,7 @@ public abstract class HelloExtension {
 
 	protected static final int TYPE_BITS = 16;
 
-	protected static final int LENGTH_BITS = 16;
+	public static final int LENGTH_BITS = 16;
 
 	// Members ////////////////////////////////////////////////////////
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
@@ -75,7 +75,8 @@ import org.slf4j.LoggerFactory;
  * Verifies behavior of {@link DTLSConnector}.
  * <p>
  * Mainly contains integration test cases verifying the correct interaction
- * between a client and a server.
+ * between a client and a server during handshakes including unusual message
+ * order and timeouts.
  */
 @Category(Medium.class)
 public class DTLSConnectorAdvancedTest {
@@ -106,7 +107,7 @@ public class DTLSConnectorAdvancedTest {
 	@BeforeClass
 	public static void loadKeys() throws IOException, GeneralSecurityException {
 		serverHelper = new ConnectorHelper();
-		serverHelper.startServer(RETRANSMISSION_TIMEOUT_MS, MAX_RETRANSMISSIONS);
+		serverHelper.startServer(RETRANSMISSION_TIMEOUT_MS, MAX_RETRANSMISSIONS, true, true);
 		executor = Executors.newFixedThreadPool(2);
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorHandshakeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorHandshakeTest.java
@@ -1,0 +1,376 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - initial creation
+ *                                                    Based on the original test
+ *                                                    in DTLSConnectorTest.
+ *                                                    Updated to use ConnectorHelper
+ ******************************************************************************/
+package org.eclipse.californium.scandium;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.eclipse.californium.scandium.ConnectorHelper.*;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.security.GeneralSecurityException;
+import java.security.Principal;
+
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.californium.elements.EndpointContext;
+import org.eclipse.californium.elements.RawData;
+import org.eclipse.californium.elements.rule.TestNameLoggerRule;
+import org.eclipse.californium.scandium.category.Medium;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.dtls.DtlsTestTools;
+import org.eclipse.californium.scandium.dtls.InMemoryConnectionStore;
+import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
+import org.eclipse.californium.scandium.dtls.pskstore.StaticPskStore;
+import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Verifies behavior of {@link DTLSConnector}.
+ * <p>
+ * Mainly contains integration test cases verifying the correct interaction
+ * between a client and a server during handshakes with and without SNI.
+ */
+@Category(Medium.class)
+public class DTLSConnectorHandshakeTest {
+
+	public static final Logger LOGGER = LoggerFactory.getLogger(DTLSConnectorHandshakeTest.class.getName());
+
+	@ClassRule
+	public static DtlsNetworkRule network = new DtlsNetworkRule(DtlsNetworkRule.Mode.DIRECT,
+			DtlsNetworkRule.Mode.NATIVE);
+
+	@Rule
+	public TestNameLoggerRule names = new TestNameLoggerRule();
+
+	private static final int CLIENT_CONNECTION_STORE_CAPACITY = 5;
+
+	ConnectorHelper serverHelper;
+
+	DTLSConnector client;
+	InMemoryConnectionStore clientConnectionStore;
+
+	@After
+	public void cleanUp() {
+		if (serverHelper != null) {
+			serverHelper.destroyServer();
+		}
+		if (client != null) {
+			client.destroy();
+		}
+	}
+
+	private void startServer(boolean enableSni, boolean clientAuthRequired)
+			throws IOException, GeneralSecurityException {
+		serverHelper = new ConnectorHelper();
+		serverHelper.startServer(DtlsConnectorConfig.DEFAULT_RETRANSMISSION_TIMEOUT_MS,
+				DtlsConnectorConfig.DEFAULT_MAX_RETRANSMISSIONS, enableSni, clientAuthRequired);
+	}
+
+	private void startClientPsk(boolean enableSni, String hostname, PskStore pskStore) throws Exception {
+		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder().setPskStore(pskStore);
+		startClient(enableSni, hostname, builder);
+	}
+
+	private void startClientRpk(boolean enableSni, String hostname) throws Exception {
+		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder().setRpkTrustAll()
+				.setIdentity(DtlsTestTools.getClientPrivateKey(), DtlsTestTools.getClientPublicKey());
+		startClient(enableSni, hostname, builder);
+	}
+
+	private void startClientX509(boolean enableSni, String hostname) throws Exception {
+		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder().setRpkTrustAll()
+				.setIdentity(DtlsTestTools.getClientPrivateKey(), DtlsTestTools.getClientCertificateChain());
+		startClient(enableSni, hostname, builder);
+	}
+
+	private void startClient(boolean enableSni, String hostname, DtlsConnectorConfig.Builder builder) throws Exception {
+		InetSocketAddress clientEndpoint = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+		builder.setAddress(clientEndpoint).setReceiverThreadCount(1).setConnectionThreadCount(1)
+				.setSniEnabled(enableSni).setClientOnly().setMaxConnections(CLIENT_CONNECTION_STORE_CAPACITY);
+		DtlsConnectorConfig clientConfig = builder.build();
+
+		client = new DTLSConnector(clientConfig);
+		RawData raw = RawData.outbound("Hello World".getBytes(),
+				new AddressEndpointContext(serverHelper.serverEndpoint, hostname, null), null, false);
+		serverHelper.givenAnEstablishedSession(client, raw, true);
+	}
+
+	@Test
+	public void testPskHandshakeClientWithoutSniAndServerWithoutSni() throws Exception {
+		startServer(false, true);
+		startClientPsk(false, null, new StaticPskStore(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()));
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), is(CLIENT_IDENTITY));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testPskHandshakeClientWithoutSniAndServerWithSni() throws Exception {
+		startServer(true, true);
+		startClientPsk(false, null, new StaticPskStore(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()));
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), is(":" + CLIENT_IDENTITY));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testPskHandshakeWithServernameClientWithoutSniAndServerWithoutSni() throws Exception {
+		startServer(false, true);
+		startClientPsk(false, SERVERNAME, new StaticPskStore(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()));
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), is(CLIENT_IDENTITY));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testPskHandshakeWithServernameClientWithoutSniAndServerWithSni() throws Exception {
+		startServer(true, true);
+		startClientPsk(false, SERVERNAME, new StaticPskStore(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()));
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), is(":" + CLIENT_IDENTITY));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testPskHandshakeClientWithSniAndServerWithoutSni() throws Exception {
+		startServer(false, true);
+		startClientPsk(true, null, new StaticPskStore(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()));
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), is(CLIENT_IDENTITY));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testPskHandshakeClientWithSniAndServerWithSni() throws Exception {
+		startServer(true, true);
+		startClientPsk(true, null, new StaticPskStore(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()));
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), is(":" + CLIENT_IDENTITY));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testPskHandshakeWithServernameClientWithSniAndServerWithoutSni() throws Exception {
+		startServer(false, true);
+		startClientPsk(true, SERVERNAME, new StaticPskStore(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()));
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), is(CLIENT_IDENTITY));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testPskHandshakeWithServernameClientWithSniAndServerWithSni() throws Exception {
+		startServer(true, true);
+		startClientPsk(true, SERVERNAME, new StaticPskStore(SCOPED_CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()));
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), is(SERVERNAME + ":" + SCOPED_CLIENT_IDENTITY));
+		assertThat(endpointContext.getVirtualHost(), is(SERVERNAME));
+	}
+
+	@Test
+	public void testRpkHandshakeClientWithSniAndServerWithSni() throws Exception {
+		startServer(true, true);
+		startClientRpk(true, null);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), startsWith("ni:///sha-256;"));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testRpkHandshakeClientWithoutSniAndServerWithoutSni() throws Exception {
+		startServer(false, true);
+		startClientRpk(false, null);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), startsWith("ni:///sha-256;"));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testRpkHandshakeWithServernameClientWithSniAndServerWithSni() throws Exception {
+		startServer(true, true);
+		startClientRpk(true, SERVERNAME);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), startsWith("ni:///sha-256;"));
+		assertThat(endpointContext.getVirtualHost(), is(SERVERNAME));
+	}
+
+	@Test
+	public void testRpkHandshakeWithServernameClientWithoutSniAndServerWithoutSni() throws Exception {
+		startServer(false, true);
+		startClientRpk(false, SERVERNAME);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), startsWith("ni:///sha-256;"));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testX509HandshakeClientWithSniAndServerWithSni() throws Exception {
+		startServer(true, true);
+		startClientX509(true, null);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), is("C=CA,L=Ottawa,O=Eclipse IoT,OU=Californium,CN=cf-client"));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testX509HandshakeClientWithoutSniAndServerWithoutSni() throws Exception {
+		startServer(false, true);
+		startClientX509(false, null);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), is("C=CA,L=Ottawa,O=Eclipse IoT,OU=Californium,CN=cf-client"));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testX509HandshakeWithServernameClientWithSniAndServerWithSni() throws Exception {
+		startServer(true, true);
+		startClientX509(true, SERVERNAME);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), is("C=CA,L=Ottawa,O=Eclipse IoT,OU=Californium,CN=cf-client"));
+		assertThat(endpointContext.getVirtualHost(), is(SERVERNAME));
+	}
+
+	@Test
+	public void testX509HandshakeWithServernameClientWithoutSniAndServerWithoutSni() throws Exception {
+		startServer(false, true);
+		startClientX509(false, SERVERNAME);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(notNullValue()));
+		assertThat(principal.getName(), is("C=CA,L=Ottawa,O=Eclipse IoT,OU=Californium,CN=cf-client"));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testRpkHandshakeNoneAuthClientWithSniAndServerWithSni() throws Exception {
+		startServer(true, false);
+		startClientRpk(true, null);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(nullValue()));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testRpkHandshakeNoneAuthClientWithoutSniAndServerWithoutSni() throws Exception {
+		startServer(false, false);
+		startClientRpk(false, null);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(nullValue()));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testRpkHandshakeNoneAuthWithServernameClientWithSniAndServerWithSni() throws Exception {
+		startServer(true, false);
+		startClientRpk(true, SERVERNAME);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(nullValue()));
+		assertThat(endpointContext.getVirtualHost(), is(SERVERNAME));
+	}
+
+	@Test
+	public void testRpkHandshakeNoneAuthWithServernameClientWithoutSniAndServerWithoutSni() throws Exception {
+		startServer(false, false);
+		startClientRpk(false, SERVERNAME);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(nullValue()));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testX509HandshakeNoneAuthClientWithSniAndServerWithSni() throws Exception {
+		startServer(true, false);
+		startClientX509(true, null);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(nullValue()));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testX509HandshakeNoneAuthClientWithoutSniAndServerWithoutSni() throws Exception {
+		startServer(false, false);
+		startClientX509(false, null);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(nullValue()));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+
+	@Test
+	public void testX509HandshakeNoneAuthWithServernameClientWithSniAndServerWithSni() throws Exception {
+		startServer(true, false);
+		startClientX509(true, SERVERNAME);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(nullValue()));
+		assertThat(endpointContext.getVirtualHost(), is(SERVERNAME));
+	}
+
+	@Test
+	public void testX509HandshakeNoneAuthWithServernameClientWithoutSniAndServerWithoutSni() throws Exception {
+		startServer(false, false);
+		startClientX509(false, SERVERNAME);
+		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
+		Principal principal = endpointContext.getPeerIdentity();
+		assertThat(principal, is(nullValue()));
+		assertThat(endpointContext.getVirtualHost(), is(nullValue()));
+	}
+}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
@@ -1,0 +1,474 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - initial creation
+ *                                                    Based on the original test
+ *                                                    in DTLSConnectorTest.
+ *                                                    Updated to use ConnectorHelper
+ ******************************************************************************/
+package org.eclipse.californium.scandium;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.eclipse.californium.scandium.ConnectorHelper.*;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.californium.elements.DtlsEndpointContext;
+import org.eclipse.californium.elements.EndpointContext;
+import org.eclipse.californium.elements.MapBasedEndpointContext;
+import org.eclipse.californium.elements.RawData;
+import org.eclipse.californium.elements.auth.RawPublicKeyIdentity;
+import org.eclipse.californium.elements.rule.TestNameLoggerRule;
+import org.eclipse.californium.scandium.ConnectorHelper.LatchDecrementingRawDataChannel;
+import org.eclipse.californium.scandium.category.Medium;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.dtls.Connection;
+import org.eclipse.californium.scandium.dtls.InMemoryConnectionStore;
+import org.eclipse.californium.scandium.dtls.Record;
+import org.eclipse.californium.scandium.dtls.SessionId;
+import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Verifies behavior of {@link DTLSConnector}.
+ * <p>
+ * Mainly contains integration test cases verifying the correct interaction
+ * between a client and a server during resumption handshakes.
+ */
+@Category(Medium.class)
+public class DTLSConnectorResumeTest {
+
+	public static final Logger LOGGER = LoggerFactory.getLogger(DTLSConnectorResumeTest.class.getName());
+
+	@ClassRule
+	public static DtlsNetworkRule network = new DtlsNetworkRule(DtlsNetworkRule.Mode.DIRECT,
+			DtlsNetworkRule.Mode.NATIVE);
+
+	@Rule
+	public TestNameLoggerRule names = new TestNameLoggerRule();
+
+	private static final int CLIENT_CONNECTION_STORE_CAPACITY = 5;
+	private static final int MAX_TIME_TO_WAIT_SECS = 2;
+
+	static ConnectorHelper serverHelper;
+
+	static ExecutorService executor;
+
+	DTLSConnector client;
+	InMemoryConnectionStore clientConnectionStore;
+	List<Record> lastReceivedFlight;
+
+	@BeforeClass
+	public static void loadKeys() throws IOException, GeneralSecurityException {
+		serverHelper = new ConnectorHelper();
+		serverHelper.startServer();
+		executor = Executors.newFixedThreadPool(2);
+	}
+
+	@AfterClass
+	public static void tearDown() {
+		serverHelper.destroyServer();
+		executor.shutdownNow();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		clientConnectionStore = new InMemoryConnectionStore(CLIENT_CONNECTION_STORE_CAPACITY, 60);
+		clientConnectionStore.setTag("client");
+		InetSocketAddress clientEndpoint = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+		DtlsConnectorConfig.Builder builder = newStandardClientConfigBuilder(clientEndpoint)
+				.setMaxConnections(CLIENT_CONNECTION_STORE_CAPACITY);
+		DtlsConnectorConfig clientConfig = builder.build();
+
+		client = new DTLSConnector(clientConfig, clientConnectionStore);
+		client.setExecutor(executor);
+	}
+
+	@After
+	public void cleanUp() {
+		if (client != null) {
+			client.destroy();
+		}
+		lastReceivedFlight = null;
+		serverHelper.cleanUpServer();
+	}
+
+	private void autoResumeSetUp(int timeout) throws Exception {
+		cleanUp();
+		serverHelper.serverSessionCache.establishedSessionCounter.set(0);
+		clientConnectionStore = new InMemoryConnectionStore(CLIENT_CONNECTION_STORE_CAPACITY, 60);
+		clientConnectionStore.setTag("client");
+		InetSocketAddress clientEndpoint = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+		DtlsConnectorConfig.Builder clientConfigBuilder = ConnectorHelper.newStandardClientConfigBuilder(clientEndpoint);
+		clientConfigBuilder.setAutoResumptionTimeoutMillis(timeout);
+		DtlsConnectorConfig clientConfig = clientConfigBuilder.build();
+		client = new DTLSConnector(clientConfig, clientConnectionStore);
+		client.setExecutor(executor);
+	}
+
+	
+	@Test
+	public void testConnectorResumesSessionFromNewConnection() throws Exception {
+		// Do a first handshake
+		serverHelper.givenAnEstablishedSession(client);
+		client.stop();
+		byte[] sessionId = serverHelper.establishedServerSession.getSessionIdentifier().getId();
+
+		// Force a resume session the next time we send data
+		client.forceResumeSessionFor(serverHelper.serverEndpoint);
+		Connection connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getId());
+
+		// create a new client with different inetAddress but with the same session store.
+		InetSocketAddress clientEndpoint = new InetSocketAddress(InetAddress.getLoopbackAddress(), 10001);
+		DtlsConnectorConfig clientConfig = ConnectorHelper.newStandardClientConfig(clientEndpoint);
+		client = new DTLSConnector(clientConfig, clientConnectionStore);
+		LatchDecrementingRawDataChannel clientRawDataChannel = new LatchDecrementingRawDataChannel(client);
+		client.setRawDataReceiver(clientRawDataChannel);
+		client.start();
+
+		// Prepare message sending
+		final String msg = "Hello Again";
+		CountDownLatch latch = new CountDownLatch(1);
+		clientRawDataChannel.setLatch(latch);
+
+		// send message
+		RawData data = RawData.outbound(msg.getBytes(), new AddressEndpointContext(serverHelper.serverEndpoint), null, false);
+		client.send(data);
+		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
+
+		// check we use the same session id
+		connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getId());
+		assertClientIdentity(RawPublicKeyIdentity.class);
+	}
+
+	@Test
+	public void testConnectorAutoResumesSession() throws Exception {
+
+		autoResumeSetUp(500);
+
+		// Do a first handshake
+		LatchDecrementingRawDataChannel clientRawDataChannel = serverHelper.givenAnEstablishedSession(client, false);
+
+		Connection connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		byte[] sessionId = connection.getSession().getSessionIdentifier().getId();
+		assertThat(serverHelper.serverSessionCache.establishedSessionCounter.get(), is(1));
+		assertThat(connection.isAutoResumptionRequired(500L), is(false));
+
+		Thread.sleep(1000);
+
+		assertThat(connection.isAutoResumptionRequired(500L), is(true));
+		
+		// Prepare message sending
+		final String msg = "Hello Again";
+		CountDownLatch latch = new CountDownLatch(1);
+		clientRawDataChannel.setLatch(latch);
+
+		// send message
+		RawData data = RawData.outbound(msg.getBytes(), new AddressEndpointContext(serverHelper.serverEndpoint), null, false);
+		client.send(data);
+		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
+
+		// check we use the same session id
+		connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getId());
+		assertClientIdentity(RawPublicKeyIdentity.class);
+
+		// check, if session is established again
+		assertThat(serverHelper.serverSessionCache.establishedSessionCounter.get(), is(2));
+	}
+
+	@Test
+	public void testConnectorNoAutoResumesSession() throws Exception {
+
+		autoResumeSetUp(1000);
+
+		// Do a first handshake
+		LatchDecrementingRawDataChannel clientRawDataChannel = serverHelper.givenAnEstablishedSession(client, false);
+
+		Connection connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		assertThat(serverHelper.serverSessionCache.establishedSessionCounter.get(), is(1));
+		assertThat(connection.isAutoResumptionRequired(1000L), is(false));
+		Thread.sleep(750);
+		// Prepare message sending
+		final String msg = "Hello Again";
+		CountDownLatch latch = new CountDownLatch(1);
+		clientRawDataChannel.setLatch(latch);
+
+		// send message
+		RawData data = RawData.outbound(msg.getBytes(), new AddressEndpointContext(serverHelper.serverEndpoint), null, false);
+		client.send(data);
+		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
+
+		Thread.sleep(750);
+
+		assertThat(connection.isAutoResumptionRequired(1000L), is(false));
+		// check, if session is established again
+		assertThat(serverHelper.serverSessionCache.establishedSessionCounter.get(), is(1));
+	}
+
+	@Test
+	public void testConnectorForceAutoResumesSession() throws Exception {
+		autoResumeSetUp(1000);
+
+		// Do a first handshake
+		LatchDecrementingRawDataChannel clientRawDataChannel = serverHelper.givenAnEstablishedSession(client, false);
+
+		Connection connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		byte[] sessionId = connection.getSession().getSessionIdentifier().getId();
+		assertThat(serverHelper.serverSessionCache.establishedSessionCounter.get(), is(1));
+
+		Thread.sleep(500);
+
+		// Prepare message sending
+		final String msg = "Hello Again";
+		CountDownLatch latch = new CountDownLatch(1);
+		clientRawDataChannel.setLatch(latch);
+
+		// send message
+		EndpointContext context = new MapBasedEndpointContext(serverHelper.serverEndpoint, null, DtlsEndpointContext.KEY_RESUMPTION_TIMEOUT, "0");
+		RawData data = RawData.outbound(msg.getBytes(), context, null, false);
+		client.send(data);
+		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
+
+		// check we use the same session id
+		connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getId());
+		assertClientIdentity(RawPublicKeyIdentity.class);
+
+		// check, if session is established again
+		assertThat(serverHelper.serverSessionCache.establishedSessionCounter.get(), is(2));
+	}
+
+	@Test
+	public void testConnectorSupressAutoResumesSession() throws Exception {
+		autoResumeSetUp(500);
+
+		// Do a first handshake
+		LatchDecrementingRawDataChannel clientRawDataChannel = serverHelper.givenAnEstablishedSession(client, false);
+
+		Connection connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		byte[] sessionId = connection.getSession().getSessionIdentifier().getId();
+		assertThat(serverHelper.serverSessionCache.establishedSessionCounter.get(), is(1));
+
+		Thread.sleep(1000);
+
+		// Prepare message sending
+		final String msg = "Hello Again";
+		CountDownLatch latch = new CountDownLatch(1);
+		clientRawDataChannel.setLatch(latch);
+
+		// send message
+		EndpointContext context = new MapBasedEndpointContext(serverHelper.serverEndpoint, null, DtlsEndpointContext.KEY_RESUMPTION_TIMEOUT, "");
+		RawData data = RawData.outbound(msg.getBytes(), context, null, false);
+		client.send(data);
+		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
+
+		// check we use the same session id
+		connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getId());
+		assertClientIdentity(RawPublicKeyIdentity.class);
+
+		// check, if session is established again
+		assertThat(serverHelper.serverSessionCache.establishedSessionCounter.get(), is(1));
+	}
+
+	@Test
+	public void testConnectorChangedAutoResumesSession() throws Exception {
+		autoResumeSetUp(500);
+
+		// Do a first handshake
+		LatchDecrementingRawDataChannel clientRawDataChannel = serverHelper.givenAnEstablishedSession(client, false);
+
+		Connection connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		byte[] sessionId = connection.getSession().getSessionIdentifier().getId();
+		assertThat(serverHelper.serverSessionCache.establishedSessionCounter.get(), is(1));
+		assertThat(connection.isAutoResumptionRequired(500L), is(false));
+
+		Thread.sleep(1000);
+
+		// Prepare message sending
+		final String msg = "Hello Again";
+		CountDownLatch latch = new CountDownLatch(1);
+		clientRawDataChannel.setLatch(latch);
+
+		// send message
+		EndpointContext context = new MapBasedEndpointContext(serverHelper.serverEndpoint, null, DtlsEndpointContext.KEY_RESUMPTION_TIMEOUT, "10000");
+		RawData data = RawData.outbound(msg.getBytes(), context, null, false);
+		client.send(data);
+		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
+
+		// check we use the same session id
+		connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getId());
+		assertClientIdentity(RawPublicKeyIdentity.class);
+
+		// check, if session is established again
+		assertThat(serverHelper.serverSessionCache.establishedSessionCounter.get(), is(1));
+	}
+
+	@Test
+	public void testConnectorResumesSessionFromSharedSessionTicket() throws Exception {
+		// Do a first handshake
+		LatchDecrementingRawDataChannel clientRawDataChannel = serverHelper.givenAnEstablishedSession(client);
+		InetSocketAddress clientAddress = clientRawDataChannel.getAddress();
+		SessionId establishedSessionId = serverHelper.establishedServerSession.getSessionIdentifier();
+
+		// Force a resume session the next time we send data
+		client.forceResumeSessionFor(serverHelper.serverEndpoint);
+		Connection connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		assertThat(connection.getEstablishedSession().getSessionIdentifier(), is(establishedSessionId));
+		client.start();
+
+		// remove connection from server's connection store and add ticket to session cache
+		// to mimic a fail over from another node
+		serverHelper.serverConnectionStore.remove(clientAddress);
+		assertThat(serverHelper.serverSessionCache.get(establishedSessionId), is(nullValue()));
+		serverHelper.serverSessionCache.put(establishedSessionId, serverHelper.establishedServerSession.getSessionTicket());
+
+		// Prepare message sending
+		final String msg = "Hello Again";
+		CountDownLatch latch = new CountDownLatch(1);
+		clientRawDataChannel.setLatch(latch);
+
+		// send message
+		RawData data = RawData.outbound(msg.getBytes(), new AddressEndpointContext(serverHelper.serverEndpoint), null, false);
+		client.send(data);
+		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
+
+		// check we use the same session id
+		connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		assertThat(connection.getEstablishedSession().getSessionIdentifier(), is(establishedSessionId));
+		assertClientIdentity(RawPublicKeyIdentity.class);
+	}
+
+	@Test
+	public void testConnectorResumesSessionFromExistingConnection() throws Exception {
+		// Do a first handshake
+		LatchDecrementingRawDataChannel clientRawDataChannel = serverHelper.givenAnEstablishedSession(client);
+		byte[] sessionId = serverHelper.establishedServerSession.getSessionIdentifier().getId();
+
+		// Force a resume session the next time we send data
+		client.forceResumeSessionFor(serverHelper.serverEndpoint);
+		Connection connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getId());
+		client.start();
+
+		// Prepare message sending
+		final String msg = "Hello Again";
+		CountDownLatch latch = new CountDownLatch(1);
+		clientRawDataChannel.setLatch(latch);
+
+		// send message
+		RawData data = RawData.outbound(msg.getBytes(), new AddressEndpointContext(serverHelper.serverEndpoint), null, false);
+		client.send(data);
+		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
+
+		// check we use the same session id
+		connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getId());
+		assertClientIdentity(RawPublicKeyIdentity.class);
+	}
+
+	@Test
+	public void testConnectorPerformsFullHandshakeWhenResumingNonExistingSession() throws Exception {
+		// Do a first handshake
+		LatchDecrementingRawDataChannel clientRawDataChannel = serverHelper.givenAnEstablishedSession(client);
+		InetSocketAddress clientAddress = clientRawDataChannel.getAddress();
+		byte[] sessionId = serverHelper.establishedServerSession.getSessionIdentifier().getId();
+
+		// Force a resume session the next time we send data
+		client.forceResumeSessionFor(serverHelper.serverEndpoint);
+		Connection connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getId());
+		client.start();
+
+		// Prepare message sending
+		final String msg = "Hello Again";
+		CountDownLatch latch = new CountDownLatch(1);
+		clientRawDataChannel.setLatch(latch);
+
+		// remove session from server
+		serverHelper.serverConnectionStore.remove(clientAddress);
+
+		// send message
+		RawData data = RawData.outbound(msg.getBytes(), new AddressEndpointContext(serverHelper.serverEndpoint), null, false);
+		client.send(data);
+		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
+
+		// check session id was not equals
+		connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		Assert.assertThat(sessionId, not(equalTo(connection.getEstablishedSession().getSessionIdentifier().getId())));
+		assertClientIdentity(RawPublicKeyIdentity.class);
+	}
+
+	@Test
+	public void testConnectorPerformsFullHandshakeWhenResumingWithDifferentSni() throws Exception {
+		// Do a first handshake
+		RawData raw = RawData.outbound("Hello World".getBytes(), new AddressEndpointContext(serverHelper.serverEndpoint, "server.one", null), null, false);
+		LatchDecrementingRawDataChannel clientRawDataChannel = serverHelper.givenAnEstablishedSession(client, raw, true);
+		byte[] sessionId = serverHelper.establishedServerSession.getSessionIdentifier().getId();
+
+		// Force a resume session the next time we send data
+		client.forceResumeSessionFor(serverHelper.serverEndpoint);
+		Connection connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getId());
+		client.start();
+
+		// Prepare message sending
+		final String msg = "Hello Again";
+		CountDownLatch latch = new CountDownLatch(1);
+		clientRawDataChannel.setLatch(latch);
+
+		// send message
+		RawData data = RawData.outbound(msg.getBytes(), new AddressEndpointContext(serverHelper.serverEndpoint, "server.two", null), null, false);
+		client.send(data);
+		assertTrue(latch.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
+
+		// check session id was not equals
+		connection = clientConnectionStore.get(serverHelper.serverEndpoint);
+		Assert.assertThat(sessionId, not(equalTo(connection.getEstablishedSession().getSessionIdentifier().getId())));
+		assertClientIdentity(RawPublicKeyIdentity.class);
+	}
+
+	private void assertClientIdentity(final Class<?> principalType) {
+
+		// assert that client identity is of given type
+		if (principalType == null) {
+			assertThat(serverHelper.serverRawDataProcessor.getClientEndpointContext().getPeerIdentity(), is(nullValue()));
+		} else {
+			assertThat(serverHelper.serverRawDataProcessor.getClientEndpointContext().getPeerIdentity(), instanceOf(principalType));
+		}
+	}
+}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorStartStopTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorStartStopTest.java
@@ -76,7 +76,6 @@ public class DTLSConnectorStartStopTest {
 	static InMemoryClientSessionCache clientSessionCache;
 
 	DTLSConnector client;
-	DtlsConnectorConfig clientConfig;
 	LatchDecrementingRawDataChannel clientChannel;
 	InMemoryConnectionStore clientConnectionStore;
 
@@ -110,7 +109,7 @@ public class DTLSConnectorStartStopTest {
 		InetSocketAddress clientEndpoint = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 		DtlsConnectorConfig.Builder builder = newStandardClientConfigBuilder(clientEndpoint)
 				.setMaxConnections(CLIENT_CONNECTION_STORE_CAPACITY);
-		clientConfig = builder.build();
+		DtlsConnectorConfig clientConfig = builder.build();
 		client = new DTLSConnector(clientConfig, clientConnectionStore);
 		clientChannel = new ConnectorHelper.LatchDecrementingRawDataChannel(client);
 		client.setRawDataReceiver(clientChannel);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
@@ -206,8 +206,10 @@ public class ClientHandshakerTest {
 		} else {
 			builder.setClientAuthenticationRequired(false);
 		}
+		DTLSSession session = new DTLSSession(peer);
+		session.setVirtualHost(virtualHost);
 		handshaker = new ClientHandshaker(
-				DTLSSession.newClientSession(peer, virtualHost),
+				session,
 				recordLayer,
 				null,
 				builder.build(),

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchangeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchangeTest.java
@@ -20,8 +20,6 @@ import static org.junit.Assert.*;
 import java.net.InetSocketAddress;
 
 import org.eclipse.californium.scandium.category.Small;
-import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm.HashAlgorithm;
-import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm.SignatureAlgorithm;
 import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
 import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedGroup;

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
@@ -163,7 +163,7 @@ public class ServerHandshakerTest {
 
 		// THEN the server names conveyed in the CLIENT_HELLO message
 		// are stored in the handshaker
-		ServerNames serverNames = handshaker.getIndicatedServerNames();
+		ServerNames serverNames = handshaker.getSession().getServerNames();
 		assertNotNull(serverNames);
 		assertThat(new String(serverNames.get(NameType.HOST_NAME)), is("iot.eclipse.org"));
 	}


### PR DESCRIPTION
Use simple PSK principal name, if SNI is disabled.

Also support session resumption with SNI.
Fixes issues #649 and #644.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>