### PR TITLE
Update link format RD attributes

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/LinkFormat.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/LinkFormat.java
@@ -39,13 +39,13 @@ public class LinkFormat {
 	public static final String LINK                  = "href";
 
 	// for Resource Directory
-	public static final String HOST		     		 = "h";
-	public static final String LIFE_TIME     		 = "lt";
-	public static final String INSTANCE		   		 = "ins";
-	public static final String DOMAIN	     		 = "d";
-	public static final String CONTEXT		   		 = "con";
-	public static final String END_POINT     		 = "ep";
-	public static final String END_POINT_TYPE		 = "et";
+	public static final String LIFE_TIME             = "lt";
+	public static final String SECTOR                = "d";
+	public static final String CONTEXT               = "anchor";
+	public static final String BASE                  = "base";
+	public static final String RELATION              = "rel";
+	public static final String END_POINT             = "ep";
+	public static final String END_POINT_TYPE        = "et";
 
 	// for parsing
 	public static final Pattern DELIMITER      = Pattern.compile("\\s*,+\\s*");


### PR DESCRIPTION
This PR updates the attributes used by LinkFormat in californium-core to follow the latest version of the Resource Directory draft ([version 20](https://tools.ietf.org/html/draft-ietf-core-resource-directory-20)).

The changes should not affect other part of the californium repository. From what I could find, only examples californium.tools are affected. I also plan to update the resource directory example there to follow the latest draft.

I split this PR into two commits to fix the mix usage of tabs and spaces first. I can squash it into one commit if necessary.