### PR TITLE
OSCORE: Improved ID Context handling and general fixes

### DIFF
--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/Decryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/Decryptor.java
@@ -29,7 +29,6 @@ import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Request;
-import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.cose.Encrypt0Message;
 
 import com.upokecenter.cbor.CBORObject;
@@ -55,6 +54,9 @@ public abstract class Decryptor {
 	 */
 	private static final Logger LOGGER = LoggerFactory.getLogger(Decryptor.class.getName());
 
+	/**
+	 * Empty option set
+	 */
 	protected static final OptionSet EMPTY = new OptionSet();
 
 	/**
@@ -75,17 +77,18 @@ public abstract class Decryptor {
 		boolean isRequest = message instanceof Request;
 		byte[] nonce = null;
 		byte[] partialIV = null;
+		byte[] aad = null;
 
 		if (isRequest) {
 
-			CBORObject tmp = enc.findAttribute(HeaderKeys.PARTIAL_IV);
+			CBORObject piv = enc.findAttribute(HeaderKeys.PARTIAL_IV);
 
-			if (tmp == null) {
+			if (piv == null) {
 				LOGGER.error("Decryption failed: no partialIV in request");
 				throw new OSException(ErrorDescriptions.DECRYPTION_FAILED);
 			} else {
 
-				partialIV = tmp.GetByteString();
+				partialIV = piv.GetByteString();
 				partialIV = expandToIntSize(partialIV);
 				seq = ByteBuffer.wrap(partialIV).getInt();
 				
@@ -94,6 +97,7 @@ public abstract class Decryptor {
 
 				nonce = OSSerializer.nonceGeneration(partialIV, ctx.getRecipientId(), ctx.getCommonIV(),
 						ctx.getIVLength());
+				aad = OSSerializer.serializeAAD(CoAP.VERSION, ctx.getAlg(), seq, ctx.getRecipientId(), message.getOptions());
 			}
 		} else {
 			if (seqByToken == null) {
@@ -101,29 +105,33 @@ public abstract class Decryptor {
 				throw new OSException(ErrorDescriptions.DECRYPTION_FAILED);
 			}
 
-			CBORObject tmp = enc.findAttribute(HeaderKeys.PARTIAL_IV);
-
-			if (tmp == null) {
-
-				// this should use the partialIV that arrived in the request and
-				// not the response
-				seq = seqByToken;
-				partialIV = ByteBuffer.allocate(INTEGER_BYTES).putInt(seqByToken).array();
+			CBORObject piv = enc.findAttribute(HeaderKeys.PARTIAL_IV);
+		
+			//Sequence number taken from original request
+			seq = seqByToken;
+			
+			if (piv == null) {
+				//Use the partialIV that arrived in the original request (response has no partial IV)
+				
+				partialIV = ByteBuffer.allocate(INTEGER_BYTES).putInt(seq).array();
 				nonce = OSSerializer.nonceGeneration(partialIV,	ctx.getSenderId(), ctx.getCommonIV(), 
 						ctx.getIVLength());
 			} else {
-
-				partialIV = tmp.GetByteString();
+				//Since the response contains a partial IV use it for nonce calculation
+				
+				partialIV = piv.GetByteString();
 				partialIV = expandToIntSize(partialIV);
-				seq = ByteBuffer.wrap(partialIV).getInt();
 				nonce = OSSerializer.nonceGeneration(partialIV, ctx.getRecipientId(), ctx.getCommonIV(),
 						ctx.getIVLength());
 			}
+			
+			//Nonce calculation uses partial IV in response (if present).
+			//AAD calculation always uses partial IV (seq. nr.) of original request.  
+			aad = OSSerializer.serializeAAD(CoAP.VERSION, ctx.getAlg(), seq, ctx.getSenderId(), message.getOptions());
 		}
 
 		byte[] plaintext = null;
 		byte[] key = ctx.getRecipientKey();
-		byte[] aad = serializeAAD(message, ctx, seq);
 
 		enc.setExternal(aad);
 			
@@ -141,6 +149,12 @@ public abstract class Decryptor {
 		return plaintext;
 	}
 
+	/**
+	 * @param partialIV partial IV to expand
+	 * @return partial IV as byte array length of int
+	 * 
+	 * @throws OSException if the partial IV is longer than length of int
+	 */
 	private static byte[] expandToIntSize(byte[] partialIV) throws OSException {
 		if (partialIV.length > INTEGER_BYTES) {
 			LOGGER.error("The partial IV is: " + partialIV.length + " long, " + INTEGER_BYTES + " was expected");
@@ -171,32 +185,12 @@ public abstract class Decryptor {
 	}
 
 	/**
-	 * Prepare the AAD.
-	 * 
-	 * @param message the message
-	 * @param ctx the OSCore context
-	 * @param seq the sequence number
-	 * 
-	 * @return the serialized AAD
-	 */
-	protected static byte[] serializeAAD(Message message, OSCoreCtx ctx, int seq) {
-		if (message instanceof Request) {
-			Request r = (Request) message;
-			return OSSerializer.serializeReceiveRequestAAD(CoAP.VERSION, seq, ctx, r.getOptions());
-		} else if (message instanceof Response) {
-			Response r = (Response) message;
-			return OSSerializer.serializeReceiveResponseAAD(CoAP.VERSION, seq, ctx, r.getOptions());
-		}
-		return null;
-	}
-
-	/**
 	 * Decompress the message.
 	 * 
 	 * @param cipherText the encrypted data
 	 * @param message the received message
 	 * @return the Encrypt0Message
-	 * @throws OSException
+	 * @throws OSException if OSCORE option fails to decode
 	 */
 	protected static Encrypt0Message decompression(byte[] cipherText, Message message) throws OSException {
 		Encrypt0Message enc = new Encrypt0Message(false, true);
@@ -222,7 +216,7 @@ public abstract class Decryptor {
 	 * 
 	 * @param message the received message
 	 * @param enc the Encrypt0Message object
-	 * @throws OSException
+	 * @throws OSException if OSCORE option fails to decode
 	 */
 	private static void decodeObjectSecurity(Message message, Encrypt0Message enc) throws OSException {
 		byte[] total = message.getOptions().getOscore();
@@ -230,7 +224,7 @@ public abstract class Decryptor {
 		/**
 		 * If the OSCORE option value is a zero length byte array
 		 * it represents a byte array of length 1 with a byte 0x00
-		 * See https://tools.ietf.org/html/draft-ietf-core-object-security-16#page-33 point 4  
+		 * See https://tools.ietf.org/html/draft-ietf-core-object-security-16#section-2  
 		 */
 		if(total.length == 0) {
 			total = new byte[] { 0x00 };
@@ -240,12 +234,14 @@ public abstract class Decryptor {
 
 		int n = flagByte & 0x07;
 		int k = flagByte & 0x08;
-		int h = flagByte & 0xa6;
+		int h = flagByte & 0x10;
 
 		byte[] partialIV = null;
 		byte[] kid = null;
+		byte[] contextID = null;
 		int index = 1;
 
+		//Parsing Partial IV
 		if (n > 0) {
 			try {
 				partialIV = Arrays.copyOfRange(total, index, index + n);
@@ -256,19 +252,27 @@ public abstract class Decryptor {
 			}
 		}
 
-		if (h == 16) {
+		//Parsing KID Context
+		if (h != 0) {
 			int s = total[index];
-			index += 1;
+
+			contextID = Arrays.copyOfRange(total, index + 1, index + 1 + s);
+
+			index += s + 1;
 
 			if (s > 0) {
-				LOGGER.error("Kidcontext is included, but it is not supported. We ignore it and continue processing.");
+				System.out.print("Received KID Context: 0x");
+				for(int i = 0 ; i < contextID.length ; i++) {
+					System.out.print(String.format("%02X", contextID[i])); }
+				System.out.println("");
 			} else {
 				LOGGER.error("Kid context is missing from message when it is expected.");
 				throw new OSException(ErrorDescriptions.FAILED_TO_DECODE_COSE);
 			}
 		}
 
-		if (k == 8) {
+		//Parsing KID
+		if (k != 0) {
 			kid = Arrays.copyOfRange(total, index, total.length);
 		} else {
 			if (message instanceof Request) {
@@ -277,12 +281,18 @@ public abstract class Decryptor {
 			}
 		}
 
+		//Adding parsed data to Encrypt0Message object
 		try {
 			if (partialIV != null) {
 				enc.addAttribute(HeaderKeys.PARTIAL_IV, CBORObject.FromObject(partialIV), Attribute.UNPROTECTED);
 			}
 			if (kid != null) {
 				enc.addAttribute(HeaderKeys.KID, CBORObject.FromObject(kid), Attribute.UNPROTECTED);
+			}
+			//COSE Header parameter for KID Context defined with label 10
+			//https://www.iana.org/assignments/cose/cose.xhtml
+			if (contextID != null) {
+				enc.addAttribute(CBORObject.FromObject(10), CBORObject.FromObject(contextID), Attribute.UNPROTECTED);
 			}
 		} catch (CoseException e) {
 			LOGGER.error("COSE processing of message failed.");

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ErrorDescriptions.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ErrorDescriptions.java
@@ -57,6 +57,7 @@ public final class ErrorDescriptions {
 	public static final String ILLEGAL_PAYLOAD_MARKED = "Payload marker found with zero-length payload";
 	public static final String STRING_NULL = "String is null";
 	public static final String CONTEXT_NULL = "Context is null";
+	public static final String ALGORITHM_NOT_DEFINED = "Algorithm not defined";
 
 	public static final String CANNOT_CREATE_ERROR_MESS = ("Cannot create error message for this error");
 

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestEncryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestEncryptor.java
@@ -14,13 +14,13 @@
  *    Joakim Brorsson
  *    Ludwig Seitz (RISE SICS)
  *    Tobias Andersson (RISE SICS)
+ *    Rikard Höglund (RISE SICS)
  *    
  ******************************************************************************/
 package org.eclipse.californium.oscore;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.cose.Encrypt0Message;
@@ -57,8 +57,7 @@ public class RequestEncryptor extends Encryptor {
 
 		OptionSet options = request.getOptions();
 		byte[] confidential = OSSerializer.serializeConfidentialData(options, request.getPayload(), realCode);
-		byte[] aad = serializeAAD(request, ctx, false);
-		Encrypt0Message enc = prepareCOSEStructure(confidential, aad);
+		Encrypt0Message enc = prepareCOSEStructure(confidential);
 		byte[] cipherText = encryptAndEncode(enc, ctx, request, false);
 		compression(ctx, cipherText, request, false);
 

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseEncryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseEncryptor.java
@@ -14,13 +14,13 @@
  *    Joakim Brorsson
  *    Ludwig Seitz (RISE SICS)
  *    Tobias Andersson (RISE SICS)
+ *    Rikard Höglund (RISE SICS)
  *    
  ******************************************************************************/
 package org.eclipse.californium.oscore;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.cose.Encrypt0Message;
@@ -57,8 +57,7 @@ public class ResponseEncryptor extends Encryptor {
 		OptionSet options = response.getOptions();
 
 		byte[] confidential = OSSerializer.serializeConfidentialData(options, response.getPayload(), realCode);
-		byte[] aad = serializeAAD(response, ctx, newPartialIV);
-		Encrypt0Message enc = prepareCOSEStructure(confidential, aad);
+		Encrypt0Message enc = prepareCOSEStructure(confidential);
 		byte[] cipherText = encryptAndEncode(enc, ctx, response, newPartialIV);
 		compression(ctx, cipherText, response, newPartialIV);
 

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/AllJUnitTests.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/AllJUnitTests.java
@@ -21,9 +21,14 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+/**
+ * Class to launch all JUnit tests defined for OSCORE
+ *
+ */
 @RunWith(Suite.class)
-@SuiteClasses({ ByteIdTest.class, HashMapCtxDBTest.class, OptionJuggleTest.class, OSCoreCtxTest.class, OSCoreTest.class,
-		OSSerializerTest.class, OSCoreServerClientTest.class, OSCoreObserveTest.class })
+@SuiteClasses({ ByteIdTest.class, HashMapCtxDBTest.class, OptionJuggleTest.class, OSCoreCtxTest.class,
+	OSCoreTest.class, OSSerializerTest.class, OSCoreServerClientTest.class, OSCoreObserveTest.class,
+	EncryptorTest.class, DecryptorTest.class })
 public class AllJUnitTests {
 
 }

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/DecryptorTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/DecryptorTest.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2018 RISE SICS and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Rikard Höglund (RISE SICS)
+ *    
+ ******************************************************************************/
+package org.eclipse.californium.oscore;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.serialization.UdpDataParser;
+import org.eclipse.californium.core.network.serialization.UdpDataSerializer;
+import org.eclipse.californium.core.coap.Message;
+import org.junit.After;
+import org.junit.Test;
+import org.eclipse.californium.cose.AlgorithmID;
+
+/**
+ * Tests the decryption of request and response messages.
+ * Uses test vectors from the OSCORE draft for comparison.
+ *
+ */
+public class DecryptorTest {
+
+	// test vector OSCORE draft Appendix C.2.2
+	private final static byte[] master_secret = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
+			0x0C, 0x0D, 0x0E, 0x0F, 0x10 };
+	private final static byte[] rid = new byte[] { 0x00 };
+	private final static byte[] sid = new byte[] { 0x01 };
+	private final static AlgorithmID alg = AlgorithmID.AES_CCM_16_64_128;
+	private final static AlgorithmID kdf = AlgorithmID.HKDF_HMAC_SHA_256;
+
+	private static OSCoreCtx ctx = null;
+
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	/**
+	 * Tests decryption of a CoAP Request.
+	 * Test vector is from OSCORE draft. (Test Vector 5)
+	 *
+	 * @throws OSException if decryption fails
+	 */
+	@Test
+	public void testRequestDecryptor() throws OSException {
+		//Set up OSCORE context
+		ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, null, null);
+		
+		OSCoreCtxDB db = HashMapCtxDB.getInstance();
+		db.addContext(ctx);
+
+		//Create the encrypted request message from raw byte array
+		byte[] encryptedRequestBytes = new byte[] { 0x44, 0x02, 0x71, (byte) 0xc3, 0x00, 0x00, (byte) 0xb9, 0x32,
+				0x39, 0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x68, 0x6f, 0x73, 0x74, 0x63, 0x09, 0x14, 0x00,
+				(byte) 0xff, 0x4e, (byte) 0xd3, 0x39, (byte) 0xa5, (byte) 0xa3, 0x79, (byte) 0xb0,
+				(byte) 0xb8, (byte) 0xbc, 0x73, 0x1f, (byte) 0xff, (byte) 0xb0 };
+		
+		UdpDataParser parser = new UdpDataParser();
+		Message mess = parser.parseMessage(encryptedRequestBytes);
+		
+		Request r = null;
+		if(mess instanceof Request) {
+			r = (Request)mess;
+		}
+		
+		//Decrypt the request message
+		Request decrypted = RequestDecryptor.decrypt(r);
+		decrypted.getOptions().removeOscore();
+		
+		//Serialize the request message to byte array
+		UdpDataSerializer serializer = new UdpDataSerializer();
+		byte[] decryptedBytes = serializer.getByteArray(decrypted);
+
+		//Check the whole decrypted request
+		byte[] predictedBytes = { 0x44, 0x01, 0x71, (byte) 0xc3, 0x00, 0x00, (byte) 0xb9, 0x32,
+				0x39, 0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x68, 0x6f, 0x73, 0x74, (byte) 0x83, 0x74, 0x76, 0x31 };
+		
+		assertArrayEquals(predictedBytes, decryptedBytes);
+		
+	}
+	
+	/**
+	 * Tests decryption of a CoAP Response with partial IV.
+	 * Test vector is from OSCORE draft. (Test Vector 8)
+	 * FIXME
+	 * @throws OSException if decryption fails
+	 */
+	@Test
+	public void testResponseDecryptor() throws OSException {
+		//Set up OSCORE context
+		// test vector OSCORE draft Appendix C.1.1
+		byte[] master_salt = new byte[] { (byte) 0x9e, 0x7c, (byte) 0xa9, 0x22, 0x23, 0x78, 0x63, 0x40 };
+		byte[] sid = new byte[0];
+		byte[] rid = new byte[] { 0x01 };
+		int seq = 20;
+		
+		ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, null);
+
+		//Create the encrypted response message from raw byte array
+		byte[] encryptedResponseBytes = new byte[] { 0x64, 0x44, 0x5d, 0x1f, 0x00, 0x00, 0x39, 0x74,
+				(byte) 0x92, 0x01, 0x00, (byte) 0xff, 0x4d, 0x4c, 0x13, 0x66, (byte) 0x93,
+				(byte) 0x84, (byte) 0xb6, 0x73, 0x54, (byte) 0xb2, (byte)0xb6, 0x17, 0x5f,
+				(byte) 0xf4, (byte) 0xb8, 0x65, (byte) 0x8c, 0x66, 0x6a, 0x6c, (byte) 0xf8,
+				(byte) 0x8e };
+		
+		UdpDataParser parser = new UdpDataParser();
+		Message mess = parser.parseMessage(encryptedResponseBytes);
+		
+		Response r = null;
+		if(mess instanceof Response) {
+			r = (Response)mess;
+		}
+		
+		//Set up some state information simulating the original outgoing request
+		OSCoreCtxDB db = HashMapCtxDB.getInstance();
+		db.addContext(r.getToken(), ctx);
+		db.addSeqByToken(r.getToken(), seq);
+		
+		//Decrypt the response message
+		Response decrypted = ResponseDecryptor.decrypt(r);
+		decrypted.getOptions().removeOscore();
+		
+		//Check the decrypted response payload
+		String predictedPayload = "Hello World!"; 
+		
+		assertEquals(predictedPayload, decrypted.getPayloadString());
+		
+		//Serialize the response message to byte array
+		UdpDataSerializer serializer = new UdpDataSerializer();
+		byte[] decryptedBytes = serializer.getByteArray(decrypted);
+
+		//Check the whole decrypted response
+		byte[] predictedBytes = { 0x64, 0x45, 0x5d, 0x1f, 0x00, 0x00, 0x39, 0x74,
+				(byte) 0xff, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21 };
+		
+		assertArrayEquals(predictedBytes, decryptedBytes);
+		
+	}
+
+}

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/EncryptorTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/EncryptorTest.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright (c) 2018 RISE SICS and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Rikard Höglund (RISE SICS)
+ *    
+ ******************************************************************************/
+package org.eclipse.californium.oscore;
+
+import static org.junit.Assert.assertArrayEquals;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.serialization.UdpDataParser;
+import org.eclipse.californium.core.network.serialization.UdpDataSerializer;
+import org.eclipse.californium.core.coap.Message;
+import org.junit.After;
+import org.junit.Test;
+import org.eclipse.californium.cose.AlgorithmID;
+
+/**
+ * Tests the encryption of request and response messages.
+ * Uses test vectors from the OSCORE draft for comparison.
+ *
+ */
+public class EncryptorTest {
+
+	// test vector OSCORE draft Appendix C.2.1
+	private final static byte[] master_secret = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
+			0x0C, 0x0D, 0x0E, 0x0F, 0x10 };
+	private final static byte[] sid = new byte[] { 0x00 };
+	private final static byte[] rid = new byte[] { 0x01 };
+	private final static AlgorithmID alg = AlgorithmID.AES_CCM_16_64_128;
+	private final static AlgorithmID kdf = AlgorithmID.HKDF_HMAC_SHA_256;
+	private final static int seq = 20;
+
+	private static OSCoreCtx ctx = null;
+
+	@After
+	public void tearDown() throws Exception {
+	}
+
+	/**
+	 * Tests encryption of a CoAP Request.
+	 * Test vector is from OSCORE draft. (Test Vector 5)
+	 *
+	 * @throws OSException if encryption fails
+	 */
+	@Test
+	public void testRequestEncryptor() throws OSException {
+		//Set up OSCORE context
+		ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, null, null);
+		ctx.setSenderSeq(seq);
+
+		//Create request message from raw byte array
+		byte[] requestBytes = new byte[] { 0x44, 0x01, 0x71, (byte) 0xc3, 0x00, 0x00, (byte) 0xb9, 0x32,
+				0x39, 0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x68, 0x6f, 0x73, 0x74, (byte) 0x83, 0x74, 0x76, 0x31 };
+		
+		UdpDataParser parser = new UdpDataParser();
+		Message mess = parser.parseMessage(requestBytes);
+		
+		Request r = null;
+		if(mess instanceof Request) {
+			r = (Request)mess;
+		}
+		
+		//Encrypt the request message
+		Request encrypted = RequestEncryptor.encrypt(r, ctx);
+		
+		//Check the OSCORE option value
+		byte[] predictedOSCoreOption = { 0x09, 0x14, 0x00 };
+		
+		assertArrayEquals(predictedOSCoreOption, encrypted.getOptions().getOscore());
+		
+		//Check the OSCORE request payload (ciphertext)
+		byte[] predictedOSCorePayload = { 0x4e, (byte) 0xd3, 0x39, (byte) 0xa5, (byte) 0xa3, 0x79, (byte) 0xb0, (byte) 0xb8,
+				(byte) 0xbc, 0x73, 0x1f, (byte) 0xff, (byte) 0xb0 };
+		
+		assertArrayEquals(predictedOSCorePayload, encrypted.getPayload());
+		
+		//Serialize the request message to byte array
+		UdpDataSerializer serializer = new UdpDataSerializer();
+		byte[] encryptedBytes = serializer.getByteArray(encrypted);
+		
+		//Check the whole OSCORE request
+		byte[] predictedOSCoreBytes = { 0x44, 0x02, 0x71, (byte) 0xc3, 0x00, 0x00, (byte) 0xb9, 0x32,
+				0x39, 0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x68, 0x6f, 0x73, 0x74, 0x63, 0x09, 0x14, 0x00,
+				(byte) 0xff, 0x4e, (byte) 0xd3, 0x39, (byte) 0xa5, (byte) 0xa3, 0x79, (byte) 0xb0,
+				(byte) 0xb8, (byte) 0xbc, 0x73, 0x1f, (byte) 0xff, (byte) 0xb0 };
+		
+		assertArrayEquals(predictedOSCoreBytes, encryptedBytes);
+		
+	}
+	
+	/**
+	 * Tests encryption of a CoAP Response with partial IV.
+	 * Test vector is from OSCORE draft. (Test Vector 8)
+	 *
+	 * @throws OSException if encryption fails
+	 */
+	@Test
+	public void testResponseEncryptor() throws OSException {
+		//Set up OSCORE context
+		// test vector OSCORE draft Appendix C.1.2
+		byte[] master_salt = new byte[] { (byte) 0x9e, 0x7c, (byte) 0xa9, 0x22, 0x23, 0x78, 0x63, 0x40 };
+		byte[] sid = new byte[] { 0x01 };
+		byte[] rid = new byte[0];
+		
+		ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, null);
+		ctx.setSenderSeq(0);
+		ctx.setReceiverSeq(seq);
+
+		//Create response message from raw byte array
+		byte[] responseBytes = new byte[] { 0x64, 0x45, 0x5d, 0x1f, 0x00, 0x00, 0x39, 0x74,
+				(byte) 0xff, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21 };
+		
+		UdpDataParser parser = new UdpDataParser();
+		Message mess = parser.parseMessage(responseBytes);
+		
+		Response r = null;
+		if(mess instanceof Response) {
+			r = (Response)mess;
+		}
+
+		//Encrypt the response message
+		boolean newPartialIV = true;
+		Response encrypted = ResponseEncryptor.encrypt(r, ctx, newPartialIV);
+		
+		//Check the OSCORE option value
+		byte[] predictedOSCoreOption = { 0x01, 0x00 };
+		
+		assertArrayEquals(predictedOSCoreOption, encrypted.getOptions().getOscore());
+		
+		//Check the OSCORE response payload (ciphertext)
+		byte[] predictedOSCorePayload = { 0x4d, 0x4c, 0x13, 0x66, (byte) 0x93, (byte) 0x84, (byte) 0xb6, 0x73,
+				0x54, (byte) 0xb2, (byte) 0xb6, 0x17, 0x5f, (byte) 0xf4, (byte) 0xb8, 0x65, (byte) 0x8c, 0x66,
+				0x6a, 0x6c, (byte) 0xf8, (byte) 0x8e };
+		
+		assertArrayEquals(predictedOSCorePayload, encrypted.getPayload());
+
+		//Serialize the response message to byte array
+		UdpDataSerializer serializer = new UdpDataSerializer();
+		byte[] encryptedBytes = serializer.getByteArray(encrypted);
+
+		//Check the whole OSCORE response
+		byte[] predictedOSCoreBytes = { 0x64, 0x44, 0x5d, 0x1f, 0x00, 0x00, 0x39, 0x74,
+				(byte) 0x92, 0x01, 0x00, (byte) 0xff, 0x4d, 0x4c, 0x13, 0x66, (byte) 0x93,
+				(byte) 0x84, (byte) 0xb6, 0x73, 0x54, (byte) 0xb2, (byte)0xb6, 0x17, 0x5f,
+				(byte) 0xf4, (byte) 0xb8, 0x65, (byte) 0x8c, 0x66, 0x6a, 0x6c, (byte) 0xf8,
+				(byte) 0x8e  };
+		
+		assertArrayEquals(predictedOSCoreBytes, encryptedBytes);
+		
+	}
+
+}

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreCtxTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreCtxTest.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *    Tobias Andersson (RISE SICS)
+ *    Rikard Höglund (RISE SICS)
  *    
  ******************************************************************************/
 package org.eclipse.californium.oscore;
@@ -30,13 +31,20 @@ import org.junit.rules.ExpectedException;
 
 import org.eclipse.californium.cose.AlgorithmID;
 
+/**
+ * Test generation of values in an OSCORE Context.
+ *
+ */
 public class OSCoreCtxTest {
 
 	private final byte[] master_secret = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D,
-			0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
-			0x20, 0x21, 0x22, 0x23 };
-	private final byte[] rid = new byte[] { 0x73, 0x65, 0x72, 0x76, 0x65, 0x72 };
-	private final byte[] sid = new byte[] { 0x63, 0x6C, 0x69, 0x65, 0x6E, 0x74 };
+			0x0E, 0x0F, 0x10 };
+	private final static byte[] master_salt = { (byte) 0x9e, (byte) 0x7c, (byte) 0xa9, (byte) 0x22, (byte) 0x23,
+			(byte) 0x78, (byte) 0x63, (byte) 0x40 };
+	private final static byte[] context_id = { 0x37, (byte) 0xCB, (byte) 0xF3, 0x21, 0x00, 0x17, (byte) 0xA2, (byte) 0xD3 };
+	private final byte[] rid = new byte[] { 0x01 };
+	private final byte[] sid = new byte[0];
+	private final byte[] sid2 = new byte[] { 0x00 };
 	private final AlgorithmID cipher = AlgorithmID.AES_CCM_16_64_128;
 	private final AlgorithmID kdf = AlgorithmID.HKDF_HMAC_SHA_256;
 
@@ -76,5 +84,104 @@ public class OSCoreCtxTest {
 		assertTrue(Arrays.equals(this.rid, ctx.getRecipientId()));
 		assertTrue(Arrays.equals(this.sid, ctx.getSenderId()));
 		assertEquals(0, ctx.getSenderSeq());
+	}
+	
+	/**
+	 * Tests generation of sender key with salt, without salt and with context ID.
+	 * Test vectors are from OSCORE draft. (Test Vector 1-3)
+	 * 
+	 * @throws OSException if sender key generation fails
+	 */
+	@Test
+	public void testSenderKey() throws OSException {
+		//Test without salt
+		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, cipher, sid2, rid, kdf, 32, null, null);
+
+		byte[] predictedSenderKey = { 0x32, 0x1b, 0x26, (byte) 0x94, 0x32, 0x53, (byte) 0xc7, (byte) 0xff,
+				(byte) 0xb6, 0x00, 0x3b, 0x0b, 0x64, (byte) 0xd7, 0x40, 0x41 };		
+
+		assertArrayEquals(predictedSenderKey, ctx.getSenderKey());
+		
+		//Test with salt
+		ctx = new OSCoreCtx(master_secret, true, cipher, sid, rid, kdf, 32, master_salt, null);
+
+		byte[] predictedSenderKeySalt = { (byte) 0xf0, (byte) 0x91, 0x0e, (byte) 0xd7, 0x29, 0x5e, 0x6a, (byte) 0xd4,
+				(byte) 0xb5, 0x4f, (byte) 0xc7, (byte) 0x93, 0x15, 0x43, 0x02, (byte) 0xff };
+		
+		assertArrayEquals(predictedSenderKeySalt, ctx.getSenderKey());
+		
+		//Test with context ID and salt
+		ctx = new OSCoreCtx(master_secret, true, cipher, sid, rid, kdf, 32, master_salt, context_id);
+
+		byte[] predictedSenderKeyContextID = { (byte) 0xaf, 0x2a, 0x13, 0x00, (byte) 0xa5, (byte) 0xe9, 0x57, (byte) 0x88,
+				(byte) 0xb3, 0x56, 0x33, 0x6e, (byte) 0xee, (byte) 0xcd, 0x2b, (byte) 0x92 };
+		
+		assertArrayEquals(predictedSenderKeyContextID, ctx.getSenderKey());
+	}
+
+	/**
+	 * Tests generation of recipient key with salt, without salt and with context ID.
+	 * Test vectors are from OSCORE draft. (Test Vector 1-3)
+	 *
+	 * @throws OSException if recipient key generation fails
+	 */
+	@Test
+	public void testRecipientKey() throws OSException {
+		//Test without salt
+		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, cipher, sid2, rid, kdf, 32, null, null);
+
+		byte[] predictedRecipientKey = { (byte) 0xe5, 0x7b, 0x56, 0x35, (byte) 0x81, 0x51, 0x77, (byte) 0xcd,
+				0x67, (byte) 0x9a, (byte) 0xb4, (byte) 0xbc, (byte) 0xec, (byte) 0x9d, 0x7d, (byte) 0xda };		
+
+		assertArrayEquals(predictedRecipientKey, ctx.getRecipientKey());
+		
+		//Test with salt
+		ctx = new OSCoreCtx(master_secret, true, cipher, sid, rid, kdf, 32, master_salt, null);
+
+		byte[] predictedRecipientKeySalt = { (byte) 0xff, (byte) 0xb1, 0x4e, 0x09, 0x3c, (byte) 0x94, (byte) 0xc9, (byte) 0xca,
+				(byte) 0xc9, 0x47, 0x16, 0x48, (byte) 0xb4, (byte) 0xf9, (byte) 0x87, 0x10 };
+		
+		assertArrayEquals(predictedRecipientKeySalt, ctx.getRecipientKey());
+		
+		//Test with context ID and salt
+		ctx = new OSCoreCtx(master_secret, true, cipher, sid, rid, kdf, 32, master_salt, context_id);
+
+		byte[] predictedRecipientKeyContextID = { (byte) 0xe3, (byte) 0x9a, 0x0c, 0x7c, 0x77, (byte) 0xb4, 0x3f, 0x03,
+				(byte) 0xb4, (byte) 0xb3, (byte) 0x9a, (byte) 0xb9, (byte) 0xa2, 0x68, 0x69, (byte) 0x9f };
+		
+		assertArrayEquals(predictedRecipientKeyContextID, ctx.getRecipientKey());
+	}
+	
+	/**
+	 * Tests generation of common IV with salt, without salt and with context ID.
+	 * Test vectors are from OSCORE draft. (Test Vector 1-3)
+	 * 
+	 * @throws OSException if common IV generation fails
+	 */
+	@Test
+	public void testCommonIV() throws OSException {
+		//Test without salt
+		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, cipher, sid2, rid, kdf, 32, null, null);
+
+		byte[] predictedCommonIV = { (byte) 0xbe, 0x35, (byte) 0xae, 0x29, 0x7d, 0x2d, (byte) 0xac, (byte) 0xe9,
+				0x10, (byte) 0xc5, 0x2e, (byte) 0x99, (byte) 0xf9 };
+		
+		assertArrayEquals(predictedCommonIV, ctx.getCommonIV());
+		
+		//Test with salt
+		ctx = new OSCoreCtx(master_secret, true, cipher, sid, rid, kdf, 32, master_salt, null);
+
+		byte[] predictedCommonIVSalt = { 0x46, 0x22, (byte) 0xd4, (byte) 0xdd, 0x6d, (byte) 0x94, 0x41, 0x68,
+				(byte) 0xee, (byte) 0xfb, 0x54, (byte) 0x98, 0x7c };
+		
+		assertArrayEquals(predictedCommonIVSalt, ctx.getCommonIV());
+		
+		//Test with context ID and salt
+		ctx = new OSCoreCtx(master_secret, true, cipher, sid, rid, kdf, 32, master_salt, context_id);
+
+		byte[] predictedCommonIVContextID = { 0x2c, (byte) 0xa5, (byte) 0x8f, (byte) 0xb8, 0x5f, (byte) 0xf1, (byte) 0xb8, 0x1c,
+				0x0b, 0x71, (byte) 0x81, (byte) 0xb8, 0x5e };
+		
+		assertArrayEquals(predictedCommonIVContextID, ctx.getCommonIV());
 	}
 }

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreObserveTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreObserveTest.java
@@ -131,7 +131,7 @@ public class OSCoreObserveTest {
 	 * After this the observation is cancelled.
 	 * Equivalent to Test 7 in the interop test specification.
 	 * 
-	 * @throws InterruptedException
+	 * @throws InterruptedException if sleep fails
 	 */
 	@Test
 	public void testObserve() throws InterruptedException {
@@ -184,7 +184,7 @@ public class OSCoreObserveTest {
 	
 		//Wait until 2 messages have been received
 		while(handler.count <= 2) {
-			Thread.sleep(500);
+			Thread.sleep(250);
 			
 			//Failsafe to abort test if needed
 			if(handler.abort > 5) {
@@ -205,13 +205,13 @@ public class OSCoreObserveTest {
 		assertEquals(resp.getOptions().getContentFormat(), MediaTypeRegistry.TEXT_PLAIN);
 		assertEquals(resp.getOptions().hasObserve(), false);
 		assertEquals(resp.getPayloadString(), "two");
+		assertEquals(relation.getCurrent().getResponseText(), "two");
 	}
 	
 	/* --- End of client Observe tests --- */
 
 	/**
 	 * Set OSCORE context information for clients
-	 * @throws OSException 
 	 */
 	@Before
 	public void setClientContext() {
@@ -232,7 +232,6 @@ public class OSCoreObserveTest {
 	
 	/**
 	 * (Re)sets the OSCORE context information for the server
-	 * @throws OSException 
 	 */
 	@Before
 	public void setServerContext() {
@@ -252,7 +251,7 @@ public class OSCoreObserveTest {
 	
 	/**
 	 * Creates server with resources to test OSCORE Observe functionality
-	 * @throws InterruptedException 
+	 * @throws InterruptedException if resource update task fails
 	 */
 	@Before
 	public void createServer() throws InterruptedException {

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSSerializerTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSSerializerTest.java
@@ -12,6 +12,7 @@
  * 
  * Contributors:
  *    Tobias Andersson (RISE SICS)
+ *    Rikard Höglund (RISE SICS)
  *    
  ******************************************************************************/
 package org.eclipse.californium.oscore;
@@ -46,7 +47,6 @@ public class OSSerializerTest {
 	private final static AlgorithmID kdf = AlgorithmID.HKDF_HMAC_SHA_256;
 
 	private final static OptionSet options = new OptionSet();
-	private final static boolean newPartialIV = false;
 	private final static int version = CoAP.VERSION;
 	private final static int seq = 1;
 	private final static byte[] partialIV = new byte[] { 0x01 };
@@ -83,87 +83,28 @@ public class OSSerializerTest {
 	}
 
 	@Test
-	public void testserializeSendResponseAADVersionInvalid() {
+	public void testserializeAADVersionInvalid() {
 		exception.expect(IllegalArgumentException.class);
-		OSSerializer.serializeSendResponseAAD(-1, ctx, options, newPartialIV);
+		OSSerializer.serializeAAD(-1, ctx.getAlg(), seq, ctx.getSenderId(), options);
 	}
 
 	@Test
-	public void testserializeSendResponseAADCtxNull() {
+	public void testserializeAADCtxNull() {
 		exception.expect(NullPointerException.class);
-		OSSerializer.serializeSendResponseAAD(version, null, options, newPartialIV);
+		ctx = null;
+		OSSerializer.serializeAAD(version, ctx.getAlg(), seq, ctx.getSenderId(), options);
 	}
 
 	@Test
-	public void testserializeSendResponseAADOptionsNull() {
+	public void testserializeAADOptionsNull() {
 		exception.expect(NullPointerException.class);
-		OSSerializer.serializeSendResponseAAD(version, ctx, null, newPartialIV);
+		OSSerializer.serializeAAD(version, ctx.getAlg(), seq, ctx.getSenderId(), null);
 	}
 
 	@Test
-	public void testserializeReceiveResponseAADVersionInvalid() {
+	public void testserializeAADSeqInvalid() {
 		exception.expect(IllegalArgumentException.class);
-		OSSerializer.serializeReceiveResponseAAD(-1, seq, ctx, options);
-	}
-
-	@Test
-	public void testserializeReceiveResponseAADSeqInvalid() {
-		exception.expect(IllegalArgumentException.class);
-		OSSerializer.serializeReceiveResponseAAD(version, -5, ctx, options);
-	}
-
-	@Test
-	public void testserializeReceiveResponseAADCtxNull() {
-		exception.expect(NullPointerException.class);
-		OSSerializer.serializeReceiveResponseAAD(version, seq, null, options);
-	}
-
-	@Test
-	public void testserializeReceiveResponseAADOptionsNull() {
-		exception.expect(NullPointerException.class);
-		OSSerializer.serializeReceiveResponseAAD(version, seq, ctx, null);
-	}
-
-	@Test
-	public void testserializeSendRequestAADVersionInvalid() {
-		exception.expect(IllegalArgumentException.class);
-		OSSerializer.serializeSendRequestAAD(-1, ctx, options);
-	}
-
-	@Test
-	public void testserializeSendRequestAADCtxNull() {
-		exception.expect(NullPointerException.class);
-		OSSerializer.serializeSendRequestAAD(version, null, options);
-	}
-
-	@Test
-	public void testserializeSendRequestAADOptionsNull() {
-		exception.expect(NullPointerException.class);
-		OSSerializer.serializeSendRequestAAD(version, ctx, null);
-	}
-
-	@Test
-	public void testserializeReceiveRequestAADVersionInvalid() {
-		exception.expect(IllegalArgumentException.class);
-		OSSerializer.serializeReceiveRequestAAD(-1, seq, ctx, options);
-	}
-
-	@Test
-	public void testserializeReceiveRequestAADSeqInvalid() {
-		exception.expect(IllegalArgumentException.class);
-		OSSerializer.serializeReceiveRequestAAD(version, -5, ctx, options);
-	}
-
-	@Test
-	public void testserializeReceiveRequestAADCtxNull() {
-		exception.expect(NullPointerException.class);
-		OSSerializer.serializeReceiveRequestAAD(version, seq, null, options);
-	}
-
-	@Test
-	public void testserializeReceiveRequestAADOptionsNull() {
-		exception.expect(NullPointerException.class);
-		OSSerializer.serializeReceiveRequestAAD(version, seq, ctx, null);
+		OSSerializer.serializeAAD(version, ctx.getAlg(), -5, ctx.getSenderId(), options);
 	}
 
 	@Test


### PR DESCRIPTION
Additions to prepare the OSCORE code for implementation of the functionality in Appendix B.2 of the OSCORE draft text. It describes how to securely derive new security contexts after a crash or power loss:
https://tools.ietf.org/html/draft-ietf-core-object-security-16#appendix-B.2

The solution relies heavily on using the ID Context parameter for deriving new contexts. This pull request updates the code to handle the ID Context better, for instance parsing it properly if included in incoming messages. Further updates are needed to finalize the functionality described in the appendix.

Furthermore some other fixes are included:
- Updates to various comments
- Inclusion of JUnit tests for message decryption and encryption
- Added JUnit tests based on test vectors in draft for AAD, nonce, sender/recipient key and common IV
- Reduction from 4 to 1 methods for AAD generation
- Fix in AAD generation when a response contains a partial IV
