### PR TITLE
Use full-handshake for resumption with empty session id.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
@@ -142,8 +142,9 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 			String value = attributes[++index];
 			if (null == key) {
 				throw new NullPointerException((index / 2) + ". key is null");
-			}
-			if (null == value) {
+			} else if (key.isEmpty()) {
+				throw new IllegalArgumentException((index / 2) + ". key is empty");
+			} else if (null == value) {
 				throw new NullPointerException((index / 2) + ". value is null");
 			}
 			String old = entries.put(key, value);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -294,6 +294,25 @@ public final class DTLSSession {
 	}
 
 	/**
+	 * System time of session creation in milliseconds.
+	 * 
+	 * @return session creation system time in milliseconds
+	 * @see System#currentTimeMillis()
+	 */
+	public long getCreationTime() {
+		return creationTime;
+	}
+
+	/**
+	 * System time tag of last handshake.
+	 * 
+	 * @return system time in milliseconds as string of the last handshake
+	 */
+	public String getLastHandshakeTime() {
+		return handshakeTimeTag;
+	}
+
+	/**
 	 * Gets the (virtual) host name for the server that this session
 	 * has been established for.
 	 * 
@@ -365,15 +384,15 @@ public final class DTLSSession {
 	}
 
 	public DtlsEndpointContext getConnectionWriteContext() {
-
-		return new DtlsEndpointContext(peer, virtualHost, peerIdentity, sessionIdentifier.toString(),
-				Integer.toString(writeEpoch), cipherSuite.name(), handshakeTimeTag);
+		String id = sessionIdentifier.isEmpty() ? "TIME:" + Long.toString(creationTime) : sessionIdentifier.toString();
+		return new DtlsEndpointContext(peer, virtualHost, peerIdentity, id, Integer.toString(writeEpoch),
+				cipherSuite.name(), handshakeTimeTag);
 	}
 
 	public DtlsEndpointContext getConnectionReadContext() {
-
-		return new DtlsEndpointContext(peer, virtualHost, peerIdentity, sessionIdentifier.toString(),
-				Integer.toString(readEpoch), cipherSuite.name(), handshakeTimeTag);
+		String id = sessionIdentifier.isEmpty() ? "TIME:" + Long.toString(creationTime) : sessionIdentifier.toString();
+		return new DtlsEndpointContext(peer, virtualHost, peerIdentity, id, Integer.toString(readEpoch),
+				cipherSuite.name(), handshakeTimeTag);
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -228,16 +228,19 @@ public final class InMemoryConnectionStore implements ResumptionSupportingConnec
 	}
 
 	public synchronized void putEstablishedSession(final DTLSSession session, final Connection connection) {
-		connectionsByEstablishedSession.put(session.getSessionIdentifier(), connection);
-		if (sessionCache != null) {
-			sessionCache.put(session);
+		SessionId sessionId = session.getSessionIdentifier();
+		if (!sessionId.isEmpty()) {
+			connectionsByEstablishedSession.put(session.getSessionIdentifier(), connection);
+			if (sessionCache != null) {
+				sessionCache.put(session);
+			}
 		}
 	}
 
 	@Override
 	public synchronized Connection find(final SessionId id) {
 
-		if (id == null) {
+		if (id == null || id.isEmpty()) {
 			return null;
 		} else {
 			Connection conFromLocalCache = findLocally(id);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -96,6 +96,9 @@ public class ServerHandshaker extends Handshaker {
 	 */
 	private DTLSFlight lastFlight;
 
+	/** Does the server use session id? */
+	private boolean useNoSessionId = false;
+
 	/** Is the client wanted to authenticate itself? */
 	private boolean clientAuthenticationWanted = false;
 
@@ -215,6 +218,7 @@ public class ServerHandshaker extends Handshaker {
 		this.sniEnabled = config.isSniEnabled();
 		this.clientAuthenticationWanted = config.isClientAuthenticationWanted();
 		this.clientAuthenticationRequired = config.isClientAuthenticationRequired();
+		this.useNoSessionId = config.useNoServerSessionId();
 
 		// the server handshake uses the config with exchanged roles!
 		this.supportedClientCertificateTypes = config.getTrustCertificateTypes();
@@ -517,7 +521,8 @@ public class ServerHandshaker extends Handshaker {
 		clientRandom = clientHello.getRandom();
 		serverRandom = new Random();
 
-		SessionId sessionId = new SessionId();
+		
+		SessionId sessionId = useNoSessionId ? SessionId.emptySessionId() : new SessionId();
 		session.setSessionIdentifier(sessionId);
 
 		// currently only NULL compression supported, no negotiation needed

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SessionId.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SessionId.java
@@ -68,6 +68,10 @@ public final class SessionId {
 		return id;
 	}
 
+	public boolean isEmpty() {
+		return id.length == 0; 
+	}
+
 	/**
 	 * Creates a new instance with an empty byte array as the ID.
 	 * 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -189,6 +189,7 @@ public class ConnectorHelper {
 	 */
 	public void cleanUpServer() {
 		serverConnectionStore.clear();
+		serverRawDataProcessor.clear();
 		serverRawDataChannel.setProcessor(serverRawDataProcessor);
 		server.setAlertHandler(null);
 	}
@@ -311,8 +312,10 @@ public class ConnectorHelper {
 		RawData getLatestInboundMessage();
 
 		EndpointContext getClientEndpointContext();
-		
+
 		boolean quiet(long quietMillis, long timeoutMillis) throws InterruptedException;
+
+		void clear();
 	}
 
 	static class MessageCapturingProcessor implements RawDataProcessor {
@@ -332,8 +335,9 @@ public class ConnectorHelper {
 
 		@Override
 		public EndpointContext getClientEndpointContext() {
-			if (inboundMessage != null) {
-				return inboundMessage.get().getEndpointContext();
+			RawData data = inboundMessage.get();
+			if (data != null) {
+				return data.getEndpointContext();
 			} else {
 				return null;
 			}
@@ -371,6 +375,10 @@ public class ConnectorHelper {
 			} finally {
 				quiet = false;
 			}
+		}
+
+		public void clear() {
+			inboundMessage.set(null);
 		}
 	}
 


### PR DESCRIPTION
Add no server session id to configuration.
Use creation time for endpoint context, if session id is empty.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>