### PR TITLE
OSCORE: Finalizing functionality to securely re-generate contexts

### DIFF
--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
@@ -18,86 +18,415 @@ package org.eclipse.californium.oscore;
 
 import java.io.IOException;
 import java.security.SecureRandom;
+import java.util.Arrays;
 
-import org.eclipse.californium.core.CoapClient;
-import org.eclipse.californium.core.CoapResponse;
-import org.eclipse.californium.core.Utils;
-import org.eclipse.californium.core.coap.Request;
-import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.cose.CoseException;
 import org.eclipse.californium.elements.exception.ConnectorException;
 import org.eclipse.californium.elements.util.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Class that implements methods for dynamic re-generation of OSCORE contexts.
+ * Methods for perform re-derivation of contexts as detailed in Appendix B.2. It
+ * uses two message exchanges together with varying the Context ID field in the
+ * OSCORE option to securely generate a new shared context. The second exchange
+ * will be for the request the client actually wants to send.
+ * 
+ * Note that the implementation requires that no additional requests are sent
+ * without first getting the response to the pending request during the 2
+ * request/response exchanges of the procedure.
  *
- * See https://tools.ietf.org/html/draft-ietf-core-object-security-16#appendix-B.2
- *
+ * See https://tools.ietf.org/html/rfc8613#appendix-B.2
  */
 public class ContextRederivation {
-	
+
+	private static SecureRandom random = new SecureRandom();
+
+	private static final String SCHEME = "coap://";
+
+	/**
+	 * The different phases of the re-derivation procedure.
+	 *
+	 */
+	public static enum PHASE {
+		INACTIVE, CLIENT_INITIATE, SERVER_PHASE_1, SERVER_PHASE_2, SERVER_PHASE_3, CLIENT_PHASE_1, CLIENT_PHASE_2, CLIENT_PHASE_3;
+	}
+
+	/**
+	 * Length of each segment (ID1, S2 and R3) in the Context ID when performing
+	 * context re-derivation. R2 will be of length 2 segments since it is
+	 * actually composed of S2 || HMAC(S2).
+	 */
+	protected static int SEGMENT_LENGTH = 8;
+
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(RequestDecryptor.class.getName());
-	
+	private static final Logger LOGGER = LoggerFactory.getLogger(ContextRederivation.class.getName());
+
 	/**
-	 * Method for an application to indicate that the mutable parts of an OSCORE context has been lost.
-	 * In such case the context re-derivation procedure is triggered.
+	 * Method to indicate that the mutable parts of an OSCORE context has been
+	 * lost. In such case the context re-derivation procedure is triggered.
 	 * 
-	 * @param uri the URI associated with the context information has been lost for
+	 * @param uri the URI associated with context information has been lost for
 	 * @throws CoapOSException if re-generation of the context fails
 	 */
 	public static void setLostContext(OSCoreCtxDB db, String uri) throws CoapOSException
 	{
 		try {
-			rederive(db, uri);
+			initiateRequest(db, uri);
 		} catch (ConnectorException | IOException | OSException e) {
 			LOGGER.error(ErrorDescriptions.CONTEXT_REGENERATION_FAILED);
 			throw new CoapOSException(ErrorDescriptions.CONTEXT_REGENERATION_FAILED, ResponseCode.BAD_REQUEST);
 		}
 	}
-	
+
+	/* Client side related methods below */
+
 	/**
-	 * Perform re-derivation of contexts as detailed in Appendix B.2.
-	 * Essentially it uses a message exchange together with the Context ID
-	 * field in the OSCORE option to securely generate a new shared context.
+	 * This method will be triggered by the client before sending a request that
+	 * initiates the context re-derivation procedure.
 	 * 
-	 * @throws IOException 
-	 * @throws ConnectorException 
-	 * @throws OSException 
+	 * @throws IOException
+	 * @throws ConnectorException
+	 * @throws OSException
 	 */
-	private static void rederive(OSCoreCtxDB db, String uri) throws ConnectorException, IOException, OSException {
-		//Generate a random 8 byte Context ID
-		SecureRandom random = new SecureRandom();
-		byte[] newContextId = new byte[8];
-		random.nextBytes(newContextId);
-		
-		//Retrieve the context for the target URI
-		OSCoreCtx oldCtx = db.getContext(uri);
-		
-		//Create new context with the generated Context ID
-		OSCoreCtx ctx = new OSCoreCtx(oldCtx.getMasterSecret(), true, oldCtx.getAlg(), oldCtx.getSenderId(),
-				oldCtx.getRecipientId(), oldCtx.getKdf(), oldCtx.getRecipientReplaySize(), oldCtx.getSalt(), newContextId);
-		ctx.setIncludeContextId(true);
-		db.addContext(uri, ctx);
-		
-		//Now send request using the new context
-		String resource = "/rederive"; //Dummy resource to access for context re-derivation
-		String URI = uri + resource;
-		System.out.println(URI);
-		
-		CoapClient c = new CoapClient(URI);
-		Request r = new Request(Code.GET);
-		r.getOptions().setOscore(Bytes.EMPTY);
-		System.out.println(Utils.prettyPrint(r));
-		
-		CoapResponse resp = null;
-		resp = c.advanced(r);
-		System.out.println(Utils.prettyPrint(resp));
-		c.shutdown();
+	private static void initiateRequest(OSCoreCtxDB db, String uri) throws ConnectorException, IOException, OSException {
+
+		// Retrieve the context for the target URI
+		OSCoreCtx ctx = db.getContext(uri);
+
+		printStateLogging(ctx);
+
+		// Generate a random Context ID (ID1)
+		byte[] contextID1 = Bytes.createBytes(random, SEGMENT_LENGTH);
+
+		// Create new context with the generated Context ID
+		OSCoreCtx newCtx = rederiveWithContextID(ctx, contextID1);
+		newCtx.setIncludeContextId(true);
+		newCtx.setContextRederivationPhase(ContextRederivation.PHASE.CLIENT_PHASE_1);
+		db.addContext(uri, newCtx);
 	}
-	
+
+	/**
+	 * Handle incoming response messages (for client).
+	 * 
+	 * @param db the context db
+	 * @param ctx the context
+	 * @param contextID the context ID in the incoming response
+	 * @return an updated context
+	 * @throws OSException if context re-derivation fails
+	 */
+	static OSCoreCtx incomingResponse(OSCoreCtxDB db, OSCoreCtx ctx, byte[] contextID) throws OSException {
+
+		// Handle client phase 3 operations
+		if (ctx.getContextRederivationPhase() == PHASE.CLIENT_PHASE_3) {
+
+			printStateLogging(ctx);
+
+			ctx.setIncludeContextId(false);
+			ctx.setContextRederivationPhase(PHASE.INACTIVE);
+			return ctx;
+		} else if (ctx.getContextRederivationPhase() == PHASE.CLIENT_PHASE_1) {
+
+			printStateLogging(ctx);
+
+			// Handle client phase 1 operations
+
+			// The Context ID in the incoming response is identified as R2
+			byte[] contextR2 = contextID;
+
+			// The Context ID of the original request in this exchange is ID1
+			byte[] contextID1 = ctx.getIdContext();
+
+			// Create Context ID to generate the new context with (R2 || ID1)
+			byte[] verifyContextID = Bytes.concatenate(contextR2, contextID1);
+
+			// Generate a new context with the concatenated Context ID
+			OSCoreCtx newCtx = rederiveWithContextID(ctx, verifyContextID);
+
+			// Add the new context to the context DB (replacing the old)
+			newCtx.setContextRederivationPhase(PHASE.CLIENT_PHASE_2);
+			db.addContext(SCHEME + ctx.getUri(), newCtx);
+			return newCtx;
+		}
+
+		return ctx;
+	}
+
+	/**
+	 * Handle outgoing request messages (for client).
+	 * 
+	 * @param db the context db
+	 * @param ctx the context
+	 * @return an updated context
+	 * @throws OSException if context re-derivation fails
+	 */
+	static OSCoreCtx outgoingRequest(OSCoreCtxDB db, OSCoreCtx ctx) throws OSException {
+
+		// Handle client phase 2 operations
+		if (ctx.getContextRederivationPhase() == PHASE.CLIENT_PHASE_2) {
+
+			printStateLogging(ctx);
+
+			// Extract the R2 Context ID value from the current context
+			// Currently the value will be R2 || ID1
+			byte[] currentContextID = ctx.getIdContext();
+			byte[] contextR2 = Arrays.copyOfRange(currentContextID, 0, currentContextID.length - SEGMENT_LENGTH);
+
+			// Now create the random Context ID value R3
+			byte[] contextR3 = Bytes.createBytes(random, SEGMENT_LENGTH);
+
+			// Concatenate R2 and R3 to get the Context ID to use
+			byte[] protectContextID = Bytes.concatenate(contextR2, contextR3);
+
+			// Generate a new context with the concatenated Context ID
+			OSCoreCtx newCtx = rederiveWithContextID(ctx, protectContextID);
+			newCtx.setReceiverSeq(0);
+
+			// In the outgoing request from this context, include the Context ID
+			newCtx.setIncludeContextId(true);
+
+			// Indicate that the context re-derivation procedure is ongoing
+			newCtx.setContextRederivationPhase(PHASE.CLIENT_PHASE_3);
+
+			// Add the new context to the context DB (replacing the old)
+			db.addContext(SCHEME + ctx.getUri(), newCtx);
+			return newCtx;
+		}
+
+		return ctx;
+	}
+
+	/* Server side related methods below */
+
+	/**
+	 * Handle incoming request messages (for server).
+	 * 
+	 * @param db db the context db
+	 * @param ctx the context
+	 * @param contextID the context ID in the incoming request
+	 * @return an updated context
+	 * @throws OSException if context re-derivation fails
+	 */
+	static OSCoreCtx incomingRequest(OSCoreCtxDB db, OSCoreCtx ctx, byte[] contextID) throws OSException {
+
+		// Handle server phase 2 operations
+		if (ctx.getContextRederivationPhase() == PHASE.SERVER_PHASE_2) {
+
+			printStateLogging(ctx);
+
+			/*
+			 * Verify the Context ID (R2) using S2 and an HMAC function. The
+			 * Context ID in this message is (R2 || R3). R2 in turn is composed
+			 * of S2 || HMAC output.
+			 */
+
+			// Extract S2 from the Context ID
+			byte[] contextS2 = Arrays.copyOfRange(ctx.getIdContext(), 0, SEGMENT_LENGTH);
+
+			// Generate HMAC output using S2
+			byte[] hmacOutput = performHMAC(ctx.getContextRederivationKey(), contextS2);
+
+			// Compare the HMAC output with the equivalent in the message
+			byte[] messageHmacOutput = Arrays.copyOfRange(ctx.getIdContext(), SEGMENT_LENGTH, SEGMENT_LENGTH * 2);
+			if (Arrays.equals(hmacOutput, messageHmacOutput) == false) {
+				throw new OSException(ErrorDescriptions.CONTEXT_REGENERATION_FAILED);
+			}
+
+			// Generate a new context with the received Context ID
+			OSCoreCtx newCtx = rederiveWithContextID(ctx, contextID);
+
+			// Set the next phase of the re-derivation procedure
+			newCtx.setContextRederivationPhase(PHASE.SERVER_PHASE_3);
+
+			// Add the new context to the context DB (replacing the old)
+			db.addContext(newCtx);
+
+			return newCtx;
+		} else if (ctx.getContextRederivationPhase() == PHASE.INACTIVE) {
+
+			printStateLogging(ctx);
+
+			// Handle initiation of re-derivation procedure
+
+			// The Context ID in the request is identified as ID1
+			byte[] contextID1 = contextID;
+
+			// Check if the received Context ID (ID1) matches the one in the
+			// context, if so do nothing. This means that this is a normal
+			// message and not meant to initiate context re-derivation.
+			if (contextID1 == null || Arrays.equals(contextID1, ctx.getIdContext())) {
+				return ctx;
+			}
+
+			// Generate a new context with the received Context ID
+			OSCoreCtx newCtx = rederiveWithContextID(ctx, contextID1);
+
+			// Set next phase of the re-derivation procedure
+			newCtx.setContextRederivationPhase(PHASE.SERVER_PHASE_1);
+
+			// Add the new context to the context DB (replacing the old)
+			db.addContext(newCtx);
+			return newCtx;
+		}
+
+		return ctx;
+	}
+
+	/**
+	 * Handle outgoing response messages (for server).
+	 * 
+	 * @param db the context db
+	 * @param ctx the context
+	 * @return an updated context
+	 * @throws OSException if context re-derivation fails
+	 */
+	static OSCoreCtx outgoingResponse(OSCoreCtxDB db, OSCoreCtx ctx) throws OSException {
+
+		// Handle server phase 3 operations
+		if (ctx.getContextRederivationPhase() == PHASE.SERVER_PHASE_3) {
+
+			printStateLogging(ctx);
+
+			ctx.setIncludeContextId(false);
+			ctx.setContextRederivationPhase(PHASE.INACTIVE);
+			return ctx;
+		} else if (ctx.getContextRederivationPhase() == PHASE.SERVER_PHASE_1) {
+
+			printStateLogging(ctx);
+
+			// Handle server phase 1 operations
+
+			// Set a random context re-derivation key
+			int keyLength = ctx.getSenderKey().length;
+			byte[] contextRederivationKey = Bytes.createBytes(random, keyLength);
+			ctx.setContextRederivationKey(contextRederivationKey);
+
+			// The Context ID in the original request is identified as ID1
+			byte[] contextID1 = ctx.getIdContext();
+
+			/*
+			 * Generate new Context ID (R2) with a byte array (S2) & an HMAC
+			 * function.
+			 */
+
+			// Generate S2
+			byte[] contextS2 = Bytes.createBytes(random, SEGMENT_LENGTH);
+
+			// Generate HMAC output using S2
+			byte[] hmacOutput = performHMAC(ctx.getContextRederivationKey(), contextS2);
+
+			// Create R2 by concatenating S2 and the HMAC output
+			byte[] contextR2 = Bytes.concatenate(contextS2, hmacOutput);
+
+			/* Create Context ID to generate the new context with (R2 || ID1) */
+
+			byte[] protectContextID = Bytes.concatenate(contextR2, contextID1);
+
+			// Generate a new context with the concatenated Context ID
+			OSCoreCtx newCtx = rederiveWithContextID(ctx, protectContextID);
+			newCtx.setReceiverSeq(0);
+
+			// In outgoing response from this context, only use R2 as
+			// Context ID (not concatenated one used to generate the
+			// context)
+			newCtx.setIncludeContextId(contextR2);
+
+			// Retain the context re-derivation key
+			newCtx.setContextRederivationKey(ctx.getContextRederivationKey());
+
+			// Respond with new partial IV
+			newCtx.setResponsesIncludePartialIV(true);
+
+			// Indicate that the context re-derivation procedure is ongoing
+			newCtx.setContextRederivationPhase(PHASE.SERVER_PHASE_2);
+
+			// Add the new context to the context DB (replacing the old)
+			db.addContext(newCtx);
+			return newCtx;
+		}
+
+		return ctx;
+	}
+
+	/**
+	 * Re-derive a context with the same input parameters except Context ID.
+	 * 
+	 * @param ctx the OSCORE context to re-derive
+	 * @param contextID the new context ID to use
+	 * @return the new re-derived context
+	 */
+	private static OSCoreCtx rederiveWithContextID(OSCoreCtx ctx, byte[] contextID) throws OSException {
+		return new OSCoreCtx(ctx.getMasterSecret(), true, ctx.getAlg(), ctx.getSenderId(), ctx.getRecipientId(),
+				ctx.getKdf(), ctx.getRecipientReplaySize(), ctx.getSalt(), contextID);
+	}
+
+	/**
+	 * Perform HMAC on input data with a key.
+	 * 
+	 * @param contextRederivationKey the context re-derivation key
+	 * @param input the input data
+	 * @return HMAC output
+	 * @throws OSException if performing the HMAC fails
+	 */
+	private static byte[] performHMAC(byte[] contextRederivationKey, byte[] input) throws OSException {
+		byte[] key = null;
+		try {
+			key = OSCoreCtx.deriveKey(contextRederivationKey, contextRederivationKey, SEGMENT_LENGTH, "SHA256", input);
+		} catch (CoseException e) {
+			throw new OSException(ErrorDescriptions.CONTEXT_REGENERATION_FAILED);
+		}
+		return key;
+	}
+
+	/**
+	 * Provides logging output indicating the current state. Uses debug level
+	 * output for the inactive state since that is the default for typical use.
+	 * 
+	 * @param ctx the OSCORE context in use
+	 */
+	private static void printStateLogging(OSCoreCtx ctx) {
+		PHASE currentPhase = ctx.getContextRederivationPhase();
+
+		String supplemental = "";
+		switch (currentPhase) {
+		case INACTIVE:
+			supplemental = "client/server context re-derivation inactive";
+			break;
+		case CLIENT_INITIATE:
+			supplemental = "client will initiate context re-derivation";
+			break;
+		case CLIENT_PHASE_1:
+			supplemental = "client has sent the first request in the procedure and is receving the response";
+			break;
+		case CLIENT_PHASE_2:
+			supplemental = "client is sending the second request in the procedure";
+			break;
+		case CLIENT_PHASE_3:
+			supplemental = "client has received the second response in the procedure and is concluding";
+			break;
+		case SERVER_PHASE_1:
+			supplemental = "server has received the first request in the procedure and is sending the response";
+			break;
+		case SERVER_PHASE_2:
+			supplemental = "server is receiving the second request in the procedure";
+			break;
+		case SERVER_PHASE_3:
+			supplemental = "server has sent the second response in the procedure and is concluding";
+			break;
+		default:
+			supplemental = "context re-derivation is in unknown state indicating a problem";
+			break;
+		}
+
+		String output = "Context re-derivation phase: " + currentPhase + " (" + supplemental + ")";
+		if (currentPhase == PHASE.INACTIVE) {
+			LOGGER.debug(output);
+		} else {
+			LOGGER.info(output);
+		}
+	}
+
 }

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/Encryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/Encryptor.java
@@ -175,8 +175,8 @@ public abstract class Encryptor {
 
 			//Encode the Context ID length and value if to be included
 			if (ctx.getIncludeContextId()) {
-				bRes.write(ctx.getIdContext().length);
-				bRes.write(ctx.getIdContext());
+				bRes.write(ctx.getMessageIdContext().length);
+				bRes.write(ctx.getMessageIdContext());
 			}
 
 			//Encode Sender ID (KID)
@@ -221,8 +221,8 @@ public abstract class Encryptor {
 		//Encode the Context ID length and value if to be included
 		if (ctx.getIncludeContextId()) {
 			try {
-				bRes.write(ctx.getIdContext().length);
-				bRes.write(ctx.getIdContext());
+				bRes.write(ctx.getMessageIdContext().length);
+				bRes.write(ctx.getMessageIdContext());
 			} catch (IOException e) {
 				e.printStackTrace();
 			}

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestEncryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestEncryptor.java
@@ -39,17 +39,28 @@ public class RequestEncryptor extends Encryptor {
 
 	/**
 	 * @param request the request
-	 * @param ctx the OSCore context
+	 * @param db the context database used
 	 * 
 	 * @return the request with the OSCore option
 	 * @throws OSException if encryption fails
 	 *
 	 */
-	public static Request encrypt(Request request, OSCoreCtx ctx) throws OSException {
+	public static Request encrypt(OSCoreCtxDB db, Request request) throws OSException {
+
+		String uri = request.getURI();
+		OSCoreCtx ctx = db.getContext(uri);
 
 		if (ctx == null) {
 			LOGGER.error(ErrorDescriptions.CTX_NULL);
 			throw new OSException(ErrorDescriptions.CTX_NULL);
+		}
+
+		// Perform context re-derivation procedure if ongoing
+		try {
+			ctx = ContextRederivation.outgoingRequest(db, ctx);
+		} catch (OSException e) {
+			LOGGER.error(ErrorDescriptions.CONTEXT_REGENERATION_FAILED);
+			throw new OSException(ErrorDescriptions.CONTEXT_REGENERATION_FAILED);
 		}
 
 		int realCode = request.getCode().value;

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseEncryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseEncryptor.java
@@ -46,10 +46,18 @@ public class ResponseEncryptor extends Encryptor {
 	 * 
 	 * @throws OSException when encryption fails
 	 */
-	public static Response encrypt(Response response, OSCoreCtx ctx, final boolean newPartialIV) throws OSException {
+	public static Response encrypt(OSCoreCtxDB db, Response response, OSCoreCtx ctx, final boolean newPartialIV) throws OSException {
 		if (ctx == null) {
 			LOGGER.error(ErrorDescriptions.CTX_NULL);
 			throw new OSException(ErrorDescriptions.CTX_NULL);
+		}
+
+		// Perform context re-derivation procedure if ongoing
+		try {
+			ctx = ContextRederivation.outgoingResponse(db, ctx);
+		} catch (OSException e) {
+			LOGGER.error(ErrorDescriptions.CONTEXT_REGENERATION_FAILED);
+			throw new OSException(ErrorDescriptions.CONTEXT_REGENERATION_FAILED);
 		}
 
 		int realCode = response.getCode().value;

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/AllJUnitTests.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/AllJUnitTests.java
@@ -26,9 +26,9 @@ import org.junit.runners.Suite.SuiteClasses;
  *
  */
 @RunWith(Suite.class)
-@SuiteClasses({ ByteIdTest.class, HashMapCtxDBTest.class, OptionJuggleTest.class, OSCoreCtxTest.class,
-	OSCoreTest.class, OSSerializerTest.class, OSCoreServerClientTest.class, OSCoreObserveTest.class,
-	EncryptorTest.class, DecryptorTest.class, EndpointContextInfoTest.class })
+@SuiteClasses({ ByteIdTest.class, HashMapCtxDBTest.class, OptionJuggleTest.class, OSCoreCtxTest.class, OSCoreTest.class,
+		OSSerializerTest.class, OSCoreServerClientTest.class, OSCoreObserveTest.class, EncryptorTest.class,
+		DecryptorTest.class, EndpointContextInfoTest.class, ContextRederivationTest.class })
 public class AllJUnitTests {
 
 }

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
@@ -16,12 +16,14 @@
  ******************************************************************************/
 package org.eclipse.californium.oscore;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
+import org.eclipse.californium.TestTools;
 import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.CoapResponse;
 import org.eclipse.californium.core.CoapServer;
@@ -29,6 +31,8 @@ import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.elements.exception.ConnectorException;
+import org.eclipse.californium.elements.util.Bytes;
+import org.eclipse.californium.oscore.ContextRederivation.PHASE;
 import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
 import org.junit.Before;
@@ -38,6 +42,7 @@ import org.junit.Test;
 import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.EndpointManager;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.cose.AlgorithmID;
@@ -57,14 +62,12 @@ public class ContextRederivationTest {
 	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT, CoapNetworkRule.Mode.NATIVE);
 	
 	private CoapServer server;
-	private int serverPort;
-	private static String serverAddress = InetAddress.getLoopbackAddress().getHostAddress();
-
-	private static String clientAddress = InetAddress.getLoopbackAddress().getHostName();
+	private Endpoint serverEndpoint;
 
 	private static String SERVER_RESPONSE = "Hello World!";
-	
-	private final static HashMapCtxDB db = new HashMapCtxDB();
+
+	private final static HashMapCtxDB dbClient = new HashMapCtxDB();
+	private final static HashMapCtxDB dbServer = new HashMapCtxDB();
 	private final static String hello1 = "/hello";
 	private final static AlgorithmID alg = AlgorithmID.AES_CCM_16_64_128;
 	private final static AlgorithmID kdf = AlgorithmID.HKDF_HMAC_SHA_256;
@@ -76,17 +79,19 @@ public class ContextRederivationTest {
 			(byte) 0x78, (byte) 0x63, (byte) 0x40 };
 	private final static byte[] sid = new byte[0];
 	private final static byte[] rid = new byte[] { 0x01 };
-	
+
+	private static int SEGMENT_LENGTH = ContextRederivation.SEGMENT_LENGTH;
+
 	@Before
 	public void initLogger() {
 		System.out.println(System.lineSeparator() + "Start " + getClass().getSimpleName());
 		EndpointManager.clear();
 	}
 
-	//Use the OSCORE stack factory
+	// Use the OSCORE stack factory with the client context DB
 	@BeforeClass
 	public static void setStackFactory() {
-		OSCoreCoapStackFactory.useAsDefault(db);
+		OSCoreCoapStackFactory.useAsDefault(dbClient);
 	}
 
 	@After
@@ -106,24 +111,67 @@ public class ContextRederivationTest {
 	 */
 	@Test
 	public void rederivationTest() throws OSException, ConnectorException, IOException {
-		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, null);
-		String serverUri = "coap://" + serverAddress + ":" + serverPort;
-		db.addContext(serverUri, ctx);
-
-		//Indicate that context information has been lost for the context associated to this URI
-		ContextRederivation.setLostContext(db, serverUri);
 		
-		//Now proceed with a normal request from the client
-		CoapClient c = new CoapClient(serverUri + hello1);
+		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, null);
+		String serverUri = serverEndpoint.getUri().toASCIIString();
+		dbClient.addContext(serverUri, ctx);
+
+		// Set the context to be in the initiate phase
+		ctx.setContextRederivationPhase(PHASE.CLIENT_INITIATE);
+
+		// Now a send request to initiate the context re-derivation
+		String resource = "/rederive"; // Dummy resource for re-derivation
+		String URI = serverUri + resource;
+
+		CoapClient c = new CoapClient(URI);
 		Request r = new Request(Code.GET);
+		r.getOptions().setOscore(Bytes.EMPTY);
+		CoapResponse resp = c.advanced(r);
+
+		OSCoreCtx currCtx = dbClient.getContext(serverUri);
+		assertEquals(ContextRederivation.PHASE.CLIENT_PHASE_2, currCtx.getContextRederivationPhase()); // Phase
+		int contextIDLen = currCtx.getIdContext().length;
+		// Length of Context ID in context
+		assertEquals(3 * SEGMENT_LENGTH, contextIDLen);
+		byte[] oscoreOption = resp.getOptions().getOscore();
+		// OSCORE option in response is 2 * SEGMENT_LENGTH (R2 as Context ID) +
+		// 2 additional bytes
+		assertEquals(2 * SEGMENT_LENGTH + 2, oscoreOption.length);
+
+		// Now proceed with a normal request from the client
+		c = new CoapClient(serverUri + hello1);
+		r = new Request(Code.GET);
 		r.getOptions().setOscore(new byte[0]);
 		System.out.println((Utils.prettyPrint(r)));
-		
-		CoapResponse resp = c.advanced(r);
+
+		resp = c.advanced(r);
 		System.out.println((Utils.prettyPrint(resp)));
-		
-		assertEquals(resp.getCode(), ResponseCode.CONTENT);
-		assertEquals(resp.getResponseText(), SERVER_RESPONSE);
+
+		assertEquals(ResponseCode.CONTENT, resp.getCode());
+		assertEquals(SERVER_RESPONSE, resp.getResponseText());
+
+		// Check current state of context after request/response
+		OSCoreCtx lastCtx = dbClient.getContext(serverUri);
+		contextIDLen = lastCtx.getIdContext().length;
+		assertNotNull(lastCtx.getUri());
+
+		assertEquals(3 * SEGMENT_LENGTH, contextIDLen);
+		assertEquals(ContextRederivation.PHASE.INACTIVE, lastCtx.getContextRederivationPhase());
+		assertFalse(lastCtx.getIncludeContextId()); // Do not include Context ID
+
+		// Empty OSCORE option
+		assertArrayEquals(new byte[0], resp.getOptions().getOscore());
+
+		// 2nd request for testing
+		resp = c.advanced(r);
+		System.out.println((Utils.prettyPrint(resp)));
+
+		assertEquals(ResponseCode.CONTENT, resp.getCode());
+		assertEquals(SERVER_RESPONSE, resp.getResponseText());
+
+		resp = c.advanced(r);
+		System.out.println((Utils.prettyPrint(resp)));
+
 		c.shutdown();
 	}
 
@@ -143,22 +191,16 @@ public class ContextRederivationTest {
 		byte[] sid = new byte[] { 0x01 };
 		byte[] rid = new byte[0];
 		OSCoreCtx ctx = new OSCoreCtx(master_secret, false, alg, sid, rid, kdf, 32, master_salt, null);
-		db.addContext("coap://" + clientAddress, ctx);
+		String clientUri = "coap://" + TestTools.LOCALHOST_EPHEMERAL.getAddress().getHostAddress();
+		dbServer.addContext(clientUri, ctx);
 
 		//Create server
 		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
-		
-		InetAddress serverInetAddress = null;
-		try {
-			serverInetAddress = InetAddress.getByName(serverAddress);
-		} catch (UnknownHostException e) {
-			System.err.println("Failed to find server address!");
-		}
-		
-		builder.setInetSocketAddress(new InetSocketAddress(serverInetAddress, 0));
-		CoapEndpoint endpoint = builder.build();
+		builder.setCustomCoapStackArgument(dbServer);
+		builder.setInetSocketAddress(TestTools.LOCALHOST_EPHEMERAL);
+		serverEndpoint = builder.build();
 		server = new CoapServer();
-		server.addEndpoint(endpoint);
+		server.addEndpoint(serverEndpoint);
 
 		/** --- Resources for tests follow --- **/
 
@@ -181,6 +223,5 @@ public class ContextRederivationTest {
 
 		//Start server
 		server.start();
-		serverPort = endpoint.getAddress().getPort();
 	}
 }

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/EncryptorTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/EncryptorTest.java
@@ -73,7 +73,9 @@ public class EncryptorTest {
 		}
 		
 		//Encrypt the request message
-		Request encrypted = RequestEncryptor.encrypt(r, ctx);
+		HashMapCtxDB db = new HashMapCtxDB();
+		db.addContext(r.getURI(), ctx);
+		Request encrypted = RequestEncryptor.encrypt(db, r);
 		
 		//Check the OSCORE option value
 		byte[] predictedOSCoreOption = { 0x09, 0x14, 0x00 };
@@ -132,7 +134,7 @@ public class EncryptorTest {
 
 		//Encrypt the response message
 		boolean newPartialIV = true;
-		Response encrypted = ResponseEncryptor.encrypt(r, ctx, newPartialIV);
+		Response encrypted = ResponseEncryptor.encrypt(null, r, ctx, newPartialIV);
 		
 		//Check the OSCORE option value
 		byte[] predictedOSCoreOption = { 0x01, 0x00 };

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreTest.java
@@ -312,7 +312,7 @@ public class OSCoreTest {
 	public void testEncryptedNoOptionsNoPayload() {
 		Request request = Request.newGet().setURI("coap://localhost:5683");
 		try {
-			ObjectSecurityLayer.prepareSend(request, dbClient.getContext("coap://localhost:5683"));
+			ObjectSecurityLayer.prepareSend(dbClient, request);
 		} catch (OSException e) {
 			e.printStackTrace();
 			assertTrue(false);
@@ -332,7 +332,7 @@ public class OSCoreTest {
 		request.getOptions().addOption(new Option(OptionNumberRegistry.OSCORE));
 		assertEquals(2, request.getOptions().getLocationPathCount());
 		try {
-			request = ObjectSecurityLayer.prepareSend(request, dbClient.getContext("coap://localhost:5683"));
+			request = ObjectSecurityLayer.prepareSend(dbClient, request);
 		} catch (OSException e) {
 			e.printStackTrace();
 			assertTrue(false);
@@ -356,7 +356,7 @@ public class OSCoreTest {
 		request.setPayload("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
 		assertTrue("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".equals(request.getPayloadString()));
 		try {
-			request = ObjectSecurityLayer.prepareSend(request, dbClient.getContext("coap://localhost:5683"));
+			request = ObjectSecurityLayer.prepareSend(dbClient, request);
 		} catch (OSException e) {
 			e.printStackTrace();
 			assertTrue(false);
@@ -426,9 +426,9 @@ public class OSCoreTest {
 		request2.setToken(t2);
 		try {
 			// sending seq 0
-			request = ObjectSecurityLayer.prepareSend(request, dbClient.getContext("coap://localhost:5683"));
+			request = ObjectSecurityLayer.prepareSend(dbClient, request);
 			dbClient.getContext("coap://localhost:5683").setSenderSeq(0);
-			request2 = ObjectSecurityLayer.prepareSend(request2, dbClient.getContext("coap://localhost:5683"));
+			request2 = ObjectSecurityLayer.prepareSend(dbClient, request2);
 		} catch (OSException e) {
 			e.printStackTrace();
 			fail();
@@ -532,7 +532,7 @@ public class OSCoreTest {
 		db.addContext(token, ctx);
 		request.getOptions().addOption(new Option(OptionNumberRegistry.OSCORE));
 		db.addSeqByToken(token, ctx.getSenderSeq());
-		return ObjectSecurityLayer.prepareSend(request, ctx);
+		return ObjectSecurityLayer.prepareSend(db, request);
 	}
 
 	private boolean assertCtxState(OSCoreCtx ctx, int send, int receive) {
@@ -570,7 +570,7 @@ public class OSCoreTest {
 		response.getOptions().addOption(new Option(OptionNumberRegistry.OSCORE));
 		response.setToken(token);
 
-		return ObjectSecurityLayer.prepareSend(response, tid, false);
+		return ObjectSecurityLayer.prepareSend(null, response, tid, false);
 	}
 
 	public Token generateToken() {


### PR DESCRIPTION
This pull request adds the remaining functionality for the context re-derivation procedure. See the steps described in the OSCORE RFC:
https://tools.ietf.org/html/rfc8613#appendix-B.2

This also includes what is described in section B.2.1 about generating certain values using an HMAC function rather that storing them.

Finally the first context re-derivation message should be automatically triggered by the client sending a request, not triggered separately.
