### PR TITLE
Redesign handshaker.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -146,8 +146,8 @@ public class ClientHandshaker extends Handshaker {
 	 *            the session to negotiate with the server.
 	 * @param recordLayer
 	 *            the object to use for sending flights to the peer.
-	 * @param sessionListener
-	 *            the listener to notify about the session's life-cycle events.
+	 * @param connection
+	 *            the connection related with the session.
 	 * @param config
 	 *            the DTLS configuration.
 	 * @param maxTransmissionUnit
@@ -157,9 +157,9 @@ public class ClientHandshaker extends Handshaker {
 	 * @throws NullPointerException
 	 *            if session, recordLayer or config is <code>null</code>
 	 */
-	public ClientHandshaker(DTLSSession session, RecordLayer recordLayer, SessionListener sessionListener,
+	public ClientHandshaker(DTLSSession session, RecordLayer recordLayer, Connection connection,
 			DtlsConnectorConfig config, int maxTransmissionUnit) {
-		super(true, session, recordLayer, sessionListener, config, maxTransmissionUnit);
+		super(true, 0, session, recordLayer, connection, config, maxTransmissionUnit);
 		this.privateKey = config.getPrivateKey();
 		this.certificateChain = config.getCertificateChain();
 		this.publicKey = config.getPublicKey();
@@ -513,7 +513,7 @@ public class ClientHandshaker extends Handshaker {
 			clientKeyExchange = new NULLClientKeyExchange(session.getPeer());
 
 			// We assume, that the premaster secret is empty
-			generateKeys(new byte[] {});
+			generateKeys(Bytes.EMPTY);
 			break;
 
 		default:

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -96,7 +96,7 @@ public final class DTLSSession {
 	/**
 	 * This session's peer's IP address and port.
 	 */
-	private final InetSocketAddress peer;
+	private InetSocketAddress peer;
 
 	/**
 	 * An arbitrary byte sequence chosen by the server to identify this session.
@@ -282,6 +282,15 @@ public final class DTLSSession {
 		return sessionIdentifier;
 	}
 
+	/**
+	 * Sets the session identifier.
+	 * 
+	 * Resets the {@link #masterSecret}, if the session identifier is changed.
+	 * 
+	 * @param sessionIdentifier new session identifier
+	 * @throws NullPointerException if the provided session identifier is
+	 *             {@code null}
+	 */
 	void setSessionIdentifier(SessionId sessionIdentifier) {
 		if (sessionIdentifier == null) {
 			throw new NullPointerException("session identifier must not be null!");
@@ -695,14 +704,15 @@ public final class DTLSSession {
 	 * Sets the master secret to use for encrypting application layer data
 	 * exchanged in this session.
 	 * 
-	 * Once the master secret has been set, it cannot be changed.
+	 * Once the master secret has been set, it cannot be changed without
+	 * changing the session id ahead.
 	 * 
 	 * @param masterSecret the secret
-	 * @throws NullPointerException if the secret is <code>null</code>
+	 * @throws NullPointerException if the master secret is {@code null}
 	 * @throws IllegalArgumentException if the secret is not exactly 48 bytes
 	 * (see <a href="http://tools.ietf.org/html/rfc5246#section-8.1">
 	 * RFC 5246 (TLS 1.2), section 8.1</a>) 
-	 * @throws IllegalStateException if the secret is already set
+	 * @throws IllegalStateException if the master secret is already set
 	 */
 	void setMasterSecret(final byte[] masterSecret) {
 		// don't overwrite the master secret, once it has been set in this session
@@ -774,6 +784,8 @@ public final class DTLSSession {
 		} else {
 			LOGGER.debug("Setting MTU for peer [{}] to {} bytes", peer, mtu);
 			this.maxTransmissionUnit = mtu;
+			// use mtu as fragment length will be detected as too large
+			// and is reduced to the maximum fragment length for this mtu
 			determineMaxFragmentLength(mtu);
 		}
 	}
@@ -827,6 +839,10 @@ public final class DTLSSession {
 	 */
 	public InetSocketAddress getPeer() {
 		return peer;
+	}
+
+	public void setPeer(InetSocketAddress peer) {
+		this.peer = peer;
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordLayer.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordLayer.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 
 /**
  * An abstraction of the DTLS record layer's capabilities for sending records to peers.
- * 
  */
 public interface RecordLayer {
 
@@ -34,6 +33,7 @@ public interface RecordLayer {
 	 * 
 	 * @param flight the records to send. The properties of the flight are used to control the
 	 *                  timespan to wait between re-transmissions. 
+	 * @param connection to send the flight
 	 */
-	void sendFlight(DTLSFlight flight) throws IOException;
+	void sendFlight(DTLSFlight flight, Connection connection) throws IOException;
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
@@ -78,8 +78,8 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 	 *            the session to resume.
 	 * @param recordLayer
 	 *            the object to use for sending flights to the peer.
-	 * @param sessionListener
-	 *            the listener to notify about the session's life-cycle events.
+	 * @param connection
+	 *            the connection related with the session.
 	 * @param config
 	 *            the DTLS configuration parameters to use for the handshake.
 	 * @param maxTransmissionUnit
@@ -91,9 +91,9 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 	 * @throws NullPointerException
 	 *            if session, recordLayer or config is <code>null</code>
 	 */
-	public ResumingClientHandshaker(DTLSSession session, RecordLayer recordLayer, SessionListener sessionListener,
+	public ResumingClientHandshaker(DTLSSession session, RecordLayer recordLayer, Connection connection,
 			DtlsConnectorConfig config, int maxTransmissionUnit) {
-		super(session, recordLayer, sessionListener, config, maxTransmissionUnit);
+		super(session, recordLayer, connection, config, maxTransmissionUnit);
 		if (session.getSessionIdentifier() == null) {
 			throw new IllegalArgumentException("Session must contain the ID of the session to resume");
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingServerHandshaker.java
@@ -61,9 +61,33 @@ public class ResumingServerHandshaker extends ServerHandshaker {
 
 	// Constructor ////////////////////////////////////////////////////
 
-	public ResumingServerHandshaker(int sequenceNumber, DTLSSession session, RecordLayer recordLayer, SessionListener sessionListener,
-			DtlsConnectorConfig config, int maxTransmissionUnit) {
-		super(sequenceNumber, session, recordLayer, sessionListener, config, maxTransmissionUnit);
+	/**
+	 * Creates a new handshaker for resuming an existing session with a client.
+	 * 
+	 * @param sequenceNumber
+	 *            the initial message sequence number to expect from the peer
+	 *            (this parameter can be used to initialize the <em>receive_next_seq</em>
+	 *            counter to another value than 0, e.g. if one or more cookie exchange round-trips
+	 *            have been performed with the peer before the handshake starts).
+	 * @param session
+	 *            the session to negotiate with the client.
+	 * @param recordLayer
+	 *            the object to use for sending flights to the peer.
+	 * @param connection
+	 *            the connection related with the session.
+	 * @param config
+	 *            the DTLS configuration parameters to use for the handshake.
+	 * @param maxTransmissionUnit
+	 *            the MTU value reported by the network interface the record layer is bound to.
+	 * @throws IllegalArgumentException
+	 *            if the given session does not contain an identifier.
+	 * @throws IllegalStateException
+	 *            if the message digest required for computing the FINISHED message hash cannot be instantiated.
+	 * @throws NullPointerException
+	 *            if session, recordLayer or config is <code>null</code>
+	 */
+	public ResumingServerHandshaker(int sequenceNumber, DTLSSession session, RecordLayer recordLayer, Connection connection, DtlsConnectorConfig config, int maxTransmissionUnit) {
+		super(sequenceNumber, session, recordLayer, connection, config, maxTransmissionUnit);
 	}
 
 	// Methods ////////////////////////////////////////////////////////
@@ -112,7 +136,7 @@ public class ResumingServerHandshaker extends ServerHandshaker {
 
 			incrementNextReceiveSeq();
 			LOGGER.debug("Processed {} message with sequence no [{}] from peer [{}]",
-					new Object[]{handshakeMsg.getMessageType(), handshakeMsg.getMessageSeq(), handshakeMsg.getPeer()});
+					handshakeMsg.getMessageType(), handshakeMsg.getMessageSeq(), handshakeMsg.getPeer());
 			break;
 
 		default:

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -158,29 +158,6 @@ public class ServerHandshaker extends Handshaker {
 	 * Creates a handshaker for negotiating a DTLS session with a client
 	 * following the full DTLS handshake protocol. 
 	 * 
-	 * @param session
-	 *            the session to negotiate with the client.
-	 * @param recordLayer
-	 *            the object to use for sending flights to the peer.
-	 * @param sessionListener
-	 *            the listener to notify about the session's life-cycle events.
-	 * @param config
-	 *            the DTLS configuration.
-	 * @param maxTransmissionUnit
-	 *            the MTU value reported by the network interface the record layer is bound to.
-	 * @throws HandshakeException if the handshaker cannot be initialized
-	 * @throws NullPointerException
-	 *            if session or recordLayer is <code>null</code>.
-	 */
-	public ServerHandshaker(DTLSSession session, RecordLayer recordLayer, SessionListener sessionListener,
-			DtlsConnectorConfig config, int maxTransmissionUnit) throws HandshakeException {
-		this(0, session, recordLayer, sessionListener, config, maxTransmissionUnit);
-	}
-	
-	/**
-	 * Creates a handshaker for negotiating a DTLS session with a client
-	 * following the full DTLS handshake protocol. 
-	 * 
 	 * @param initialMessageSequenceNo
 	 *            the initial message sequence number to expect from the peer
 	 *            (this parameter can be used to initialize the <em>receive_next_seq</em>
@@ -190,8 +167,8 @@ public class ServerHandshaker extends Handshaker {
 	 *            the session to negotiate with the client.
 	 * @param recordLayer
 	 *            the object to use for sending flights to the peer.
-	 * @param sessionListener
-	 *            the listener to notify about the session's life-cycle events.
+	 * @param connection
+	 *            the connection related with the session.
 	 * @param config
 	 *            the DTLS configuration.
 	 * @param maxTransmissionUnit
@@ -204,9 +181,9 @@ public class ServerHandshaker extends Handshaker {
 	 * @throws NullPointerException
 	 *            if session, recordLayer or config is <code>null</code>.
 	 */
-	public ServerHandshaker(int initialMessageSequenceNo, DTLSSession session, RecordLayer recordLayer, SessionListener sessionListener,
-			DtlsConnectorConfig config, int maxTransmissionUnit) { 
-		super(false, initialMessageSequenceNo, session, recordLayer, sessionListener, config, maxTransmissionUnit);
+	public ServerHandshaker(int initialMessageSequenceNo, DTLSSession session, RecordLayer recordLayer,
+			Connection connection, DtlsConnectorConfig config, int maxTransmissionUnit) {
+		super(false, initialMessageSequenceNo, session, recordLayer, connection, config, maxTransmissionUnit);
 
 		this.supportedCipherSuites = config.getSupportedCipherSuites();
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -194,6 +194,20 @@ public class ConnectorHelper {
 		server.setAlertHandler(null);
 	}
 
+	/**
+	 * Remove connect from server side connection store.
+	 * 
+	 * @param client address of client
+	 * @param removeFromSessionCache {@code true} remove from session cache
+	 *            also.
+	 */
+	public void remove(InetSocketAddress client, boolean removeFromSessionCache) {
+		Connection connection = serverConnectionStore.get(client);
+		if (connection != null) {
+			serverConnectionStore.remove(connection, removeFromSessionCache);
+		}
+	}
+
 	static DtlsConnectorConfig newStandardClientConfig(final InetSocketAddress bindAddress) throws IOException, GeneralSecurityException {
 		return newStandardClientConfigBuilder(bindAddress).build();
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
@@ -158,8 +158,8 @@ public class DTLSConnectorAdvancedTest {
 			// to send message in bad order.
 			LatchSessionListener sessionListener = new LatchSessionListener();
 			ClientHandshaker clientHandshaker = new ClientHandshaker(new DTLSSession(serverHelper.serverEndpoint),
-					new ReverseRecordLayer(rawClient), sessionListener, clientConfig, 1280);
-
+					new ReverseRecordLayer(rawClient), null, clientConfig, 1280);
+			clientHandshaker.addSessionListener(sessionListener);
 			// Start handshake (Send CLIENT HELLO)
 			clientHandshaker.startHandshake();
 
@@ -210,8 +210,9 @@ public class DTLSConnectorAdvancedTest {
 
 			// Create server handshaker
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ServerHandshaker serverHandshaker = new ServerHandshaker(new DTLSSession(client.getAddress(), 1),
-					new ReverseRecordLayer(rawServer), sessionListener, serverHelper.serverConfig, 1280);
+			ServerHandshaker serverHandshaker = new ServerHandshaker(0, new DTLSSession(client.getAddress(), 1),
+					new ReverseRecordLayer(rawServer), null, serverHelper.serverConfig, 1280);
+			serverHandshaker.addSessionListener(sessionListener);
 
 			// Wait to receive response (should be CLIENT HELLO, flight 3)
 			List<Record> rs = waitForFlightReceived("flight 3", collector, 1);
@@ -250,9 +251,9 @@ public class DTLSConnectorAdvancedTest {
 			// Create handshaker
 			DTLSSession clientSession = new DTLSSession(serverHelper.serverEndpoint);
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ClientHandshaker clientHandshaker = new ClientHandshaker(clientSession, clientRecordLayer, sessionListener,
-					clientConfig, 1280);
-
+			ClientHandshaker clientHandshaker = new ClientHandshaker(clientSession, clientRecordLayer,
+					null, clientConfig, 1280);
+			clientHandshaker.addSessionListener(sessionListener);
 			// Start 1. handshake (Send CLIENT HELLO)
 			clientHandshaker.startHandshake();
 
@@ -288,7 +289,8 @@ public class DTLSConnectorAdvancedTest {
 			DTLSSession resumableSession = new DTLSSession(clientSession.getSessionIdentifier(),
 					serverHelper.serverEndpoint, clientSession.getSessionTicket(), 0);
 			ResumingClientHandshaker resumingClientHandshaker = new ResumingClientHandshaker(resumableSession,
-					clientRecordLayer, sessionListener, clientConfig, 1280);
+					clientRecordLayer, null, clientConfig, 1280);
+			resumingClientHandshaker.addSessionListener(sessionListener);
 
 			// Start resuming handshake (Send CLIENT HELLO, additional flight)
 			resumingClientHandshaker.startHandshake();
@@ -337,8 +339,9 @@ public class DTLSConnectorAdvancedTest {
 			// Create server handshaker
 			DTLSSession serverSession = new DTLSSession(client.getAddress(), 1);
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ServerHandshaker serverHandshaker = new ServerHandshaker(serverSession, serverRecordLayer, sessionListener,
-					serverHelper.serverConfig, 1280);
+			ServerHandshaker serverHandshaker = new ServerHandshaker(0, serverSession, serverRecordLayer,
+					null, serverHelper.serverConfig, 1280);
+			serverHandshaker.addSessionListener(sessionListener);
 
 			// 1. handshake
 			// Wait to receive response (should be CLIENT HELLO)
@@ -366,7 +369,8 @@ public class DTLSConnectorAdvancedTest {
 			DTLSSession resumableSession = new DTLSSession(serverSession.getSessionIdentifier(), client.getAddress(),
 					serverSession.getSessionTicket(), 0);
 			ResumingServerHandshaker resumingServerHandshaker = new ResumingServerHandshaker(0, resumableSession,
-					serverRecordLayer, sessionListener, serverHelper.serverConfig, 1280);
+					serverRecordLayer, null, serverHelper.serverConfig, 1280);
+			resumingServerHandshaker.addSessionListener(sessionListener);
 
 			// force resuming handshake
 			client.forceResumeSessionFor(rawServer.getAddress());
@@ -430,7 +434,8 @@ public class DTLSConnectorAdvancedTest {
 			// Create handshaker
 			LatchSessionListener sessionListener = new LatchSessionListener();
 			ClientHandshaker clientHandshaker = new ClientHandshaker(new DTLSSession(serverHelper.serverEndpoint),
-					clientRecordLayer, sessionListener, clientConfig, 1280);
+					clientRecordLayer, null, clientConfig, 1280);
+			clientHandshaker.addSessionListener(sessionListener);
 
 			// Start handshake (Send CLIENT HELLO, flight 1)
 			clientHandshaker.startHandshake();
@@ -505,8 +510,9 @@ public class DTLSConnectorAdvancedTest {
 			// Create server handshaker
 			DTLSSession serverSession = new DTLSSession(client.getAddress(), 1);
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ServerHandshaker serverHandshaker = new ServerHandshaker(serverSession, serverRecordLayer, sessionListener,
-					serverHelper.serverConfig, 1280);
+			ServerHandshaker serverHandshaker = new ServerHandshaker(0, serverSession, serverRecordLayer,
+					null, serverHelper.serverConfig, 1280);
+			serverHandshaker.addSessionListener(sessionListener);
 
 			// 1. handshake
 			// Wait to receive response (should be CLIENT HELLO)
@@ -533,7 +539,8 @@ public class DTLSConnectorAdvancedTest {
 			DTLSSession resumableSession = new DTLSSession(serverSession.getSessionIdentifier(), client.getAddress(),
 					serverSession.getSessionTicket(), 0);
 			ResumingServerHandshaker resumingServerHandshaker = new ResumingServerHandshaker(0, resumableSession,
-					serverRecordLayer, sessionListener, serverHelper.serverConfig, 1280);
+					serverRecordLayer, null, serverHelper.serverConfig, 1280);
+			resumingServerHandshaker.addSessionListener(sessionListener);
 
 			// force resuming handshake
 			client.forceResumeSessionFor(rawServer.getAddress());
@@ -600,8 +607,9 @@ public class DTLSConnectorAdvancedTest {
 
 			// Create server handshaker
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ServerHandshaker serverHandshaker = new ServerHandshaker(new DTLSSession(client.getAddress(), 1),
-					new BasicRecordLayer(rawServer), sessionListener, serverHelper.serverConfig, 1280);
+			ServerHandshaker serverHandshaker = new ServerHandshaker(0, new DTLSSession(client.getAddress(), 1),
+					new BasicRecordLayer(rawServer), null, serverHelper.serverConfig, 1280);
+			serverHandshaker.addSessionListener(sessionListener);
 
 			// Wait to receive response (should be CLIENT HELLO, flight 3)
 			List<Record> rs = waitForFlightReceived("flight 1", collector, 1);
@@ -655,8 +663,9 @@ public class DTLSConnectorAdvancedTest {
 			// Create handshaker
 			DTLSSession clientSession = new DTLSSession(serverHelper.serverEndpoint);
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ClientHandshaker clientHandshaker = new ClientHandshaker(clientSession, clientRecordLayer, sessionListener,
-					clientConfig, 1280);
+			ClientHandshaker clientHandshaker = new ClientHandshaker(clientSession, clientRecordLayer,
+					null, clientConfig, 1280);
+			clientHandshaker.addSessionListener(sessionListener);
 
 			// Start 1. handshake (Send CLIENT HELLO)
 			clientHandshaker.startHandshake();
@@ -693,7 +702,8 @@ public class DTLSConnectorAdvancedTest {
 			DTLSSession resumableSession = new DTLSSession(clientSession.getSessionIdentifier(),
 					serverHelper.serverEndpoint, clientSession.getSessionTicket(), 0);
 			ResumingClientHandshaker resumingClientHandshaker = new ResumingClientHandshaker(resumableSession,
-					clientRecordLayer, sessionListener, clientConfig, 1280);
+					clientRecordLayer, null, clientConfig, 1280);
+			resumingClientHandshaker.addSessionListener(sessionListener);
 
 			// Start resuming handshake (Send CLIENT HELLO, additional flight)
 			resumingClientHandshaker.startHandshake();
@@ -744,8 +754,9 @@ public class DTLSConnectorAdvancedTest {
 			// Create handshaker
 			DTLSSession clientSession = new DTLSSession(serverHelper.serverEndpoint);
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ClientHandshaker clientHandshaker = new ClientHandshaker(clientSession, clientRecordLayer, sessionListener,
-					clientConfig, 1280);
+			ClientHandshaker clientHandshaker = new ClientHandshaker(clientSession, clientRecordLayer,
+					null, clientConfig, 1280);
+			clientHandshaker.addSessionListener(sessionListener);
 
 			// Start 1. handshake (Send CLIENT HELLO)
 			clientHandshaker.startHandshake();
@@ -782,7 +793,8 @@ public class DTLSConnectorAdvancedTest {
 			DTLSSession resumableSession = new DTLSSession(clientSession.getSessionIdentifier(),
 					serverHelper.serverEndpoint, clientSession.getSessionTicket(), 0);
 			ResumingClientHandshaker resumingClientHandshaker = new ResumingClientHandshaker(resumableSession,
-					clientRecordLayer, sessionListener, clientConfig, 1280);
+					clientRecordLayer, null, clientConfig, 1280);
+			resumingClientHandshaker.addSessionListener(sessionListener);
 
 			// Start resuming handshake (Send CLIENT HELLO, additional flight)
 			resumingClientHandshaker.startHandshake();
@@ -832,8 +844,9 @@ public class DTLSConnectorAdvancedTest {
 			// Create handshaker
 			DTLSSession clientSession = new DTLSSession(serverHelper.serverEndpoint);
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ClientHandshaker clientHandshaker = new ClientHandshaker(clientSession, clientRecordLayer, sessionListener,
-					clientConfig, 1280);
+			ClientHandshaker clientHandshaker = new ClientHandshaker(clientSession, clientRecordLayer,
+					null, clientConfig, 1280);
+			clientHandshaker.addSessionListener(sessionListener);
 
 			// Start 1. handshake (Send CLIENT HELLO)
 			clientHandshaker.startHandshake();
@@ -890,8 +903,9 @@ public class DTLSConnectorAdvancedTest {
 			// Create server handshaker
 			DTLSSession serverSession = new DTLSSession(client.getAddress(), 1);
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ServerHandshaker serverHandshaker = new ServerHandshaker(serverSession, serverRecordLayer, sessionListener,
-					serverHelper.serverConfig, 1280);
+			ServerHandshaker serverHandshaker = new ServerHandshaker(0, serverSession, serverRecordLayer,
+					null, serverHelper.serverConfig, 1280);
+			serverHandshaker.addSessionListener(sessionListener);
 
 			// 1. handshake
 			// Wait to receive response (should be CLIENT HELLO)
@@ -918,7 +932,8 @@ public class DTLSConnectorAdvancedTest {
 			DTLSSession resumableSession = new DTLSSession(serverSession.getSessionIdentifier(), client.getAddress(),
 					serverSession.getSessionTicket(), 0);
 			ResumingServerHandshaker resumingServerHandshaker = new ResumingServerHandshaker(0, resumableSession,
-					serverRecordLayer, sessionListener, serverHelper.serverConfig, 1280);
+					serverRecordLayer, null, serverHelper.serverConfig, 1280);
+			resumingServerHandshaker.addSessionListener(sessionListener);
 
 			// force resuming handshake
 			client.forceResumeSessionFor(rawServer.getAddress());
@@ -968,8 +983,9 @@ public class DTLSConnectorAdvancedTest {
 			// Create server handshaker
 			BasicRecordLayer serverRecordLayer = new BasicRecordLayer(rawServer);
 			LatchSessionListener sessionListener = new LatchSessionListener();
-			ServerHandshaker serverHandshaker = new ServerHandshaker(new DTLSSession(client.getAddress(), 1),
-					serverRecordLayer, sessionListener, serverHelper.serverConfig, 1280);
+			ServerHandshaker serverHandshaker = new ServerHandshaker(0, new DTLSSession(client.getAddress(), 1),
+					serverRecordLayer, null, serverHelper.serverConfig, 1280);
+			serverHandshaker.addSessionListener(sessionListener);
 
 			// Wait to receive response (should be CLIENT HELLO, flight 3)
 			List<Record> rs = waitForFlightReceived("flight 1", collector, 1);
@@ -996,9 +1012,8 @@ public class DTLSConnectorAdvancedTest {
 			int timeout = RETRANSMISSION_TIMEOUT_MS * (2 << (MAX_RETRANSMISSIONS + 2));
 			Throwable error = clientSessionListener.waitForSessionFailed(timeout, TimeUnit.MILLISECONDS);
 			assertNotNull("client handshake not failed", error);
-
 			assertThat(clientConnectionStore.remainingCapacity(), is(remain));
-	} finally {
+		} finally {
 			rawServer.stop();
 		}
 	}
@@ -1023,7 +1038,8 @@ public class DTLSConnectorAdvancedTest {
 			// Create handshaker
 			LatchSessionListener sessionListener = new LatchSessionListener();
 			ClientHandshaker clientHandshaker = new ClientHandshaker(clientSession, new BasicRecordLayer(rawClient),
-					sessionListener, clientConfig, 1280);
+					null, clientConfig, 1280);
+			clientHandshaker.addSessionListener(sessionListener);
 
 			// Start 1. handshake (Send CLIENT HELLO)
 			clientHandshaker.startHandshake();
@@ -1061,7 +1077,8 @@ public class DTLSConnectorAdvancedTest {
 			DTLSSession resumableSession = new DTLSSession(clientSession.getSessionIdentifier(),
 					serverHelper.serverEndpoint, clientSession.getSessionTicket(), 0);
 			ResumingClientHandshaker resumingClientHandshaker = new ResumingClientHandshaker(resumableSession,
-					new BasicRecordLayer(rawAlt1Client), alt1SessionListener, clientConfig, 1280);
+					new BasicRecordLayer(rawAlt1Client), null, clientConfig, 1280);
+			resumingClientHandshaker.addSessionListener(alt1SessionListener);
 
 			// Start resuming handshake (Send CLIENT HELLO, additional flight)
 			resumingClientHandshaker.startHandshake();
@@ -1078,7 +1095,8 @@ public class DTLSConnectorAdvancedTest {
 			resumableSession = new DTLSSession(clientSession.getSessionIdentifier(), serverHelper.serverEndpoint,
 					clientSession.getSessionTicket(), 0);
 			resumingClientHandshaker = new ResumingClientHandshaker(resumableSession,
-					new BasicRecordLayer(rawAlt2Client), alt2SessionListener, clientConfig, 1280);
+					new BasicRecordLayer(rawAlt2Client), null, clientConfig, 1280);
+			resumingClientHandshaker.addSessionListener(alt2SessionListener);
 
 			// Start resuming handshake (Send CLIENT HELLO, additional flight)
 			resumingClientHandshaker.startHandshake();
@@ -1171,8 +1189,7 @@ public class DTLSConnectorAdvancedTest {
 			Record record2 = flight2.get(index);
 			assertThat("retransmitted flight record has different epoch", record2.getEpoch(), is(record1.getEpoch()));
 			assertThat("retransmitted flight record has different type", record2.getType(), is(record1.getType()));
-			assertThat("retransmitted flight record has different lenght", record2.getLength(),
-					is(record1.getLength()));
+			assertThat("retransmitted flight record has different lenght", record2.getLength(), is(record1.getLength()));
 			assertThat("retransmitted flight record has no newer seqn", record2.getSequenceNumber(),
 					is(greaterThan(record1.getSequenceNumber())));
 		}
@@ -1229,6 +1246,7 @@ public class DTLSConnectorAdvancedTest {
 		private final AtomicInteger drop = new AtomicInteger(0);
 		protected final UdpConnector connector;
 		protected volatile DTLSFlight lastFlight;
+		protected volatile Connection lastConnection;
 
 		public BasicRecordLayer(UdpConnector connector) {
 			this.connector = connector;
@@ -1239,8 +1257,9 @@ public class DTLSConnectorAdvancedTest {
 		}
 
 		@Override
-		public void sendFlight(DTLSFlight flight) throws IOException {
+		public void sendFlight(DTLSFlight flight, Connection connection) throws IOException {
 			lastFlight = flight;
+			lastConnection = connection;
 			for (Record record : getMessagesOfFlight(flight)) {
 				connector.sendRecord(record.getPeerAddress(), record.toByteArray());
 			}
@@ -1248,12 +1267,13 @@ public class DTLSConnectorAdvancedTest {
 
 		public void resendLastFlight() throws GeneralSecurityException, IOException {
 			DTLSFlight flight = lastFlight;
+			Connection connection = lastConnection;
 			if (null == flight) {
 				throw new IllegalStateException("no last flight!");
 			}
 			flight.incrementTries();
 			flight.setNewSequenceNumbers();
-			sendFlight(flight);
+			sendFlight(flight, connection);
 		}
 
 		public List<Record> getMessagesOfFlight(DTLSFlight flight) {

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
@@ -118,7 +118,7 @@ public class HandshakerTest {
 		builder.setCertificateVerifier(new StaticCertificateVerifier(null));
 		builder.setRpkTrustStore(rpkStore);
 		
-		handshaker = new Handshaker(false, session, recordLayer, null, builder.build(), 1500) {
+		handshaker = new Handshaker(false, 0, session, recordLayer, null, builder.build(), 1500) {
 
 			@Override
 			public void startHandshake() {
@@ -138,7 +138,7 @@ public class HandshakerTest {
 		builder.setCertificateVerifier(new StaticCertificateVerifier(trustAnchor));
 		builder.setRpkTrustStore(rpkStore);
 
-		handshakerWithAnchors = new Handshaker(false, session, recordLayer, null,
+		handshakerWithAnchors = new Handshaker(false, 0, session, recordLayer, null,
 				 builder.build(), 1500) {
 
 			@Override
@@ -399,7 +399,7 @@ public class HandshakerTest {
 
 		ChangeCipherSpecTestHandshaker(final DTLSSession session, final RecordLayer recordLayer,
 				DtlsConnectorConfig config) {
-			super(false, session, recordLayer, null, config, 1500);
+			super(false, 0, session, recordLayer, null, config, 1500);
 		}
 
 		@Override

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
@@ -116,7 +116,7 @@ public class ServerHandshakerTest {
 		int networkMtu = ETHERNET_MTU;
 
 		// when instantiating a ServerHandshaker to negotiate a new session
-		handshaker = new ServerHandshaker(session, recordLayer, null, config, networkMtu);
+		handshaker = new ServerHandshaker(0, session, recordLayer, null, config, networkMtu);
 
 		// then a fragment created under the session's current write state should
 		// fit into a single unfragmented UDP datagram
@@ -358,7 +358,7 @@ public class ServerHandshakerTest {
 	}
 
 	private ServerHandshaker newHandshaker(final DtlsConnectorConfig config, final DTLSSession session) throws HandshakeException {
-		return new ServerHandshaker(session, recordLayer, null, config, ETHERNET_MTU);
+		return new ServerHandshaker(0, session, recordLayer, null, config, ETHERNET_MTU);
 	}
 
 	private Record givenAHandshakerWithAQueuedMessage() throws Exception {

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/SimpleRecordLayer.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/SimpleRecordLayer.java
@@ -21,7 +21,7 @@ public class SimpleRecordLayer implements RecordLayer {
 	private DTLSFlight sentFlight;
 
 	@Override
-	public void sendFlight(DTLSFlight flight) {
+	public void sendFlight(DTLSFlight flight, Connection connection) {
 		sentFlight = flight;
 	}
 


### PR DESCRIPTION
Keep associate connection in handshaker.
Split deprecated processing of incoming and outgoing records.
Call on onError for outgoing records on failed handshakes.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>