### PR TITLE
Early blockwise negociation block2 configuration

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -178,6 +178,18 @@ public final class NetworkConfig {
 		 * {@link NetworkConfigDefaults#DEFAULT_BLOCKWISE_STATUS_LIFETIME}.
 		 */
 		public static final String BLOCKWISE_STATUS_LIFETIME = "BLOCKWISE_STATUS_LIFETIME";
+		
+		/**
+		 * Property to indicate if the response should always include the Block2 option when client request early blockwise negociation but the response can be sent on one packet.
+		 * <p>
+		 * The default value of this property is
+		 * {@link NetworkConfigDefaults#DEFAULT_BLOCKWISE_STRICT_BLOCK2_OPTION}.
+		 * <p>
+		 * A value of {@code false} indicate that the server will respond without block2 option if no further blocks are required.<br/>
+		 * A value of {@code true} indicate that the server will response with block2 option event if no further blocks are required.
+		 *  
+		 */
+		public static final String BLOCKWISE_STRICT_BLOCK2_OPTION = "BLOCKWISE_STRICT_BLOCK2_OPTION";
 
 		public static final String NOTIFICATION_CHECK_INTERVAL_TIME = "NOTIFICATION_CHECK_INTERVAL";
 		public static final String NOTIFICATION_CHECK_INTERVAL_COUNT = "NOTIFICATION_CHECK_INTERVAL_COUNT";
@@ -601,6 +613,24 @@ public final class NetworkConfig {
 		return result;
 	}
 
+	/**
+	 * Gets the value for the specified key as boolean or the provided default value if not found.
+	 *
+	 * @param key the key
+	 * @param defaultValue the default value to return if there is no value
+	 *            registered for the key.
+	 * @return the boolean
+	 */
+	public boolean getBoolean(final String key, final boolean defaultValue) {
+		String value = properties.getProperty(key);
+		if (value != null) {
+			return Boolean.parseBoolean(value);
+		} else {
+			LOGGER.warn("Key [{}] is undefined, returning defaultValue", key);
+			return defaultValue;
+		}
+	}
+	
 	/**
 	 * Gets the value for the specified key as boolean or false if not found.
 	 *

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
@@ -66,6 +66,13 @@ public class NetworkConfigDefaults {
 	public static final int DEFAULT_BLOCKWISE_STATUS_LIFETIME = 5 * 60 * 1000; // 5 mins [ms]
 	
 	/**
+	 * The default mode used to respond for early bockwise negociation when response can be sent on one packet.
+	 * <p>
+	 * The default value is false, which indicate that the server will not include the Block2 option.
+	 */
+	public static final boolean DEFAULT_BLOCKWISE_STRICT_BLOCK2_OPTION = false;
+	
+	/**
 	 * The default value for {@link Keys#PREFERRED_BLOCK_SIZE}
 	 */
 	public static final int DEFAULT_PREFERRED_BLOCK_SIZE = 512;
@@ -194,7 +201,9 @@ public class NetworkConfigDefaults {
 		config.setInt(Keys.MAX_MESSAGE_SIZE, DEFAULT_MAX_MESSAGE_SIZE);
 		config.setInt(Keys.MAX_RESOURCE_BODY_SIZE, DEFAULT_MAX_RESOURCE_BODY_SIZE);
 		config.setInt(Keys.BLOCKWISE_STATUS_LIFETIME, DEFAULT_BLOCKWISE_STATUS_LIFETIME); // [ms]
+		config.setBoolean(Keys.BLOCKWISE_STRICT_BLOCK2_OPTION, DEFAULT_BLOCKWISE_STRICT_BLOCK2_OPTION);
 
+		
 		config.setLong(Keys.NOTIFICATION_CHECK_INTERVAL_TIME, 24 * 60 * 60 * 1000); //24 [ms]
 		config.setInt(Keys.NOTIFICATION_CHECK_INTERVAL_COUNT, 100);
 		config.setLong(Keys.NOTIFICATION_REREGISTRATION_BACKOFF, 2000); // [ms]

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/BlockwiseTransferTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/BlockwiseTransferTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.californium.category.Medium;
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
@@ -81,27 +82,59 @@ public class BlockwiseTransferTest {
 
 	private static CoapServer server;
 	private static NetworkConfig config;
+	private static NetworkConfig configEndpointStrictBlock2Option;
+
 	private static Endpoint serverEndpoint;
+	private static Endpoint serverEndpointStrictBlock2Option;
+
 	private static ServerBlockwiseInterceptor interceptor = new ServerBlockwiseInterceptor();
 
+
+	private static NetworkConfig configEndpointWithoutTransparentBlockwise;
+	
 	private Endpoint clientEndpoint;
+	
+	private Endpoint clientEndpointWithoutTransparentBlockwise;
 
 	@BeforeClass
 	public static void prepare() {
 		System.out.println(System.lineSeparator() + "Start " + BlockwiseTransferTest.class.getSimpleName());
+	
 		config = network.getStandardTestConfig()
+				.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 32)
+				.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 32)
+				.setInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE, 500)
+				.setBoolean(NetworkConfig.Keys.BLOCKWISE_STRICT_BLOCK2_OPTION, false);
+		
+		configEndpointStrictBlock2Option = network.createTestConfig()
+				.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 32)
+				.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 32)
+				.setInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE, 500)
+				.setBoolean(NetworkConfig.Keys.BLOCKWISE_STRICT_BLOCK2_OPTION, true);
+		
+		
+		configEndpointWithoutTransparentBlockwise = network.createTestConfig()
 			.setInt(NetworkConfig.Keys.PREFERRED_BLOCK_SIZE, 32)
 			.setInt(NetworkConfig.Keys.MAX_MESSAGE_SIZE, 32)
-			.setInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE, 500);
+			.setInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE, 0)
+			.setBoolean(NetworkConfig.Keys.BLOCKWISE_STRICT_BLOCK2_OPTION, true);
+		
 		server = createSimpleServer();
 	}
 
 	@Before
-	public void createClient() throws IOException {
+	public void createClients() throws IOException {
+
+		
 		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setNetworkConfig(config);
 		clientEndpoint = builder.build();
 		clientEndpoint.start();
+		
+		CoapEndpoint.Builder builderBis = new CoapEndpoint.Builder();
+		builderBis.setNetworkConfig(configEndpointWithoutTransparentBlockwise);
+		clientEndpointWithoutTransparentBlockwise = builderBis.build();
+		clientEndpointWithoutTransparentBlockwise.start();		
 	}
 
 	@After
@@ -182,6 +215,64 @@ public class BlockwiseTransferTest {
 		});
 		clientEndpoint.sendRequest(req);
 		assertTrue(latch.await(1000, TimeUnit.MILLISECONDS));
+	}
+	
+	/**
+	 * Send request to the server with early blockwise negociation through block2 option. The response content should fits into a single response.
+	 * <p>The targeted endpoint has the {@link NetworkConfig.Keys#BLOCKWISE_STRICT_BLOCK2_OPTION} set to true and should respond with a block2 option indicating that no more blocks are available. </p>
+	 * 
+	 * @throws InterruptedException
+	 */
+	@Test
+	public void testEarlyNegociationWithStrictBlock2() throws InterruptedException {
+		
+		testGetRequestWithEarlyNegocition(true);
+	}
+	
+	/**
+	 * Send request to the server with early blockwise negociation through block2 option. The response content should fits into a single response.
+	 * <p>The targeted endpoint has the {@link NetworkConfig.Keys#BLOCKWISE_STRICT_BLOCK2_OPTION} set to false and should respond without a block2 option. </p>
+	 * 
+	 * @throws InterruptedException
+	 */
+	@Test
+	public void testEarlyNegociationWithoutStrictBlock2() throws InterruptedException {
+	
+		testGetRequestWithEarlyNegocition(false);
+	}
+	
+	private void testGetRequestWithEarlyNegocition(final boolean strictBlock2) throws InterruptedException {
+
+		final AtomicInteger counter = new AtomicInteger(0);
+
+		final Endpoint targetEndpoint = strictBlock2 ? serverEndpointStrictBlock2Option : serverEndpoint;
+		Request req = Request.newGet().setURI(getUri(targetEndpoint, RESOURCE_TEST));
+		req.getOptions().addUriQuery(PARAM_SHORT_RESP);
+		req.getOptions().setBlock2(BlockOption.size2Szx(256), false, 0);
+
+		req.addMessageObserver(new MessageObserverAdapter() {
+
+			@Override
+			public void onResponse(Response resp) {
+				counter.getAndIncrement();
+			}
+		});
+		clientEndpointWithoutTransparentBlockwise.sendRequest(req);
+
+		// receive response and check
+		Response response = req.waitForResponse(10000);
+		
+		assertEquals("More than one block received", 1, counter.get());
+		
+		if(strictBlock2) {
+			
+			BlockOption block2 = response.getOptions().getBlock2();
+			assertNotNull(block2);
+			assertEquals("Block2 option should indicate that all blocks have been transfered", false, block2.isM());
+		}else {
+			
+			assertNull(response.getOptions().getBlock2());
+		}
 	}
 
 	private void executeGETRequest(final boolean respondShort) throws Exception {
@@ -281,6 +372,15 @@ public class BlockwiseTransferTest {
 		serverEndpoint = builder.build();
 		serverEndpoint.addInterceptor(interceptor);
 		result.addEndpoint(serverEndpoint);
+		
+		//add another endpoint which purpose is to test the NetworkConfig.Keys.BLOCKWISE_STRICT_BLOCK2_OPTION
+		CoapEndpoint.Builder builderStrictBlock2 = new CoapEndpoint.Builder();
+
+		builderStrictBlock2.setInetSocketAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+		builderStrictBlock2.setNetworkConfig(configEndpointStrictBlock2Option);
+		serverEndpointStrictBlock2Option = builderStrictBlock2.build();
+		result.addEndpoint(serverEndpointStrictBlock2Option);
+		
 		result.add(new CoapResource(RESOURCE_TEST) {
 
 			private boolean isShortRequest(final CoapExchange exchange) {


### PR DESCRIPTION
This pull request aims to configure the way to handle early blockwise negociation when the content fits into a single response. It should fix the #810 issue.

Currently the block2 option wasn't included though this can be confusing for some client library which expects to receive it with the "m" flag set to false.

By default the current process is used (no block2 option) but by setting the `NetworkConfig.Keys.BLOCKWISE_STRICT_BLOCK2_OPTION` to `true` the blockwise layer will include the block2 option even if the content fits into a single response.

I didn't have the time to test it against the client library with which we detected this problem yet but will try to do it in the following days.

I look forward for your review ans I hope I didn't make to many mistakes :-)