### PR TITLE
Cleanup handshaker

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -1065,7 +1065,8 @@ public class DTLSConnector implements Connector, RecordLayer {
 	 * @param record received record.
 	 * @param connection connection to process record.
 	 */
-	private void processRecord(Record record, Connection connection) {
+	@Override
+	public void processRecord(Record record, Connection connection) {
 
 		try {
 			// ensure, that connection is still related to record 
@@ -1080,6 +1081,28 @@ public class DTLSConnector implements Connector, RecordLayer {
 			LOGGER.trace("Received DTLS record of type [{}], length: {}, [epoche:{},reqn:{}]", 
 					record.getType(), record.getFragmentLength(), epoch, record.getSequenceNumber());
 
+			DTLSSession session = connection.getSession(epoch);
+			if (session == null) {
+				Handshaker handshaker = connection.getOngoingHandshake();
+				if (handshaker != null && handshaker.getSession().getReadEpoch() == 0 && epoch == 1) {
+					// future records, apply session after handshake finished.
+					handshaker.addRecordsForDeferredProcessing(record);
+				} else {
+					LOGGER.debug("Discarding {} record received from peer [{}] without an active session for epoch {}",
+							record.getType(), record.getPeerAddress(), epoch);
+				}
+				return;
+			}
+
+			// The DTLS 1.2 spec (section 4.1.2.6) advises to do replay detection
+			// before MAC validation based on the record's sequence numbers
+			// see http://tools.ietf.org/html/rfc6347#section-4.1.2.6
+			if (useFilter && (session != null) && !session.isRecordProcessable(record.getEpoch(), record.getSequenceNumber(), useWindowFilter)) {
+				LOGGER.debug("Discarding duplicate {} record received from peer [{}]",
+						record.getType(), record.getPeerAddress());
+				return;
+			}
+
 			boolean useCid = connectionIdGenerator != null && connectionIdGenerator.useConnectionId();
 			if (record.getType() == ContentType.TLS12_CID) {
 				// !useCid already dropped in Record.fromByteArray
@@ -1088,36 +1111,19 @@ public class DTLSConnector implements Connector, RecordLayer {
 							record.getPeerAddress());
 					return;
 				}
-				DTLSSession session = connection.getSession(epoch);
-				if (session == null && epoch > 0) {
-					// received record of epoch 1 during handshake
-					Handshaker handshaker = connection.getOngoingHandshake();
-					if (handshaker != null && handshaker.isChangeCipherSpecMessageExpected()) {
-						handshaker.addRecordsForDeferredProcessing(record);
-					} else {
-						LOGGER.debug("Discarding TLS_CID record received from peer [{}] without an active session",
-								record.getPeerAddress());
-					}
-					return;
-				} else {
-					// decode record to access "inner type" with record.getType()
-					record.applySession(session);
-					record.getFragment();
-				}
-			} else if (epoch > 0 && useCid) {
-				DTLSSession session = connection.getSession();
-				if (session != null && session.getWriteConnectionId() != null) {
-					LOGGER.debug("Discarding record received from peer [{}], CID required!", record.getPeerAddress());
-					return;
-				}
+			} else if (epoch > 0 && useCid && connection.expectCid()) {
+				LOGGER.debug("Discarding record received from peer [{}], CID required!", record.getPeerAddress());
+				return;
 			}
+
+			record.applySession(session);
 
 			switch (record.getType()) {
 			case APPLICATION_DATA:
 				processApplicationDataRecord(record, connection);
 				break;
 			case ALERT:
-				processAlertRecord(record, connection);
+				processAlertRecord(record, connection, session);
 				break;
 			case CHANGE_CIPHER_SPEC:
 				processChangeCipherSpecRecord(record, connection);
@@ -1246,69 +1252,51 @@ public class DTLSConnector implements Connector, RecordLayer {
 		final Handshaker ongoingHandshake = connection.getOngoingHandshake();
 		final DTLSSession session = connection.getEstablishedSession();
 		if (session != null) {
-			// The DTLS 1.2 spec (section 4.1.2.6) advises to do replay detection
-			// before MAC validation based on the record's sequence numbers
-			// see http://tools.ietf.org/html/rfc6347#section-4.1.2.6
-			if (!useFilter || session.isRecordProcessable(record.getEpoch(), record.getSequenceNumber(), useWindowFilter)) {
-				try {
-					// APPLICATION_DATA can only be processed within the context of
-					// an established, i.e. fully negotiated, session
-					record.applySession(session);
-					ApplicationMessage message = (ApplicationMessage) record.getFragment();
+			// APPLICATION_DATA can only be processed within the context of
+			// an established, i.e. fully negotiated, session
+			ApplicationMessage message = (ApplicationMessage) record.getFragment();
+			InetSocketAddress newAddress = record.getPeerAddress();
+			if (connectionStore.get(newAddress) == connection) {
+				// no address update required!
+				newAddress = null;
+			}
+			// the fragment could be de-crypted, mark it
+			if (!session.markRecordAsRead(record.getEpoch(), record.getSequenceNumber())
+					&& useCidUpdateAddressOnNewerRecordFilter) {
+				// suppress address update!
+				newAddress = null;
+			}
+			if (ongoingHandshake != null) {
+				// the handshake has been completed successfully
+				ongoingHandshake.handshakeCompleted();
+			}
+			connection.refreshAutoResumptionTime();
+			connectionStore.update(connection, newAddress);
 
-					InetSocketAddress newAddress = record.getPeerAddress();
-					if (connection.equalsPeerAddress(newAddress)) {
-						// no address update required!
-						newAddress = null;
-					}
-					// the fragment could be de-crypted, mark it
-					if (!session.markRecordAsRead(record.getEpoch(), record.getSequenceNumber())
-							&& useCidUpdateAddressOnNewerRecordFilter) {
-						// suppress address update!
-						newAddress = null;
-					}
-					if (ongoingHandshake != null) {
-						// the handshake has been completed successfully
-						ongoingHandshake.handshakeCompleted();
-					}
-					connection.refreshAutoResumptionTime();
-					connectionStore.update(connection, newAddress);
-
-					final RawDataChannel channel = messageHandler;
-					// finally, forward de-crypted message to application layer
-					if (channel != null) {
-						DtlsEndpointContext context;
-						if (session.getPeer() == null) {
-							// endpoint context would fail ...
-							session.setPeer(record.getPeerAddress());
-							context = session.getConnectionWriteContext();
-							session.setPeer(null);
-							LOGGER.warn("Received APPLICATION_DATA from deprecated {}", record.getPeerAddress());
-						} else {
-							context = session.getConnectionWriteContext();
-						}
-						// create application message.
-						LOGGER.debug("Received APPLICATION_DATA for {}", context);
-						RawData receivedApplicationMessage = RawData.inbound(message.getData(), context, false);
-						channel.receiveData(receivedApplicationMessage);
-					}
-				} catch (HandshakeException | GeneralSecurityException e) {
-					// this means that we could not parse or decrypt the message
-					LOGGER.debug("Discarding APPLICATION_DATA record received from peer [{}]",
-							record.getPeerAddress(), e);
-					discardRecord(record, e);
+			final RawDataChannel channel = messageHandler;
+			// finally, forward de-crypted message to application layer
+			if (channel != null) {
+				// create application message.
+				DtlsEndpointContext context;
+				if (session.getPeer() == null) {
+					// endpoint context would fail ...
+					session.setPeer(record.getPeerAddress());
+					context = session.getConnectionWriteContext();
+					session.setPeer(null);
+					LOGGER.warn("Received APPLICATION_DATA from deprecated {}", record.getPeerAddress());
+				} else {
+					context = session.getConnectionWriteContext();
 				}
-			} else {
-				LOGGER.debug("Discarding duplicate APPLICATION_DATA record received from peer [{}]",
-						record.getPeerAddress());
+				LOGGER.debug("Received APPLICATION_DATA for {}", context);
+				RawData receivedApplicationMessage = RawData.inbound(message.getData(), context, false);
+				channel.receiveData(receivedApplicationMessage);
 			}
+		} else if (ongoingHandshake != null) {
+			// wait for FINISH
+			ongoingHandshake.addRecordsForDeferredProcessing(record);
 		} else {
-			if (ongoingHandshake != null && ongoingHandshake.isChangeCipherSpecMessageExpected()) {
-				ongoingHandshake.addRecordsForDeferredProcessing(record);
-			} else {
-				LOGGER.debug("Discarding APPLICATION_DATA record received from peer [{}] without an active session",
-						record.getPeerAddress());
-			}
+			LOGGER.debug("Discarding APPLICATION_DATA record received from peer [{}]",
+					record.getPeerAddress());
 		}
 	}
 
@@ -1317,58 +1305,47 @@ public class DTLSConnector implements Connector, RecordLayer {
 	 * 
 	 * @param record alert record
 	 * @param connection connection to process the received record
+	 * @param session session applied to decode record
 	 */
-	private void processAlertRecord(final Record record, final Connection connection) {
-		DTLSSession session = connection.getSession(record.getEpoch());
-		if (session == null) {
-			LOGGER.debug(
-					"Epoch of ALERT record [epoch={}] from [{}] does not match expected epoch(s), discarding ...",
-					record.getEpoch(), record.getPeerAddress());
-			return;
+	private void processAlertRecord(Record record, Connection connection, DTLSSession session) {
+		AlertMessage alert = (AlertMessage) record.getFragment();
+		Handshaker handshaker = connection.getOngoingHandshake();
+		HandshakeException error = null;
+		LOGGER.trace("Processing {} ALERT from [{}]: {}",
+				alert.getLevel(), alert.getPeer(), alert.getDescription());
+		if (AlertDescription.CLOSE_NOTIFY.equals(alert.getDescription())) {
+			// according to section 7.2.1 of the TLS 1.2 spec
+			// (http://tools.ietf.org/html/rfc5246#section-7.2.1)
+			// we need to respond with a CLOSE_NOTIFY alert and
+			// then close and remove the connection immediately
+			error = new HandshakeException("Received 'close notify'", alert);
+			if (handshaker != null) {
+				handshaker.setFailureCause(error);
+			}
+			terminateConnection(
+					connection,
+					new AlertMessage(AlertLevel.WARNING, AlertDescription.CLOSE_NOTIFY, alert.getPeer()),
+					session);
+		} else if (AlertLevel.FATAL.equals(alert.getLevel())) {
+			// according to section 7.2 of the TLS 1.2 spec
+			// (http://tools.ietf.org/html/rfc5246#section-7.2)
+			// the connection needs to be terminated immediately
+			error = new HandshakeException("Received 'fatal alert'", alert);
+			if (handshaker != null) {
+				handshaker.setFailureCause(error);
+			}
+			terminateConnection(connection);
+		} else {
+			// non-fatal alerts do not require any special handling
 		}
-		try {
-			record.applySession(session);
-			AlertMessage alert = (AlertMessage) record.getFragment();
-			Handshaker handshaker = connection.getOngoingHandshake();
-			HandshakeException error = null;
-			LOGGER.trace("Processing {} ALERT from [{}]: {}",
-					alert.getLevel(), alert.getPeer(), alert.getDescription());
-			if (AlertDescription.CLOSE_NOTIFY.equals(alert.getDescription())) {
-				// according to section 7.2.1 of the TLS 1.2 spec
-				// (http://tools.ietf.org/html/rfc5246#section-7.2.1)
-				// we need to respond with a CLOSE_NOTIFY alert and
-				// then close and remove the connection immediately
-				error = new HandshakeException("Received 'close notify'", alert);
-				if (handshaker != null) {
-					handshaker.setFailureCause(error);
-				}
-				terminateConnection(
-						connection,
-						new AlertMessage(AlertLevel.WARNING, AlertDescription.CLOSE_NOTIFY, alert.getPeer()),
-						session);
-			} else if (AlertLevel.FATAL.equals(alert.getLevel())) {
-				// according to section 7.2 of the TLS 1.2 spec
-				// (http://tools.ietf.org/html/rfc5246#section-7.2)
-				// the connection needs to be terminated immediately
-				error = new HandshakeException("Received 'fatal alert'", alert);
-				if (handshaker != null) {
-					handshaker.setFailureCause(error);
-				}
-				terminateConnection(connection);
-			} else {
-				// non-fatal alerts do not require any special handling
-			}
 
-			synchronized (alertHandlerLock) {
-				if (alertHandler != null) {
-					alertHandler.onAlert(alert.getPeer(), alert);
-				}
+		synchronized (alertHandlerLock) {
+			if (alertHandler != null) {
+				alertHandler.onAlert(alert.getPeer(), alert);
 			}
-			if (null != error && null != handshaker) {
-				handshaker.handshakeFailed(error);
-			}
-		} catch (HandshakeException | GeneralSecurityException e) {
-			discardRecord(record, e);
+		}
+		if (null != error && null != handshaker) {
+			handshaker.handshakeFailed(error);
 		}
 	}
 
@@ -1403,90 +1380,36 @@ public class DTLSConnector implements Connector, RecordLayer {
 	private void processHandshakeRecord(final Record record, final Connection connection) {
 		LOGGER.debug("Received {} record from peer [{}]", record.getType(), record.getPeerAddress());
 		try {
-			if (connection.hasOngoingHandshake()) {
-				DTLSSession handshakeSession = connection.getOngoingHandshake().getSession();
-				if (handshakeSession.getReadEpoch() == record.getEpoch()) {
-					// evaluate message in context of ongoing handshake
-					record.applySession(handshakeSession);
-				} else if (!record.isNewClientHello()) {
-					// epoch is not the same as the current session so we
-					// can not decrypt the message now. Let handshaker handle it
-					// (it can queue it to deal with it later)
-					connection.getOngoingHandshake().processMessage(record);
-					return;
-				}
-			} else if (connection.hasEstablishedSession()
-					&& connection.getEstablishedSession().getReadEpoch() == record.getEpoch()) {
-				// client wants to re-negotiate established connection's
-				// crypto params evaluate message in context of established session
-				record.applySession(connection.getEstablishedSession());
-			} else if (record.isNewClientHello()) {
-				// client has lost track of existing connection and wants to
-				// negotiate a new connection
-				// in epoch 0 no crypto params have been established yet, thus
-				// we do not need to set a session
-			} else {
-				LOGGER.debug(
-						"Discarding HANDSHAKE message [epoch={}] from peer [{}] which does not match expected epoch(s) [{}]",
-						record.getEpoch(), record.getPeerAddress());
-				return;
+			if (record.isNewClientHello()) {
+				throw new IllegalArgumentException("new CLIENT_HELLO must be processed by processClientHello!");
 			}
-
 			HandshakeMessage handshakeMessage = (HandshakeMessage) record.getFragment();
-			processDecryptedHandshakeMessage(handshakeMessage, record, connection);
-		} catch (GeneralSecurityException e) {
-				discardRecord(record, e);
+			switch (handshakeMessage.getMessageType()) {
+			case CLIENT_HELLO:
+				// We do not support re-negotiation as recommended in :
+				// https://tools.ietf.org/html/rfc7925#section-17
+				if (record.getEpoch() > 0) {
+					DTLSSession session = connection.getEstablishedSession();
+					send(new AlertMessage(AlertLevel.WARNING, AlertDescription.NO_RENEGOTIATION, record.getPeerAddress()),
+							session);
+				}
+				break;
+			case HELLO_REQUEST:
+				processHelloRequest(connection);
+				break;
+			default:
+				Handshaker handshaker = connection.getOngoingHandshake();
+				if (handshaker != null) {
+					handshaker.processMessage(record);
+				} else {
+					LOGGER.debug(
+							"Discarding HANDSHAKE message [epoch={}] from peer [{}], no ongoing handshake!",
+							record.getEpoch(), record.getPeerAddress());
+				}
+				break;
+			}
 		} catch (HandshakeException e) {
 			handleExceptionDuringHandshake(e, e.getAlert().getLevel(), e.getAlert().getDescription(), connection, record);
-		}
-	}
-
-	/**
-	 * Process handshake message.
-	 * 
-	 * @param handshakeMessage handshake message
-	 * @param record record of handshake message
-	 * @param connection connection to process the handshake message
-	 * @throws HandshakeException if the handshake message cannot be processed
-	 */
-	private void processDecryptedHandshakeMessage(final HandshakeMessage handshakeMessage, final Record record,
-			final Connection connection) throws HandshakeException {
-		switch (handshakeMessage.getMessageType()) {
-		case CLIENT_HELLO:
-			// We do not support re-negotiation as recommended in :
-			// https://tools.ietf.org/html/rfc7925#section-17
-			if (record.getEpoch() > 0) {
-				DTLSSession session = connection.getEstablishedSession();
-				send(new AlertMessage(AlertLevel.WARNING, AlertDescription.NO_RENEGOTIATION, record.getPeerAddress()),
-						session);
-			} else {
-				LOGGER.error("Unexpected CLIENT_HELLO {}", record.getPeerAddress(),
-						new IllegalArgumentException("Unexpected CLIENT_HELLO"));
-			}
-			break;
-		case HELLO_REQUEST:
-			processHelloRequest(connection);
-			break;
-		default:
-			processOngoingHandshakeMessage(handshakeMessage, record, connection);
-		}
-	}
-
-	/**
-	 * Process handshake message of an ongoing handshake.
-	 * 
-	 * @param message handshake message
-	 * @param record record of handshake message
-	 * @param connection connection to process handshake message.
-	 * @throws HandshakeException if the handshake message cannot be processed
-	 */
-	private void processOngoingHandshakeMessage(final HandshakeMessage message, final Record record, final Connection connection) throws HandshakeException {
-		if (connection.hasOngoingHandshake()) {
-			connection.getOngoingHandshake().processMessage(record);
-		} else {
-			LOGGER.debug(
-				"Discarding {} message received from peer [{}] with no handshake going on",
-				message.getMessageType(), message.getPeer());
 		}
 	}
 
@@ -1667,8 +1590,7 @@ public class DTLSConnector implements Connector, RecordLayer {
 	 * @param clientHello the peer's client hello method including the cookie to
 	 *            verify
 	 * @param record the received record
-	 * @param connections expect the {@link AvailableConnections#byAddress} to
-	 *            be provided and set the
+	 * @param connections used to set the
 	 *            {@link AvailableConnections#bySessionId} with the result of
 	 *            {@link ResumptionSupportingConnectionStore#find(SessionId)}.
 	 * @return <code>true</code> if the client hello message contains a cookie

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
@@ -211,6 +211,17 @@ public final class Connection {
 	}
 
 	/**
+	 * Check, if this connection expects connection ID for incoming records.
+	 * 
+	 * @return {@code true}, if connection ID is expected, {@code false},
+	 *         otherwise
+	 */
+	public boolean expectCid() {
+		DTLSSession session = getSession();
+		return session != null && session.getWriteConnectionId() != null;
+	}
+
+	/**
 	 * Gets the connection id.
 	 * 
 	 * @return the cid

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordLayer.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordLayer.java
@@ -37,4 +37,12 @@ public interface RecordLayer {
 	 * @throws IOException if an io error occurs
 	 */
 	void sendFlight(DTLSFlight flight, Connection connection) throws IOException;
+
+	/**
+	 * Process received record.
+	 * 
+	 * @param record received record.
+	 * @param connection connection to process record.
+	 */
+	void processRecord(Record record, Connection connection);
 }

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
@@ -211,12 +211,13 @@ public class ClientHandshakerTest {
 		} else {
 			builder.setClientAuthenticationRequired(false);
 		}
+		Connection connection = new Connection(peer, new SyncSerialExecutor());
 		DTLSSession session = new DTLSSession(peer);
 		session.setVirtualHost(virtualHost);
 		handshaker = new ClientHandshaker(
 				session,
 				recordLayer,
-				null,
+				connection,
 				builder.build(),
 				MAX_TRANSMISSION_UNIT);
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/SimpleRecordLayer.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/SimpleRecordLayer.java
@@ -17,8 +17,15 @@
  ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
+import java.security.GeneralSecurityException;
+
 public class SimpleRecordLayer implements RecordLayer {
+
+	private volatile Handshaker handshaker;
 	private DTLSFlight sentFlight;
+
+	public SimpleRecordLayer() {
+	}
 
 	@Override
 	public void sendFlight(DTLSFlight flight, Connection connection) {
@@ -27,5 +34,26 @@ public class SimpleRecordLayer implements RecordLayer {
 
 	public DTLSFlight getSentFlight() {
 		return sentFlight;
+	}
+
+	@Override
+	public void processRecord(Record record, Connection connection) {
+		Handshaker handshaker = this.handshaker;
+		if (handshaker != null) {
+			try {
+				record.applySession(handshaker.getSession());
+				handshaker.processMessage(record);
+			} catch (HandshakeException e) {
+				e.printStackTrace();
+				throw new IllegalArgumentException(e);
+			} catch (GeneralSecurityException e) {
+				e.printStackTrace();
+				throw new IllegalArgumentException(e);
+			}
+		}
+	}
+
+	public void setHandshaker(Handshaker handshaker) {
+		this.handshaker = handshaker;
 	}
 }


### PR DESCRIPTION
Cleanup handshaker.

Process records only, if they match the current epoch.
Remove duplicate epoch checks and applySession.
Generally apply the record sequence number filter.
Forward deferred records (next epoch) with CCS to the record layer to
apply general processing and decryption with the new session.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>