### PR TITLE
Introduce in process processing of multicast messages.

### DIFF
--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/AbstractDatagramSocketImpl.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/AbstractDatagramSocketImpl.java
@@ -18,6 +18,7 @@
  *                                                    use the erroneous internal
  *                                                    "old implementation mode".
  *    Achim Kraus (Bosch Software Innovations GmbH) - fix deprecation of setTTL and getTTL
+ *    Achim Kraus (Bosch Software Innovations GmbH) - implement multicast support
  ******************************************************************************/
 package org.eclipse.californium.elements.util;
 
@@ -38,7 +39,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * Intended to be extended by an implementation for "in process message
  * exchange". Throws IOException with message containing "not supported" on
  * {@link #peek(InetAddress)}, {@link #setTTL(byte)}, {@link #getTTL()},
- * {@link #join(InetAddress)}, {@link #leave(InetAddress)},
  * {@link #joinGroup(SocketAddress, NetworkInterface)}, and
  * {@link #leaveGroup(SocketAddress, NetworkInterface)}.
  * 
@@ -105,16 +105,6 @@ public abstract class AbstractDatagramSocketImpl extends DatagramSocketImpl {
 	@Override
 	protected int getTimeToLive() throws IOException {
 		return ttl;
-	}
-
-	@Override
-	protected void join(InetAddress inetaddr) throws IOException {
-		throw new IOException("join(InetAddress) not supported!");
-	}
-
-	@Override
-	protected void leave(InetAddress inetaddr) throws IOException {
-		throw new IOException("leave(InetAddress) not supported!");
 	}
 
 	@Override


### PR DESCRIPTION
NON multicast message shown to be too unreliable for unit test.
Therefore extend the DirectDatagramSocketImpl to process multicast
messages also.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>