### PR TITLE
Introduce strict payload checks.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/EmptyMessage.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/EmptyMessage.java
@@ -74,6 +74,16 @@ public class EmptyMessage extends Message {
 	}
 
 	/**
+	 * {@inheritDoc}
+	 * 
+	 * EMPTY messages are never intended to have payload!
+	 */
+	@Override
+	public boolean isIntendedPayload() {
+		return false;
+	}
+
+	/**
 	 * Create a new acknowledgment for the specified message.
 	 *
 	 * @param message the message to acknowledge

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
@@ -117,6 +117,9 @@ public abstract class Message {
 	/** The payload of this message. */
 	private byte[] payload;
 
+	/** Marks this message to have payload even if this is not intended */
+	private boolean unintendedPayload;
+
 	/**
 	 * Destination endpoint context. Used for outgoing messages.
 	 */
@@ -242,6 +245,41 @@ public abstract class Message {
 	 * @return the code value.
 	 */
 	public abstract int getRawCode();
+
+	/**
+	 * Checks, if this message is intended to have payload.
+	 * 
+	 * To be overwritten by subclass to provide a specific check.
+	 * 
+	 * @return {@code true}, if message is intended to have payload
+	 */
+	public boolean isIntendedPayload() {
+		return true;
+	}
+
+	/**
+	 * Set marker for unintended payload.
+	 * 
+	 * Enables to use payload with messages, which are not intended to have
+	 * payload.
+	 * 
+	 * @throws IllegalStateException if message is intended to have payload
+	 */
+	public void setUnintendedPayload() {
+		if (isIntendedPayload()) {
+			throw new IllegalStateException("Message is already intended to have payload!");
+		}
+		unintendedPayload = true;
+	}
+
+	/**
+	 * Checks, if message is marked to have unintended payload.
+	 * 
+	 * @return {@code true} if message is marked to have unintended payload
+	 */
+	public boolean isUnintendedPayload() {
+		return unintendedPayload;
+	}
 
 	/**
 	 * Gets the 16-bit message identification.
@@ -472,8 +510,15 @@ public abstract class Message {
 	 * 
 	 * Provides a fluent API to chain setters.
 	 * 
-	 * @param payload the payload as sting
+	 * @param payload the payload as string. {@code null} or a empty string are
+	 *            not considered to be payload and therefore not cause a
+	 *            IllegalArgumentException, if this message must not have
+	 *            payload.
 	 * @return this Message
+	 * @throws IllegalArgumentException if this message must not have payload
+	 * @see #isIntendedPayload()
+	 * @see #isUnintendedPayload()
+	 * @see #setUnintendedPayload()
 	 */
 	public Message setPayload(String payload) {
 		if (payload == null) {
@@ -489,10 +534,20 @@ public abstract class Message {
 	 *
 	 * Provides a fluent API to chain setters.
 	 *
-	 * @param payload the new payload
+	 * @param payload the new payload. {@code null} or a empty array are not
+	 *            considered to be payload and therefore not cause a
+	 *            IllegalArgumentException, if this message must not have
+	 *            payload.
 	 * @return this Message
+	 * @throws IllegalArgumentException if this message must not have payload
+	 * @see #isIntendedPayload()
+	 * @see #isUnintendedPayload()
+	 * @see #setUnintendedPayload()
 	 */
 	public Message setPayload(byte[] payload) {
+		if (payload != null && payload.length > 0 && !isIntendedPayload() && !isUnintendedPayload()) {
+			throw new IllegalArgumentException("Message must not have payload!");
+		}
 		this.payload = payload;
 		return this;
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -209,7 +209,15 @@ public class Request extends Message {
 	/**
 	 * {@inheritDoc}
 	 * 
-	 * Required in Request to keep class for fluent API.
+	 * GET and DELETE request are not intended to have payload.
+	 */
+	@Override
+	public boolean isIntendedPayload() {
+		return code != Code.GET && code != Code.DELETE;
+	}
+
+	/**
+	 * {@inheritDoc}
 	 */
 	@Override
 	public Request setPayload(String payload) {
@@ -219,8 +227,6 @@ public class Request extends Message {
 
 	/**
 	 * {@inheritDoc}
-	 * 
-	 * Required in Request to keep class for fluent API.
 	 */
 	@Override
 	public Request setPayload(byte[] payload) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataParser.java
@@ -180,6 +180,9 @@ public abstract class DataParser {
 						message.getMID(), message.getRawCode(), message.isConfirmable());
 			} else {
 				// get payload
+				if (!message.isIntendedPayload()) {
+					message.setUnintendedPayload();
+				}
 				message.setPayload(reader.readBytesLeft());
 			}
 		} else {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
@@ -127,6 +127,9 @@ public final class Block1BlockwiseStatus extends BlockwiseStatus {
 			// indicate overall body size to peer
 			block.getOptions().setSize1(request.getPayloadSize());
 		}
+		if (request.isUnintendedPayload()) {
+			block.setUnintendedPayload();
+		}
 
 		int currentSize = getCurrentSize();
 		int from = num * currentSize;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -64,7 +64,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.californium.core.coap.BlockOption;
-import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.MessageObserver;
@@ -1142,10 +1141,7 @@ public class BlockwiseLayer extends AbstractLayer {
 	}
 
 	private boolean requiresBlockwise(final Request request) {
-		boolean blockwiseRequired = false;
-		if (request.getCode() == Code.PUT || request.getCode() == Code.POST) {
-			blockwiseRequired = request.getPayloadSize() > maxMessageSize;
-		}
+		boolean blockwiseRequired = request.getPayloadSize() > maxMessageSize;
 		if (blockwiseRequired) {
 			LOGGER.debug("request body [{}/{}] requires blockwise transfer", request.getPayloadSize(), maxMessageSize);
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseStatus.java
@@ -274,6 +274,9 @@ public abstract class BlockwiseStatus {
 		message.setOptions(new OptionSet(first.getOptions()));
 		message.getOptions().removeBlock1();
 		message.getOptions().removeBlock2();
+		if (!message.isIntendedPayload()) {
+			message.setUnintendedPayload();
+		}
 		message.setPayload(getBody());
 	}
 

--- a/californium-proxy/src/test/java/org/eclipse/californium/proxy/HttpTranslatorTest.java
+++ b/californium-proxy/src/test/java/org/eclipse/californium/proxy/HttpTranslatorTest.java
@@ -32,8 +32,8 @@ import org.junit.Test;
 public class HttpTranslatorTest {
 
 	@Test
-	public void testGetHttpEntity() throws Exception {
-		Request req = new Request(Code.GET);
+	public void testPutHttpEntity() throws Exception {
+		Request req = new Request(Code.PUT);
 		req.setPayload("payload");
 		req.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
 
@@ -41,8 +41,8 @@ public class HttpTranslatorTest {
 	}
 
 	@Test
-	public void testGetHttpEntityWithJSON() throws Exception {
-		Request req = new Request(Code.GET);
+	public void testPutHttpEntityWithJSON() throws Exception {
+		Request req = new Request(Code.PUT);
 		req.setPayload("{}");
 		req.getOptions().setContentFormat(MediaTypeRegistry.APPLICATION_JSON);
 

--- a/oscore-cf/src/test/java/org/eclipse/californium/oscore/OptionJuggleTest.java
+++ b/oscore-cf/src/test/java/org/eclipse/californium/oscore/OptionJuggleTest.java
@@ -138,7 +138,7 @@ public class OptionJuggleTest {
 		options.setAccept(accept);
 
 		request.setOptions(options);
-		Code realCode = Code.GET;
+		Code realCode = Code.PUT;
 
 		Request realed = OptionJuggle.setRealCodeRequest(request, realCode);
 		OptionSet realOptions = realed.getOptions();


### PR DESCRIPTION
Check, it message is intended to have payload and thorw exceptions, if
not. Overwrite that check by mark a message to have unintended payload.

issue #834

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>