### PR TITLE
Add GCM test.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -1034,11 +1034,13 @@ public final class DtlsConnectorConfig {
 		 * order) during the DTLS handshake when negotiating a cipher suite with
 		 * a peer.
 		 * 
-		 * @param cipherSuites the supported cipher suites in the order of preference
+		 * @param cipherSuites the supported cipher suites in the order of
+		 *            preference
 		 * @return this builder for command chaining
 		 * @throws NullPointerException if the given array is <code>null</code>
 		 * @throws IllegalArgumentException if the given array is empty or
-		 *             contains {@link CipherSuite#TLS_NULL_WITH_NULL_NULL}
+		 *             contains {@link CipherSuite#TLS_NULL_WITH_NULL_NULL}, or
+		 *             contains a cipher suite, not supported by the JVM.
 		 */
 		public Builder setSupportedCipherSuites(List<CipherSuite> cipherSuites) {
 			if (cipherSuites == null) {
@@ -1052,6 +1054,11 @@ public final class DtlsConnectorConfig {
 			}
 			if (extendedCipherSuites) {
 				throw new IllegalArgumentException("Extended default cipher-suites are already provided!");
+			}
+			for (CipherSuite cipherSuite : cipherSuites) {
+				if (!cipherSuite.isSupported()) {
+					throw new IllegalArgumentException("cipher-suites " + cipherSuite + " is not supported by JVM!");
+				}
 			}
 			config.supportedCipherSuites = cipherSuites;
 			return this;
@@ -1773,6 +1780,11 @@ public final class DtlsConnectorConfig {
 			if (config.supportedCipherSuites == null || config.supportedCipherSuites.isEmpty()) {
 				throw new IllegalStateException("Supported cipher suites must be set either " +
 						"explicitly or implicitly by means of setting the identity or PSK store");
+			}
+			for (CipherSuite cipherSuite : config.supportedCipherSuites) {
+				if (!cipherSuite.isSupported()) {
+					throw new IllegalStateException("cipher-suites " + cipherSuite + " is not supported by JVM!");
+				}
 			}
 
 			if (config.trustCertificateTypes != null) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/AeadBlockCipher.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/AeadBlockCipher.java
@@ -36,15 +36,18 @@ public class AeadBlockCipher {
 	 * Test, if cipher is supported.
 	 * 
 	 * @param transformation name of cipher
+	 * @param keyLength key length in bytes
 	 * @return {@code true}, if supported
 	 */
-	public final static boolean isSupported(String transformation) {
+	public final static boolean isSupported(String transformation, int keyLength) {
+		String cipherName = transformation;
 		if (AES_CCM.equals(transformation)) {
-			return true;
+			cipherName = CCMBlockCipher.CIPHER_NAME;
 		}
 		try {
-			CipherManager.getInstance(transformation);
-			return true;
+			CipherManager.getInstance(cipherName);
+			int maxAllowedKeyLengthBits = Cipher.getMaxAllowedKeyLength(cipherName);
+			return keyLength * 8 <= maxAllowedKeyLengthBits;
 		} catch (GeneralSecurityException ex) {
 			return false;
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CCMBlockCipher.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CCMBlockCipher.java
@@ -44,7 +44,7 @@ public class CCMBlockCipher {
 	/**
 	 * The underlying block cipher.
 	 */
-	private static final String CIPHER_NAME = "AES/ECB/NoPadding";
+	public static final String CIPHER_NAME = "AES/ECB/NoPadding";
 
 	private static abstract class Block {
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
@@ -671,7 +671,7 @@ public enum CipherSuite {
 			this.recordIvLength = recordIvLength;
 			this.macLength = macLength;
 			if (type == CipherType.AEAD || type == CipherType.BLOCK) {
-				this.supported = AeadBlockCipher.isSupported(transformation);
+				this.supported = AeadBlockCipher.isSupported(transformation, keyLength);
 			} else {
 				this.supported = true;
 			}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -148,20 +148,10 @@ public class ConnectorHelper {
 				.setServerOnly(true);
 
 		if (builder.getIncompleteConfig().getSupportedCipherSuites() == null) {
-			builder.setSupportedCipherSuites(
-					CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
-					CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
-					CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM,
-					CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8,
-					CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CCM,
-					CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-					CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
-					CipherSuite.TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256,
-					CipherSuite.TLS_PSK_WITH_AES_128_CCM_8,
-					CipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA256,
-					CipherSuite.TLS_PSK_WITH_AES_256_CCM_8,
-					CipherSuite.TLS_PSK_WITH_AES_128_CCM,
-					CipherSuite.TLS_PSK_WITH_AES_256_CCM);
+			CipherSuite.getEcdsaCipherSuites(true);
+			List<CipherSuite> list = new ArrayList<>(CipherSuite.getEcdsaCipherSuites(true));
+			list.addAll(CipherSuite.getPskCipherSuites(true, true));
+			builder.setSupportedCipherSuites(list);
 		}
 		if (!Boolean.FALSE.equals(builder.getIncompleteConfig().isClientAuthenticationRequired()) ||
 				Boolean.TRUE.equals(builder.getIncompleteConfig().isClientAuthenticationWanted())) {

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorHandshakeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorHandshakeTest.java
@@ -20,6 +20,7 @@ package org.eclipse.californium.scandium;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.junit.Assume.*;
 import static org.eclipse.californium.scandium.ConnectorHelper.*;
 
 import java.io.IOException;
@@ -550,6 +551,7 @@ public class DTLSConnectorHandshakeTest {
 
 	@Test
 	public void testPsk256Ccm8Handshake() throws Exception {
+		assumeTrue("AES256 requires JVM support!", CipherSuite.TLS_PSK_WITH_AES_256_CCM_8.isSupported());
 		startServer(false, false,  false,  null);
 		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder()
 				.setPskStore(new StaticPskStore(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()))
@@ -570,12 +572,24 @@ public class DTLSConnectorHandshakeTest {
 
 	@Test
 	public void testPsk256CcmHandshake() throws Exception {
+		assumeTrue("AES256 requires JVM support!", CipherSuite.TLS_PSK_WITH_AES_256_CCM.isSupported());
 		startServer(false, false,  false,  null);
 		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder()
 				.setPskStore(new StaticPskStore(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()))
 				.setSupportedCipherSuites(CipherSuite.TLS_PSK_WITH_AES_256_CCM);
 		startClient(false,  null, builder);
 		assertThat(serverHelper.establishedServerSession.getCipherSuite(), is(CipherSuite.TLS_PSK_WITH_AES_256_CCM));
+	}
+
+	@Test
+	public void testPskGcmHandshake() throws Exception {
+		assumeTrue("GCM requires JVM support!", CipherSuite.TLS_PSK_WITH_AES_128_GCM_SHA256.isSupported());
+		startServer(false, false,  false,  null);
+		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder()
+				.setPskStore(new StaticPskStore(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()))
+				.setSupportedCipherSuites(CipherSuite.TLS_PSK_WITH_AES_128_GCM_SHA256);
+		startClient(false,  null, builder);
+		assertThat(serverHelper.establishedServerSession.getCipherSuite(), is(CipherSuite.TLS_PSK_WITH_AES_128_GCM_SHA256));
 	}
 
 	@Test
@@ -602,6 +616,7 @@ public class DTLSConnectorHandshakeTest {
 
 	@Test
 	public void testRpk256Ccm8Handshake() throws Exception {
+		assumeTrue("AES256 requires JVM support!", CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8.isSupported());
 		startServer(false, false, false, null);
 		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder()
 				.setRpkTrustAll()
@@ -624,6 +639,7 @@ public class DTLSConnectorHandshakeTest {
 
 	@Test
 	public void testRpk256CcmHandshake() throws Exception {
+		assumeTrue("AES256 requires JVM support!", CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CCM.isSupported());
 		startServer(false, false, false, null);
 		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder()
 				.setRpkTrustAll()
@@ -635,6 +651,7 @@ public class DTLSConnectorHandshakeTest {
 
 	@Test
 	public void testRpk256CbcHandshake() throws Exception {
+		assumeTrue("AES256 requires JVM support!", CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA.isSupported());
 		startServer(false, false, false, null);
 		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder()
 				.setRpkTrustAll()
@@ -646,6 +663,7 @@ public class DTLSConnectorHandshakeTest {
 
 	@Test
 	public void testRpk256Cbc384Handshake() throws Exception {
+		assumeTrue("AES256 requires JVM support!", CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384.isSupported());
 		startServer(false, false, false, null);
 		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder()
 				.setRpkTrustAll()
@@ -653,5 +671,17 @@ public class DTLSConnectorHandshakeTest {
 				.setSupportedCipherSuites(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384);
 		startClient(false,  null, builder);
 		assertThat(serverHelper.establishedServerSession.getCipherSuite(), is(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384));
+	}
+
+	@Test
+	public void testRpkGcmHandshake() throws Exception {
+		assumeTrue("GCM requires JVM support!", CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256.isSupported());
+		startServer(false, false, false, null);
+		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder()
+				.setRpkTrustAll()
+				.setIdentity(DtlsTestTools.getClientPrivateKey(), DtlsTestTools.getClientPublicKey())
+				.setSupportedCipherSuites(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256);
+		startClient(false,  null, builder);
+		assertThat(serverHelper.establishedServerSession.getCipherSuite(), is(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256));
 	}
 }


### PR DESCRIPTION
Also extend test of JVM support by key length.
Not all JVMs seems to support AES256.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>