### PR TITLE
Shutdown attached executor on destroy even if server is stopped.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/server/CoapServerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/server/CoapServerTest.java
@@ -15,8 +15,14 @@
  ******************************************************************************/
 package org.eclipse.californium.core.server;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.elements.util.ExecutorsUtil;
+import org.eclipse.californium.rule.CoapNetworkRule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -26,9 +32,36 @@ import org.junit.experimental.categories.Category;
 @Category(Small.class)
 public class CoapServerTest {
 
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT,
+			CoapNetworkRule.Mode.NATIVE);
+
+	@BeforeClass
+	public static void init() {
+		ExecutorsUtil.getScheduledExecutor();
+	}
+
 	@Test
 	public void testDestroyWithoutStart() {
 		CoapServer server = new CoapServer();
 		server.destroy();
+	}
+
+	@Test
+	public void testStartStopDestroy() {
+		// look at nb active thread before.
+		int numberOfThreadbefore = Thread.activeCount();
+
+		CoapServer server = new CoapServer();
+		server.start();
+		server.stop();
+		server.destroy();
+
+		// ensure all thread are destroyed
+		try {
+			Thread.sleep(500);
+		} catch (InterruptedException e) {
+		}
+		assertEquals("All news threads created must be destroyed", numberOfThreadbefore, Thread.activeCount());
 	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/ExecutorsUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/ExecutorsUtil.java
@@ -64,6 +64,7 @@ public class ExecutorsUtil {
 		ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(2,
 				new DaemonThreadFactory("Timer#", TIMER_THREAD_GROUP));
 		executor.execute(WARMUP);
+		executor.prestartAllCoreThreads();
 		scheduler = executor;
 	}
 


### PR DESCRIPTION
The test was useful to check this in eclipse but :
1. I don't know how it behave if junit tests are launched in parallel
2. It fails because like this in maven : 
```
[ERROR] Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.034 s <<< FAILURE! - in org.eclipse.californium.core.server.CoapServerTest
[ERROR] testStartStopDestroy(org.eclipse.californium.core.server.CoapServerTest)  Time elapsed: 0.021 s  <<< ERROR!
java.io.IOError: java.net.SocketException: Use org.eclipse.californium.elements.rule.NetworkRule to define DatagramSocket behaviour!
	at org.eclipse.californium.core.server.CoapServerTest.testStartStopDestroy(CoapServerTest.java:43)
Caused by: java.net.SocketException: Use org.eclipse.californium.elements.rule.NetworkRule to define DatagramSocket behaviour!
	at org.eclipse.californium.core.server.CoapServerTest.testStartStopDestroy(CoapServerTest.java:43)
```

So we can not merge it, if you prefer.