### PR TITLE
Shutdown client in examples. (As now it's mandatory by default)

### DIFF
--- a/demo-apps/cf-cocoa/src/main/java/org/eclipse/californium/examples/CocoaClient.java
+++ b/demo-apps/cf-cocoa/src/main/java/org/eclipse/californium/examples/CocoaClient.java
@@ -89,5 +89,6 @@ public class CocoaClient {
 			semaphore.acquire(NUMBER);
 		} catch (InterruptedException e) {
 		}
+		client.shutdown();
 	}
 }

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/ReceivetestClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/ReceivetestClient.java
@@ -153,7 +153,7 @@ public class ReceivetestClient {
 		} else {
 			System.out.println("No response received.");
 		}
-
+		client.shutdown();
 		System.exit(0);
 	}
 

--- a/demo-apps/cf-helloworld-client/src/main/java/org/eclipse/californium/examples/GETClient.java
+++ b/demo-apps/cf-helloworld-client/src/main/java/org/eclipse/californium/examples/GETClient.java
@@ -77,7 +77,7 @@ public class GETClient {
 			} else {
 				System.out.println("No response received.");
 			}
-			
+			client.shutdown();
 		} else {
 			// display help
 			System.out.println("Californium (Cf) GET Client");

--- a/demo-apps/cf-helloworld-client/src/main/java/org/eclipse/californium/examples/MulticastTestClient.java
+++ b/demo-apps/cf-helloworld-client/src/main/java/org/eclipse/californium/examples/MulticastTestClient.java
@@ -90,6 +90,7 @@ public class MulticastTestClient {
 		client.advanced(handler, multicastRequest);
 		while (handler.waitOn(2000))
 			;
+		client.shutdown();
 	}
 
 	private static final MultiCoapHandler handler = new MultiCoapHandler();

--- a/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/PlugtestClient.java
+++ b/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/PlugtestClient.java
@@ -338,6 +338,8 @@ public class PlugtestClient {
 		response = client.putIfNoneMatch("CC23 at " + new SimpleDateFormat("HH:mm:ss.SSS").format(new Date()),
 				MediaTypeRegistry.TEXT_PLAIN);
 		System.out.println(response.getCode());
+
+		client.shutdown();
 	}
 
 	public static void testCB(String uri) throws ConnectorException, IOException {
@@ -400,6 +402,8 @@ public class PlugtestClient {
 		response = client.get();
 		System.out.println(response.getCode());
 		System.out.println(response.getResponseText());
+
+		client.shutdown();
 	}
 
 	public static void testCO(String uri) throws ConnectorException, IOException {
@@ -555,6 +559,8 @@ public class PlugtestClient {
 			Thread.sleep(6 * 1000);
 		} catch (InterruptedException e) {
 		}
+
+		client.shutdown();
 	}
 
 	public static void testCL(String uri) throws ConnectorException, IOException {
@@ -637,6 +643,8 @@ public class PlugtestClient {
 				System.out.println(response.getResponseText());
 			}
 		}
+
+		client.shutdown();
 	}
 
 	public static String getLargeRequestPayload() {


### PR DESCRIPTION
Since #937, shutdown client is mandatory in case you don't use a detached executor.

``` java
/**
 * Shutdown the client-specific executor service, when not detached. Always
 * needed unless you used detached executor.
 */
public void shutdown()
```

This is mainly added for didactic purpose.