### PR TITLE
Introduce raw byte arrays for psk hint and identity.

### DIFF
--- a/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/TestUtilPskStore.java
+++ b/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/TestUtilPskStore.java
@@ -20,12 +20,13 @@ import java.net.InetSocketAddress;
 import java.util.Arrays;
 
 import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
+import org.eclipse.californium.scandium.dtls.pskstore.StringPskStore;
 import org.eclipse.californium.scandium.util.ServerNames;
 
 /**
  * Simple {@link PskStore} implementation with exchangeable credentials.
  */
-public class TestUtilPskStore implements PskStore {
+public class TestUtilPskStore extends StringPskStore {
 
 	/**
 	 * PSK identity.
@@ -63,17 +64,17 @@ public class TestUtilPskStore implements PskStore {
 	}
 
 	@Override
-	public synchronized byte[] getKey(ServerNames serverNames, String identity) {
+	public byte[] getKey(ServerNames serverNames, String identity) {
 		return getKey(identity);
 	}
 
 	@Override
-	public synchronized String getIdentity(InetSocketAddress inetAddress) {
+	public synchronized String getIdentityAsString(InetSocketAddress inetAddress) {
 		return identity;
 	}
 
 	@Override
-	public synchronized String getIdentity(InetSocketAddress peerAddress, ServerNames virtualHost) {
-		return getIdentity(peerAddress);
+	public String getIdentityAsString(InetSocketAddress peerAddress, ServerNames virtualHost) {
+		return getIdentityAsString(peerAddress);
 	}
 }

--- a/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/ClientInitializer.java
+++ b/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/ClientInitializer.java
@@ -46,7 +46,7 @@ import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.CertificateType;
-import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
+import org.eclipse.californium.scandium.dtls.pskstore.StringPskStore;
 import org.eclipse.californium.scandium.util.ServerNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -222,7 +222,7 @@ public class ClientInitializer {
 		return endpoint;
 	}
 
-	public static class PlugPskStore implements PskStore {
+	public static class PlugPskStore extends StringPskStore {
 
 		private final String identity;
 		private final byte[] secret;
@@ -256,13 +256,13 @@ public class ClientInitializer {
 		}
 
 		@Override
-		public String getIdentity(InetSocketAddress inetAddress) {
+		public String getIdentityAsString(InetSocketAddress inetAddress) {
 			return identity;
 		}
 
 		@Override
-		public String getIdentity(InetSocketAddress peerAddress, ServerNames virtualHost) {
-			return getIdentity(peerAddress);
+		public String getIdentityAsString(InetSocketAddress peerAddress, ServerNames virtualHost) {
+			return getIdentityAsString(peerAddress);
 		}
 	}
 

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
@@ -43,7 +43,7 @@ import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.CertificateType;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
-import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
+import org.eclipse.californium.scandium.dtls.pskstore.StringPskStore;
 import org.eclipse.californium.scandium.util.ServerNames;
 
 /**
@@ -307,7 +307,7 @@ public abstract class AbstractTestServer extends CoapServer {
 				+ endpoint.getConfig().getInt(Keys.PREFERRED_BLOCK_SIZE));
 	}
 
-	private static class PlugPskStore implements PskStore {
+	private static class PlugPskStore extends StringPskStore {
 
 		@Override
 		public byte[] getKey(String identity) {
@@ -326,13 +326,13 @@ public abstract class AbstractTestServer extends CoapServer {
 		}
 
 		@Override
-		public String getIdentity(InetSocketAddress inetAddress) {
+		public String getIdentityAsString(InetSocketAddress inetAddress) {
 			return PSK_IDENTITY_PREFIX + "sandbox";
 		}
 
 		@Override
-		public String getIdentity(InetSocketAddress peerAddress, ServerNames virtualHost) {
-			return getIdentity(peerAddress);
+		public String getIdentityAsString(InetSocketAddress peerAddress, ServerNames virtualHost) {
+			return getIdentityAsString(peerAddress);
 		}
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -502,17 +502,17 @@ public class ClientHandshaker extends Handshaker {
 			break;
 		case PSK:
 			PskUtil pskUtilPlain = new PskUtil(sniEnabled, session, pskStore);
-			LOGGER.debug("Using PSK identity: {}", pskUtilPlain.getPskIdentity());
-			session.setPeerIdentity(pskUtilPlain.getPskIdentity());
-			clientKeyExchange = new PSKClientKeyExchange(pskUtilPlain.getPskIdentity().getIdentity(), session.getPeer());
+			LOGGER.debug("Using PSK identity: {}", pskUtilPlain.getPskPrincipal());
+			session.setPeerIdentity(pskUtilPlain.getPskPrincipal());
+			clientKeyExchange = new PSKClientKeyExchange(pskUtilPlain.getPskPublicIdentity(), session.getPeer());
 			premasterSecret = generatePremasterSecretFromPSK(pskUtilPlain.getPreSharedKey(), null);
 			generateKeys(premasterSecret);
 			break;
 		case ECDHE_PSK:
 			PskUtil pskUtil = new PskUtil(sniEnabled, session, pskStore);
-			LOGGER.debug("Using PSK identity: {}", pskUtil.getPskIdentity());
-			session.setPeerIdentity(pskUtil.getPskIdentity());
-			clientKeyExchange = new EcdhPskClientKeyExchange(pskUtil.getPskIdentity().getIdentity(), ecdhe.getPublicKey(), session.getPeer());
+			LOGGER.debug("Using PSK identity: {}", pskUtil.getPskPrincipal());
+			session.setPeerIdentity(pskUtil.getPskPrincipal());
+			clientKeyExchange = new EcdhPskClientKeyExchange(pskUtil.getPskPublicIdentity(), ecdhe.getPublicKey(), session.getPeer());
 			byte[] otherSecret = ecdhe.getSecret(ephemeralServerPublicKey).getEncoded();
 			premasterSecret = generatePremasterSecretFromPSK(pskUtil.getPreSharedKey(), otherSecret);
 			generateKeys(premasterSecret);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchange.java
@@ -15,8 +15,6 @@
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
-import static org.eclipse.californium.elements.util.StandardCharsets.UTF_8;
-
 import java.net.InetSocketAddress;
 import java.security.PublicKey;
 import java.security.interfaces.ECPublicKey;
@@ -43,31 +41,26 @@ public final class EcdhPskClientKeyExchange extends ClientKeyExchange {
 	/**
 	 *See <a href="https://tools.ietf.org/html/rfc5489#section-2">RFC 5489</a>.
 	 */
-	private final byte[] identityEncoded;
-	/**
-	 *See <a href="https://tools.ietf.org/html/rfc5489#section-2">RFC 5489</a>.
-	 */
-	private final String identity;
+	private final PskPublicInformation identity;
 	private final byte[] pointEncoded;
 	
 	/**
 	 * Creates a new key exchange message for an identity hint and a public key.
 	 * 
-	 * @param hint PSK identity as clear text
+	 * @param identity PSK identity as public information
 	 * @param clientPublicKey ephemeral public key of client
 	 * @param peerAddress peer's address
 	 * @throws NullPointerException if either hint or clietPublicKey are {@code null}
 	 */
-	public EcdhPskClientKeyExchange(String hint, PublicKey clientPublicKey, InetSocketAddress peerAddress) {
+	public EcdhPskClientKeyExchange(PskPublicInformation identity, PublicKey clientPublicKey, InetSocketAddress peerAddress) {
 		super(peerAddress);
-		if (hint == null) {
+		if (identity == null) {
 			throw new NullPointerException("identity cannot be null");
 		}
 		if (clientPublicKey == null) {
 			throw new NullPointerException("ephemeral public key cannot be null");
 		}
-		this.identity = hint;
-		this.identityEncoded = hint.getBytes(UTF_8);
+		this.identity = identity;
 		ECPublicKey publicKey = (ECPublicKey) clientPublicKey;
 		ECPoint point = publicKey.getW();
 		ECParameterSpec params = publicKey.getParams();
@@ -78,29 +71,28 @@ public final class EcdhPskClientKeyExchange extends ClientKeyExchange {
 	/**
 	 * Creates a new key exchange message for an identity hint and a public key.
 	 * 
-	 * @param hintEncoded opaque encoded PSK identity hint for server
+	 * @param identityEncoded opaque encoded PSK identity hint for server
 	 * @param pointEncoded ephemeral public key of client (encoded point)
 	 * @param peerAddress peer's address
 	 * @throws NullPointerException if either hintEncoded or pointEncoded are {@code null}
 	 */
-	public EcdhPskClientKeyExchange(byte[] hintEncoded, byte[] pointEncoded, InetSocketAddress peerAddress) {
+	public EcdhPskClientKeyExchange(byte[] identityEncoded, byte[] pointEncoded, InetSocketAddress peerAddress) {
 		super(peerAddress);
-		if (hintEncoded ==null) {
+		if (identityEncoded ==null) {
 			throw new NullPointerException("identity cannot be null");
 		}
 		if (pointEncoded == null) {
 			throw new NullPointerException("epehemeral public key cannot be null");
 		}
-		this.identityEncoded = Arrays.copyOf(hintEncoded, hintEncoded.length);
-		this.identity = new String(this.identityEncoded,UTF_8);
+		this.identity = PskPublicInformation.fromByteArray(identityEncoded);
 		this.pointEncoded = Arrays.copyOf(pointEncoded, pointEncoded.length);
 	}
 
 	@Override
 	public byte[] fragmentToByteArray() {
 		DatagramWriter writer = new DatagramWriter();
-		writer.write(identityEncoded.length, IDENTITY_LENGTH_BITS);
-		writer.writeBytes(identityEncoded);
+		writer.write(identity.length(), IDENTITY_LENGTH_BITS);
+		writer.writeBytes(identity.getBytes());
 		writer.write(pointEncoded.length, LENGTH_BITS);
 		writer.writeBytes(pointEncoded);
 		return writer.toByteArray();
@@ -132,7 +124,7 @@ public final class EcdhPskClientKeyExchange extends ClientKeyExchange {
 
 	@Override
 	public int getMessageLength() {
-		return 3 + identityEncoded.length + pointEncoded.length;
+		return 3 + identity.length() + pointEncoded.length;
 	}
 
 	/**
@@ -149,7 +141,7 @@ public final class EcdhPskClientKeyExchange extends ClientKeyExchange {
 		StringBuilder sb = new StringBuilder();
 		sb.append(super.toString());
 		sb.append("\t\t Encoded identity value: ");
-		sb.append(StringUtil.byteArray2Hex(identityEncoded)).append(StringUtil.lineSeparator());;
+		sb.append(identity).append(StringUtil.lineSeparator());;
 		sb.append("\t\tEC Diffie-Hellman public value: ");		
 		sb.append(StringUtil.byteArray2Hex(pointEncoded));
 		sb.append(StringUtil.lineSeparator());
@@ -157,11 +149,11 @@ public final class EcdhPskClientKeyExchange extends ClientKeyExchange {
 	}		
 	
 	/**
-	 * This method returns the PSK identity as clear text.
+	 * This method returns the PSK identity as public information.
 	 * 
 	 * @return psk identity
 	 */
-	public String getIdentity() {
+	public PskPublicInformation getIdentity() {
 		return identity;
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PSKServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PSKServerKeyExchange.java
@@ -17,10 +17,7 @@
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
-import static org.eclipse.californium.elements.util.StandardCharsets.UTF_8;
-
 import java.net.InetSocketAddress;
-import java.util.Arrays;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
@@ -42,28 +39,19 @@ public final class PSKServerKeyExchange extends ServerKeyExchange {
 
 	// Members ////////////////////////////////////////////////////////
 
-	/**
-	 * The PSK identity MUST be first converted to a character string, and then
-	 * encoded to octets using UTF-8. See <a
-	 * href="http://tools.ietf.org/html/rfc4279#section-5.1">RFC 4279</a>.
-	 */
-	private final byte[] hintEncoded;
-
 	/** The hint in cleartext. */
-	private final String hint;
+	private final PskPublicInformation hint;
 
 	// Constructors ///////////////////////////////////////////////////
 	
-	public PSKServerKeyExchange(String hint, InetSocketAddress peerAddress) {
+	public PSKServerKeyExchange(PskPublicInformation hint, InetSocketAddress peerAddress) {
 		super(peerAddress);
 		this.hint = hint;
-		this.hintEncoded = hint.getBytes(UTF_8);
 	}
 	
 	private PSKServerKeyExchange(byte[] hintEncoded, InetSocketAddress peerAddress) {
 		super(peerAddress);
-		this.hintEncoded = Arrays.copyOf(hintEncoded, hintEncoded.length);
-		this.hint = new String(this.hintEncoded, UTF_8);
+		this.hint = PskPublicInformation.fromByteArray(hintEncoded);
 	}
 
 	// Methods ////////////////////////////////////////////////////////
@@ -72,7 +60,7 @@ public final class PSKServerKeyExchange extends ServerKeyExchange {
 	public int getMessageLength() {
 		// fixed: 2 bytes for the length field
 		// http://tools.ietf.org/html/rfc4279#section-2: opaque psk_identity_hint<0..2^16-1>
-		return 2 + hintEncoded.length;
+		return 2 + hint.length();
 	}
 
 	@Override
@@ -89,8 +77,8 @@ public final class PSKServerKeyExchange extends ServerKeyExchange {
 	public byte[] fragmentToByteArray() {
 		DatagramWriter writer = new DatagramWriter();
 		
-		writer.write(hintEncoded.length, IDENTITY_HINT_LENGTH_BITS);
-		writer.writeBytes(hintEncoded);
+		writer.write(hint.length(), IDENTITY_HINT_LENGTH_BITS);
+		writer.writeBytes(hint.getBytes());
 		
 		return writer.toByteArray();
 	}
@@ -106,7 +94,7 @@ public final class PSKServerKeyExchange extends ServerKeyExchange {
 	
 	// Getters and Setters ////////////////////////////////////////////
 
-	public String getHint() {
+	public PskPublicInformation getHint() {
 		return hint;
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PskPublicInformation.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PskPublicInformation.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import static org.eclipse.californium.elements.util.StandardCharsets.UTF_8;
+
+import java.util.Arrays;
+
+import org.eclipse.californium.elements.auth.PreSharedKeyIdentity;
+import org.eclipse.californium.elements.util.Bytes;
+import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
+
+/**
+ * Implementation of byte array based PSK public information (hint or identity).
+ * 
+ * Note: <a "https://tools.ietf.org/html/rfc4279#section-5.1">RFC 4279, Section
+ * 5.1</a> defines to use UTF-8 to encode the identities. However, some peers
+ * seems to use non UTF-8 encoded identities. This byte array based
+ * implementation allows to support such non-compliant clients. The string based
+ * identity is used for {@link PreSharedKeyIdentity}, therefore it's required to
+ * use {@link #PskPublicInformation(String, byte[])} to setup a proper name for
+ * such non-compliant peers in the
+ * {@link org.eclipse.californium.scandium.dtls.pskstore.BytesPskStore}. During
+ * the lookup of the secret key in the handshake, such a non-compliant identity
+ * is normalized with the identity provided by the store.
+ * 
+ * <pre>
+ * 
+ */
+public final class PskPublicInformation extends Bytes {
+
+	public static final PskPublicInformation EMPTY = new PskPublicInformation("");
+
+	private static final int MAX_LENGTH = 65535;
+
+	/**
+	 * {@code true}, if the byte array contains the string compliant encoded in
+	 * UTF-8.
+	 */
+	private boolean compliantEncoding;
+
+	/**
+	 * Public information as string. The "hint" or "identity".
+	 */
+	private String publicInfo;
+
+	/**
+	 * Create PSK public information from bytes (identity or hint).
+	 * 
+	 * Used by {@link #fromByteArray(byte[])} for received public information
+	 * (identity or hint).
+	 * 
+	 * @param publicInfoBytes PSK public information encoded as bytes. Identity
+	 *            or hint.
+	 * @throws NullPointerException if public information is {@code null}
+	 * @throws IllegalArgumentException if public information length is larger
+	 *             than {@link #MAX_LENGTH}.
+	 */
+	private PskPublicInformation(byte[] publicInfoBytes) {
+		this(new String(publicInfoBytes, UTF_8), publicInfoBytes);
+	}
+
+	/**
+	 * Create PSK public information from string (identity or hint).
+	 * 
+	 * @param publicInfo PSK public information as string. Identity or hint.
+	 * @throws NullPointerException if public information is {@code null}
+	 * @throws IllegalArgumentException if public information encoded in UTF-8
+	 *             is larger than {@link #MAX_LENGTH}.
+	 */
+	public PskPublicInformation(String publicInfo) {
+		super(publicInfo == null ? null : publicInfo.getBytes(UTF_8), MAX_LENGTH, false);
+		this.publicInfo = publicInfo;
+		this.compliantEncoding = true;
+	}
+
+	/**
+	 * Create PSK public information from string and bytes (identity or hint).
+	 * 
+	 * Enables to create public information for none-compliant encodings!
+	 * 
+	 * Note: Please use this with care! Prefer to fix the clients and use it
+	 * only as temporary work around!
+	 * 
+	 * @param publicInfo PSK public information as string. Identity or hint.
+	 * @param publicInfoBytes PSK public information encoded as bytes. Identity
+	 *            or hint.
+	 * @throws NullPointerException if one of the parameters are {@code null}
+	 * @throws IllegalArgumentException if public information encoded as bytes
+	 *             is larger than {@link #MAX_LENGTH}.
+	 */
+	public PskPublicInformation(String publicInfo, byte[] publicInfoBytes) {
+		super(publicInfoBytes, MAX_LENGTH, false);
+		this.publicInfo = publicInfo;
+		this.compliantEncoding = Arrays.equals(publicInfoBytes, publicInfo.getBytes(UTF_8));
+	}
+
+	/**
+	 * Normalize public information.
+	 * 
+	 * Overwrite the decoded string with the intended string. Intended to be
+	 * used during the PSK lookup and called, if a bytes-matching entry was
+	 * found. The normalized string could then be used to create a
+	 * {@link PreSharedKeyIdentity}.
+	 * 
+	 * @param publicInfo PSK public information as string. Identity or hint.
+	 * @throws NullPointerException if public information is {@code null}
+	 * @throws IllegalArgumentException if public information is empty.
+	 * @see PskStore#getKey(PskPublicInformation)
+	 * @see PskStore#getKey(org.eclipse.californium.scandium.util.ServerNames,
+	 *      PskPublicInformation)
+	 */
+	public void normalize(String publicInfo) {
+		if (publicInfo == null) {
+			throw new NullPointerException("public information must not be null");
+		}
+		if (publicInfo.isEmpty()) {
+			throw new IllegalArgumentException("public information must not be empty");
+		}
+		this.publicInfo = publicInfo;
+		this.compliantEncoding = Arrays.equals(getBytes(), publicInfo.getBytes(UTF_8));
+	}
+
+	/**
+	 * Check, if string is compliant encoded as bytes.
+	 * 
+	 * @return {@code true}, if encoding is compliant.
+	 */
+	public boolean isCompliantEncoding() {
+		return compliantEncoding;
+	}
+
+	/**
+	 * Get public information as string.
+	 * 
+	 * @return public information as string
+	 */
+	public String getPublicInfoAsString() {
+		return publicInfo;
+	}
+
+	@Override
+	public String toString() {
+		if (compliantEncoding) {
+			return publicInfo;
+		} else {
+			return publicInfo + "/" + getAsString();
+		}
+	}
+
+	/**
+	 * Create public information from received byte array.
+	 * 
+	 * @param byteArray received byte array
+	 * @return public information
+	 * @throws IllegalArgumentException if public information length is larger
+	 *             than {@link #MAX_LENGTH}.
+	 */
+	public static PskPublicInformation fromByteArray(byte[] byteArray) {
+		if (byteArray == null || byteArray.length == 0) {
+			return EMPTY;
+		}
+		return new PskPublicInformation(byteArray);
+	}
+
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/pskstore/InMemoryPskStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/pskstore/InMemoryPskStore.java
@@ -23,43 +23,68 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.californium.elements.util.Bytes;
+import org.eclipse.californium.scandium.dtls.PskPublicInformation;
 import org.eclipse.californium.scandium.util.ServerName;
-import org.eclipse.californium.scandium.util.ServerNames;
 import org.eclipse.californium.scandium.util.ServerName.NameType;
+import org.eclipse.californium.scandium.util.ServerNames;
 
 /**
  * An in-memory pre-shared key storage.
  * <p>
- * If you don't need to initiate connection,
- * you could just add identity/key with {@link #setKey(String, byte[])}.
- * If you need to initiate connection, 
- * you should add known peers with {@link #addKnownPeer(InetSocketAddress, String, byte[])}.
+ * If you don't need to initiate handshake/connection, you could just add
+ * identity/key with {@link #setKey(String, byte[])} or
+ * {@link #setKey(PskPublicInformation, byte[])}. If you need to initiate
+ * connection, you should add known peers with
+ * {@link #addKnownPeer(InetSocketAddress, String, byte[])} or
+ * {@link #addKnownPeer(InetSocketAddress, PskPublicInformation, byte[])}.
+ * </p>
+ * <p>
+ * If non-compliant encoded identities are used, please provide
+ * {@link PskPublicInformation#PskPublicInformation(String, byte[])} identities
+ * with the non-compliant encoded bytes and the intended string.
+ * </p>
  * <p>
  * To be used only for testing and evaluation. 
  * You are supposed to store your key in a secure way:
  * keeping them in-memory is not a good idea.
+ * </p>
  */
 public class InMemoryPskStore implements PskStore {
 
 	private static final ServerName GLOBAL_SCOPE = ServerName.from(NameType.UNDEFINED, Bytes.EMPTY);
 
-	private final Map<ServerName, Map<String, byte[]>> scopedKeys = new ConcurrentHashMap<>();
-	private final Map<InetSocketAddress, Map<ServerName, String>> scopedIdentities = new ConcurrentHashMap<>();
+	private static class Psk {
+
+		private final PskPublicInformation identity;
+		private final byte[] key;
+
+		private Psk(PskPublicInformation identity, byte[] key) {
+			this.identity = identity;
+			this.key = Arrays.copyOf(key, key.length);
+		}
+
+		private byte[] getKey() {
+			return Arrays.copyOf(key, key.length);
+		}
+	}
+
+	private final Map<ServerName, Map<PskPublicInformation, Psk>> scopedKeys = new ConcurrentHashMap<>();
+	private final Map<InetSocketAddress, Map<ServerName, PskPublicInformation>> scopedIdentities = new ConcurrentHashMap<>();
 
 	@Override
-	public byte[] getKey(final String identity) {
+	public byte[] getKey(final PskPublicInformation identity) {
 
 		if (identity == null) {
 			throw new NullPointerException("identity must not be null");
 		} else {
 			synchronized (scopedKeys) {
-				return getKeyFromMap(identity, scopedKeys.get(GLOBAL_SCOPE));
+				return getKeyFromMapAndNormalizeIdentity(identity, scopedKeys.get(GLOBAL_SCOPE));
 			}
 		}
 	}
 
 	@Override
-	public byte[] getKey(final ServerNames serverNames, final String identity) {
+	public byte[] getKey(final ServerNames serverNames, final PskPublicInformation identity) {
 
 		if (serverNames == null) {
 			return getKey(identity);
@@ -68,40 +93,54 @@ public class InMemoryPskStore implements PskStore {
 		} else {
 			synchronized (scopedKeys) {
 				for (ServerName serverName : serverNames) {
-					byte[] key = getKeyFromMap(identity, scopedKeys.get(serverName));
-					if (key != null) {
-						return key;
-					}
+					return getKeyFromMapAndNormalizeIdentity(identity, scopedKeys.get(serverName));
 				}
 				return null;
 			}
 		}
 	}
 
-	private static byte[] getKeyFromMap(final String identity, final Map<String, byte[]> keyMap) {
+	private static byte[] getKeyFromMapAndNormalizeIdentity(final PskPublicInformation identity,
+			final Map<PskPublicInformation, Psk> keyMap) {
 
-		byte[] result = null;
 		if (keyMap != null) {
-			byte[] key = keyMap.get(identity);
-			if (key != null) {
-				// defensive copy
-				result = Arrays.copyOf(key, key.length);
+			Psk psk = keyMap.get(identity);
+			if (psk != null) {
+				if (!psk.identity.isCompliantEncoding()) {
+					identity.normalize(psk.identity.getPublicInfoAsString());
+				}
+				return psk.getKey();
 			}
 		}
-		return result;
+		return null;
 	}
 
 	/**
 	 * Sets a key value for a given identity.
 	 * <p>
 	 * If the key already exists, it will be replaced.
+	 * </p>
 	 * 
-	 * @param identity
-	 *            the identity associated with the key
-	 * @param key
-	 *            the key used to authenticate the identity
+	 * @param identity the identity associated with the key
+	 * @param key the key used to authenticate the identity
+	 * @see #setKey(PskPublicInformation, byte[])
 	 */
 	public void setKey(final String identity, final byte[] key) {
+
+		setKey(new PskPublicInformation(identity), key, GLOBAL_SCOPE);
+	}
+
+	/**
+	 * Sets a key value for a given identity.
+	 * <p>
+	 * If the key already exists, it will be replaced.
+	 * </p>
+	 * 
+	 * @param identity the identity associated with the key
+	 * @param key the key used to authenticate the identity
+	 * @see #setKey(String, byte[])
+	 */
+	public void setKey(final PskPublicInformation identity, final byte[] key) {
 
 		setKey(identity, key, GLOBAL_SCOPE);
 	}
@@ -110,12 +149,31 @@ public class InMemoryPskStore implements PskStore {
 	 * Sets a key for an identity scoped to a virtual host.
 	 * <p>
 	 * If the key already exists, it will be replaced.
+	 * </p>
 	 * 
 	 * @param identity The identity to set the key for.
 	 * @param key The key to set for the identity.
-	 * @param virtualHost The virtual host to associate the identity and key with.
+	 * @param virtualHost The virtual host to associate the identity and key
+	 *            with.
+	 * @see #setKey(PskPublicInformation, byte[], String)
 	 */
 	public void setKey(final String identity, final byte[] key, final String virtualHost) {
+		setKey(new PskPublicInformation(identity), key, ServerName.fromHostName(virtualHost));
+	}
+
+	/**
+	 * Sets a key for an identity scoped to a virtual host.
+	 * <p>
+	 * If the key already exists, it will be replaced.
+	 * </p>
+	 * 
+	 * @param identity The identity to set the key for.
+	 * @param key The key to set for the identity.
+	 * @param virtualHost The virtual host to associate the identity and key
+	 *            with.
+	 * @see #setKey(String, byte[], String)
+	 */
+	public void setKey(final PskPublicInformation identity, final byte[] key, final String virtualHost) {
 		setKey(identity, key, ServerName.fromHostName(virtualHost));
 	}
 
@@ -123,12 +181,31 @@ public class InMemoryPskStore implements PskStore {
 	 * Sets a key for an identity scoped to a virtual host.
 	 * <p>
 	 * If the key already exists, it will be replaced.
+	 * </p>
 	 * 
 	 * @param identity The identity to set the key for.
 	 * @param key The key to set for the identity.
-	 * @param virtualHost The virtual host to associate the identity and key with.
+	 * @param virtualHost The virtual host to associate the identity and key
+	 *            with.
+	 * @see #setKey(PskPublicInformation, byte[], ServerName)
 	 */
 	public void setKey(final String identity, final byte[] key, final ServerName virtualHost) {
+		setKey(new PskPublicInformation(identity), key, virtualHost);
+	}
+
+	/**
+	 * Sets a key for an identity scoped to a virtual host.
+	 * <p>
+	 * If the key already exists, it will be replaced.
+	 * </p>
+	 * 
+	 * @param identity The identity to set the key for.
+	 * @param key The key to set for the identity.
+	 * @param virtualHost The virtual host to associate the identity and key
+	 *            with.
+	 * @see #setKey(String, byte[], ServerName)
+	 */
+	public void setKey(final PskPublicInformation identity, final byte[] key, final ServerName virtualHost) {
 
 		if (identity == null) {
 			throw new NullPointerException("identity must not be null");
@@ -138,12 +215,12 @@ public class InMemoryPskStore implements PskStore {
 			throw new NullPointerException("serverName must not be null");
 		} else {
 			synchronized (scopedKeys) {
-				Map<String, byte[]> keysForServerName = scopedKeys.get(virtualHost);
+				Map<PskPublicInformation, Psk> keysForServerName = scopedKeys.get(virtualHost);
 				if (keysForServerName == null) {
 					keysForServerName = new ConcurrentHashMap<>();
 					scopedKeys.put(virtualHost, keysForServerName);
 				}
-				keysForServerName.put(identity, Arrays.copyOf(key, key.length));
+				keysForServerName.put(identity, new Psk(identity, key));
 			}
 		}
 	}
@@ -152,13 +229,32 @@ public class InMemoryPskStore implements PskStore {
 	 * Adds a shared key for a peer.
 	 * <p>
 	 * If the key already exists, it will be replaced.
+	 * </p>
 	 * 
 	 * @param peerAddress the IP address and port to use the key for
 	 * @param identity the PSK identity
 	 * @param key the shared key
 	 * @throws NullPointerException if any of the parameters are {@code null}.
+	 * @see #addKnownPeer(InetSocketAddress, PskPublicInformation, byte[])
 	 */
 	public void addKnownPeer(final InetSocketAddress peerAddress, final String identity, final byte[] key) {
+		addKnownPeer(peerAddress, GLOBAL_SCOPE, new PskPublicInformation(identity), key);
+	}
+
+	/**
+	 * Adds a shared key for a peer.
+	 * <p>
+	 * If the key already exists, it will be replaced.
+	 * </p>
+	 * 
+	 * @param peerAddress the IP address and port to use the key for
+	 * @param identity the PSK identity
+	 * @param key the shared key
+	 * @throws NullPointerException if any of the parameters are {@code null}.
+	 * @see #addKnownPeer(InetSocketAddress, String, byte[])
+	 */
+	public void addKnownPeer(final InetSocketAddress peerAddress, final PskPublicInformation identity,
+			final byte[] key) {
 
 		addKnownPeer(peerAddress, GLOBAL_SCOPE, identity, key);
 	}
@@ -166,21 +262,43 @@ public class InMemoryPskStore implements PskStore {
 	/**
 	 * Adds a shared key for a virtual host on a peer.
 	 * <p>
-	 * If the key already exists, it will be replaced.
-	 * serverNames
+	 * If the key already exists, it will be replaced. serverNames
+	 * </p>
+	 * 
 	 * @param peerAddress the IP address and port to use the key for
 	 * @param virtualHost the virtual host to use the key for
 	 * @param identity the PSK identity
 	 * @param key the shared key
 	 * @throws NullPointerException if any of the parameters are {@code null}.
+	 * @see #addKnownPeer(InetSocketAddress, String, PskPublicInformation,
+	 *      byte[])
 	 */
-	public void addKnownPeer(final InetSocketAddress peerAddress, final String virtualHost, final String identity, final byte[] key) {
+	public void addKnownPeer(final InetSocketAddress peerAddress, final String virtualHost, final String identity,
+			final byte[] key) {
+		addKnownPeer(peerAddress, ServerName.fromHostName(virtualHost), new PskPublicInformation(identity), key);
+	}
+
+	/**
+	 * Adds a shared key for a virtual host on a peer.
+	 * <p>
+	 * If the key already exists, it will be replaced. serverNames
+	 * </p>
+	 * 
+	 * @param peerAddress the IP address and port to use the key for
+	 * @param virtualHost the virtual host to use the key for
+	 * @param identity the PSK identity
+	 * @param key the shared key
+	 * @throws NullPointerException if any of the parameters are {@code null}.
+	 * @see #addKnownPeer(InetSocketAddress, String, String, byte[])
+	 */
+	public void addKnownPeer(final InetSocketAddress peerAddress, final String virtualHost,
+			final PskPublicInformation identity, final byte[] key) {
 
 		addKnownPeer(peerAddress, ServerName.fromHostName(virtualHost), identity, key);
 	}
 
 	private void addKnownPeer(final InetSocketAddress peerAddress, final ServerName virtualHost,
-			final String identity, final byte[] key) {
+			final PskPublicInformation identity, final byte[] key) {
 
 		if (peerAddress == null) {
 			throw new NullPointerException("peer address must not be null");
@@ -192,7 +310,7 @@ public class InMemoryPskStore implements PskStore {
 			throw new NullPointerException("key must not be null");
 		} else {
 			synchronized (scopedKeys) {
-				Map<ServerName, String> identities = scopedIdentities.get(peerAddress);
+				Map<ServerName, PskPublicInformation> identities = scopedIdentities.get(peerAddress);
 				if (identities == null) {
 					identities = new ConcurrentHashMap<>();
 					scopedIdentities.put(peerAddress, identities);
@@ -204,7 +322,7 @@ public class InMemoryPskStore implements PskStore {
 	}
 
 	@Override
-	public String getIdentity(final InetSocketAddress peerAddress) {
+	public PskPublicInformation getIdentity(final InetSocketAddress peerAddress) {
 
 		if (peerAddress == null) {
 			throw new NullPointerException("address must not be null");
@@ -216,7 +334,7 @@ public class InMemoryPskStore implements PskStore {
 	}
 
 	@Override
-	public String getIdentity(final InetSocketAddress peerAddress, final ServerNames virtualHost) {
+	public PskPublicInformation getIdentity(final InetSocketAddress peerAddress, final ServerNames virtualHost) {
 
 		if (virtualHost == null) {
 			return getIdentity(peerAddress);
@@ -225,7 +343,7 @@ public class InMemoryPskStore implements PskStore {
 		} else {
 			synchronized (scopedKeys) {
 				for (ServerName serverName : virtualHost) {
-					String identity = getIdentityFromMap(serverName, scopedIdentities.get(peerAddress));
+					PskPublicInformation identity = getIdentityFromMap(serverName, scopedIdentities.get(peerAddress));
 					if (identity != null) {
 						return identity;
 					}
@@ -235,7 +353,8 @@ public class InMemoryPskStore implements PskStore {
 		}
 	}
 
-	private static String getIdentityFromMap(final ServerName virtualHost, final Map<ServerName, String> identities) {
+	private static PskPublicInformation getIdentityFromMap(final ServerName virtualHost,
+			final Map<ServerName, PskPublicInformation> identities) {
 
 		if (identities != null) {
 			return identities.get(virtualHost);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/pskstore/StaticPskStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/pskstore/StaticPskStore.java
@@ -19,6 +19,7 @@ package org.eclipse.californium.scandium.dtls.pskstore;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 
+import org.eclipse.californium.scandium.dtls.PskPublicInformation;
 import org.eclipse.californium.scandium.util.ServerNames;
 
 /**
@@ -33,7 +34,7 @@ import org.eclipse.californium.scandium.util.ServerNames;
 public class StaticPskStore implements PskStore {
 
 	private final byte[] key;
-	private final String fixedIdentity;
+	private final PskPublicInformation fixedIdentity;
 
 	/**
 	 * Creates a new store for an identity and key.
@@ -42,27 +43,43 @@ public class StaticPskStore implements PskStore {
 	 * @param key The (single) key for the identity.
 	 */
 	public StaticPskStore(final String identity, final byte[] key) {
+		this(new PskPublicInformation(identity), key);
+	}
+
+	/**
+	 * Creates a new store for an identity and key.
+	 * 
+	 * @param identity The (single) identity to always use.
+	 * @param key The (single) key for the identity.
+	 */
+	public StaticPskStore(final PskPublicInformation identity, final byte[] key) {
 		this.fixedIdentity = identity;
 		this.key = Arrays.copyOf(key, key.length);
 	}
 
 	@Override
-	public String getIdentity(final InetSocketAddress inetAddress) {
+	public PskPublicInformation getIdentity(final InetSocketAddress inetAddress) {
 		return fixedIdentity;
 	}
 
 	@Override
-	public String getIdentity(InetSocketAddress peerAddress, ServerNames virtualHost) {
+	public PskPublicInformation getIdentity(InetSocketAddress peerAddress, ServerNames virtualHost) {
 		return getIdentity(peerAddress);
 	}
 
 	@Override
-	public byte[] getKey(final String identity) {
+	public byte[] getKey(final PskPublicInformation identity) {
+		if (!fixedIdentity.equals(identity)) {
+			return null;
+		}
+		if (!fixedIdentity.isCompliantEncoding()) {
+			identity.normalize(fixedIdentity.getPublicInfoAsString());
+		}
 		return key;
 	}
 
 	@Override
-	public byte[] getKey(final ServerNames serverNames, final String identity) {
+	public byte[] getKey(final ServerNames serverNames, final PskPublicInformation identity) {
 		return getKey(identity);
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/util/PskUtil.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/util/PskUtil.java
@@ -21,6 +21,7 @@ import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
 import org.eclipse.californium.scandium.dtls.DTLSSession;
 import org.eclipse.californium.scandium.dtls.HandshakeException;
+import org.eclipse.californium.scandium.dtls.PskPublicInformation;
 import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,13 +30,15 @@ import org.slf4j.LoggerFactory;
  * Extracts psk credentials from the current {@code DTLSSession}.
  */
 public class PskUtil {
-	
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(PskUtil.class.getName());
-	
-	private byte[] psk;
-	
-	private PreSharedKeyIdentity pskIdentity;
-	
+
+	private byte[] pskSecret;
+
+	private PskPublicInformation pskIdentity;
+
+	private PreSharedKeyIdentity pskPrincipal;
+
 	/**
 	 * Retrieves preshared key identity and preshared key for the given dtls session and psk store.
 	 * 
@@ -53,68 +56,79 @@ public class PskUtil {
 			throw new NullPointerException("psk store cannot be null");
 		}
 		ServerNames virtualHost = session.getServerNames();
-		String identity = null;
 		if (sniEnabled && virtualHost != null) {
 			if (!session.isSniSupported()) {
-				LOGGER.warn("client is configured to use SNI but server does not support it, PSK authentication is likely to fail");
+				LOGGER.warn(
+						"client is configured to use SNI but server does not support it, PSK authentication is likely to fail");
 			}
 			// look up identity in scope of virtual host
 			String virtualHostName = session.getVirtualHost();
-			identity = pskStore.getIdentity(session.getPeer(), virtualHost);
-			if (identity == null) {
-				AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, session.getPeer());
+			pskIdentity = pskStore.getIdentity(session.getPeer(), virtualHost);
+			if (pskIdentity == null) {
+				AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE,
+						session.getPeer());
+				throw new HandshakeException(String.format("No Identity found for peer [address: %s, virtual host: %s]",
+						session.getPeer(), virtualHostName), alert);
+			}
+			this.pskSecret = pskStore.getKey(virtualHost, pskIdentity);
+			if (pskSecret == null) {
+				AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE,
+						session.getPeer());
 				throw new HandshakeException(
-						String.format("No Identity found for peer [address: %s, virtual host: %s]",
-								session.getPeer(), virtualHostName),
+						String.format("No pre-shared key found for [virtual host: %s, identity: %s]", virtualHostName,
+								pskIdentity),
 						alert);
 			}
-			this.psk = pskStore.getKey(virtualHost, identity);
-			if (psk == null) {
-				AlertMessage alert = new AlertMessage(AlertLevel.FATAL,	AlertDescription.HANDSHAKE_FAILURE, session.getPeer());
-				throw new HandshakeException(
-						String.format("No pre-shared key found for [virtual host: %s, identity: %s]",
-								virtualHostName, identity),
-						alert);
-			} 
-			this.pskIdentity = new PreSharedKeyIdentity(virtualHostName, identity);
+			this.pskPrincipal = new PreSharedKeyIdentity(virtualHostName, pskIdentity.getPublicInfoAsString());
 		} else {
-			identity = pskStore.getIdentity(session.getPeer());
-			if (identity == null) {
-				AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, session.getPeer());
+			pskIdentity = pskStore.getIdentity(session.getPeer());
+			if (pskIdentity == null) {
+				AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE,
+						session.getPeer());
 				throw new HandshakeException(
 						String.format("No Identity found for peer [address: %s]", session.getPeer()), alert);
 			}
-			this.psk = pskStore.getKey(identity);
-			if (psk == null) {
-				AlertMessage alert = new AlertMessage(AlertLevel.FATAL,	AlertDescription.HANDSHAKE_FAILURE, session.getPeer());
-				throw new HandshakeException(
-						String.format("No pre-shared key found for [identity: %s]", identity), alert);
+			this.pskSecret = pskStore.getKey(pskIdentity);
+			if (pskSecret == null) {
+				AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE,
+						session.getPeer());
+				throw new HandshakeException(String.format("No pre-shared key found for [identity: %s]", pskIdentity),
+						alert);
 			}
 			if (sniEnabled) {
-				this.pskIdentity = new PreSharedKeyIdentity(null, identity);
+				this.pskPrincipal = new PreSharedKeyIdentity(null, pskIdentity.getPublicInfoAsString());
 			} else {
-				this.pskIdentity = new PreSharedKeyIdentity(identity);
+				this.pskPrincipal = new PreSharedKeyIdentity(pskIdentity.getPublicInfoAsString());
 			}
-		}		
+		}
 	}
-	
+
 	/**
-	 * This method returns the psk identity either for the virtual host hosted on session's peer 
-	 * or for the session's peer itself.
+	 * This method returns the psk principal either for the virtual host hosted
+	 * on session's peer or for the session's peer itself.
 	 * 
 	 * @return {@code PreSharedKeyIdentity}
 	 */
-	public PreSharedKeyIdentity getPskIdentity() {
+	public PreSharedKeyIdentity getPskPrincipal() {
+		return this.pskPrincipal;
+	}
+
+	/**
+	 * Returns the PSK identity.
+	 * 
+	 * @return identity as public information
+	 */
+	public PskPublicInformation getPskPublicIdentity() {
 		return this.pskIdentity;
 	}
-	
+
 	/**
-	 * This method returns the pre shared key for the current 
+	 * This method returns the pre shared key for the current
 	 * {@code DTLSSession} and {@code PskStore}.
 	 * 
 	 * @return byte array
 	 */
-	public byte[] getPreSharedKey(){
-		return this.psk;
+	public byte[] getPreSharedKey() {
+		return this.pskSecret;
 	}
 }

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -105,6 +105,7 @@ import org.eclipse.californium.scandium.dtls.InMemoryConnectionStore;
 import org.eclipse.californium.scandium.dtls.InMemorySessionCache;
 import org.eclipse.californium.scandium.dtls.PSKClientKeyExchange;
 import org.eclipse.californium.scandium.dtls.ProtocolVersion;
+import org.eclipse.californium.scandium.dtls.PskPublicInformation;
 import org.eclipse.californium.scandium.dtls.Record;
 import org.eclipse.californium.scandium.dtls.SessionId;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
@@ -142,7 +143,7 @@ public class DTLSConnectorTest {
 
 	private static final int CLIENT_CONNECTION_STORE_CAPACITY = 5;
 	private static final int SERVER_CONNECTION_STORE_CAPACITY = 2;
-	private static final String CLIENT_IDENTITY = "Client_identity";
+	private static final PskPublicInformation CLIENT_IDENTITY = new PskPublicInformation("Client_identity");
 	private static final String CLIENT_IDENTITY_SECRET = "secretPSK";
 	private static final int MAX_TIME_TO_WAIT_SECS = 2;
 
@@ -178,7 +179,7 @@ public class DTLSConnectorTest {
 		InMemoryPskStore pskStore = new InMemoryPskStore() {
 
 			@Override
-			public byte[] getKey(String identity) {
+			public byte[] getKey(PskPublicInformation identity) {
 				if (pskStoreLatency != 0) {
 					try {
 						Thread.sleep(pskStoreLatency);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchangeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchangeTest.java
@@ -35,14 +35,14 @@ public class EcdhPskClientKeyExchangeTest {
 	EcdhPskClientKeyExchange msg;
 	InetSocketAddress peerAddress = new InetSocketAddress(5000);
 	byte[] ephemeralKeyPointEncoded;
-	String identity;
+	PskPublicInformation identity;
 	
 	@Before
 	public void setUp() throws Exception {
 
 		SupportedGroup usableGroup = SupportedGroup.secp256r1;
 		ECDHECryptography ecdhe = ECDHECryptography.fromNamedCurveId(usableGroup.getId());
-		msg = new EcdhPskClientKeyExchange("ID", ecdhe.getPublicKey(), peerAddress);
+		msg = new EcdhPskClientKeyExchange(new PskPublicInformation("ID"), ecdhe.getPublicKey(), peerAddress);
 		ephemeralKeyPointEncoded = msg.getEncodedPoint();
 		identity = msg.getIdentity();
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchangeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchangeTest.java
@@ -40,7 +40,8 @@ public class EcdhPskServerKeyExchangeTest {
 	public void setUp() throws Exception {
 
 		SupportedGroup usableGroup = SupportedGroup.secp256r1;
-		msg = new EcdhPskServerKeyExchange(ECDHECryptography.fromNamedCurveId(usableGroup.getId()),
+		msg = new EcdhPskServerKeyExchange(PskPublicInformation.EMPTY,
+				ECDHECryptography.fromNamedCurveId(usableGroup.getId()),
 				new Random(),
 				new Random(),
 				usableGroup.getId(),

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
@@ -174,7 +174,7 @@ public class HandshakerTest {
 		// THEN the ChangeCipherSpec message is not processed until the missing message arrives
 		assertFalse(handshaker.changeCipherSpecProcessed.get());
 		handshaker.expectChangeCipherSpecMessage();
-		PSKClientKeyExchange msg = new PSKClientKeyExchange("id", endpoint);
+		PSKClientKeyExchange msg = new PSKClientKeyExchange(new PskPublicInformation("id"), endpoint);
 		msg.setMessageSeq(0);
 		Record keyExchangeRecord = getRecordForMessage(0, 6, msg, senderAddress);
 		handshaker.processMessage(keyExchangeRecord);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/PskPublicInformationTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/PskPublicInformationTest.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation
+ *******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import static org.eclipse.californium.elements.util.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.californium.elements.util.Bytes;
+import org.eclipse.californium.scandium.category.Small;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+
+@Category(Small.class)
+public class PskPublicInformationTest {
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testCompliantPublicInformation() {
+		PskPublicInformation information = new PskPublicInformation("test");
+		assertTrue("is compliant", information.isCompliantEncoding());
+	}
+
+	@Test
+	public void testPublicInformationEquals() {
+		PskPublicInformation information1 = new PskPublicInformation("test1");
+		PskPublicInformation information2 = new PskPublicInformation("test1");
+		assertEquals(information1, information2);
+		PskPublicInformation information3 = new PskPublicInformation("test2");
+		assertFalse(information1.equals(information3));
+	}
+
+	@Test
+	public void testPublicInformationNormalize() {
+		PskPublicInformation information = new PskPublicInformation("none", "compliant".getBytes(UTF_8));
+		assertFalse(information.isCompliantEncoding());
+		information.normalize("compliant");
+		assertTrue(information.isCompliantEncoding());
+	}
+
+	@Test
+	public void testPublicInformationNormalizeNull() {
+		PskPublicInformation information = new PskPublicInformation("none", "compliant".getBytes(UTF_8));
+		assertFalse(information.isCompliantEncoding());
+		exception.expect(NullPointerException.class);
+		exception.expectMessage("public information must not be null");
+		information.normalize(null);
+	}
+
+	@Test
+	public void testPublicInformationNormalizeEmpty() {
+		PskPublicInformation information = new PskPublicInformation("none", "compliant".getBytes(UTF_8));
+		assertFalse(information.isCompliantEncoding());
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("public information must not be empty");
+		information.normalize("");
+	}
+
+	@Test
+	public void testPublicInformationNull() {
+		exception.expect(NullPointerException.class);
+		exception.expectMessage("bytes must not be null");
+		new PskPublicInformation((String) null);
+	}
+
+	@Test
+	public void testPublicInformationFromByteArrayNull() {
+		PskPublicInformation information = PskPublicInformation.fromByteArray(null);
+		assertEquals(PskPublicInformation.EMPTY, information);
+	}
+
+	@Test
+	public void testPublicInformationFromByteArrayEmpty() {
+		PskPublicInformation information = PskPublicInformation.fromByteArray(Bytes.EMPTY);
+		assertEquals(PskPublicInformation.EMPTY, information);
+	}
+
+	@Test
+	public void testPublicInformationFromByteArray() {
+		PskPublicInformation information1 = PskPublicInformation.fromByteArray("test".getBytes(UTF_8));
+		PskPublicInformation information2 = new PskPublicInformation("test");
+		assertEquals(information1, information2);
+	}
+
+}


### PR DESCRIPTION
Support PSK clients with non-compliant encoding.
Fixes issue #902 .

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>