### PR TITLE
OSCORE: Implements setting of peer identity and Principal for OSCORE

### DIFF
--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/HashMapCtxDB.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/HashMapCtxDB.java
@@ -131,7 +131,9 @@ public class HashMapCtxDB implements OSCoreCtxDB {
 	@Override
 	public synchronized void addContext(String uri, OSCoreCtx ctx) throws OSException {
 		if (uri != null) {
-			uriMap.put(normalizeServerUri(uri), ctx);
+			String normalizedUri = normalizeServerUri(uri);
+			uriMap.put(normalizedUri, ctx);
+			ctx.setUri(normalizedUri);
 		}
 		addContext(ctx);
 	}

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtx.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtx.java
@@ -82,6 +82,9 @@ public class OSCoreCtx {
 	//Include the context id in messages generated using this context
 	private boolean includeContextId;
 
+	//URI this Context is associated with if any
+	private String uri;
+
 	/**
 	 * Constructor. Generates the context from the base parameters with the
 	 * minimal input.
@@ -479,6 +482,22 @@ public class OSCoreCtx {
 			LOGGER.error("Common_alg has not yet been initiated.");
 			throw new RuntimeException("Common_alg has not yet been initiated.");
 		}
+	}
+
+	/**
+	 * @return the URI this context is associated with if any.
+	 */
+	public String getUri() {
+		return uri;
+	}
+
+	/**
+	 * Sets the URI this context is associated with.
+	 *
+	 * This will be set when added to the HashMapCtxDB.
+	 */
+	protected void setUri(String uri) {
+		this.uri = uri;
 	}
 
 	/**

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCorePeerIdentityHandler.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCorePeerIdentityHandler.java
@@ -17,6 +17,8 @@
 package org.eclipse.californium.oscore;
 
 import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.auth.OSCorePeerIdentity;
@@ -27,29 +29,68 @@ import org.eclipse.californium.elements.auth.OSCorePeerIdentity;
  * It provides functionality to set an appropriate OSCORE peer identity
  * for an EndpointContext.
  *
+ * Will only add a peer identity for endpoint contexts that have
+ * an empty or OSCORE peer identity. If for instance Scandium has
+ * set another type of Principal as peer identity it will not be updated.
+ *
  */
 public class OSCorePeerIdentityHandler {
 
 	/**
-	 * Updates the currently set endpoint contexts adding an OSCORE peer identity.
-	 * Will only update endpoint contexts that are set as type AddressEndpointContext
-	 * and have an empty or OSCORE peer identity.
-	 * 
-	 * If for instance Scandium has set another type of EndpointContext or another
-	 * type of Principal as peer identity it will not be updated.
-	 * 
+	 * Sets destination endpoint context for outgoing requests with an OSCORE peer identity.
+	 *
 	 * @param oscoreCtx the OSCORE context used for this message
-	 * @param message the message to set the endpoint context for
+	 * @param request the request to set the endpoint context for
 	 */
-	public static void setPeerIdentity(OSCoreCtx oscoreCtx, Message message) {
+	public static void sendingRequest(OSCoreCtx oscoreCtx, Request request) {
+		setPeerIdentityOutgoing(oscoreCtx, request);
+	}
 
+	/**
+	 * Sets source endpoint context for incoming requests with an OSCORE peer identity.
+	 *
+	 * @param oscoreCtx the OSCORE context used for this message
+	 * @param request the request to set the endpoint context for
+	 */
+	public static void receivingRequest(OSCoreCtx oscoreCtx, Request request) {
+		setPeerIdentityIncoming(oscoreCtx, request);
+	}
+
+	/**
+	 * Sets destination endpoint context for outgoing responses with an OSCORE peer identity.
+	 *
+	 * @param oscoreCtx the OSCORE context used for this message
+	 * @param response the response to set the endpoint context for
+	 */
+	public static void sendingResponse(OSCoreCtx oscoreCtx, Response response) {
+		setPeerIdentityOutgoing(oscoreCtx, response);
+	}
+
+	/**
+	 * Sets destination endpoint context for incoming responses with an OSCORE peer identity.
+	 *
+	 * @param oscoreCtx the OSCORE context used for this message
+	 * @param response the response to set the endpoint context for
+	 */
+	public static void receivingResponse(OSCoreCtx oscoreCtx, Response response) {
+		setPeerIdentityIncoming(oscoreCtx, response);
+	}
+
+	/**
+	 * Updates the currently set destination endpoint context for outgoing
+	 * messages adding an OSCORE peer identity.
+	 *
+	 * @param oscoreCtx the OSCORE context used for this message
+	 * @param message the message to set the destination endpoint context for
+	 */
+	private static void setPeerIdentityOutgoing(OSCoreCtx oscoreCtx, Message message) {
 		//Create a new OSCORE peer identity
 		OSCorePeerIdentity newPeerIdentity = new OSCorePeerIdentity(oscoreCtx.getUri(),
 				oscoreCtx.getIdContext(), oscoreCtx.getRecipientId(), oscoreCtx.getSenderId());
 
 		//Set updated destination context with new OSCORE peer identity
 		EndpointContext dstContext = message.getDestinationContext();
-		if(dstContext instanceof AddressEndpointContext &&
+		if(dstContext != null &&
 				(dstContext.getPeerIdentity() == null || dstContext.getPeerIdentity() instanceof OSCorePeerIdentity)) {
 
 			AddressEndpointContext newContext = new AddressEndpointContext(dstContext.getPeerAddress(),
@@ -57,10 +98,23 @@ public class OSCorePeerIdentityHandler {
 
 			message.setDestinationContext(newContext);
 		}
+	}
+
+	/**
+	 * Updates the currently set source endpoint context for incoming
+	 * messages adding an OSCORE peer identity.
+	 *
+	 * @param oscoreCtx the OSCORE context used for this message
+	 * @param message the message to set the source endpoint context for
+	 */
+	private static void setPeerIdentityIncoming(OSCoreCtx oscoreCtx, Message message) {
+		//Create a new OSCORE peer identity
+		OSCorePeerIdentity newPeerIdentity = new OSCorePeerIdentity(oscoreCtx.getUri(),
+				oscoreCtx.getIdContext(), oscoreCtx.getRecipientId(), oscoreCtx.getSenderId());
 
 		//Set updated source context with new OSCORE peer identity
 		EndpointContext srcContext = message.getSourceContext();
-		if(srcContext instanceof AddressEndpointContext &&
+		if(srcContext != null &&
 				(srcContext.getPeerIdentity() == null || srcContext.getPeerIdentity() instanceof OSCorePeerIdentity)) {
 
 			AddressEndpointContext newContext = new AddressEndpointContext(srcContext.getPeerAddress(),
@@ -68,7 +122,5 @@ public class OSCorePeerIdentityHandler {
 
 			message.setSourceContext(newContext);
 		}
-
 	}
-
 }

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCorePeerIdentityHandler.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCorePeerIdentityHandler.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2019 RISE SICS and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Rikard Höglund (RISE SICS)
+ *    
+ ******************************************************************************/
+package org.eclipse.californium.oscore;
+
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.californium.elements.EndpointContext;
+import org.eclipse.californium.elements.auth.OSCorePeerIdentity;
+
+/**
+ * Class that handles the EndpointContext for OSCORE messages. 
+ *
+ * It provides functionality to set an appropriate OSCORE peer identity
+ * for an EndpointContext.
+ *
+ */
+public class OSCorePeerIdentityHandler {
+
+	/**
+	 * Updates the currently set endpoint contexts adding an OSCORE peer identity.
+	 * Will only update endpoint contexts that are set as type AddressEndpointContext
+	 * and have an empty or OSCORE peer identity.
+	 * 
+	 * If for instance Scandium has set another type of EndpointContext or another
+	 * type of Principal as peer identity it will not be updated.
+	 * 
+	 * @param oscoreCtx the OSCORE context used for this message
+	 * @param message the message to set the endpoint context for
+	 */
+	public static void setPeerIdentity(OSCoreCtx oscoreCtx, Message message) {
+
+		//Create a new OSCORE peer identity
+		OSCorePeerIdentity newPeerIdentity = new OSCorePeerIdentity(oscoreCtx.getUri(),
+				oscoreCtx.getIdContext(), oscoreCtx.getRecipientId(), oscoreCtx.getSenderId());
+
+		//Set updated destination context with new OSCORE peer identity
+		EndpointContext dstContext = message.getDestinationContext();
+		if(dstContext instanceof AddressEndpointContext &&
+				(dstContext.getPeerIdentity() == null || dstContext.getPeerIdentity() instanceof OSCorePeerIdentity)) {
+
+			AddressEndpointContext newContext = new AddressEndpointContext(dstContext.getPeerAddress(),
+					dstContext.getVirtualHost(), newPeerIdentity);
+
+			message.setDestinationContext(newContext);
+		}
+
+		//Set updated source context with new OSCORE peer identity
+		EndpointContext srcContext = message.getSourceContext();
+		if(srcContext instanceof AddressEndpointContext &&
+				(srcContext.getPeerIdentity() == null || srcContext.getPeerIdentity() instanceof OSCorePeerIdentity)) {
+
+			AddressEndpointContext newContext = new AddressEndpointContext(srcContext.getPeerAddress(),
+					srcContext.getVirtualHost(), newPeerIdentity);
+
+			message.setSourceContext(newContext);
+		}
+
+	}
+
+}

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestDecryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestDecryptor.java
@@ -62,7 +62,7 @@ public class RequestDecryptor extends Decryptor {
 	 * @throws CoapOSException if decryption fails
 	 */
 	public static Request decrypt(Request request) throws CoapOSException {
-		
+
 		LOGGER.info("Removes E options from outer options which are not allowed there");
 		discardEOptions(request);
 
@@ -133,6 +133,10 @@ public class RequestDecryptor extends Decryptor {
 
 		// We need the kid value on layer level
 		request.getOptions().setOscore(rid);
+
+		//Set an OSCORE peer identity for this message
+		OSCorePeerIdentityHandler.setPeerIdentity(ctx, request);
+
 		return OptionJuggle.setRealCodeRequest(request, ctx.getCoAPCode());
 	}
 

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestDecryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestDecryptor.java
@@ -135,7 +135,7 @@ public class RequestDecryptor extends Decryptor {
 		request.getOptions().setOscore(rid);
 
 		//Set an OSCORE peer identity for this message
-		OSCorePeerIdentityHandler.setPeerIdentity(ctx, request);
+		OSCorePeerIdentityHandler.receivingRequest(ctx, request);
 
 		return OptionJuggle.setRealCodeRequest(request, ctx.getCoAPCode());
 	}

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestEncryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestEncryptor.java
@@ -47,6 +47,9 @@ public class RequestEncryptor extends Encryptor {
 	 */
 	public static Request encrypt(Request request, OSCoreCtx ctx) throws OSException {
 
+		//Set an OSCORE peer identity for this message
+		OSCorePeerIdentityHandler.setPeerIdentity(ctx, request);
+
 		if (ctx == null) {
 			LOGGER.error(ErrorDescriptions.CTX_NULL);
 			throw new OSException(ErrorDescriptions.CTX_NULL);

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestEncryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestEncryptor.java
@@ -48,7 +48,7 @@ public class RequestEncryptor extends Encryptor {
 	public static Request encrypt(Request request, OSCoreCtx ctx) throws OSException {
 
 		//Set an OSCORE peer identity for this message
-		OSCorePeerIdentityHandler.setPeerIdentity(ctx, request);
+		OSCorePeerIdentityHandler.sendingRequest(ctx, request);
 
 		if (ctx == null) {
 			LOGGER.error(ErrorDescriptions.CTX_NULL);

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseDecryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseDecryptor.java
@@ -108,7 +108,7 @@ public class ResponseDecryptor extends Decryptor {
 		}
 
 		//Set an OSCORE peer identity for this message
-		OSCorePeerIdentityHandler.setPeerIdentity(ctx, response);
+		OSCorePeerIdentityHandler.receivingResponse(ctx, response);
 
 		return response;
 	}

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseDecryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseDecryptor.java
@@ -107,6 +107,9 @@ public class ResponseDecryptor extends Decryptor {
 			db.removeToken(token);
 		}
 
+		//Set an OSCORE peer identity for this message
+		OSCorePeerIdentityHandler.setPeerIdentity(ctx, response);
+
 		return response;
 	}
 }

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseEncryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseEncryptor.java
@@ -51,6 +51,9 @@ public class ResponseEncryptor extends Encryptor {
 			throw new OSException(ErrorDescriptions.CTX_NULL);
 		}
 
+		//Set an OSCORE peer identity for this message
+		OSCorePeerIdentityHandler.setPeerIdentity(ctx, response);
+
 		int realCode = response.getCode().value;
 		response = OptionJuggle.setFakeCodeResponse(response);
 
@@ -68,7 +71,7 @@ public class ResponseEncryptor extends Encryptor {
 		if(newPartialIV) {
 			ctx.increaseSenderSeq();
 		}
-		
+
 		return response;
 	}
 }

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseEncryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseEncryptor.java
@@ -52,7 +52,7 @@ public class ResponseEncryptor extends Encryptor {
 		}
 
 		//Set an OSCORE peer identity for this message
-		OSCorePeerIdentityHandler.setPeerIdentity(ctx, response);
+		OSCorePeerIdentityHandler.sendingResponse(ctx, response);
 
 		int realCode = response.getCode().value;
 		response = OptionJuggle.setFakeCodeResponse(response);

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/AllJUnitTests.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/AllJUnitTests.java
@@ -28,7 +28,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({ ByteIdTest.class, HashMapCtxDBTest.class, OptionJuggleTest.class, OSCoreCtxTest.class,
 	OSCoreTest.class, OSSerializerTest.class, OSCoreServerClientTest.class, OSCoreObserveTest.class,
-	EncryptorTest.class, DecryptorTest.class })
+	EncryptorTest.class, DecryptorTest.class, PeerIdentityMessageTest.class })
 public class AllJUnitTests {
 
 }

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/DecryptorTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/DecryptorTest.java
@@ -96,7 +96,7 @@ public class DecryptorTest {
 	/**
 	 * Tests decryption of a CoAP Response with partial IV.
 	 * Test vector is from OSCORE draft. (Test Vector 8)
-	 * FIXME
+	 *
 	 * @throws OSException if decryption fails
 	 */
 	@Test

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/PeerIdentityMessageTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/PeerIdentityMessageTest.java
@@ -1,0 +1,228 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * This test class is based on org.eclipse.californium.core.test.SmallServerClientTest
+ *
+ * Contributors:
+ *    Matthias Kovatsch - creator and main architect
+ *    Martin Lanter - architect and re-implementation
+ *    Dominique Im Obersteg - parsers and initial implementation
+ *    Daniel Pauli - parsers and initial implementation
+ *    Kai Hudalla - logging
+ *    Achim Kraus (Bosch Software Innovations GmbH) - use CoapNetworkRule for
+ *                                                    setup of test-network
+ *    Achim Kraus (Bosch Software Innovations GmbH) - destroy server after test
+ *    Rikard Höglund (RISE SICS) - testing OSCORE peer identity
+ ******************************************************************************/
+package org.eclipse.californium.oscore;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.eclipse.californium.TestTools;
+import org.eclipse.californium.category.Medium;
+import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.EndpointManager;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.server.MessageDeliverer;
+import org.eclipse.californium.cose.AlgorithmID;
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.californium.elements.auth.OSCorePeerIdentity;
+import org.eclipse.californium.elements.util.Bytes;
+import org.eclipse.californium.rule.CoapNetworkRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+/**
+ * Tests setting and checking of OSCORE peer identity during communication.
+ *
+ */
+@Category(Medium.class)
+public class PeerIdentityMessageTest {
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
+
+	private static String SERVER_RESPONSE = "server responds hi";
+
+	private CoapServer server;
+
+	private Endpoint serverEndpoint;
+
+	//OSCORE context information shared between server and client
+	//private final static HashMapCtxDB dbServer = new HashMapCtxDB();
+	//private final static HashMapCtxDB dbClient = new HashMapCtxDB();
+	private final static HashMapCtxDB db = HashMapCtxDB.getInstance();
+	private final static AlgorithmID alg = AlgorithmID.AES_CCM_16_64_128;
+	private final static AlgorithmID kdf = AlgorithmID.HKDF_HMAC_SHA_256;
+	private final static byte[] master_secret = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
+			0x0C, 0x0D, 0x0E, 0x0F, 0x10 };
+
+	@Before
+	public void initLogger() {
+		System.out.println(System.lineSeparator() + "Start " + getClass().getSimpleName());
+		EndpointManager.clear();
+	}
+
+	//Use the OSCORE stack factory
+	@BeforeClass
+	public static void setStackFactory() {
+		//OSCoreCoapStackFactory.useAsDefault(dbClient);
+		OSCoreCoapStackFactory.useAsDefault();
+	}
+
+	@After
+	public void after() {
+		if (null != server) {
+			server.destroy();
+		}
+		System.out.println("End " + getClass().getSimpleName());
+	}
+
+	/**
+	 * Sends two requests and checks that an appropriate OSCORE peer identity has
+	 * been set on the destination/source endpoint context for both request and response
+	 * on both the server and client side.
+	 *
+	 * @throws Exception if message processing or creating the OSCORE context fails
+	 */
+	@Test
+	public void testPeerIdentity() throws Exception {
+		createSimpleServer();
+
+		//Set up OSCORE context information for request (client)
+		byte[] sid = new byte[0];
+		byte[] rid = new byte[] { 0x01 };
+		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, null, null);
+		db.addContext("coap://" + serverEndpoint.getAddress().getAddress().getHostAddress(), ctx);
+
+		//Send request
+		Request request = new Request(CoAP.Code.GET);
+		request.getOptions().setOscore(Bytes.EMPTY); //Use OSCORE
+		request.setDestinationContext(new AddressEndpointContext(serverEndpoint.getAddress()));
+		request.send();
+		System.out.println("client sent request");
+
+		//Receive response and check its content
+		Response response = request.waitForResponse(1000);
+		assertNotNull("Client received no response", response);
+		System.out.println("client received response");
+		assertEquals(response.getPayloadString(), SERVER_RESPONSE);
+
+		//Check response source context peer identity
+		assertNotNull(response.getSourceContext());
+		assertNotNull(response.getSourceContext().getPeerIdentity());
+		assertEquals(response.getSourceContext().getPeerIdentity().getClass(), OSCorePeerIdentity.class); 
+		OSCorePeerIdentity srcPeerIdentity = (OSCorePeerIdentity) response.getSourceContext().getPeerIdentity();
+		assertArrayEquals(srcPeerIdentity.getContextId(), ctx.getIdContext());
+		assertArrayEquals(srcPeerIdentity.getRecipientId(), ctx.getSenderId());
+		assertArrayEquals(srcPeerIdentity.getSenderId(), ctx.getRecipientId());
+		assertEquals(srcPeerIdentity.getHost(), ctx.getUri());
+
+		//Check request destination context peer identity
+		assertNotNull(request.getDestinationContext());
+		assertNotNull(request.getDestinationContext().getPeerIdentity());
+		assertEquals(request.getDestinationContext().getPeerIdentity().getClass(), OSCorePeerIdentity.class);
+		OSCorePeerIdentity dstPeerIdentity = (OSCorePeerIdentity) request.getDestinationContext().getPeerIdentity();
+		assertArrayEquals(dstPeerIdentity.getContextId(), ctx.getIdContext());
+		assertArrayEquals(dstPeerIdentity.getRecipientId(), ctx.getSenderId());
+		assertArrayEquals(dstPeerIdentity.getSenderId(), ctx.getRecipientId());
+		assertEquals(dstPeerIdentity.getHost(), ctx.getUri());
+
+		//Send second request
+		//This makes sure the server did not fail any of its checks on the first request.
+		request.send();
+		System.out.println("client sent second request");
+
+		//Receive response
+		response = request.waitForResponse(1000);
+		assertNotNull("Client received no response", response);
+		System.out.println("client received response");
+		assertEquals(response.getPayloadString(), SERVER_RESPONSE);
+	}
+
+	/**
+	 * Creates a simple server for testing.
+	 *
+	 * It will check that an appropriate OSCORE peer identity has been set
+	 * for the incoming request and the outgoing response.
+	 *
+	 * @throws OSException if creating the OSCORE context fails
+	 *
+	 */
+	private void createSimpleServer() throws OSException {
+		//Set up OSCORE context information for response (server)
+		byte[] sid = new byte[] { 0x01 };
+		byte[] rid = new byte[0];
+		final OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, null, null);
+		db.addContext("coap://" + TestTools.LOCALHOST_EPHEMERAL.getAddress().getHostName(), ctx);
+
+		//Create server
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
+		//builder.setCustomCoapStackArgument(dbServer);
+		builder.setInetSocketAddress(TestTools.LOCALHOST_EPHEMERAL);
+		serverEndpoint = builder.build();
+		server = new CoapServer();
+		server.addEndpoint(serverEndpoint);
+		server.setMessageDeliverer(new MessageDeliverer() {
+			@Override
+			public void deliverRequest(Exchange exchange) {
+				System.out.println("server received request");
+
+				//Check request source context peer identity
+				assertNotNull(exchange.getRequest().getSourceContext());
+				assertNotNull(exchange.getRequest().getSourceContext().getPeerIdentity());
+				assertEquals(exchange.getRequest().getSourceContext().getPeerIdentity().getClass(), OSCorePeerIdentity.class);
+				OSCorePeerIdentity srcPeerIdentity = (OSCorePeerIdentity) exchange.getRequest().getSourceContext().getPeerIdentity();
+				assertArrayEquals(srcPeerIdentity.getContextId(), ctx.getIdContext());
+				assertArrayEquals(srcPeerIdentity.getRecipientId(), ctx.getSenderId());
+				assertArrayEquals(srcPeerIdentity.getSenderId(), ctx.getRecipientId());
+				assertEquals(srcPeerIdentity.getHost(), ctx.getUri());
+
+				//Prepare and send response
+				Response response = new Response(ResponseCode.CONTENT);
+				response.setPayload(SERVER_RESPONSE);
+				exchange.sendResponse(response);
+
+				//Check response destination context peer identity (destroy server if these checks fail)
+				try {
+					assertNotNull(response.getDestinationContext());
+					assertNotNull(response.getDestinationContext().getPeerIdentity());
+					assertEquals(response.getDestinationContext().getPeerIdentity().getClass(), OSCorePeerIdentity.class);
+					OSCorePeerIdentity dstPeerIdentity = (OSCorePeerIdentity) response.getDestinationContext().getPeerIdentity();
+					assertArrayEquals(dstPeerIdentity.getContextId(), ctx.getIdContext());
+					assertArrayEquals(dstPeerIdentity.getRecipientId(), ctx.getSenderId());
+					assertArrayEquals(dstPeerIdentity.getSenderId(), ctx.getRecipientId());
+					assertEquals(dstPeerIdentity.getHost(), ctx.getUri());
+				} catch (AssertionError e) {
+					System.out.println("checking properties of outgoing response on server failed");
+					System.out.println(e.getMessage());
+					server.destroy();
+				}
+
+			}
+			@Override
+			public void deliverResponse(Exchange exchange, Response response) { }
+		});
+		server.start();
+	}
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/OSCorePeerIdentity.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/OSCorePeerIdentity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Institute for Pervasive Computing, ETH Zurich and others.
+ * Copyright (c) 2015, 2019 Institute for Pervasive Computing, ETH Zurich and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/OSCorePeerIdentity.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/OSCorePeerIdentity.java
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2018 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Kai Hudalla (Bosch Software Innovations GmbH) - initial creation
+ *    Achim Kraus (Bosch Software Innovations GmbH) - add scoped identity indicator
+ *                                                    issue #649
+ *    Rikard Höglund (RISE SICS)                    - principal for OSCORE
+ ******************************************************************************/
+package org.eclipse.californium.elements.auth;
+
+import java.security.Principal;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.eclipse.californium.elements.util.StringUtil;
+
+/**
+ * A principal representing an OSCORE peer's identity with
+ * information from its associated OSCORE Context.
+ */
+public final class OSCorePeerIdentity implements Principal {
+
+	private final String host;
+	private final byte[] contextId;
+	private final byte[] senderId;
+	private final byte[] recipientId;
+	private final String name;
+
+	/**
+	 * Creates a new instance for an OSCORE identity.
+	 * 
+	 * It is defined by a set of fields from its corresponding OSCORE Context.
+	 * 
+	 * @param host the host this context is associated with if any
+	 * @param contextId the Context ID
+	 * @param senderId the Sender ID
+	 * @param recipientId the Recipient ID
+	 */
+	public OSCorePeerIdentity(String host, byte[] contextId, byte[] senderId, byte[] recipientId) {
+		if (host != null && host.isEmpty()) {
+			throw new IllegalArgumentException("Host must have a non-zero length");
+		} else if (host != null && !StringUtil.isValidHostName(host)) {
+			throw new IllegalArgumentException("Host is not a valid hostname");
+		}
+
+		if(senderId == null) {
+			throw new IllegalArgumentException("Sender ID must be set");
+		}
+
+		if(recipientId == null) {
+			throw new IllegalArgumentException("Recipient ID must be set");
+		}
+
+		this.host = host;
+		this.senderId = senderId.clone();
+		this.recipientId = recipientId.clone();
+
+		if(contextId != null) {
+			this.contextId = contextId.clone();
+		} else {
+			this.contextId = null;
+		}
+
+		name = generateName();
+	}
+
+	/**
+	 * Gets the name of this principal.
+	 * 
+	 * @return the name
+	 */
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Generates a name for this principal based on its properties.
+	 * 
+	 * @return name of this Principal
+	 */
+	private String generateName() {
+		StringBuilder b = new StringBuilder();
+
+		b.append(OSCorePeerIdentity.class.getSimpleName()).append(" [");
+		b.append("Host: ").append(host).append(", ");
+
+		b.append("Context ID: ");
+		if(contextId != null) {
+			b.append("0x").append(DatatypeConverter.printHexBinary(contextId));
+		} else {
+			b.append("null");
+		}
+		b.append(", ");
+
+		b.append("Sender ID: 0x").append(DatatypeConverter.printHexBinary(senderId)).append(", ");
+		b.append("Recipient ID: 0x").append(DatatypeConverter.printHexBinary(recipientId));
+		b.append("]");
+
+		return b.toString();
+	}
+
+	/**
+	 * Gets a string representation of this principal.
+	 *
+	 * Clients should not assume any particular format of the returned string
+	 * since it may change over time.
+	 *
+	 * @return the string representation
+	 */
+	@Override
+	public String toString() {
+			return name;
+	}
+
+	@Override
+	public int hashCode() {
+		return name.hashCode();
+	}
+
+	/**
+	 * Compares another object to this identity.
+	 * 
+	 * @return {@code true} if the other object is a {@code OSCorePeerIdentity} and
+	 *         its properties have the same value as this instance.
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+
+		OSCorePeerIdentity other = (OSCorePeerIdentity) obj;
+
+		if (host == null) {
+			if (other.host != null) {
+				return false;
+			}
+		} else if (!host.equals(other.host)) {
+			return false;
+		}
+
+		if (contextId == null) {
+			if (other.contextId != null) {
+				return false;
+			}
+		} else if (!contextId.equals(other.contextId)) {
+			return false;
+		}
+
+		if (senderId == null) {
+			if (other.senderId != null) {
+				return false;
+			}
+		} else if (!senderId.equals(other.senderId)) {
+			return false;
+		}
+
+		if (recipientId == null) {
+			if (other.recipientId != null) {
+				return false;
+			}
+		} else if (!recipientId.equals(other.recipientId)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @return the host this context is associated with
+	 */
+	public String getHost() {
+		return host;
+	}
+
+	/**
+	 * @return the contextID
+	 */
+	public byte[] getContextId() {
+		if(contextId != null) {
+			return contextId.clone();
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * @return the senderID
+	 */
+	public byte[] getSenderId() {
+		return senderId.clone();
+	}
+
+	/**
+	 * @return the recipientID
+	 */
+	public byte[] getRecipientId() {
+		return recipientId.clone();
+	}
+}


### PR DESCRIPTION
This commit adds a new Principal for endpoint context information when using OSCORE. It will be set in the endpoint context when communicating using OSCORE.

Currently it will only update the endpoint context if it is of type AddressEndpointContext and if the Principal is of type OSCorePeerIdentity.This means that it will not overwrite Principal information set by Scandium when using DTLS. So if both DTLS and OSCORE are used DTLS peer identity information will take precedence.

This should resolve the following issue:
https://github.com/eclipse/californium/issues/974
