### PR TITLE
Fix issue #776.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AbstractMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AbstractMessage.java
@@ -15,12 +15,14 @@
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
+import java.io.Serializable;
 import java.net.InetSocketAddress;
 
 /**
  * An abstract base class for DTLS messages providing support for the peer address.
  */
-public abstract class AbstractMessage implements DTLSMessage {
+public abstract class AbstractMessage implements DTLSMessage, Serializable{
+	private static final long serialVersionUID = 1L;
 
 	private final InetSocketAddress peerAddress;
 	

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AlertMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AlertMessage.java
@@ -38,6 +38,7 @@ import org.eclipse.californium.elements.util.StringUtil;
 public final class AlertMessage extends AbstractMessage {
 
 	// CoAP-specific constants/////////////////////////////////////////
+	private static final long serialVersionUID = 1L;
 
 	private static final int BITS = 8;
 


### PR DESCRIPTION
Add Serializable to AbstractMessage to make the AlertMessage
Serializable.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>