### PR TITLE
Add cid generator.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
@@ -444,19 +444,22 @@ public class CoapServer implements ServerInterface {
 		private static final String SPACE = "                                               "; // 47 until line end
 		private final String VERSION = CoapServer.class.getPackage().getImplementationVersion()!=null ?
 				"Cf "+CoapServer.class.getPackage().getImplementationVersion() : SPACE;
-		private final String msg = new StringBuilder()
-			.append("************************************************************\n")
-			.append("CoAP RFC 7252").append(SPACE.substring(VERSION.length())).append(VERSION).append("\n")
-			.append("************************************************************\n")
-			.append("This server is using the Eclipse Californium (Cf) CoAP framework\n")
-			.append("published under EPL+EDL: http://www.eclipse.org/californium/\n")
-			.append("\n")
-			.append("(c) 2014, 2015, 2016 Institute for Pervasive Computing, ETH Zurich and others\n")
-			.append("************************************************************")
-			.toString();
+		private final String msg;
 
 		public RootResource() {
 			super("");
+			String nodeId = config.getString(NetworkConfig.Keys.DTLS_CONNECTION_ID_NODE_ID);
+			StringBuilder builder = new StringBuilder()
+					.append("************************************************************\n").append("CoAP RFC 7252")
+					.append(SPACE.substring(VERSION.length())).append(VERSION).append("\n")
+					.append("************************************************************\n")
+					.append("This server is using the Eclipse Californium (Cf) CoAP framework\n")
+					.append("published under EPL+EDL: http://www.eclipse.org/californium/\n").append("\n");
+			if (nodeId != null && !nodeId.isEmpty()) {
+				builder.append("node id = ").append(nodeId).append("\n\n");
+			}
+			msg = builder.append("(c) 2014, 2015, 2016 Institute for Pervasive Computing, ETH Zurich and others\n")
+					.append("************************************************************").toString();
 		}
 
 		@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -260,6 +260,14 @@ public final class NetworkConfig {
 		 * </ul>
 		 */
 		public static final String DTLS_CONNECTION_ID_LENGTH = "DTLS_CONNECTION_ID_LENGTH";
+		/**
+		 * If {@link #DTLS_CONNECTION_ID_LENGTH} enables the use of a connection
+		 * id, this node id could be used to configure the generation of
+		 * connection ids specific for node in a multi-node deployment
+		 * (cluster). The value is used as first byte in generated connection
+		 * ids.
+		 */
+		public static final String DTLS_CONNECTION_ID_NODE_ID = "DTLS_CONNECTION_ID_NODE_ID";
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
@@ -166,6 +166,7 @@ public class NetworkConfigDefaults {
 	 * The default value is "" for disabled.
 	 */
 	public static final String DEFAULT_DTLS_CONNECTION_ID_LENGTH = ""; // disabled
+	public static final String DEFAULT_DTLS_CONNECTION_ID_NODE_ID = ""; // disabled
 
 	public static void setDefaults(final NetworkConfig config) {
 
@@ -242,6 +243,7 @@ public class NetworkConfigDefaults {
 		config.setLong(Keys.SECURE_SESSION_TIMEOUT, DEFAULT_SECURE_SESSION_TIMEOUT);
 		config.setLong(Keys.DTLS_AUTO_RESUME_TIMEOUT, DEFAULT_DTLS_AUTO_RESUME_TIMEOUT);
 		config.setString(Keys.DTLS_CONNECTION_ID_LENGTH, DEFAULT_DTLS_CONNECTION_ID_LENGTH);
+		config.setString(Keys.DTLS_CONNECTION_ID_NODE_ID, DEFAULT_DTLS_CONNECTION_ID_NODE_ID);
 
 		config.setInt(Keys.MULTICAST_BASE_MID, DEFAULT_MULTICAST_BASE_MID);
 	}

--- a/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureNatTest.java
+++ b/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureNatTest.java
@@ -46,8 +46,10 @@ import org.eclipse.californium.examples.NatUtil;
 import org.eclipse.californium.integration.test.util.CoapsNetworkRule;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.dtls.ConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.DebugConnectionStore;
 import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
+import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -122,7 +124,7 @@ public class SecureNatTest {
 	@Test
 	public void testSecureGetWithCID() throws Exception {
 
-		createSecureServer(MatcherMode.STRICT, 4);
+		createSecureServer(MatcherMode.STRICT, new SingleNodeConnectionIdGenerator(4));
 		createNat();
 
 		CoapClient client = new CoapClient(uri);
@@ -139,7 +141,7 @@ public class SecureNatTest {
 
 	@Test
 	public void testMultipleSecureGetWithCID() throws Exception {
-		createSecureServer(MatcherMode.STRICT, 4);
+		createSecureServer(MatcherMode.STRICT, new SingleNodeConnectionIdGenerator(4));
 		createNat();
 
 		CoapClient client = new CoapClient(uri);
@@ -148,7 +150,7 @@ public class SecureNatTest {
 		assertNotNull("Response not received", coapResponse);
 
 		for (int count = 0; count < NUM_OF_CLIENTS; ++count) {
-			createClientEndpoint(MatcherMode.STRICT, 4);
+			createClientEndpoint(MatcherMode.STRICT, new SingleNodeConnectionIdGenerator(4));
 		}
 		testMultipleSecureGet(0, 0, null);
 
@@ -163,7 +165,7 @@ public class SecureNatTest {
 
 	@Test
 	public void testMultipleSecureGetWithCIDAndResumption() throws Exception {
-		createSecureServer(MatcherMode.STRICT, 4);
+		createSecureServer(MatcherMode.STRICT, new SingleNodeConnectionIdGenerator(4));
 		createNat();
 
 		int overallResumes = 0;
@@ -175,7 +177,7 @@ public class SecureNatTest {
 		assertNotNull("Response not received", coapResponse);
 
 		for (int count = 0; count < NUM_OF_CLIENTS; ++count) {
-			createClientEndpoint(MatcherMode.STRICT, 4);
+			createClientEndpoint(MatcherMode.STRICT, new SingleNodeConnectionIdGenerator(4));
 		}
 		testMultipleSecureGet(0, overallResumes, resumeEndpoints);
 
@@ -192,7 +194,7 @@ public class SecureNatTest {
 
 	@Test
 	public void testSecureGetWithMixedAddressesAndCID() throws Exception {
-		createSecureServer(MatcherMode.STRICT, 4);
+		createSecureServer(MatcherMode.STRICT, new SingleNodeConnectionIdGenerator(4));
 		createNat();
 
 		CoapClient client = new CoapClient(uri);
@@ -201,7 +203,7 @@ public class SecureNatTest {
 		assertNotNull("Response not received", coapResponse);
 
 		for (int count = 0; count < NUM_OF_CLIENTS; ++count) {
-			createClientEndpoint(MatcherMode.STRICT, 4);
+			createClientEndpoint(MatcherMode.STRICT, new SingleNodeConnectionIdGenerator(4));
 		}
 		testMultipleSecureGet(0, 0, null);
 
@@ -216,7 +218,7 @@ public class SecureNatTest {
 
 	@Test
 	public void testSecureGetWithMixedAddressesCIDAndResumption() throws Exception {
-		createSecureServer(MatcherMode.STRICT, 4);
+		createSecureServer(MatcherMode.STRICT, new SingleNodeConnectionIdGenerator(4));
 		createNat();
 
 		int overallResumes = 0;
@@ -228,7 +230,7 @@ public class SecureNatTest {
 		assertNotNull("Response not received", coapResponse);
 
 		for (int count = 0; count < NUM_OF_CLIENTS; ++count) {
-			createClientEndpoint(MatcherMode.STRICT, 4);
+			createClientEndpoint(MatcherMode.STRICT, new SingleNodeConnectionIdGenerator(4));
 		}
 		testMultipleSecureGet(0, overallResumes, resumeEndpoints);
 
@@ -317,7 +319,7 @@ public class SecureNatTest {
 		}
 	}
 
-	private void createSecureServer(MatcherMode mode, Integer cidLength) throws IOException {
+	private void createSecureServer(MatcherMode mode, ConnectionIdGenerator cidGenerator) throws IOException {
 		setupNetworkConfig(mode);
 
 		DtlsConnectorConfig dtlsConfig = new DtlsConnectorConfig.Builder()
@@ -326,11 +328,10 @@ public class SecureNatTest {
 				.setServerOnly(true)
 				.setReceiverThreadCount(2)
 				.setConnectionThreadCount(2)
-				.setConnectionIdLength(cidLength)
+				.setConnectionIdGenerator(cidGenerator)
 				.setPskStore(pskStore).build();
 
 		connections = new DebugConnectionStore(
-				dtlsConfig.getConnectionIdLength(),
 				dtlsConfig.getMaxConnections(),
 				dtlsConfig.getStaleConnectionThreshold(),
 				null);
@@ -351,13 +352,13 @@ public class SecureNatTest {
 		uri = serverEndpoint.getUri() + "/" + TARGET;
 
 		// prepare secure client endpoint
-		clientEndpoint = createClientEndpoint(mode, cidLength);
+		clientEndpoint = createClientEndpoint(mode, cidGenerator);
 		EndpointManager.getEndpointManager().setDefaultEndpoint(clientEndpoint);
 		System.out.println("coap-server " + uri);
 		System.out.println("coap-client " + clientEndpoint.getUri());
 	}
 
-	private CoapEndpoint createClientEndpoint(MatcherMode mode, Integer cidLength) throws IOException {
+	private CoapEndpoint createClientEndpoint(MatcherMode mode, ConnectionIdGenerator cidGenerator) throws IOException {
 		setupNetworkConfig(mode);
 
 		String tag = "client";
@@ -372,7 +373,7 @@ public class SecureNatTest {
 				.setLoggingTag(tag)
 				.setReceiverThreadCount(2)
 				.setConnectionThreadCount(2)
-				.setConnectionIdLength(cidLength)
+				.setConnectionIdGenerator(cidGenerator)
 				.setPskStore(pskStore).build();
 
 		DTLSConnector clientConnector = new DTLSConnector(clientdtlsConfig);

--- a/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureObserveTest.java
+++ b/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureObserveTest.java
@@ -62,6 +62,8 @@ import org.eclipse.californium.examples.NatUtil;
 import org.eclipse.californium.integration.test.util.CoapsNetworkRule;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.dtls.ConnectionIdGenerator;
+import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -215,7 +217,7 @@ public class SecureObserveTest {
 	@Test
 	public void testSecureObserveServerAddressChangedWithCid() throws Exception {
 
-		createSecureServer(MatcherMode.STRICT, 6);
+		createSecureServer(MatcherMode.STRICT, new SingleNodeConnectionIdGenerator(6));
 
 		createInverseNat();
 
@@ -485,14 +487,14 @@ public class SecureObserveTest {
 				is(instanceOf(EndpointMismatchException.class)));
 	}
 
-	private void createSecureServer(MatcherMode mode, Integer cidLength) {
+	private void createSecureServer(MatcherMode mode, ConnectionIdGenerator cidGenerator) {
 		pskStore = new TestUtilPskStore(IDENITITY, KEY.getBytes());
 		DtlsConnectorConfig dtlsConfig = new DtlsConnectorConfig.Builder()
 				.setAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0))
 				.setLoggingTag("server")
 				.setReceiverThreadCount(2)
 				.setConnectionThreadCount(2)
-				.setConnectionIdLength(cidLength)
+				.setConnectionIdGenerator(cidGenerator)
 				.setPskStore(pskStore).build();
 
 		NetworkConfig config = network.createTestConfig()
@@ -523,7 +525,7 @@ public class SecureObserveTest {
 				.setLoggingTag("client")
 				.setReceiverThreadCount(2)
 				.setConnectionThreadCount(2)
-				.setConnectionIdLength(cidLength)
+				.setConnectionIdGenerator(cidGenerator)
 				.setPskStore(pskStore).build();
 		clientConnector = new DTLSConnector(clientdtlsConfig);
 		builder = new CoapEndpoint.Builder();

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
@@ -149,7 +149,8 @@ public class BenchmarkClient {
 			config.setInt(Keys.MAX_MESSAGE_SIZE, DEFAULT_BLOCK_SIZE);
 			config.setInt(Keys.PREFERRED_BLOCK_SIZE, DEFAULT_BLOCK_SIZE);
 			config.setInt(Keys.MAX_ACTIVE_PEERS, 10);
-			config.setInt(Keys.DTLS_CONNECTION_ID_LENGTH, 0); // support it, but don't use for incoming traffic
+			config.setInt(Keys.DTLS_AUTO_RESUME_TIMEOUT, 0);
+			config.setInt(Keys.DTLS_CONNECTION_ID_LENGTH, 0); // support it, but don't use it
 			config.setInt(Keys.MAX_PEER_INACTIVITY_PERIOD, 60 * 60 * 24); // 24h
 			config.setInt(Keys.TCP_CONNECTION_IDLE_TIMEOUT, 60 * 60 * 12); // 12h
 			config.setInt(Keys.TCP_CONNECT_TIMEOUT, 30 * 1000); // 20s

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
@@ -77,6 +77,7 @@ public class ExtendedTestServer extends AbstractTestServer {
 			config.setInt(Keys.PREFERRED_BLOCK_SIZE, DEFAULT_BLOCK_SIZE);
 			config.setInt(Keys.EXCHANGE_LIFETIME, 24700); // 24.7s instead of 247s
 			config.setInt(Keys.MAX_ACTIVE_PEERS, 20000);
+			config.setInt(Keys.DTLS_AUTO_RESUME_TIMEOUT, 0);
 			config.setInt(Keys.DTLS_CONNECTION_ID_LENGTH, 6);
 			config.setInt(Keys.MAX_PEER_INACTIVITY_PERIOD, 60 * 60 * 24); // 24h
 			config.setInt(Keys.TCP_CONNECTION_IDLE_TIMEOUT, 60 * 60 * 12); // 12h

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/PlugtestChecker.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/PlugtestChecker.java
@@ -86,6 +86,8 @@ public class PlugtestChecker {
 			config.setInt(Keys.NOTIFICATION_CHECK_INTERVAL_TIME, 30000);
 			config.setInt(Keys.HEALTH_STATUS_INTERVAL, 300);
 			config.setInt(Keys.MAX_ACTIVE_PEERS, 10);
+			config.setInt(Keys.DTLS_AUTO_RESUME_TIMEOUT, 0);
+			config.setInt(Keys.DTLS_CONNECTION_ID_LENGTH, 0); // support it, but don't use it
 		}
 
 	};

--- a/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/ClientInitializer.java
+++ b/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/ClientInitializer.java
@@ -47,6 +47,7 @@ import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.CertificateType;
 import org.eclipse.californium.scandium.dtls.pskstore.StringPskStore;
+import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.util.ServerNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -191,7 +192,7 @@ public class ClientInitializer {
 					random.nextBytes(rid);
 					dtlsConfig.setPskStore(new PlugPskStore(StringUtil.byteArray2Hex(rid)));
 				}
-				dtlsConfig.setConnectionIdLength(cidLength);
+				dtlsConfig.setConnectionIdGenerator(new SingleNodeConnectionIdGenerator(cidLength));
 				dtlsConfig.setClientOnly();
 				dtlsConfig.setMaxConnections(maxPeers);
 				dtlsConfig.setConnectionThreadCount(senderThreads);

--- a/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/PlugtestClient.java
+++ b/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/PlugtestClient.java
@@ -70,6 +70,8 @@ public class PlugtestClient {
 			config.setInt(Keys.NOTIFICATION_CHECK_INTERVAL_TIME, 30000);
 			config.setInt(Keys.HEALTH_STATUS_INTERVAL, 300);
 			config.setInt(Keys.MAX_ACTIVE_PEERS, 10);
+			config.setInt(Keys.DTLS_AUTO_RESUME_TIMEOUT, 0);
+			config.setInt(Keys.DTLS_CONNECTION_ID_LENGTH, 0); // support it, but don't use it
 		}
 		
 	};

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
@@ -42,6 +42,8 @@ import org.eclipse.californium.elements.util.SslContextUtil;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.CertificateType;
+import org.eclipse.californium.scandium.dtls.MultiNodeConnectionIdGenerator;
+import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.StringPskStore;
 import org.eclipse.californium.scandium.util.ServerNames;
@@ -253,8 +255,13 @@ public abstract class AbstractTestServer extends CoapServer {
 					int dtlsReceiverThreads = dtlsConfig.getInt(Keys.NETWORK_STAGE_RECEIVER_THREAD_COUNT);
 					int maxPeers = dtlsConfig.getInt(Keys.MAX_ACTIVE_PEERS);
 					Integer cidLength = dtlsConfig.getOptInteger(Keys.DTLS_CONNECTION_ID_LENGTH);
+					Integer cidNode = dtlsConfig.getOptInteger(Keys.DTLS_CONNECTION_ID_NODE_ID);
 					DtlsConnectorConfig.Builder dtlsConfigBuilder = new DtlsConnectorConfig.Builder();
-					dtlsConfigBuilder.setConnectionIdLength(cidLength);
+					if (cidLength != null && cidLength > 4 && cidNode != null) {
+						dtlsConfigBuilder.setConnectionIdGenerator(new MultiNodeConnectionIdGenerator(cidNode, cidLength));
+					} else {
+						dtlsConfigBuilder.setConnectionIdGenerator(new SingleNodeConnectionIdGenerator(cidLength));
+					}
 					dtlsConfigBuilder.setAddress(bindToAddress);
 					dtlsConfigBuilder.setSupportedCipherSuites(CipherSuite.TLS_PSK_WITH_AES_128_CCM_8,
 							CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8, CipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA256,

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/PlugtestServer.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/PlugtestServer.java
@@ -79,6 +79,7 @@ public class PlugtestServer extends AbstractTestServer {
 
 		@Override
 		public void applyDefaults(NetworkConfig config) {
+			config.setInt(Keys.DTLS_AUTO_RESUME_TIMEOUT, 0);
 			config.setInt(Keys.DTLS_CONNECTION_ID_LENGTH, 6);
 			config.setInt(Keys.MAX_RESOURCE_BODY_SIZE, DEFAULT_MAX_RESOURCE_SIZE);
 			config.setInt(Keys.MAX_MESSAGE_SIZE, DEFAULT_BLOCK_SIZE);

--- a/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/CredentialsUtil.java
+++ b/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/CredentialsUtil.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.eclipse.californium.elements.util.SslContextUtil;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.CertificateType;
+import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.InMemoryPskStore;
 
@@ -143,7 +144,7 @@ public class CredentialsUtil {
 				} catch (NumberFormatException e) {
 					System.err.println("'" + value + "' is no number! Use cid-lenght default " + DEFAULT_CID_LENGTH);
 				}
-				builder.setConnectionIdLength(cidLength);
+				builder.setConnectionIdGenerator(new SingleNodeConnectionIdGenerator(cidLength));
 				if (cidLength == 0) {
 					System.out.println("Enable cid support");
 				} else {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -47,6 +47,7 @@ import java.util.List;
 import org.eclipse.californium.elements.DtlsEndpointContext;
 import org.eclipse.californium.elements.util.SslContextUtil;
 import org.eclipse.californium.scandium.dtls.CertificateType;
+import org.eclipse.californium.scandium.dtls.ConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.SessionCache;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
@@ -277,9 +278,13 @@ public final class DtlsConnectorConfig {
 	private String loggingTag;
 
 	/**
-	 * Enables use of connection id. 
+	 * Connection id generator. {@code null}, if connection id is not supported.
+	 * The generator may only support the use of a connection id without using
+	 * it by itself. In that case
+	 * {@link ConnectionIdGenerator#useConnectionId()} will return
+	 * {@code false}.
 	 */
-	private Integer connectionIdLength;
+	private ConnectionIdGenerator connectionIdGenerator;
 
 	private DtlsConnectorConfig() {
 		// empty
@@ -431,13 +436,16 @@ public final class DtlsConnectorConfig {
 	}
 
 	/**
-	 * Gets connection ID length.
+	 * Gets connection ID generator.
 	 * 
-	 * @return length of connection id. 0 for support connection id, but not
-	 *         using it. {@code null} for no supported.
+	 * @return connection id generator. {@code null} for not supported. The
+	 *         returned generator may only support the use of a connection id
+	 *         without using it by itself. In that case
+	 *         {@link ConnectionIdGenerator#useConnectionId()} will return
+	 *         {@code false}.
 	 */
-	public Integer getConnectionIdLength() {
-		return connectionIdLength;
+	public ConnectionIdGenerator getConnectionIdGenerator() {
+		return connectionIdGenerator;
 	}
 
 	/**
@@ -751,9 +759,9 @@ public final class DtlsConnectorConfig {
 		cloned.verifyPeersOnResumptionThreshold = verifyPeersOnResumptionThreshold;
 		cloned.useNoServerSessionId = useNoServerSessionId;
 		cloned.loggingTag = loggingTag;
-		cloned.connectionIdLength = connectionIdLength;
 		cloned.useAntiReplayFilter = useAntiReplayFilter;
 		cloned.useWindowFilter = useWindowFilter;
+		cloned.connectionIdGenerator = connectionIdGenerator;
 		return cloned;
 	}
 
@@ -1555,18 +1563,17 @@ public final class DtlsConnectorConfig {
 		}
 
 		/**
-		 * Sets the connection ID length.
+		 * Sets the connection id generator.
 		 * 
-		 * @param connectionIdLength length of connection id. 0 for support
-		 *            connection id, but not using it. {@code null} for no
-		 *            supported.
+		 * @param connectionIdGenerator connection id generator. {@code null}
+		 *            for not supported. The generator may only support the use
+		 *            of a connection id without using it by itself. In that
+		 *            case {@link ConnectionIdGenerator#useConnectionId()} must
+		 *            return {@code false}.
 		 * @return this builder for command chaining.
 		 */
-		public Builder setConnectionIdLength(final Integer connectionIdLength) {
-			if (connectionIdLength != null && connectionIdLength < 0) {
-				throw new IllegalArgumentException("cid length must be at least 0");
-			}
-			config.connectionIdLength = connectionIdLength;
+		public Builder setConnectionIdGenerator(ConnectionIdGenerator connectionIdGenerator) {
+			config.connectionIdGenerator = connectionIdGenerator;
 			return this;
 		}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -369,7 +369,7 @@ public class ClientHandshaker extends Handshaker {
 								message.getPeer()));
 			}
 		}
-		if (connectionIdLength != null) {
+		if (connectionIdGenerator != null) {
 			ConnectionIdExtension extension = serverHello.getConnectionIdExtension();
 			if (extension != null) {
 				ConnectionId connectionId = extension.getConnectionId();
@@ -722,9 +722,9 @@ public class ClientHandshaker extends Handshaker {
 	}
 
 	protected void addConnectionId(final ClientHello helloMessage) {
-		if (connectionIdLength != null) {
+		if (connectionIdGenerator != null) {
 			final ConnectionId connectionId;
-			if (connectionIdLength > 0) {
+			if (connectionIdGenerator.useConnectionId()) {
 				// use the already created unique cid
 				connectionId = getConnection().getConnectionId();
 			} else {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ConnectionIdGenerator.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ConnectionIdGenerator.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Achim Kraus (Bosch Software Innovations GmbH) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import org.eclipse.californium.elements.util.DatagramReader;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+
+/**
+ * Connection id generator.
+ * 
+ * Responsible for generating ID which identifies scandium connections in store.
+ * 
+ * By default, DTLS defined that IP address and port of the peer are used to
+ * identify the DTLS Connection. The DTLS connection ID draft defines a way to
+ * identify connection using Connection ID and so supports environments where IP
+ * address/port changes. See <a href=
+ * "https://tools.ietf.org/html/draft-ietf-tls-dtls-connection-id-03">draft-ietf-tls-dtls-connection-id-03</a>.
+ * 
+ * The draft enables the peers to chose the level of support or usage. The dtls
+ * client peer informs the dtls server peer about its preference using a new
+ * HELLO_EXTENSION in it's CLIENT_HELLO.
+ * <p>
+ * The dtls client can chose:
+ * <dl>
+ * <dt>client doesn't support it</dt>
+ * <dd>the new extension is not included in the client hello</dd>
+ * <dt>client supports it (but doesn't use it)</dt>
+ * <dd>the new extension with an empty connection id (0 length) is included in
+ * the client hello</dd>
+ * <dt>client uses it</dt>
+ * <dd>the new extension with a non-empty connection id is included in the
+ * client hello</dd>
+ * </dl>
+ * <p>
+ * If the client doesn't support it, the server must reply with a server hello
+ * without the new hello extension, regardless of the configuration.
+ * <p>
+ * If the client supports or uses it, the server can chose.
+ * <dl>
+ * <dt>server doesn't support it</dt>
+ * <dd>the new extension is not included in the server hello</dd>
+ * <dt>server supports it (but doesn't use it)</dt>
+ * <dd>the new extension with an empty connection id (0 length) is included in
+ * the server hello</dd>
+ * <dt>server uses it</dt>
+ * <dd>the new extension with a non-empty connection id is included in the
+ * server hello</dd>
+ * </dl>
+ * <p>
+ * The behavior of a peer within the above rules could be configured using
+ * {@link DtlsConnectorConfig.Builder#setConnectionIdGenerator(ConnectionIdGenerator)}.
+ * <dl>
+ * <dt>do not support it</dt>
+ * <dd>use a {@code null} as connection id generator</dd>
+ * <dt>support it (but doesn't use it)</dt>
+ * <dd>use a {@link ConnectionIdGenerator}, which returns {@code false} on
+ * {@link #useConnectionId()}</dd>
+ * <dt>use it</dt>
+ * <dd>use a {@link ConnectionIdGenerator}, which returns {@code true} on
+ * {@link #useConnectionId()} and generates and reads connection ids.</dd>
+ * </dl>
+ */
+public interface ConnectionIdGenerator {
+
+	/**
+	 * Indicates, if connection ids are used or just supported.
+	 * 
+	 * @return {@code true}, if a connection is used, {@code false}, if only a
+	 *         connection id from the other peer is supported.
+	 */
+	boolean useConnectionId();
+
+	/**
+	 * Creates a connection id.
+	 * 
+	 * The caller must take care to use only unique connection ids. In cases
+	 * where the generated connection id is already in use, it's intended to
+	 * create a next connection id calling this method again.
+	 * 
+	 * @return created connection id or {@code null}, if this generator only
+	 *         supports connection ids from the other peer.
+	 */
+	ConnectionId createConnectionId();
+
+	/**
+	 * Read connection id from record header bytes.
+	 * 
+	 * @param reader reader with header bytes at the position of the connection
+	 *            id.
+	 * @return read connection id or {@code null}, if this generator only
+	 *         supports connection ids from the other peer.
+	 */
+	ConnectionId read(DatagramReader reader);
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DebugConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DebugConnectionStore.java
@@ -31,9 +31,6 @@ public final class DebugConnectionStore extends InMemoryConnectionStore {
 	/**
 	 * Creates a store based on given configuration parameters.
 	 * 
-	 * @param cidLength connection id length. If {@code null} or {@code 0}, the
-	 *            number of bytes required for the provided capacity plus
-	 *            {@link #DEFAULT_EXTRA_CID_LENGTH} is used.
 	 * @param capacity the maximum number of connections the store can manage
 	 * @param threshold the period of time of inactivity (in seconds) after
 	 *            which a connection is considered stale and can be evicted from
@@ -43,9 +40,8 @@ public final class DebugConnectionStore extends InMemoryConnectionStore {
 	 *            {@link ClientSessionCache}, restore connection from the cache
 	 *            and mark them to resume.
 	 */
-	public DebugConnectionStore(final Integer cidLength, final int capacity, final long threshold,
-			final SessionCache sessionCache) {
-		super(cidLength, capacity, threshold, sessionCache);
+	public DebugConnectionStore(final int capacity, final long threshold, final SessionCache sessionCache) {
+		super(capacity, threshold, sessionCache);
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -148,7 +148,7 @@ public abstract class Handshaker {
 	 * The configured connection id length. {@code null}, not supported,
 	 * {@code 0} supported but not used.
 	 */
-	protected final Integer connectionIdLength;
+	protected final ConnectionIdGenerator connectionIdGenerator;
 
 	/**
 	 * The current sequence number (in the handshake message called message_seq)
@@ -259,7 +259,7 @@ public abstract class Handshaker {
 		this.session = session;
 		this.recordLayer = recordLayer;
 		this.connection = connection;
-		this.connectionIdLength = config.getConnectionIdLength();
+		this.connectionIdGenerator = config.getConnectionIdGenerator();
 		this.maxFragmentedHandshakeMessageLength = config.getMaxFragmentedHandshakeMessageLength();
 		this.maxDeferredProcessedApplicationDataMessages = config.getMaxDeferredProcessedApplicationDataMessages();
 		this.deferredApplicationData = new ArrayList<RawData>(maxDeferredProcessedApplicationDataMessages);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/MultiNodeConnectionIdGenerator.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/MultiNodeConnectionIdGenerator.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Achim Kraus (Bosch Software Innovations GmbH) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import java.util.Random;
+
+import org.eclipse.californium.elements.util.DatagramReader;
+
+/**
+ * Connection id generator for multiple nodes systems (cluster).
+ * 
+ * Encodes node id into first byte of generated connection id. The node id must
+ * be unique in the cluster, to ensure, that other nodes of the cluster don't
+ * generate the same connection id.
+ */
+public class MultiNodeConnectionIdGenerator implements ConnectionIdGenerator {
+
+	private final Random random = new Random(System.currentTimeMillis());
+	/**
+	 * Node id. Must be unique in cluster.
+	 */
+	private final int nodeId;
+	/**
+	 * Length of connection id.
+	 */
+	private final int connectionIdLength;
+
+	/**
+	 * Create new connection id generator for multiple nodes.
+	 * 
+	 * @param nodeId node id of this node. The lowest byte must be unique in the
+	 *            cluster, to ensure, that other nodes of the cluster don't
+	 *            generate the same connection id.
+	 * @param connectionIdLength length of connection id
+	 * @throws IllegalArgumentException if length is less than 2 bytes
+	 */
+	public MultiNodeConnectionIdGenerator(int nodeId, int connectionIdLength) {
+		if (connectionIdLength < 2) {
+			throw new IllegalArgumentException("cid length must be at least 2 bytes!");
+		}
+		this.nodeId = nodeId;
+		this.connectionIdLength = connectionIdLength;
+	}
+
+	@Override
+	public boolean useConnectionId() {
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * Places the {@link #nodeId} into the first byte of the connection id.
+	 */
+	@Override
+	public ConnectionId createConnectionId() {
+		byte[] cidBytes = new byte[connectionIdLength];
+		random.nextBytes(cidBytes);
+		cidBytes[0] = (byte) nodeId;
+		return new ConnectionId(cidBytes);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * Returns {@code null}, if {@link #nodeId} doesn't match the first byte of
+	 * the connection id.
+	 */
+	@Override
+	public ConnectionId read(DatagramReader reader) {
+		byte[] cidBytes = reader.readBytes(connectionIdLength);
+		if ((cidBytes[0] & 0xff) != nodeId) {
+			return null;
+		}
+		return new ConnectionId(cidBytes);
+	}
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
@@ -178,7 +178,7 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 				} else {
 					this.serverHello = serverHello;
 					serverRandom = serverHello.getRandom();
-					if (connectionIdLength != null) {
+					if (connectionIdGenerator != null) {
 						ConnectionIdExtension extension = serverHello.getConnectionIdExtension();
 						if (extension != null) {
 							ConnectionId connectionId = extension.getConnectionId();

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumptionSupportingConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumptionSupportingConnectionStore.java
@@ -30,28 +30,37 @@ import java.util.List;
 public interface ResumptionSupportingConnectionStore {
 
 	/**
-	 * Get connection id length.
+	 * Attach connection id generator.
 	 * 
-	 * return connection id length
+	 * Must be called before {@link #put(Connection)}.
+	 * 
+	 * @param connectionIdGenerator connection id generator. If {@code null} a
+	 *            default connection id generator is created.
+	 * @throws IllegalStateException if {@link #attach(ConnectionIdGenerator)}
+	 *             was already called before.
 	 */
-	public int getConnectionIdLength();
+	void attach(ConnectionIdGenerator connectionIdGenerator);
 
 	/**
 	 * Puts a connection into the store.
 	 * 
 	 * The connection is primary associated with its connection id
 	 * {@link Connection#getConnectionId()}. If the connection doesn't have a
-	 * connection id, a randomly unique connection id is assigned. If the
-	 * connection has also a peer address and/or a established session, it get's
-	 * associated with that. It removes also an other connection from these
+	 * connection id, a unique connection id created with the
+	 * {@link #attach(ConnectionIdGenerator)} is assigned. If the connection has
+	 * also a peer address and/or a established session, it get's associated
+	 * with that as well. It removes also an other connection from these
 	 * associations.
+	 * 
+	 * Note: {@link #attach(ConnectionIdGenerator)} must be called before!
 	 * 
 	 * @param connection the connection to store
 	 * @return {@code true} if the connection could be stored, {@code false},
 	 *         otherwise (e.g. because the store's capacity is exhausted)
 	 * @throws IllegalStateException if the connection is not executing, the
 	 *             connection ids are exhausted, or the connection id is empty
-	 *             or in use!
+	 *             or in use, or the connection id generator is not
+	 *             {@link #attach(ConnectionIdGenerator)} before!
 	 * @see #get(ConnectionId)
 	 * @see #get(InetSocketAddress)
 	 * @see #find(SessionId)

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -713,12 +713,12 @@ public class ServerHandshaker extends Handshaker {
 			}
 		}
 
-		if (connectionIdLength != null) {
+		if (connectionIdGenerator != null) {
 			ConnectionIdExtension connectionIdExtension = clientHello.getConnectionIdExtension();
 			if (connectionIdExtension != null) {
 				session.setWriteConnectionId(connectionIdExtension.getConnectionId());
 				final ConnectionId connectionId;
-				if (connectionIdLength > 0) {
+				if (connectionIdGenerator.useConnectionId()) {
 					// use the already created unique cid
 					connectionId = getConnection().getConnectionId();
 				} else {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SingleNodeConnectionIdGenerator.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SingleNodeConnectionIdGenerator.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Achim Kraus (Bosch Software Innovations GmbH) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import java.util.Random;
+
+import org.eclipse.californium.elements.util.DatagramReader;
+
+/**
+ * Connection id generator for single node systems (no cluster).
+ */
+public class SingleNodeConnectionIdGenerator implements ConnectionIdGenerator {
+
+	private final Random random = new Random(System.currentTimeMillis());
+	/**
+	 * Length of connection id.
+	 */
+	private final int connectionIdLength;
+
+	/**
+	 * Create new connection id generator.
+	 * 
+	 * @param connectionIdLength length of connection id. {@code 0} to support
+	 *            connection id of the other peer, but not using it for this
+	 *            peer.
+	 * @throws IllegalArgumentException if length is less than 0 bytes
+	 */
+	public SingleNodeConnectionIdGenerator(int connectionIdLength) {
+		if (connectionIdLength < 0) {
+			throw new IllegalArgumentException("cid length must not be less than 0 bytes!");
+		}
+		this.connectionIdLength = connectionIdLength;
+	}
+
+	@Override
+	public boolean useConnectionId() {
+		return connectionIdLength > 0;
+	}
+
+	@Override
+	public ConnectionId createConnectionId() {
+		if (useConnectionId()) {
+			byte[] cidBytes = new byte[connectionIdLength];
+			random.nextBytes(cidBytes);
+			return new ConnectionId(cidBytes);
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public ConnectionId read(DatagramReader reader) {
+		if (useConnectionId()) {
+			return new ConnectionId(reader.readBytes(connectionIdLength));
+		} else {
+			return null;
+		}
+	}
+}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -160,7 +160,7 @@ public class ConnectorHelper {
 		serverConfig = builder.build();
 
 		serverSessionCache = new InMemorySessionCache();
-		serverConnectionStore = new DebugConnectionStore(serverConfig.getConnectionIdLength(), SERVER_CONNECTION_STORE_CAPACITY, 5 * 60, serverSessionCache); // connection timeout 5mins
+		serverConnectionStore = new DebugConnectionStore(SERVER_CONNECTION_STORE_CAPACITY, 5 * 60, serverSessionCache); // connection timeout 5mins
 		serverConnectionStore.setTag("server");
 
 		server = new DTLSConnector(serverConfig, serverConnectionStore);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorStartStopTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorStartStopTest.java
@@ -117,7 +117,7 @@ public class DTLSConnectorStartStopTest {
 	@Before
 	public void setUp() throws IOException, GeneralSecurityException {
 		testLogTag = testLogTagHead + testLogTagCounter++;
-		clientConnectionStore = new DebugConnectionStore(null, CLIENT_CONNECTION_STORE_CAPACITY, 60, clientSessionCache);
+		clientConnectionStore = new DebugConnectionStore(CLIENT_CONNECTION_STORE_CAPACITY, 60, clientSessionCache);
 		clientConnectionStore.setTag(testLogTag + "-client");
 		InetSocketAddress clientEndpoint = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 		DtlsConnectorConfig.Builder builder = newStandardClientConfigBuilder(clientEndpoint)

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -173,7 +173,7 @@ public class DTLSConnectorTest {
 
 		serverRawDataProcessor = new MessageCapturingProcessor();
 		serverSessionCache = new InMemorySessionCache();
-		serverConnectionStore = new InMemoryConnectionStore(null, SERVER_CONNECTION_STORE_CAPACITY, 5 * 60, serverSessionCache); // connection timeout 5mins
+		serverConnectionStore = new InMemoryConnectionStore(SERVER_CONNECTION_STORE_CAPACITY, 5 * 60, serverSessionCache); // connection timeout 5mins
 		serverRawDataChannel = new SimpleRawDataChannel(serverRawDataProcessor);
 
 		InMemoryPskStore pskStore = new InMemoryPskStore() {
@@ -565,6 +565,8 @@ public class DTLSConnectorTest {
 
 		// WHEN starting a new handshake (epoch 0) reusing the same client IP
 		clientConfig = newStandardConfig(clientEndpoint);
+		clientConnectionStore = new InMemoryConnectionStore(CLIENT_CONNECTION_STORE_CAPACITY, 60);
+		clientConnectionStore.setTag("client");
 		client = new DTLSConnector(clientConfig, clientConnectionStore);
 
 		// THEN assert that the handshake succeeds and a session is established
@@ -957,6 +959,8 @@ public class DTLSConnectorTest {
 			.setLoggingTag("client")
 			.setPskStore(new StaticPskStore(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()))
 			.build();
+		clientConnectionStore = new InMemoryConnectionStore(CLIENT_CONNECTION_STORE_CAPACITY, 60);
+		clientConnectionStore.setTag("client");
 		client = new DTLSConnector(clientConfig, clientConnectionStore);
 		givenAnEstablishedSession();
 
@@ -978,6 +982,8 @@ public class DTLSConnectorTest {
 			.setIdentity(DtlsTestTools.getClientPrivateKey(), DtlsTestTools.getClientCertificateChain(), CertificateType.X_509)
 			.setTrustStore(DtlsTestTools.getTrustedCertificates())
 			.build();
+		clientConnectionStore = new InMemoryConnectionStore(CLIENT_CONNECTION_STORE_CAPACITY, 60);
+		clientConnectionStore.setTag("client");
 		client = new DTLSConnector(clientConfig, clientConnectionStore);
 		givenAnEstablishedSession();
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStoreTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStoreTest.java
@@ -44,6 +44,7 @@ public class InMemoryConnectionStoreTest {
 	@Before
 	public void setUp() throws Exception {
 		store = new InMemoryConnectionStore(INITIAL_CAPACITY, 1000);
+		store.attach(null);
 		con = newConnection(50L);
 		sessionId = con.getEstablishedSession().getSessionIdentifier();
 	}
@@ -100,7 +101,7 @@ public class InMemoryConnectionStoreTest {
 		// GIVEN an empty connection store with a cached session shared by another node
 		SessionCache sessionCache = new InMemorySessionCache();
 		sessionCache.put(con.getEstablishedSession());
-		store = new InMemoryConnectionStore(null, INITIAL_CAPACITY, 1000, sessionCache);
+		store = new InMemoryConnectionStore(INITIAL_CAPACITY, 1000, sessionCache);
 
 		// WHEN retrieving the connection for the given peer
 		Connection connectionWithPeer = store.find(sessionId);
@@ -119,7 +120,8 @@ public class InMemoryConnectionStoreTest {
 		// and a (local) connection based on this session
 		SessionCache sessionCache = new InMemorySessionCache();
 		sessionCache.put(con.getEstablishedSession());
-		store = new InMemoryConnectionStore(null, INITIAL_CAPACITY, 1000, sessionCache);
+		store = new InMemoryConnectionStore(INITIAL_CAPACITY, 1000, sessionCache);
+		store.attach(null);
 		store.put(con);
 		store.putEstablishedSession(con.getEstablishedSession(), con);
 		InetSocketAddress peerAddress = con.getPeerAddress();


### PR DESCRIPTION
Use cid to support unique cids in cluster nodes.
Enables also to generate cids with encoded flexible length.

Uses alternative `attach` approach.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>