### PR TITLE
Add principal converter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ You can find all the details in the [Contributing via Git](http://wiki.eclipse.o
 1. Consider to start with creating an issue on GitHub to discuss your plans and get the proper startup information.
 1. Ensure, your plans will work with java 1.7
 1. Fork the repository on GitHub
-1. Create a new branch for your changes based on the 2.0.x branch. 
+1. Create a new branch for your changes based on the master branch.
    Please note: work based on other branches without prior discussion in an issue, may be in vain.
 1. If you use the eclipse IDE, please import our prefer formatter `eclipse-formatter-profile.xml` from the californium parent-folder and apply it to your changes (only :-) ).
 1. Make your changes 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+# Please providing basic issue information
+
+Issues may be answered much faster, if you provide more details ahead!
+
+* branch your faced the issue. Currently 
+   * 1.0 is the release, 
+   * 1.1 is the master, 
+   * and 2.0 is the development branch
+* If you use a SNAPSHOT, ensure your updated to the latest. Please provide the
+  commit your using
+* If your issue is related to your own snippet, please provide that
+* If you have logs, please provide them
+* If you have tcpdump captures (wireshark), please provide them.
+

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -3,9 +3,9 @@
 Issues may be answered much faster, if you provide more details ahead!
 
 * branch your faced the issue. Currently 
-   * 1.0 is the release,
-   * 1.1 is the previous master,
-   * and master / 2.0 is the development branch
+   * 1.0 is the current release,
+   * 1.1 is the previous master (no plans to continue this)
+   * and master (previous 2.0) is the development branch and our upcoming release!
 * If you use a SNAPSHOT, ensure your updated to the latest. Please provide the
   commit your using
 * If your issue is related to your own snippet, please provide that

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -3,9 +3,9 @@
 Issues may be answered much faster, if you provide more details ahead!
 
 * branch your faced the issue. Currently 
-   * 1.0 is the release, 
-   * 1.1 is the master, 
-   * and 2.0 is the development branch
+   * 1.0 is the release,
+   * 1.1 is the previous master,
+   * and master / 2.0 is the development branch
 * If you use a SNAPSHOT, ensure your updated to the latest. Please provide the
   commit your using
 * If your issue is related to your own snippet, please provide that

--- a/demo-apps/cf-helloworld-client/src/main/java/org/eclipse/californium/examples/GETClient.java
+++ b/demo-apps/cf-helloworld-client/src/main/java/org/eclipse/californium/examples/GETClient.java
@@ -16,6 +16,7 @@
  ******************************************************************************/
 package org.eclipse.californium.examples;
 
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
@@ -25,15 +26,35 @@ import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.CoapResponse;
 import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.elements.exception.ConnectorException;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.config.NetworkConfigDefaultHandler;
+import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 
 
 public class GETClient {
+
+	private static final File CONFIG_FILE = new File("Californium.properties");
+	private static final String CONFIG_HEADER = "Californium CoAP Properties file for Fileclient";
+	private static final int DEFAULT_MAX_RESOURCE_SIZE = 2 * 1024 * 1024; // 2 MB
+	private static final int DEFAULT_BLOCK_SIZE = 512;
+
+	private static NetworkConfigDefaultHandler DEFAULTS = new NetworkConfigDefaultHandler() {
+
+		@Override
+		public void applyDefaults(NetworkConfig config) {
+			config.setInt(Keys.MAX_RESOURCE_BODY_SIZE, DEFAULT_MAX_RESOURCE_SIZE);
+			config.setInt(Keys.MAX_MESSAGE_SIZE, DEFAULT_BLOCK_SIZE);
+			config.setInt(Keys.PREFERRED_BLOCK_SIZE, DEFAULT_BLOCK_SIZE);
+		}
+	};
 
 	/*
 	 * Application entry point.
 	 * 
 	 */	
 	public static void main(String args[]) {
+		NetworkConfig config = NetworkConfig.createWithFile(CONFIG_FILE, CONFIG_HEADER, DEFAULTS);
+		NetworkConfig.setStandard(config);
 		
 		URI uri = null; // URI parameter of the request
 		

--- a/demo-apps/cf-simplefile-server/pom.xml
+++ b/demo-apps/cf-simplefile-server/pom.xml
@@ -23,7 +23,15 @@
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>californium-core</artifactId>
+			<artifactId>cf-plugtest-server</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<!-- runtime dependencies -->
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>demo-certs</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
 

--- a/demo-apps/cf-simplefile-server/src/main/java/org/eclipse/californium/examples/SimpleFileServer.java
+++ b/demo-apps/cf-simplefile-server/src/main/java/org/eclipse/californium/examples/SimpleFileServer.java
@@ -21,35 +21,58 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.SocketException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.eclipse.californium.core.CoapResource;
-import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
-import org.eclipse.californium.core.network.CoapEndpoint;
-import org.eclipse.californium.core.network.EndpointManager;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.config.NetworkConfigDefaultHandler;
+import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.californium.plugtests.AbstractTestServer;
 
-public class SimpleFileServer extends CoapServer {
+public class SimpleFileServer extends AbstractTestServer {
+
 	private static final Logger LOG = LoggerFactory.getLogger(SimpleFileServer.class.getName());
 
-	private static final int COAP_PORT = NetworkConfig.getStandard().getInt(NetworkConfig.Keys.COAP_PORT);
+	private static final File CONFIG_FILE = new File("Californium.properties");
+	private static final String CONFIG_HEADER = "Californium CoAP Properties file for Fileserver";
+	private static final int DEFAULT_MAX_RESOURCE_SIZE = 2 * 1024 * 1024; // 2 MB
+	private static final int DEFAULT_BLOCK_SIZE = 512;
+
+	private static NetworkConfigDefaultHandler DEFAULTS = new NetworkConfigDefaultHandler() {
+
+		@Override
+		public void applyDefaults(NetworkConfig config) {
+			config.setInt(Keys.MAX_RESOURCE_BODY_SIZE, DEFAULT_MAX_RESOURCE_SIZE);
+			config.setInt(Keys.MAX_MESSAGE_SIZE, DEFAULT_BLOCK_SIZE);
+			config.setInt(Keys.PREFERRED_BLOCK_SIZE, DEFAULT_BLOCK_SIZE);
+		}
+	};
+
 	private static final String DEFAULT_PATH = "data";
 
 	/*
 	 * Application entry point.
 	 */
 	public static void main(String[] args) {
+		NetworkConfig config = NetworkConfig.createWithFile(CONFIG_FILE, CONFIG_HEADER, DEFAULTS);
+		NetworkConfig udpConfig = new NetworkConfig(config);
+		udpConfig.setInt(Keys.MAX_MESSAGE_SIZE, 64);
+		udpConfig.setInt(Keys.PREFERRED_BLOCK_SIZE, 64);
+		Map<Select, NetworkConfig> protocolConfig = new HashMap<>();
+		protocolConfig.put(new Select(Protocol.UDP, InterfaceType.EXTERNAL), udpConfig);
 
 		try {
 			String filesRootPath = DEFAULT_PATH;
@@ -59,8 +82,7 @@ public class SimpleFileServer extends CoapServer {
 			case 2:
 				coapRootPath = args[1];
 				if (0 <= coapRootPath.indexOf('/')) {
-					LOG.error("{} don't use '/'! Only one path segement for coap root allowed!",
-							coapRootPath);
+					LOG.error("{} don't use '/'! Only one path segement for coap root allowed!", coapRootPath);
 					return;
 				}
 			case 1:
@@ -80,14 +102,14 @@ public class SimpleFileServer extends CoapServer {
 			File[] files = filesRoot.listFiles();
 			for (File file : files) {
 				if (file.isFile() && file.canRead()) {
-					LOG.info("GET: coap://<host>/{}/{}", new Object[] { coapRootPath, file.getName() });
+					LOG.info("GET: coap://<host>/{}/{}", coapRootPath, file.getName());
 					break;
 				}
 			}
 			// create server
-			SimpleFileServer server = new SimpleFileServer(coapRootPath, filesRoot);
+			SimpleFileServer server = new SimpleFileServer(config, protocolConfig, coapRootPath, filesRoot);
 			// add endpoints on all IP addresses
-			server.addEndpoints();
+			server.addEndpoints(null, null, Arrays.asList(Protocol.UDP, Protocol.DTLS, Protocol.TCP, Protocol.TLS));
 			server.start();
 
 		} catch (SocketException e) {
@@ -95,27 +117,18 @@ public class SimpleFileServer extends CoapServer {
 		}
 	}
 
-	/**
-	 * Add individual endpoints listening on default CoAP port on all IPv4
-	 * addresses of all network interfaces.
-	 */
-	private void addEndpoints() {
-		for (InetAddress addr : EndpointManager.getEndpointManager().getNetworkInterfaces()) {
-			CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
-			builder.setInetSocketAddress(new InetSocketAddress(addr, COAP_PORT));
-			addEndpoint(builder.build());
-		}
-	}
-
 	/*
 	 * Constructor for a new simple file server. Here, the resources of the
 	 * server are initialized.
 	 */
-	public SimpleFileServer(String coapRootPath, File filesRoot) throws SocketException {
-		add(new FileResource(coapRootPath, filesRoot));
+	public SimpleFileServer(NetworkConfig config, Map<Select, NetworkConfig> protocolConfig, String coapRootPath, File filesRoot) throws SocketException {
+		super(config, protocolConfig);
+		add(new FileResource(config, coapRootPath, filesRoot));
 	}
 
 	class FileResource extends CoapResource {
+
+		private final NetworkConfig config;
 		/**
 		 * Files root directory.
 		 */
@@ -124,15 +137,14 @@ public class SimpleFileServer extends CoapServer {
 		/**
 		 * Create CoAP file resource.
 		 * 
-		 * @param coapRootPath
-		 *            CoAP resource (base) name
-		 * @param fileRootPath
-		 *            path to file root
-		 * @param maxFileLength
-		 *            maximum file length
+		 * @param config network configuration
+		 * @param coapRootPath CoAP resource (base) name
+		 * @param fileRootPath path to file root
+		 * @param maxFileLength maximum file length
 		 */
-		public FileResource(String coapRootPath, File filesRoot) {
+		public FileResource(NetworkConfig config, String coapRootPath, File filesRoot) {
 			super(coapRootPath);
+			this.config = config;
 			this.filesRoot = filesRoot;
 		}
 
@@ -171,13 +183,13 @@ public class SimpleFileServer extends CoapServer {
 			String myURI = getURI() + "/";
 			String path = "/" + request.getOptions().getUriPathString();
 			if (!path.startsWith(myURI)) {
-				LOG.info("Request {} does not match {}!", new Object[] { path, myURI });
+				LOG.info("Request {} does not match {}!", path, myURI);
 				exchange.respond(CoAP.ResponseCode.INTERNAL_SERVER_ERROR);
 				return;
 			}
 			path = path.substring(myURI.length());
 			if (request.getOptions().hasBlock2()) {
-				LOG.info("Send file {} {}", new Object[] { path, request.getOptions().getBlock2() });
+				LOG.info("Send file {} {}", path, request.getOptions().getBlock2());
 			} else {
 				LOG.info("Send file {}", path);
 			}
@@ -188,8 +200,7 @@ public class SimpleFileServer extends CoapServer {
 				return;
 			}
 			if (!checkFileLocation(file, filesRoot)) {
-				LOG.warn("File {} is not in {}!",
-						new Object[] { file.getAbsolutePath(), filesRoot.getAbsolutePath() });
+				LOG.warn("File {} is not in {}!", file.getAbsolutePath(), filesRoot.getAbsolutePath());
 				exchange.respond(CoAP.ResponseCode.UNAUTHORIZED);
 				return;
 			}
@@ -199,11 +210,10 @@ public class SimpleFileServer extends CoapServer {
 				exchange.respond(CoAP.ResponseCode.UNAUTHORIZED);
 				return;
 			}
-			long maxLength = NetworkConfig.getStandard().getInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE);
+			long maxLength = config.getInt(NetworkConfig.Keys.MAX_RESOURCE_BODY_SIZE);
 			long length = file.length();
 			if (length > maxLength) {
-				LOG.warn("File {} is too large {} (max.: {})!",
-						new Object[] { file.getAbsolutePath(), length, maxLength });
+				LOG.warn("File {} is too large {} (max.: {})!", file.getAbsolutePath(), length, maxLength);
 				exchange.respond(CoAP.ResponseCode.INTERNAL_SERVER_ERROR);
 				return;
 			}
@@ -231,10 +241,8 @@ public class SimpleFileServer extends CoapServer {
 		 * 
 		 * Detect attacks via "../.../../file".
 		 * 
-		 * @param file
-		 *            file to check
-		 * @param root
-		 *            file root
+		 * @param file file to check
+		 * @param root file root
 		 * @return true, if file is locate in root (or a sub-folder of root),
 		 *         false, otherwise.
 		 */
@@ -247,5 +255,4 @@ public class SimpleFileServer extends CoapServer {
 			}
 		}
 	}
-
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/AbstractExtensiblePrincipal.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/AbstractExtensiblePrincipal.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ *******************************************************************************/
+
+
+package org.eclipse.californium.elements.auth;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.Map;
+
+
+/**
+ * A base class for implementing {@link ExtensiblePrincipal}s.
+ *
+ * @param <T> The type of the principal.
+ */
+public abstract class AbstractExtensiblePrincipal<T extends Principal> implements ExtensiblePrincipal<T> {
+
+	private final Map<String, Principal> additionalInfo;
+
+	/**
+	 * Creates a new principal with no additional information.
+	 */
+	protected AbstractExtensiblePrincipal() {
+		this(null);
+	}
+
+	/**
+	 * Creates a new principal with additional information.
+	 * 
+	 * @param additionalInformation The additional information.
+	 */
+	protected AbstractExtensiblePrincipal(Map<String, Principal> additionalInformation) {
+		if (additionalInformation == null) {
+			this.additionalInfo = Collections.emptyMap();
+		} else {
+			this.additionalInfo = Collections.unmodifiableMap(additionalInformation);
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public final Map<String, Principal> getExtendedInfo() {
+		return additionalInfo;
+	}
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/ExtensiblePrincipal.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/ExtensiblePrincipal.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ *******************************************************************************/
+
+
+package org.eclipse.californium.elements.auth;
+
+import java.security.Principal;
+import java.util.Map;
+
+/**
+ * A {@code Principal} that can be extended with additional information.
+ *
+ * @param <T> The type of the principal.
+ */
+public interface ExtensiblePrincipal<T extends Principal> extends Principal {
+
+	/**
+	 * Creates a shallow copy of this principal which contains additional information.
+	 * <p>
+	 * The additional information can be retrieved from the returned copy using the
+	 * {@link #getExtendedInfo()} method.
+	 * 
+	 * @param additionInfo The additional information.
+	 * @return The copy.
+	 */
+	T amend(Map<String, Principal> additionInfo);
+
+	/**
+	 * Gets additional information about this principal.
+	 * 
+	 * @return An unmodifiable map of additional information for this principal.
+	 *         The map will be empty if no additional information is available.
+	 */
+	Map<String, Principal> getExtendedInfo();
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentity.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Institute for Pervasive Computing, ETH Zurich and others.
+ * Copyright (c) 2015, 2019 Institute for Pervasive Computing, ETH Zurich and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@
 package org.eclipse.californium.elements.auth;
 
 import java.security.Principal;
+import java.util.Map;
 
 import org.eclipse.californium.elements.util.StringUtil;
 
@@ -25,7 +26,7 @@ import org.eclipse.californium.elements.util.StringUtil;
  * A principal representing an authenticated peer's identity as used in a
  * <em>pre-shared key</em> handshake.
  */
-public final class PreSharedKeyIdentity implements Principal {
+public final class PreSharedKeyIdentity extends AbstractExtensiblePrincipal<PreSharedKeyIdentity> {
 
 	private final boolean scopedIdentity;
 	private final String virtualHost;
@@ -39,7 +40,18 @@ public final class PreSharedKeyIdentity implements Principal {
 	 * @throws NullPointerException if the identity is <code>null</code>
 	 */
 	public PreSharedKeyIdentity(String identity) {
-		this(false, null, identity);
+		this(false, null, identity, null);
+	}
+
+	/**
+	 * Creates a new instance for an identity.
+	 * 
+	 * @param identity the identity
+	 * @param additionalInformation Additional information for this principal.
+	 * @throws NullPointerException if the identity is <code>null</code>
+	 */
+	public PreSharedKeyIdentity(String identity, Map<String, Principal> additionalInformation) {
+		this(false, null, identity, additionalInformation);
 	}
 
 	/**
@@ -53,7 +65,22 @@ public final class PreSharedKeyIdentity implements Principal {
 	 *             as per <a href="http://tools.ietf.org/html/rfc1123">RFC 1123</a>.
 	 */
 	public PreSharedKeyIdentity(String virtualHost, String identity) {
-		this(true, virtualHost, identity);
+		this(true, virtualHost, identity, null);
+	}
+
+	/**
+	 * Creates a new instance for an identity scoped to a virtual host.
+	 * 
+	 * @param virtualHost The virtual host name that the identity is scoped to.
+	 *                    The host name will be converted to lower case.
+	 * @param identity the identity.
+	 * @param additionalInformation Additional information for this principal.
+	 * @throws NullPointerException if the identity is <code>null</code>
+	 * @throws IllegalArgumentException if virtual host is not a valid host name
+	 *             as per <a href="http://tools.ietf.org/html/rfc1123">RFC 1123</a>.
+	 */
+	public PreSharedKeyIdentity(String virtualHost, String identity, Map<String, Principal> additionalInformation) {
+		this(true, virtualHost, identity, additionalInformation);
 	}
 
 	/**
@@ -63,12 +90,14 @@ public final class PreSharedKeyIdentity implements Principal {
 	 * @param virtualHost The virtual host name that the identity is scoped to.
 	 *            The host name will be converted to lower case.
 	 * @param identity the identity.
+	 * @param additionalInformation Additional information for this principal.
 	 * @throws NullPointerException if the identity is <code>null</code>
 	 * @throws IllegalArgumentException if virtual host is not a valid host name
 	 *             as per <a href="http://tools.ietf.org/html/rfc1123">RFC
 	 *             1123</a>.
 	 */
-	private PreSharedKeyIdentity(boolean sni, String virtualHost, String identity) {
+	private PreSharedKeyIdentity(boolean sni, String virtualHost, String identity, Map<String, Principal> additionalInformation) {
+		super(additionalInformation);
 		if (identity == null) {
 			throw new NullPointerException("Identity must not be null");
 		} else {
@@ -95,6 +124,22 @@ public final class PreSharedKeyIdentity implements Principal {
 			b.append(identity);
 			this.name = b.toString();
 		}
+	}
+
+	private PreSharedKeyIdentity(boolean scopedIdentity, String virtualHost, String identity, String name, Map<String, Principal> additionalInfo) {
+		super(additionalInfo);
+		this.scopedIdentity = scopedIdentity;
+		this.virtualHost = virtualHost;
+		this.identity = identity;
+		this.name = name;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public PreSharedKeyIdentity amend(Map<String, Principal> additionInfo) {
+		return new PreSharedKeyIdentity(scopedIdentity, virtualHost, identity, name, additionInfo);
 	}
 
 	/**

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/RawPublicKeyIdentity.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/RawPublicKeyIdentity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Institute for Pervasive Computing, ETH Zurich and others.
+ * Copyright (c) 2015, 2019 Institute for Pervasive Computing, ETH Zurich and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -27,6 +27,7 @@ import java.security.Principal;
 import java.security.PublicKey;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
+import java.util.Map;
 
 import org.eclipse.californium.elements.util.Asn1DerDecoder;
 import org.eclipse.californium.elements.util.Base64;
@@ -34,7 +35,7 @@ import org.eclipse.californium.elements.util.Base64;
 /**
  * A principal representing an authenticated peer's <em>RawPublicKey</em>.
  */
-public class RawPublicKeyIdentity implements Principal {
+public class RawPublicKeyIdentity extends AbstractExtensiblePrincipal<RawPublicKeyIdentity> {
 
 	private static final int BASE_64_ENCODING_OPTIONS = Base64.ENCODE | Base64.URL_SAFE | Base64.NO_PADDING;
 	private String niUri;
@@ -47,6 +48,18 @@ public class RawPublicKeyIdentity implements Principal {
 	 * @throws NullPointerException if the key is <code>null</code>
 	 */
 	public RawPublicKeyIdentity(PublicKey key) {
+		this(key, null);
+	}
+
+	/**
+	 * Creates a new instance for a given public key.
+	 * 
+	 * @param key the public key
+	 * @param additionalInformation Additional information for this principal.
+	 * @throws NullPointerException if the key is <code>null</code>
+	 */
+	public RawPublicKeyIdentity(PublicKey key, Map<String, Principal> additionalInformation) {
+		super(additionalInformation);
 		if (key == null) {
 			throw new NullPointerException("Public key must not be null");
 		} else {
@@ -57,8 +70,6 @@ public class RawPublicKeyIdentity implements Principal {
 
 	/**
 	 * Creates a new instance for a given ASN.1 subject public key info structure.
-	 * <p>
-	 * The given subject info is expected to represent an EC public key.
 	 * 
 	 * @param subjectInfo the ASN.1 encoded X.509 subject public key info.
 	 * @throws NullPointerException if the subject info is <code>null</code>
@@ -66,7 +77,20 @@ public class RawPublicKeyIdentity implements Principal {
 	 *             algorithm used by the public key.
 	 */
 	public RawPublicKeyIdentity(byte[] subjectInfo) throws GeneralSecurityException {
-		this(subjectInfo, null);
+		this(subjectInfo, null, null);
+	}
+
+	/**
+	 * Creates a new instance for a given ASN.1 subject public key info structure.
+	 * 
+	 * @param subjectInfo the ASN.1 encoded X.509 subject public key info.
+	 * @param additionalInformation Additional information for this principal.
+	 * @throws NullPointerException if the subject info is <code>null</code>
+	 * @throws GeneralSecurityException if the JVM does not support the key
+	 *             algorithm used by the public key.
+	 */
+	public RawPublicKeyIdentity(byte[] subjectInfo, Map<String, Principal> additionalInformation) throws GeneralSecurityException {
+		this(subjectInfo, null, additionalInformation);
 	}
 
 	/**
@@ -75,13 +99,31 @@ public class RawPublicKeyIdentity implements Principal {
 	 * @param subjectInfo the ASN.1 encoded X.509 subject public key info.
 	 * @param keyAlgorithm the algorithm name to verify, that the subject public
 	 *            key uses this key algorithm, or to support currently not
-	 *            supported key algorithms for serialization/deserialization. If
-	 *            {@code null}, use the to key algorithm provided by the ASN.1
-	 *            DER encoded subject public key.
+	 *            supported key algorithms for serialization/deserialization.
+	 *            If {@code null}, the key algorithm provided by the ASN.1
+	 *            DER encoded subject public key is used.
 	 * @throws NullPointerException if the subject info is <code>null</code>
 	 * @throws GeneralSecurityException if the JVM does not support the given key algorithm.
 	 */
 	public RawPublicKeyIdentity(byte[] subjectInfo, String keyAlgorithm) throws GeneralSecurityException {
+		this(subjectInfo, keyAlgorithm, null);
+	}
+
+	/**
+	 * Creates a new instance for a given ASN.1 subject public key info structure.
+	 * 
+	 * @param subjectInfo the ASN.1 encoded X.509 subject public key info.
+	 * @param keyAlgorithm the algorithm name to verify, that the subject public
+	 *            key uses this key algorithm, or to support currently not
+	 *            supported key algorithms for serialization/deserialization.
+	 *            If {@code null}, the key algorithm provided by the ASN.1
+	 *            DER encoded subject public key is used.
+	 * @param additionalInformation Additional information for this principal.
+	 * @throws NullPointerException if the subject info is <code>null</code>
+	 * @throws GeneralSecurityException if the JVM does not support the given key algorithm.
+	 */
+	public RawPublicKeyIdentity(byte[] subjectInfo, String keyAlgorithm, Map<String, Principal> additionalInformation) throws GeneralSecurityException {
+		super(additionalInformation);
 		if (subjectInfo == null) {
 			throw new NullPointerException("SubjectPublicKeyInfo must not be null");
 		} else {
@@ -106,6 +148,14 @@ public class RawPublicKeyIdentity implements Principal {
 			this.publicKey = KeyFactory.getInstance(specKeyAlgorithm).generatePublic(spec);
 			createNamedInformationUri(subjectInfo);
 		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public RawPublicKeyIdentity amend(Map<String, Principal> additionInfo) {
+		return new RawPublicKeyIdentity(publicKey, additionInfo);
 	}
 
 	private void createNamedInformationUri(byte[] subjectPublicKeyInfo) {

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/X509CertPath.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/X509CertPath.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2016 - 2019 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -26,6 +26,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -40,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * the asserted identity) at first position and the certificate issued by the
  * trust anchor at the end of the list.
  */
-public class X509CertPath implements Principal {
+public class X509CertPath extends AbstractExtensiblePrincipal<X509CertPath> {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(X509CertPath.class.getCanonicalName());
 	private static final String TYPE_X509 = "X.509";
@@ -56,6 +57,19 @@ public class X509CertPath implements Principal {
 	 *             or does not contain X.509 certificates only.
 	 */
 	public X509CertPath(final CertPath certPath) {
+		this(certPath, null);
+	}
+
+	/**
+	 * Creates a new instance for a certificate chain.
+	 * 
+	 * @param certPath The certificate chain asserting the peer's identity.
+	 * @param additionalInformation Additional information for this principal.
+	 * @throws IllegalArgumentException if the given certificate chain is empty
+	 *             or does not contain X.509 certificates only.
+	 */
+	public X509CertPath(final CertPath certPath, Map<String, Principal> additionalInformation) {
+		super(additionalInformation);
 		if (!TYPE_X509.equals(certPath.getType())) {
 			throw new IllegalArgumentException("Cert path must contain X.509 certificates only");
 		} else if (certPath.getCertificates().isEmpty()) {
@@ -64,6 +78,14 @@ public class X509CertPath implements Principal {
 			this.path = certPath;
 			this.target = (X509Certificate) certPath.getCertificates().get(0);
 		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public X509CertPath amend(Map<String, Principal> additionInfo) {
+		return new X509CertPath(path, additionInfo);
 	}
 
 	/**

--- a/license_header_template.txt
+++ b/license_header_template.txt
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) <year (e.g. 2017)> <(company) name> and others.
+ * Copyright (c) <year (e.g. 2019)> <(company) name> and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/auth/ApplicationLevelInfoSupplier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/auth/ApplicationLevelInfoSupplier.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial creation
+ *******************************************************************************/
+
+
+package org.eclipse.californium.scandium.auth;
+
+import java.security.Principal;
+import java.util.Map;
+
+/**
+ * A strategy for retrieving additional (application level) information about an authenticated peer.
+ */
+public interface ApplicationLevelInfoSupplier {
+
+    /**
+     * Gets additional information about an authenticated peer.
+     * 
+     * @param peerIdentity The peer identity.
+     * @return The additional information about the peer.
+     */
+	Map<String, Principal> getInfo(Principal peerIdentity);
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 - 2017 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2015 - 2019 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -256,7 +256,7 @@ public final class DtlsConnectorConfig {
 	/**
 	 * Use anti replay filter.
 	 * 
-	 * @see http://tools.ietf.org/html/rfc6347#section-4.1
+	 * @see "http://tools.ietf.org/html/rfc6347#section-4.1"
 	 */
 	private Boolean useAntiReplayFilter;
 
@@ -265,7 +265,7 @@ public final class DtlsConnectorConfig {
 	 * 
 	 * Messages too old for the filter window will pass the filter.
 	 * 
-	 * @see http://tools.ietf.org/html/rfc6347#section-4.1
+	 * @see "http://tools.ietf.org/html/rfc6347#section-4.1"
 	 */
 	private Boolean useWindowFilter;
 
@@ -686,7 +686,7 @@ public final class DtlsConnectorConfig {
 	 * Use anti replay filter.
 	 * 
 	 * @return {@code true}, apply anti replay filter
-	 * @see http://tools.ietf.org/html/rfc6347#section-4.1
+	 * @see "http://tools.ietf.org/html/rfc6347#section-4.1"
 	 */
 	public Boolean useAntiReplayFilter() {
 		return useAntiReplayFilter;
@@ -698,7 +698,7 @@ public final class DtlsConnectorConfig {
 	 * Messages too old for the filter window will pass the filter.
 	 * 
 	 * @return {@code true}, apply window filter
-	 * @see http://tools.ietf.org/html/rfc6347#section-4.1
+	 * @see "http://tools.ietf.org/html/rfc6347#section-4.1"
 	 */
 	public Boolean useWindowFilter() {
 		return useWindowFilter;
@@ -1179,11 +1179,9 @@ public final class DtlsConnectorConfig {
 		 * public key pair.
 		 * <p>
 		 * Using this method implies that the connector <em>only</em> supports
-		 * <em>RawPublicKey</em> mode for authenticating to a peer. This sets
-		 * the {@link DtlsConnectorConfig#identityCertificateTypes} to
-		 * RAW_PUBLIC_KEY also. Please ensure, that you setup
-		 * {@link #setRpkTrustStore(TrustedRpkStore)}, or [@link
-		 * {@link #setRpkTrustAll()}}, if you want to trust the other peer using
+		 * <em>RawPublicKey</em> mode for authenticating to a peer. Please ensure,
+		 * that you setup {@link #setRpkTrustStore(TrustedRpkStore)}, or
+		 * {@link #setRpkTrustAll()}, if you want to trust the other peer using
 		 * RAW_PUBLIC_KEY also.
 		 * 
 		 * If X_509 is intended to be supported together with RAW_PUBLIC_KEY,
@@ -1642,7 +1640,6 @@ public final class DtlsConnectorConfig {
 		 *            {@link DtlsConnectorConfig#DEFAULT_VERIFY_PEERS_ON_RESUMPTION_THRESHOLD_IN_PERCENT}
 		 * @return this builder for command chaining.
 		 * @throws IllegalArgumentException if threshold is not between 0 and 100
-		 * @see DtlsConnectorConfig#verifyPeersOnResumptionThreshold
 		 */
 		public Builder setVerifyPeersOnResumptionThreshold(int threshold) {
 			if (threshold < 0 || threshold > 100) {
@@ -1674,7 +1671,7 @@ public final class DtlsConnectorConfig {
 		 * @param enable {@code true} to enable filter. Default {@code true}.
 		 * @return this builder for command chaining.
 		 * @throws IllegalArgumentException if window filter is active.
-		 * @see http://tools.ietf.org/html/rfc6347#section-4.1
+		 * @see "http://tools.ietf.org/html/rfc6347#section-4.1"
 		 */
 		public Builder setUseAntiReplayFilter(boolean enable) {
 			if (enable && Boolean.TRUE.equals(config.useWindowFilter)) {
@@ -1692,7 +1689,7 @@ public final class DtlsConnectorConfig {
 		 * @param enable {@code true} to enable filter. Default {@code false}.
 		 * @return this builder for command chaining.
 		 * @throws IllegalArgumentException if anti replay window filter is active.
-		 * @see http://tools.ietf.org/html/rfc6347#section-4.1
+		 * @see "http://tools.ietf.org/html/rfc6347#section-4.1"
 		 */
 		public Builder setUseWindowFilter(boolean enable) {
 			if (enable && Boolean.TRUE.equals(config.useAntiReplayFilter)) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -46,6 +46,7 @@ import java.util.List;
 
 import org.eclipse.californium.elements.DtlsEndpointContext;
 import org.eclipse.californium.elements.util.SslContextUtil;
+import org.eclipse.californium.scandium.auth.ApplicationLevelInfoSupplier;
 import org.eclipse.californium.scandium.dtls.CertificateType;
 import org.eclipse.californium.scandium.dtls.ConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.SessionCache;
@@ -285,6 +286,8 @@ public final class DtlsConnectorConfig {
 	 * {@code false}.
 	 */
 	private ConnectionIdGenerator connectionIdGenerator;
+
+	private ApplicationLevelInfoSupplier applicationLevelInfoSupplier;
 
 	private DtlsConnectorConfig() {
 		// empty
@@ -548,6 +551,15 @@ public final class DtlsConnectorConfig {
 	}
 
 	/**
+	 * Gets the supplier of application level information for an authenticated peer's identity.
+	 * 
+	 * @return the supplier or {@code null} if not set
+	 */
+	public ApplicationLevelInfoSupplier getApplicationLevelInfoSupplier() {
+		return applicationLevelInfoSupplier;
+	}
+
+	/**
 	 * Gets whether the connector wants (requests) DTLS clients to authenticate
 	 * during the handshake. The handshake doesn't fail, if the client didn't
 	 * authenticate itself during the handshake. That mostly requires the client
@@ -762,6 +774,7 @@ public final class DtlsConnectorConfig {
 		cloned.useAntiReplayFilter = useAntiReplayFilter;
 		cloned.useWindowFilter = useWindowFilter;
 		cloned.connectionIdGenerator = connectionIdGenerator;
+		cloned.applicationLevelInfoSupplier = applicationLevelInfoSupplier;
 		return cloned;
 	}
 
@@ -1402,6 +1415,21 @@ public final class DtlsConnectorConfig {
 				throw new IllegalStateException("CertificateVerifier must not be used after trust store is set!");
 			}
 			config.certificateVerifier = verifier;
+			return this;
+		}
+
+		/**
+		 * Sets a supplier of application level information for an authenticated peer's identity.
+		 * 
+		 * @param supplier The supplier.
+		 * @return this  builder for command chaining.
+		 * @throws NullPointerException if supplier is {@code null}.
+		 */
+		public Builder setApplicationLevelInfoSupplier(ApplicationLevelInfoSupplier supplier) {
+			if (supplier == null) {
+				throw new NullPointerException("Supplier must not be null");
+			}
+			config.applicationLevelInfoSupplier = supplier;
 			return this;
 		}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Institute for Pervasive Computing, ETH Zurich and others.
+ * Copyright (c) 2015, 2019 Institute for Pervasive Computing, ETH Zurich and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -56,16 +56,21 @@ package org.eclipse.californium.scandium.dtls;
 
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
+import java.security.Principal;
 import java.security.PublicKey;
 import java.security.cert.CertPath;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
+import org.eclipse.californium.elements.auth.ExtensiblePrincipal;
 import org.eclipse.californium.elements.auth.PreSharedKeyIdentity;
 import org.eclipse.californium.elements.auth.RawPublicKeyIdentity;
 import org.eclipse.californium.elements.auth.X509CertPath;
 import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.elements.util.StringUtil;
+import org.eclipse.californium.scandium.auth.ApplicationLevelInfoSupplier;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
@@ -185,7 +190,6 @@ public class ServerHandshaker extends Handshaker {
 		this.supportedCipherSuites = config.getSupportedCipherSuites();
 
 		this.pskStore = config.getPskStore();
-
 		this.privateKey = config.getPrivateKey();
 		this.certificateChain = config.getCertificateChain();
 		this.publicKey = config.getPublicKey();
@@ -447,6 +451,7 @@ public class ServerHandshaker extends Handshaker {
 		// http://tools.ietf.org/html/rfc6347#section-4.2.4
 		lastFlight = flight;
 		sendFlight(flight);
+
 		sessionEstablished();
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -32,6 +32,7 @@
  ******************************************************************************/
 package org.eclipse.californium.scandium;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.*;
@@ -42,6 +43,7 @@ import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.GeneralSecurityException;
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -60,6 +62,7 @@ import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
+import org.eclipse.californium.elements.auth.ExtensiblePrincipal;
 import org.eclipse.californium.elements.util.TestThreadFactory;
 import org.eclipse.californium.elements.util.ClockUtil;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
@@ -276,6 +279,15 @@ public class ConnectorHelper {
 			}
 		}
 		return clientChannel;
+	}
+
+	static void assertPrincipalHasAdditionalInfo(Principal peerIdentity, String expectedName) {
+		assertThat(peerIdentity, instanceOf(ExtensiblePrincipal.class));
+		@SuppressWarnings("unchecked")
+		ExtensiblePrincipal<? extends Principal> p = (ExtensiblePrincipal<? extends Principal>) peerIdentity;
+		assertFalse(p.getExtendedInfo().isEmpty());
+		Principal extendedInfo = p.getExtendedInfo().values().iterator().next();
+		assertThat(extendedInfo.getName(), is(expectedName));
 	}
 
 	static class LatchDecrementingRawDataChannel implements RawDataChannel {


### PR DESCRIPTION
The Principal instances created by Scandium when a client has been
authenticated contain only the authentication identifier used by the
client, e.g. the PSK identity or the client cert subject DN.

However, applications will often map the (technical) authentication
identifier used at the DTLS level to a logical application level
identifier which is used to refer to the client.

The PrincipalConverter can be implemented by applications to convert the
technical Principal created by Scandium to a Principal that contains
applications level information which can then be used when processing
CoAP requests.
