### PR TITLE
Use full-handshake for resumption with empty session id.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -1179,6 +1179,14 @@ public class DTLSConnector implements Connector {
 						// start fresh handshake
 						handshaker = new ClientHandshaker(message, new DTLSSession(peerAddress, true), connection, config, maximumTransmissionUnit);
 					}
+					else if (session.getSessionIdentifier().isEmpty()) {
+						// full-handshake
+						Connection newConnection = new Connection(peerAddress);
+						terminateConnection(connection, null, null);
+						connectionStore.put(newConnection);
+						handshaker = new ClientHandshaker(message, new DTLSSession(peerAddress, true), newConnection, config, maximumTransmissionUnit);
+						connection = newConnection;
+					}
 					// TODO what if there already is an ongoing handshake with the peer
 					else {
 						// create the session to resume from the previous one.
@@ -1189,6 +1197,7 @@ public class DTLSConnector implements Connector {
 						terminateConnection(connection, null, null);
 						connectionStore.put(newConnection);
 						handshaker = new ResumingClientHandshaker(message, resumableSession, newConnection, config, maximumTransmissionUnit);
+						connection = newConnection;
 					}
 					// start DTLS handshake protocol
 					// get starting handshake message

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SessionId.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SessionId.java
@@ -62,6 +62,10 @@ public final class SessionId {
 		return id;
 	}
 
+	public boolean isEmpty() {
+		return id.length == 0; 
+	}
+
 	/**
 	 * Creates a new instance with an empty byte array as the ID.
 	 * 


### PR DESCRIPTION
Fix connection for pending flight to new connection to prevent
retransmissions after finishing the handshake.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>