### PR TITLE
Cleanup record decryption.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
@@ -42,28 +42,17 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
  */
 class DTLSConnectionState {
 
+	public static final DTLSConnectionState NULL = new DTLSConnectionState(CipherSuite.TLS_NULL_WITH_NULL_NULL, CompressionMethod.NULL, null, null, null);
+
 	// Members ////////////////////////////////////////////////////////
 
-	private CipherSuite cipherSuite;
-	private CompressionMethod compressionMethod;
-	private SecretKey encryptionKey;
-	private IvParameterSpec iv;
-	private SecretKey macKey;
+	private final CipherSuite cipherSuite;
+	private final CompressionMethod compressionMethod;
+	private final SecretKey encryptionKey;
+	private final IvParameterSpec iv;
+	private final SecretKey macKey;
 
 	// Constructors ///////////////////////////////////////////////////
-
-	/**
-	 * Convenience constructor for creating an instance representing
-	 * the initial connection state.
-	 * 
-	 * Simply invokes 
-	 * {@link #DTLSConnectionState(CipherSuite, CompressionMethod, SecretKey, IvParameterSpec, SecretKey)}
-	 * with the default {@link CipherSuite#TLS_NULL_WITH_NULL_NULL} and default
-	 * {@link CompressionMethod#NULL} and <code>null</code> for all other parameters.
-	 */
-	DTLSConnectionState() {
-		this(CipherSuite.TLS_NULL_WITH_NULL_NULL, CompressionMethod.NULL, null, null, null);
-	}
 
 	/**
 	 * Initializes all fields with given values.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -140,12 +140,12 @@ public final class DTLSSession {
 	/**
 	 * The <em>current read state</em> used for processing all inbound records.
 	 */
-	private DTLSConnectionState readState = new DTLSConnectionState();
+	private DTLSConnectionState readState = DTLSConnectionState.NULL;
 
 	/**
 	 * The <em>current write state</em> used for processing all outbound records.
 	 */
-	private DTLSConnectionState writeState = new DTLSConnectionState();
+	private DTLSConnectionState writeState = DTLSConnectionState.NULL;
 
 	/**
 	 * The current read epoch, incremented with every CHANGE_CIPHER_SPEC message received

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -327,7 +327,8 @@ public abstract class Handshaker {
 
 				for (Record record : queue) {
 					if (record.getEpoch() == session.getReadEpoch()) {
-						HandshakeMessage msg = (HandshakeMessage) record.getFragment(session.getReadState());
+						record.applySession(session);
+						HandshakeMessage msg = (HandshakeMessage) record.getFragment();
 						if (msg.getMessageSeq() == nextReceiveSeq) {
 							result = msg;
 							queue.remove(record);
@@ -367,6 +368,7 @@ public abstract class Handshaker {
 						getPeerAddress(), epoch, session.getReadEpoch());
 				return null;
 			} else if (epoch == session.getReadEpoch()) {
+				candidate.applySession(session);
 				DTLSMessage fragment = candidate.getFragment();
 				switch (fragment.getContentType()) {
 				case ALERT:
@@ -444,7 +446,6 @@ public abstract class Handshaker {
 		if ((sameEpoch && !session.isDuplicate(record.getSequenceNumber()))
 				|| (session.getReadEpoch() + 1) == record.getEpoch()) {
 			try {
-				record.setSession(session);
 				DTLSMessage messageToProcess = inboundMessageBuffer.getNextMessage(record);
 				while (messageToProcess != null) {
 					if (messageToProcess instanceof FragmentedHandshakeMessage) {

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -311,6 +311,7 @@ public class DTLSConnectorTest {
 	public void testRetransmission() throws Exception {
 		// Configure UDP connector
 		RecordCollectorDataHandler collector = new RecordCollectorDataHandler();
+		collector.applySession(null);
 		UdpConnector rawClient = new UdpConnector(clientEndpoint.getPort(), collector);
 
 		try {
@@ -379,6 +380,7 @@ public class DTLSConnectorTest {
 	public void testNoRetransmissionIfMessageReceived() throws Exception {
 		// Configure UDP connector
 		RecordCollectorDataHandler collector = new RecordCollectorDataHandler();
+		collector.applySession(null);
 		UdpConnector rawClient = new UdpConnector(clientEndpoint.getPort(), collector);
 
 		// Add latency to PSK store
@@ -454,6 +456,7 @@ public class DTLSConnectorTest {
 		// now we try to establish a new session with a client connecting from the
 		// same IP address and port again
 		RecordCollectorDataHandler handler = new RecordCollectorDataHandler();
+		handler.applySession(null);
 
 		UdpConnector rawClient = new UdpConnector(clientEndpoint.getPort(), handler);
 		rawClient.start();
@@ -534,7 +537,7 @@ public class DTLSConnectorTest {
 	public void testClientHelloRetransmissionDoNotRestartHandshake() throws Exception {
 		// configure UDP connector
 		RecordCollectorDataHandler handler = new RecordCollectorDataHandler();
-
+		handler.applySession(null);
 		UdpConnector rawClient = new UdpConnector(clientEndpoint.getPort(), handler);
 		try {
 			rawClient.start();
@@ -745,7 +748,7 @@ public class DTLSConnectorTest {
 
 		InetSocketAddress endpoint = new InetSocketAddress(12000);
 		RecordCollectorDataHandler handler = new RecordCollectorDataHandler();
-
+		handler.applySession(null);
 		UdpConnector rawClient = new UdpConnector(endpoint.getPort(), handler);
 
 		try{
@@ -1036,7 +1039,7 @@ public class DTLSConnectorTest {
 	private void givenAnIncompleteHandshake() throws Exception {
 		// configure UDP connector
 		RecordCollectorDataHandler handler = new RecordCollectorDataHandler();
-
+		handler.applySession(null);
 		UdpConnector rawClient = new UdpConnector(clientEndpoint.getPort(), handler);
 
 		try {

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordDecryptTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordDecryptTest.java
@@ -132,7 +132,7 @@ public class RecordDecryptTest {
 		List<Record> list = Record.fromByteArray(raw, session.getPeer(), null, ClockUtil.nanoRealtime());
 		assertFalse("failed to decode raw message", list.isEmpty());
 		for (Record recv : list) {
-			recv.setSession(session);
+			recv.applySession(session);
 			DTLSMessage message = recv.getFragment();
 			assertArrayEquals("decrypted payload differs", payload, message.toByteArray());
 		}
@@ -241,10 +241,15 @@ public class RecordDecryptTest {
 				new ApplicationMessage(payload, session.getPeer()), session, true, 0);
 		byte[] raw = record.toByteArray();
 		byte[] jraw = juggler.juggle(raw);
+		if (jraw.length > 4) {
+			// fix epoch to 1, prevent session read epoch check failure!
+			jraw[3] = 0;
+			jraw[4] = 1;
+		}
 		dumpDiff(raw, jraw);
 		List<Record> list = Record.fromByteArray(jraw, session.getPeer(), null, ClockUtil.nanoRealtime());
 		for (Record recv : list) {
-			recv.setSession(session);
+			recv.applySession(session);
 			recv.getFragment();
 		}
 	}
@@ -286,7 +291,7 @@ public class RecordDecryptTest {
 		byte[] raw = toByteArray(record, jfragment);
 		List<Record> list = Record.fromByteArray(raw, session.getPeer(), null, ClockUtil.nanoRealtime());
 		for (Record recv : list) {
-			recv.setSession(session);
+			recv.applySession(session);
 			recv.getFragment();
 		}
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordTest.java
@@ -49,7 +49,7 @@ public class RecordTest {
 
 	static final long SEQUENCE_NO = 5;
 	static final int TYPE_APPL_DATA = 23;
-	static final int EPOCH = 0;
+	static final int EPOCH = 1;
 	// byte representation of a 128 bit AES symmetric key
 	static final byte[] aesKey = new byte[]{(byte) 0xC9, 0x0E, 0x6A, (byte) 0xA2, (byte) 0xEF, 0x60, 0x34, (byte) 0x96,
 		(byte) 0x90, 0x54, (byte) 0xC4, (byte) 0x96, 0x65, (byte) 0xBA, 0x03, (byte) 0x9E};
@@ -88,7 +88,7 @@ public class RecordTest {
 		}
 
 		try {
-			new Record(ContentType.HANDSHAKE, DtlsTestTools.MAX_SEQUENCE_NO + 1, new HelloRequest(session.getPeer()), session.getPeer());
+			new Record(ContentType.HANDSHAKE, 0, DtlsTestTools.MAX_SEQUENCE_NO + 1, new HelloRequest(session.getPeer()), session, false, 0);
 			Assert.fail("Record constructor should have rejected sequence no > 2^48 - 1");
 		} catch (IllegalArgumentException e) {
 			// all is well
@@ -97,7 +97,7 @@ public class RecordTest {
 	
 	@Test
 	public void testSetSequenceNumberEnforcesMaxSequenceNo() throws GeneralSecurityException {
-		Record record = new Record(ContentType.HANDSHAKE, 0, new HelloRequest(session.getPeer()), session.getPeer());
+		Record record = new Record(ContentType.HANDSHAKE, 0, 0, new HelloRequest(session.getPeer()), session, false, 0);
 		record.updateSequenceNumber(DtlsTestTools.MAX_SEQUENCE_NO);
 		try {
 			record.updateSequenceNumber(DtlsTestTools.MAX_SEQUENCE_NO + 1);
@@ -152,9 +152,9 @@ public class RecordTest {
 		
 		byte[] fragment = newGenericAEADCipherFragment();
 		Record record = new Record(ContentType.APPLICATION_DATA, protocolVer, EPOCH, SEQUENCE_NO, null, fragment, session.getPeer(), ClockUtil.nanoRealtime());
-		record.setSession(session);
+		record.applySession(session);
 		
-		byte[] decryptedData = record.decryptAEAD(fragment, session.getReadState());
+		byte[] decryptedData = record.decryptAEAD(fragment);
 		assertTrue(Arrays.equals(decryptedData, payloadData));
 	}
 	


### PR DESCRIPTION
Decrypt record when apply the matching session.
Cleanup javadoc. Mark outgoing and incoming specific methods.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>