### PR TITLE
Fix javadoc of ExecutorsUtil.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/ExecutorsUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/ExecutorsUtil.java
@@ -33,9 +33,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Utility to create executors.
  * 
- * Note: THE INTERNAL/PRIVATE {@code SplitScheduledThreadPoolExecutor} IS
- * EXPERIMENTAL! IT'S INTENDED TO BE USED FOR REPRODUCING BENCHMARKS OF ISSUE
- * #690
+ * Note: THE INTERNAL/PRIVATE {@code SplitScheduledThreadPoolExecutor} IS A
+ * WORKAROUND! IT MAY BE REPLACED IN THE FUTURE. See issue #690.
  */
 public class ExecutorsUtil {
 
@@ -69,19 +68,17 @@ public class ExecutorsUtil {
 	}
 
 	/**
-	 * Threshold for using the experimental
-	 * {@link SplitScheduledThreadPoolExecutor} to split thread pool into
-	 * scheduled and immediately executing threads. Experimental! {@code 0} to
-	 * disable the use of the {@link SplitScheduledThreadPoolExecutor}.
+	 * Threshold for using the {@link SplitScheduledThreadPoolExecutor} to split
+	 * thread pool into scheduled and immediately executing threads. {@code 0}
+	 * to disable the use of the {@link SplitScheduledThreadPoolExecutor}.
 	 */
 	private static final int SPLIT_THRESHOLD = 1;
 
 	/**
 	 * Create a scheduled thread pool executor service.
 	 * 
-	 * Experimentally, if the provided number of threads exceeds the
-	 * {@link #SPLIT_THRESHOLD}, the {@code SplitScheduledThreadPoolExecutor} is
-	 * returned.
+	 * If the provided number of threads exceeds the {@link #SPLIT_THRESHOLD},
+	 * the {@code SplitScheduledThreadPoolExecutor} is returned.
 	 * 
 	 * @param poolSize number of threads for thread pool.
 	 * @param threadFactory thread factory
@@ -141,14 +138,13 @@ public class ExecutorsUtil {
 	}
 
 	/**
-	 * Experimental executor, which uses a {@link ScheduledThreadPoolExecutor}
+	 * Executor, which uses a {@link ScheduledThreadPoolExecutor}
 	 * with {@link ExecutorsUtil#SPLIT_THRESHOLD} threads for scheduling, and an
 	 * additional {@link ThreadPoolExecutor} for execution. This may result in
 	 * better performance for direct job, when many scheduled job are queued for
 	 * execution.
 	 * 
-	 * Note: IS EXPERIMENTAL! IT'S NOT INTENDED TO BE USED, EXCEPT FOR
-	 * REPRODUCING BENCHMARKS OF ISSUE #690
+	 * Note: IT'S A WORKAROUND! IT MAY BE REPLACED IN THE FUTURE! See issue #690.
 	 */
 	private static class SplitScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
 


### PR DESCRIPTION
Replace experimental by workaround.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>