### PR TITLE
Set fragment length on setCookie.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -327,9 +327,7 @@ public class ClientHandshaker extends Handshaker {
 	protected void receivedHelloVerifyRequest(HelloVerifyRequest message) throws HandshakeException {
 
 		clientHello.setCookie(message.getCookie());
-		// update the length (cookie added)
-		clientHello.setFragmentLength(clientHello.getMessageLength());
-		
+
 		flightNumber = 3;
 		DTLSFlight flight = new DTLSFlight(getSession(), flightNumber);
 		flight.addMessage(wrapMessage(clientHello));

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHello.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHello.java
@@ -382,8 +382,23 @@ public final class ClientHello extends HandshakeMessage {
 		return cookie;
 	}
 
+	/**
+	 * Set received cookie.
+	 * 
+	 * Adjust fragment length.
+	 * 
+	 * @param cookie recevied cookie
+	 * @throws NullPointerException if cookie is {@code null}
+	 * @throws IllegalArgumentException if cookie is empty
+	 */
 	public void setCookie(byte[] cookie) {
+		if (cookie == null) {
+			throw new NullPointerException("cookie must not be null!");
+		} else if (cookie.length == 0) {
+			throw new IllegalArgumentException("cookie must not be empty!");
+		}
 		this.cookie = Arrays.copyOf(cookie, cookie.length);
+		setFragmentLength(getMessageLength());
 	}
 
 	public List<CipherSuite> getCipherSuites() {

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -370,7 +370,6 @@ public class DTLSConnectorTest {
 
 			// Send CLIENT_HELLO with cookie
 			clientHello.setCookie(cookie);
-			clientHello.setFragmentLength(clientHello.getMessageLength());
 			rawClient.sendRecord(serverEndpoint,
 					DtlsTestTools.newDTLSRecord(ContentType.HANDSHAKE.getCode(), 0, 0, clientHello.toByteArray()));
 
@@ -442,7 +441,6 @@ public class DTLSConnectorTest {
 
 			// Send CLIENT_HELLO with cookie
 			clientHello.setCookie(cookie);
-			clientHello.setFragmentLength(clientHello.getMessageLength());
 			rawClient.sendRecord(serverEndpoint,
 					DtlsTestTools.newDTLSRecord(ContentType.HANDSHAKE.getCode(), 0, 0, clientHello.toByteArray()));
 
@@ -616,7 +614,6 @@ public class DTLSConnectorTest {
 			latch = new CountDownLatch(1);
 			handler.setLatch(latch);
 			clientHello.setCookie(cookie);
-			clientHello.setFragmentLength(clientHello.getMessageLength());
 			rawClient.sendRecord(
 					serverEndpoint,
 					DtlsTestTools.newDTLSRecord(ContentType.HANDSHAKE.getCode(), 0, 0, clientHello.toByteArray()));
@@ -1284,7 +1281,6 @@ public class DTLSConnectorTest {
 			latch = new CountDownLatch(1);
 			handler.setLatch(latch);
 			clientHello.setCookie(cookie);
-			clientHello.setFragmentLength(clientHello.getMessageLength());
 			rawClient.sendRecord(
 					serverEndpoint,
 					DtlsTestTools.newDTLSRecord(ContentType.HANDSHAKE.getCode(), 0, 0, clientHello.toByteArray()));


### PR DESCRIPTION
Remove additional setFragmentLength after calling setCookie.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>