### PR TITLE
OSCORE: Initial support for method to securely re-generate contexts

### DIFF
--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ErrorDescriptions.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ErrorDescriptions.java
@@ -24,42 +24,43 @@ package org.eclipse.californium.oscore;
  */
 public final class ErrorDescriptions {
 
-	public static final String CONTEXT_NOT_FOUND = ("Security context not found");
-	public static final String FAILED_TO_DECODE_COSE = ("Failed to decode COSE");
-	public static final String REPLAY_DETECT = ("Replay detected");
-	public static final String DECRYPTION_FAILED = ("Decryption failed");
-	public static final String MAC_CCM_FAILED = ("MAC check in CCM failed");
-	public static final String TOKEN_NULL = ("Token is null");
-	public static final String TOKEN_INVALID = ("Token is invalid");
-	public static final String SEQ_NBR_INVALID = ("Sequence number is invalid");
-	public static final String URI_NULL = ("URI is null");
-	public static final String DB_NULL = ("DB is null");
-	public static final String CTX_NULL = ("Context is null");
-	public static final String TYPE_NULL = ("Type is null");
-	public static final String UNEXPECTED_OBSERVE = ("Unexpected observe option");
-	public static final String SOURCE_ADRESS_NULL = ("Source address is null");
-	public static final String SOURCE_PORT_NULL = ("Source port is null");
-	public static final String SOURCE_PORT_INVALID = ("Source port is invalid");
-	public static final String ERROR_MESS_NULL = ("Error message is null");
-	public static final String MID_INVALID = ("MID is invalid");
-	public static final String MISSING_KID = ("KID is missing");
-	public static final String EXCEPTION_NULL = ("Exception is null");
-	public static final String REQUEST_NULL = ("Request is null");
-	public static final String OPTIONSET_NULL = ("OptionSet is null");
-	public static final String WRONG_VERSION_NBR = ("Wrong version number");
-	public static final String BYTE_ARRAY_NULL = ("Byte array is null");
-	public static final String NONCE_FAILED = ("Nonce generation failed");
-	public static final String PARTIAL_IV_NULL = ("PartialIV is null");
-	public static final String SENDER_ID_NULL = ("SenderID is null");
-	public static final String COMMON_IV_NULL = ("CommonIV is null");
-	public static final String NONCE_LENGTH_INVALID = ("Nonce length is invalid");
-	public static final String COAP_CODE_INVALID = ("Coap Code is invalid");
+	public static final String CONTEXT_NOT_FOUND = "Security context not found";
+	public static final String FAILED_TO_DECODE_COSE = "Failed to decode COSE";
+	public static final String REPLAY_DETECT = "Replay detected";
+	public static final String DECRYPTION_FAILED = "Decryption failed";
+	public static final String MAC_CCM_FAILED = "MAC check in CCM failed";
+	public static final String TOKEN_NULL = "Token is null";
+	public static final String TOKEN_INVALID = "Token is invalid";
+	public static final String SEQ_NBR_INVALID = "Sequence number is invalid";
+	public static final String URI_NULL = "URI is null";
+	public static final String DB_NULL = "DB is null";
+	public static final String CTX_NULL = "Context is null";
+	public static final String TYPE_NULL = "Type is null";
+	public static final String UNEXPECTED_OBSERVE = "Unexpected observe option";
+	public static final String SOURCE_ADRESS_NULL = "Source address is null";
+	public static final String SOURCE_PORT_NULL = "Source port is null";
+	public static final String SOURCE_PORT_INVALID = "Source port is invalid";
+	public static final String ERROR_MESS_NULL = "Error message is null";
+	public static final String MID_INVALID = "MID is invalid";
+	public static final String MISSING_KID = "KID is missing";
+	public static final String EXCEPTION_NULL = "Exception is null";
+	public static final String REQUEST_NULL = "Request is null";
+	public static final String OPTIONSET_NULL = "OptionSet is null";
+	public static final String WRONG_VERSION_NBR = "Wrong version number";
+	public static final String BYTE_ARRAY_NULL = "Byte array is null";
+	public static final String NONCE_FAILED = "Nonce generation failed";
+	public static final String PARTIAL_IV_NULL = "PartialIV is null";
+	public static final String SENDER_ID_NULL = "SenderID is null";
+	public static final String COMMON_IV_NULL = "CommonIV is null";
+	public static final String NONCE_LENGTH_INVALID = "Nonce length is invalid";
+	public static final String COAP_CODE_INVALID = "Coap Code is invalid";
 	public static final String ILLEGAL_PAYLOAD_MARKED = "Payload marker found with zero-length payload";
 	public static final String STRING_NULL = "String is null";
 	public static final String CONTEXT_NULL = "Context is null";
 	public static final String ALGORITHM_NOT_DEFINED = "Algorithm not defined";
+	public static final String CONTEXT_REGENERATION_FAILED = "Security context re-generation failed";
 
-	public static final String CANNOT_CREATE_ERROR_MESS = ("Cannot create error message for this error");
+	public static final String CANNOT_CREATE_ERROR_MESS = "Cannot create error message for this error";
 
 	private ErrorDescriptions() {
 	}

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtx.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtx.java
@@ -79,6 +79,9 @@ public class OSCoreCtx {
 
 	private Code CoAPCode = null;
 
+	//Include the context id in messages generated using this context
+	private boolean includeContextId;
+
 	/**
 	 * Constructor. Generates the context from the base parameters with the
 	 * minimal input.
@@ -172,6 +175,8 @@ public class OSCoreCtx {
 		} else {
 			this.context_id = null;
 		}
+
+		includeContextId = false;
 
 		String digest = null;
 		switch (this.kdf) {
@@ -365,6 +370,35 @@ public class OSCoreCtx {
 	 */
 	public byte[] getIdContext() {
 		return context_id;
+	}
+
+	/**
+	 * Get the flag controlling whether or not to include the Context ID in
+	 * messages generated using this context.
+	 *
+	 * @return the includeContextId
+	 */
+	public boolean getIncludeContextId() {
+		return includeContextId;
+	}
+
+	/**
+	 * Set the flag controlling whether or not to include the Context ID in
+	 * messages generated using this context.
+	 * 
+	 * Note that this flag should never be set to true in a context without a Context ID set.
+	 *
+	 * @param includeContextId the includeContextId to set
+	 *
+	 * @throws IllegalStateException if a Context ID has not been set for this context
+	 */
+	public void setIncludeContextId(boolean includeContextId) {
+		if(context_id == null) {
+			LOGGER.error("Context ID cannot be included for a context without one set.");
+			throw new IllegalStateException("Context ID cannot be included for a context without one set.");
+		}
+		
+		this.includeContextId = includeContextId;
 	}
 
 	public int rollbackRecipientSeq() {

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestDecryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestDecryptor.java
@@ -20,6 +20,8 @@
 package org.eclipse.californium.oscore;
 
 import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,6 +84,16 @@ public class RequestDecryptor extends Decryptor {
 		}
 		byte[] rid = kid.GetByteString();
 
+		//Retrieve Context ID (kid context)
+		CBORObject kidContext = enc.findAttribute(CBORObject.FromObject(10));
+		byte[] contextID = null;
+		if (kidContext != null) {
+			contextID = kidContext.GetByteString();
+		}
+
+		//Trigger context re-derivation if applicable
+		checkContextRederivation(rid, contextID);
+
 		OSCoreCtx ctx = db.getContext(rid);
 
 		if (ctx == null) {
@@ -94,7 +106,7 @@ public class RequestDecryptor extends Decryptor {
 			plaintext = decryptAndDecode(enc, request, ctx, null);
 		} catch (OSException e) {
 			//First check for replay exceptions
-			if(e.getMessage().equals(ErrorDescriptions.REPLAY_DETECT)) { 
+			if (e.getMessage().equals(ErrorDescriptions.REPLAY_DETECT)) { 
 				LOGGER.error(ErrorDescriptions.REPLAY_DETECT);
 				throw new CoapOSException(ErrorDescriptions.REPLAY_DETECT, ResponseCode.UNAUTHORIZED);
 			}
@@ -122,5 +134,39 @@ public class RequestDecryptor extends Decryptor {
 		// We need the kid value on layer level
 		request.getOptions().setOscore(rid);
 		return OptionJuggle.setRealCodeRequest(request, ctx.getCoAPCode());
+	}
+
+	/**
+	 * Checks if an incoming messages should trigger re-derivation of the security
+	 * context as detailed in Appendix B.2. If so this re-derivation is also performed.
+	 *
+	 * See https://tools.ietf.org/html/draft-ietf-core-object-security-16#section-5.2
+	 *
+	 * @throws CoapOSException if re-generation of the context fails
+	 */
+	private static void checkContextRederivation(byte[] rid, byte[] receivedContextID) throws CoapOSException {
+		//Get the context corresponding to the incoming rid
+		OSCoreCtxDB db = HashMapCtxDB.getInstance();
+		OSCoreCtx ctx = db.getContext(rid);
+
+		//Check if the received Context ID matches the one in the context, if so do nothing
+		if (receivedContextID == null || Arrays.equals(receivedContextID, ctx.getIdContext())) {
+			return;
+		}
+
+		//Otherwise generate a new context with the newly received Context ID
+		OSCoreCtx newCtx = null;
+		try {
+			newCtx = new OSCoreCtx(ctx.getMasterSecret(), true, ctx.getAlg(),
+					ctx.getSenderId(), ctx.getRecipientId(), ctx.getKdf(),
+					ctx.getRecipientReplaySize(), ctx.getSalt(), receivedContextID);
+		} catch (OSException e) {
+			LOGGER.error(ErrorDescriptions.CONTEXT_REGENERATION_FAILED);
+			throw new CoapOSException(ErrorDescriptions.CONTEXT_REGENERATION_FAILED, ResponseCode.BAD_REQUEST);
+		}
+		newCtx.setIncludeContextId(true);
+
+		//Now replace the old context with the newly generated in the context DB
+		db.addContext(newCtx);
 	}
 }

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2018 RISE SICS and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Rikard Höglund (RISE SICS)
+ *    
+ ******************************************************************************/
+package org.eclipse.californium.oscore;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.security.SecureRandom;
+
+import org.eclipse.californium.core.CoapClient;
+import org.eclipse.californium.core.CoapResponse;
+import org.eclipse.californium.core.Utils;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.elements.exception.ConnectorException;
+import org.eclipse.californium.rule.CoapNetworkRule;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.cose.AlgorithmID;
+
+/**
+ * Class that implements test of functionality for re-derivation of contexts.
+ * As detailed in Appendix B.2. of the OSCORE draft:
+ * https://tools.ietf.org/html/draft-ietf-core-object-security-16#appendix-B.2
+ *
+ * This can for instance be used when one device has lost power and information
+ * about the mutable parts of a context (e.g. sequence number) but retains information
+ * about static parts (e.g. master secret)
+ * 
+ * To be ran together with the HelloWorldServer
+ */
+public class ContextRederivationTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
+	
+	private static String SERVER_RESPONSE = "Hello World!";
+	
+	private final static HashMapCtxDB db = HashMapCtxDB.getInstance();
+	private final static String uriLocal = "coap://localhost";
+	private final static String hello1 = "/hello/1";
+	private final static AlgorithmID alg = AlgorithmID.AES_CCM_16_64_128;
+	private final static AlgorithmID kdf = AlgorithmID.HKDF_HMAC_SHA_256;
+
+	// test vector OSCORE draft Appendix C.1.1
+	private final static byte[] master_secret = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
+			0x0C, 0x0D, 0x0E, 0x0F, 0x10 };
+	private final static byte[] master_salt = { (byte) 0x9e, (byte) 0x7c, (byte) 0xa9, (byte) 0x22, (byte) 0x23,
+			(byte) 0x78, (byte) 0x63, (byte) 0x40 };
+	private final static byte[] sid = new byte[0];
+	private final static byte[] rid = new byte[] { 0x01 };
+	
+	/**
+	 * Test context re-derivation followed by a normal message exchange.
+	 * 
+	 * @throws OSException
+	 * @throws ConnectorException
+	 * @throws IOException
+	 */
+	@Ignore
+	@Test
+	public void rederivationTest() throws OSException, ConnectorException, IOException {
+		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, null);
+		db.addContext(uriLocal, ctx);
+		OSCoreCoapStackFactory.useAsDefault();
+
+		rederive(uriLocal);
+		
+		CoapClient c = new CoapClient(uriLocal + hello1);
+		Request r = new Request(Code.GET);
+		r.getOptions().setOscore(new byte[0]);
+		System.out.println((Utils.prettyPrint(r)));
+		
+		CoapResponse resp = c.advanced(r);
+		System.out.println((Utils.prettyPrint(resp)));
+		
+		assertEquals(resp.getCode(), ResponseCode.CONTENT);
+		assertEquals(resp.getResponseText(), SERVER_RESPONSE);
+	}
+
+	/**
+	 * Perform re-derivation of contexts as detailed in Appendix B.2.
+	 * Essentially it uses a message exchange together with the Context ID
+	 * field in the OSCORE option to securely generate a new shared context.
+	 * 
+	 * @throws IOException 
+	 * @throws ConnectorException 
+	 * @throws OSException 
+	 */
+	public static void rederive(String uriLocal) throws ConnectorException, IOException, OSException {
+		//Generate a random 8 byte Context ID
+		SecureRandom random = new SecureRandom();
+		byte[] newContextId = new byte[8];
+		random.nextBytes(newContextId);
+		
+		//Create new context with the generated Context ID
+		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, newContextId);
+		ctx.setIncludeContextId(true);
+		db.addContext(uriLocal, ctx);
+		OSCoreCoapStackFactory.useAsDefault();
+		
+		//Now send request using the new context
+		String resource = "/rederive"; //Dummy resource to access for context re-derivation
+		String URI = uriLocal + resource;
+		System.out.println(URI);
+		OSCoreCoapStackFactory.useAsDefault();
+		
+		CoapClient c = new CoapClient(URI);
+		Request r = new Request(Code.GET);
+		r.getOptions().setOscore(new byte[0]);
+		System.out.println(Utils.prettyPrint(r));
+		
+		CoapResponse resp = null;
+		resp = c.advanced(r);
+		System.out.println(Utils.prettyPrint(resp));
+	}
+	
+}


### PR DESCRIPTION
This pull request adds initial support for the method described in Appendix B.2. of the OSCORE draft for securely re-generating contexts:
https://tools.ietf.org/html/draft-ietf-core-object-security-16#appendix-B.2

The idea is to perform context re-derivation by essentially using a message exchange together with the Context ID field in the OSCORE option to securely generate a new shared context.

This can for instance be used when one device has lost power and information about the mutable parts of a context (e.g. sequence number) but retains information about static parts (e.g. master secret).

This pull request includes initial support for this functionality together with a JUnit test to test it. It also includes functionality in the OSCORE code to dynamically re-generate context information depending on the incoming Context ID. Logic was also added to enable controlling whether messages generated from a particular context will include Context IDs (that is not always needed and can increase the message overhead). A further update will come to finalize the full functionality as described in the appendix.
