### PR TITLE
Introduce key-token to support client-local tokens.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
@@ -76,6 +76,7 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.Exchange.Origin;
+import org.eclipse.californium.core.network.TokenGenerator.Scope;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.observe.Observation;
@@ -181,7 +182,7 @@ public abstract class BaseMatcher implements Matcher {
 			Token token = request.getToken();
 			if (token == null) {
 				do {
-					token = tokenGenerator.createToken(true);
+					token = tokenGenerator.createToken(Scope.LONG_TERM);
 					request.setToken(token);
 				} while (observationStore.putIfAbsent(token, new Observation(request, null)) != null);
 			} else {
@@ -257,11 +258,11 @@ public abstract class BaseMatcher implements Matcher {
 	}
 
 	/**
+	 * {@inheritDoc}
+	 * 
 	 * Cancels all pending blockwise requests that have been induced by a
 	 * notification we have received indicating a blockwise transfer of the
 	 * resource.
-	 * 
-	 * @param token the token of the observation.
 	 */
 	@Override
 	public void cancelObserve(Token token) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -317,7 +317,7 @@ public class CoapEndpoint implements Endpoint {
 			coapStackFactory = getDefaultCoapStackFactory();
 		}
 		this.exchangeStore = (null != exchangeStore) ? exchangeStore
-				: new InMemoryMessageExchangeStore(config, tokenGenerator);
+				: new InMemoryMessageExchangeStore(config, tokenGenerator, endpointContextMatcher);
 		observationStore = (null != store) ? store : new InMemoryObservationStore(config);
 		if (null == endpointContextMatcher) {
 			endpointContextMatcher = EndpointContextMatcherFactory.create(connector, config);
@@ -1359,11 +1359,11 @@ public class CoapEndpoint implements Endpoint {
 			if (observationStore == null) {
 				observationStore = new InMemoryObservationStore(config);
 			}
-			if (exchangeStore == null) {
-				exchangeStore = new InMemoryMessageExchangeStore(config, tokenGenerator);
-			}
 			if (endpointContextMatcher == null) {
 				endpointContextMatcher = EndpointContextMatcherFactory.create(connector, config);
+			}
+			if (exchangeStore == null) {
+				exchangeStore = new InMemoryMessageExchangeStore(config, tokenGenerator, endpointContextMatcher);
 			}
 			if (coapStackFactory == null) {
 				coapStackFactory = getDefaultCoapStackFactory();

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
@@ -206,9 +206,10 @@ public interface Endpoint {
 	/**
 	 * Cancel observation for this request.
 	 * 
-	 * @param token
-	 *            the token of the original request which establishes the
-	 *            observe relation to cancel.
+	 * @param token the token of the original request which establishes the
+	 *            observe relation to cancel. The token must have none
+	 *            client-local scope.
+	 * @throws IllegalArgumentException if the token has client-local scope.
 	 */
 	void cancelObservation(Token token);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -52,10 +52,9 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
-import java.net.InetSocketAddress;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
-import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
@@ -64,7 +63,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.EmptyMessage;
@@ -201,6 +199,19 @@ public class Exchange {
 	 * Mark exchange as notification.
 	 */
 	private final boolean notification;
+	/**
+	 * The key mid for the current request.
+	 */
+	private KeyMID currentKeyMID;
+	/**
+	 * The key token for the original request, if {@link #keepRequestInStore} is
+	 * {@code true}. {@code null} otherwise.
+	 */
+	private KeyToken originalKeyToken;
+	/**
+	 * The key token for the current request.
+	 */
+	private KeyToken currentKeyToken;
 
 	/**
 	 * The actual request that caused this exchange. Layers below the
@@ -255,13 +266,17 @@ public class Exchange {
 	// The relation that the target resource has established with the source
 	private volatile ObserveRelation relation;
 
+	/** The notifications that have been sent, so they can be removed from the Matcher */
+	private volatile List<KeyMID> notifications;
+
 	private final AtomicReference<EndpointContext> endpointContext = new AtomicReference<EndpointContext>();
+
 	private volatile EndpointContextOperator endpointContextPreOperator;
 
 	//If object security option is used, the Cryptographic context identifier is stored here
-    // for request/response mapping of contexts
-    private byte[] cryptoContextId;
-	
+	// for request/response mapping of contexts
+	private byte[] cryptoContextId;
+
 	/**
 	 * Creates a new exchange with the specified request and origin.
 	 * 
@@ -271,7 +286,7 @@ public class Exchange {
 	 * @throws NullPointerException, if request is {@code null}
 	 */
 	public Exchange(Request request, Origin origin, Executor executor) {
-		this(request, origin, executor, null, request != null && request.isObserve(), false);
+		this(request, origin, executor, null, false);
 	}
 
 	/**
@@ -287,24 +302,6 @@ public class Exchange {
 	 * @throws NullPointerException, if request is {@code null}
 	 */
 	public Exchange(Request request, Origin origin, Executor executor, EndpointContext ctx, boolean notification) {
-		this(request, origin, executor, ctx, request != null && request.isObserve() && !notification, notification);
-	}
-
-	/**
-	 * Creates a new exchange with the specified request, origin and context.
-	 * 
-	 * @param request the request that starts the exchange
-	 * @param origin the origin of the request (LOCAL or REMOTE)
-	 * @param executor executor to be used for exchanges. Maybe {@code null} for unit tests.
-	 * @param ctx the endpoint context of this exchange
-	 * @param keepRequestInStore {@code true}, to keep the original request in
-	 *            store until completed, {@code false} otherwise.
-	 * @param notification {@code true} for notification exchange, {@code false}
-	 *            otherwise
-	 * @throws NullPointerException, if request is {@code null}
-	 */
-	private Exchange(Request request, Origin origin, Executor executor, EndpointContext ctx, boolean keepRequestInStore,
-			boolean notification) {
 		// might only be the first block of the whole request
 		if (request == null) {
 			throw new NullPointerException("request must not be null!");
@@ -315,7 +312,7 @@ public class Exchange {
 		this.request = request;
 		this.origin = origin;
 		this.endpointContext.set(ctx);
-		this.keepRequestInStore = keepRequestInStore;
+		this.keepRequestInStore = !notification && request.isObserve() && origin == Origin.LOCAL;
 		this.notification = notification;
 		this.nanoTimestamp = ClockUtil.nanoRealtime();
 	}
@@ -459,25 +456,7 @@ public class Exchange {
 		if (currentRequest != newCurrentRequest) {
 			setRetransmissionHandle(null);
 			failedTransmissionCount = 0;
-			Token token = currentRequest.getToken();
-			if (token != null) {
-				if (token.equals(newCurrentRequest.getToken())) {
-					token = null;
-				} else if (keepRequestInStore && token.equals(request.getToken())) {
-					token = null;
-				}
-			}
-			KeyMID key = null;
-			if (currentRequest.hasMID() && currentRequest.getMID() != newCurrentRequest.getMID()) {
-				key = KeyMID.fromOutboundMessage(currentRequest);
-			}
-			if (token != null || key != null) {
-				LOGGER.debug("{} replace {} by {}", this, currentRequest, newCurrentRequest);
-				RemoveHandler obs = this.removeHandler;
-				if (obs != null) {
-					obs.remove(this, token, key);
-				}
-			}
+			LOGGER.debug("{} replace {} by {}", this, currentRequest, newCurrentRequest);
 			currentRequest = newCurrentRequest;
 		}
 	}
@@ -528,14 +507,61 @@ public class Exchange {
 	public void setCurrentResponse(Response newCurrentResponse) {
 		assertOwner();
 		if (currentResponse != newCurrentResponse) {
-			if (currentResponse != null && currentResponse.getType() == Type.CON && currentResponse.hasMID()) {
-				RemoveHandler handler = this.removeHandler;
-				if (handler != null) {
-					KeyMID key = KeyMID.fromOutboundMessage(currentResponse);
-					handler.remove(this, null, key);
-				}
+			if (!isOfLocalOrigin() && currentKeyMID != null && currentResponse != null
+					&& currentResponse.getType() == Type.NON && currentResponse.isNotification()) {
+				// keep NON notifies in KeyMID store.
+				LOGGER.info("{} store NON notification: {}", this, currentKeyMID);
+				notifications.add(currentKeyMID);
+				currentKeyMID = null;
 			}
 			currentResponse = newCurrentResponse;
+		}
+	}
+
+	public KeyMID getKeyMID() {
+		return currentKeyMID;
+	}
+
+	/**
+	 * Set key mid used to register this exchange.
+	 * 
+	 * @param keyMID key mid.
+	 * @throws ConcurrentModificationException, if not executed within
+	 *             {@link #execute(Runnable)}.
+	 */
+	public void setKeyMID(KeyMID keyMID) {
+		assertOwner();
+		if (!keyMID.equals(currentKeyMID)) {
+			RemoveHandler handler = this.removeHandler;
+			if (handler != null && currentKeyMID != null) {
+				handler.remove(this, null, currentKeyMID);
+			}
+			currentKeyMID = keyMID;
+		}
+	}
+
+	/**
+	 * Set key token used to register this exchange.
+	 * 
+	 * @param keyToken key token
+	 * @throws ConcurrentModificationException, if not executed within
+	 *             {@link #execute(Runnable)}.
+	 */
+	public void setKeyToken(KeyToken keyToken) {
+		assertOwner();
+		if (!isOfLocalOrigin()) {
+			throw new IllegalStateException("Token is only supported for local exchanges!");
+		}
+		if (!keyToken.equals(currentKeyToken)) {
+			RemoveHandler handler = this.removeHandler;
+			if (handler != null && currentKeyToken != null && !currentKeyToken.equals(originalKeyToken)) {
+				handler.remove(this, currentKeyToken, null);
+			}
+			currentKeyToken = keyToken;
+			if (keepRequestInStore && originalKeyToken == null) {
+				// keep the original key token
+				originalKeyToken = keyToken;
+			}
 		}
 	}
 
@@ -743,7 +769,7 @@ public class Exchange {
 	 * <p>
 	 * This means that both request and response have been sent/received.
 	 * <p>
-	 * This method invokes the {@linkplain RemoveHandler#remove(Exchange, Token, KeyMID)
+	 * This method invokes the {@linkplain RemoveHandler#remove(Exchange, KeyToken, KeyMID)
 	 * remove} method on the observer registered on this exchange (if any).
 	 * <p>
 	 * Call this method to trigger a clean-up in the Matcher through its
@@ -774,35 +800,28 @@ public class Exchange {
 			RemoveHandler handler = this.removeHandler;
 			if (handler != null) {
 				if (origin == Origin.LOCAL) {
-					Request currrentRequest = getCurrentRequest();
-					Token token = currrentRequest.getToken();
-					KeyMID key = currrentRequest.hasMID() ? KeyMID.fromOutboundMessage(currrentRequest) : null;
-					if (token != null || key != null) {
-						handler.remove(this, token, key);
+					if (currentKeyToken != null || currentKeyMID != null) {
+						handler.remove(this, currentKeyToken, currentKeyMID);
 					}
-					Request request = getRequest();
-					if (keepRequestInStore) {
-						if (request != currrentRequest) {
-							token = request.getToken();
-							key = request.hasMID() ? KeyMID.fromOutboundMessage(request) : null;
-							if (token != null || key != null) {
-								handler.remove(this, token, key);
-							}
+					if (currentKeyToken != originalKeyToken) {
+						handler.remove(this, originalKeyToken, null);
+					}
+					if (LOGGER.isDebugEnabled()) {
+						Request currrentRequest = getCurrentRequest();
+						Request request = getRequest();
+						if (request == currrentRequest) {
+							LOGGER.debug("local {} completed {}!", this, request);
+						} else {
+							LOGGER.debug("local {} completed {} -/- {}!", this, request, currrentRequest);
 						}
-					}
-					if (request == currrentRequest) {
-						LOGGER.debug("local {} completed {}!", this, request);
-					} else {
-						LOGGER.debug("local {} completed {} -/- {}!", this, request, currrentRequest);
 					}
 				} else {
 					Response currentResponse = getCurrentResponse();
 					if (currentResponse == null) {
 						LOGGER.debug("remote {} rejected (without response)!", this);
 					} else {
-						if (currentResponse.getType() == Type.CON && currentResponse.hasMID()) {
-							KeyMID key = KeyMID.fromOutboundMessage(currentResponse);
-							handler.remove(this, null, key);
+						if (currentKeyMID != null) {
+							handler.remove(this, null, currentKeyMID);
 						}
 						removeNotifications();
 						Response response = getResponse();
@@ -883,9 +902,21 @@ public class Exchange {
 	 * Sets the observe relation this exchange has established.
 	 * 
 	 * @param relation the CoAP observe relation
+	 * @throws ConcurrentModificationException, if not executed within
+	 *             {@link #execute(Runnable)}.
+	 * @throws NullPointerException if relation is null
+	 * @throws IllegalStateException if relation was already set before
 	 */
 	public void setRelation(ObserveRelation relation) {
+		assertOwner();
+		if (relation == null) {
+			throw new NullPointerException("Observer relation must not be null!");
+		}
+		if (this.relation != null || notifications != null) {
+			throw new IllegalStateException("Observer relation already set!");
+		}
 		this.relation = relation;
+		notifications = new ArrayList<KeyMID>();
 	}
 
 	/**
@@ -900,29 +931,18 @@ public class Exchange {
 	 */
 	public void removeNotifications() {
 		assertOwner();
-		ObserveRelation relation = this.relation;
 		RemoveHandler handler = this.removeHandler;
-		if (relation != null) {
-			boolean removed = false;
-			for (Iterator<Response> iterator = relation.getNotificationIterator(); iterator.hasNext();) {
-				Response previous = iterator.next();
-				LOGGER.debug("{} removing NON notification: {}", this, previous);
+		if (notifications != null && !notifications.isEmpty()) {
+			for (KeyMID keyMid : notifications) {
+				LOGGER.info("{} removing NON notification: {}", this, keyMid);
 				// notifications are local MID namespace
-				if (previous.hasMID()) {
-					if (handler != null) {
-						KeyMID key = KeyMID.fromOutboundMessage(previous);
-						handler.remove(this, null, key);
-					}
-				} else {
-					previous.cancel();
+				if (handler != null) {
+					handler.remove(this, null, keyMid);
 				}
-				iterator.remove();
-				removed = true;
 			}
-			if (removed) {
-				LOGGER.debug("{} removing all remaining NON-notifications of observe relation with {}", this,
-						relation.getSource());
-			}
+			notifications.clear();
+			LOGGER.debug("{} removing all remaining NON-notifications of observe relation with {}", this,
+					relation.getSource());
 		}
 	}
 
@@ -1037,108 +1057,6 @@ public class Exchange {
 			return executor.checkOwner();
 		} else {
 			return true;
-		}
-	}
-
-	/**
-	 * A CoAP message ID scoped to a remote endpoint.
-	 * <p>
-	 * This class is used by the matcher to correlate messages by MID and
-	 * endpoint address.
-	 */
-	public static final class KeyMID {
-
-		private static final int MAX_PORT_NO = (1 << 16) - 1;
-		private final int MID;
-		private final byte[] address;
-		private final int port;
-		private final int hash;
-
-		/**
-		 * Creates a key based on a message ID and a remote endpoint address.
-		 * 
-		 * @param mid the message ID.
-		 * @param address the IP address of the remote endpoint.
-		 * @param port the port of the remote endpoint.
-		 * @throws NullPointerException if address or origin is {@code null}
-		 * @throws IllegalArgumentException if mid or port &lt; 0 or &gt; 65535.
-		 * 
-		 */
-		private KeyMID(final int mid, final byte[] address, final int port) {
-			if (mid < 0 || mid > Message.MAX_MID) {
-				throw new IllegalArgumentException("MID must be a 16 bit unsigned int: " + mid);
-			} else if (address == null) {
-				throw new NullPointerException("address must not be null");
-			} else if (port < 0 || port > MAX_PORT_NO) {
-				throw new IllegalArgumentException("Port must be a 16 bit unsigned int");
-			} else {
-				this.MID = mid;
-				this.address = address;
-				this.port = port;
-				this.hash = createHashCode();
-			}
-		}
-
-		@Override
-		public int hashCode() {
-			return hash;
-		}
-
-		private int createHashCode() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + MID;
-			result = prime * result + Arrays.hashCode(address);
-			result = prime * result + port;
-			return result;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			KeyMID other = (KeyMID) obj;
-			if (MID != other.MID)
-				return false;
-			if (!Arrays.equals(address, other.address))
-				return false;
-			if (port != other.port)
-				return false;
-			return true;
-		}
-
-		@Override
-		public String toString() {
-			return new StringBuilder("KeyMID[").append(MID).append(", ").append(Utils.toHexString(address)).append(":")
-					.append(port).append("]").toString();
-		}
-
-		/**
-		 * Creates a key from an inbound CoAP message.
-		 * 
-		 * @param message the message.
-		 * @return the key derived from the message. The key's <em>mid</em> is
-		 *         scoped to the message's source address and port.
-		 */
-		public static KeyMID fromInboundMessage(Message message) {
-			InetSocketAddress address = message.getSourceContext().getPeerAddress();
-			return new KeyMID(message.getMID(), address.getAddress().getAddress(), address.getPort());
-		}
-
-		/**
-		 * Creates a key from an outbound CoAP message.
-		 * 
-		 * @param message the message.
-		 * @return the key derived from the message. The key's <em>mid</em> is
-		 *         scoped to the message's destination address and port.
-		 */
-		public static KeyMID fromOutboundMessage(Message message) {
-			InetSocketAddress address = message.getDestinationContext().getPeerAddress();
-			return new KeyMID(message.getMID(), address.getAddress().getAddress(), address.getPort());
 		}
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
@@ -61,11 +61,13 @@ import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.Token;
-import org.eclipse.californium.core.network.Exchange.KeyMID;
+import org.eclipse.californium.core.network.TokenGenerator.Scope;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfigDefaults;
 import org.eclipse.californium.core.network.deduplication.Deduplicator;
 import org.eclipse.californium.core.network.deduplication.DeduplicatorFactory;
+import org.eclipse.californium.elements.EndpointIdentityResolver;
+import org.eclipse.californium.elements.UdpEndpointContextMatcher;
 
 /**
  * A {@code MessageExchangeStore} that manages all exchanges in local memory.
@@ -77,11 +79,12 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 	// for all
 	private final ConcurrentMap<KeyMID, Exchange> exchangesByMID = new ConcurrentHashMap<>();
 	// for outgoing
-	private final ConcurrentMap<Token, Exchange> exchangesByToken = new ConcurrentHashMap<>();
+	private final ConcurrentMap<KeyToken, Exchange> exchangesByToken = new ConcurrentHashMap<>();
 	private volatile boolean enableStatus;
 
 	private final NetworkConfig config;
 	private final TokenGenerator tokenGenerator;
+	private final EndpointIdentityResolver endpointIdentityResolver;
 	private volatile boolean running = false;
 	private volatile Deduplicator deduplicator;
 	private volatile MessageIdProvider messageIdProvider;
@@ -93,9 +96,10 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 	 * 
 	 * @param config the configuration to use.
 	 * 
+	 * @throws NullPointerException if config is {@code null}
 	 */
 	public InMemoryMessageExchangeStore(final NetworkConfig config) {
-		this(config, new RandomTokenGenerator(config));
+		this(config, new RandomTokenGenerator(config), new UdpEndpointContextMatcher());
 		LOGGER.debug("using default TokenProvider {}", RandomTokenGenerator.class.getName());
 	}
 
@@ -103,18 +107,24 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 	 * Creates a new store for configuration values.
 	 * 
 	 * @param config the configuration to use.
-	 * @param tokenProvider the TokenProvider which provides CoAP tokens that
-	 *            are guaranteed to be not in use.
-	 * 
+	 * @param tokenProvider the TokenProvider which provides CoAP tokens.
+	 * @param endpointResolver the endpoint resolver which provides endpoint
+	 *            identity.
+	 * @throws NullPointerException if one or the parameter is {@code null}
 	 */
-	public InMemoryMessageExchangeStore(final NetworkConfig config, TokenGenerator tokenProvider) {
+	public InMemoryMessageExchangeStore(final NetworkConfig config, TokenGenerator tokenProvider,
+			EndpointIdentityResolver endpointResolver) {
 		if (config == null) {
 			throw new NullPointerException("Configuration must not be null");
 		}
 		if (tokenProvider == null) {
 			throw new NullPointerException("TokenProvider must not be null");
 		}
+		if (endpointResolver == null) {
+			throw new NullPointerException("EndpointContextResolver must not be null");
+		}
 		this.tokenGenerator = tokenProvider;
+		this.endpointIdentityResolver = endpointResolver;
 		this.config = config;
 	}
 
@@ -211,75 +221,90 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 		return mid;
 	}
 
-	private int registerWithMessageId(final Exchange exchange, final Message message) {
+	private KeyMID registerWithMessageId(final Exchange exchange, final Message message) {
 		enableStatus = true;
 		exchange.assertIncomplete(message);
+		Object peer = endpointIdentityResolver.getEndpointIdentity(message.getDestinationContext());
+		KeyMID key;
 		int mid = message.getMID();
 		if (Message.NONE == mid) {
 			mid = assignMessageId(message);
 			if (Message.NONE != mid) {
-				KeyMID key = KeyMID.fromOutboundMessage(message);
+				key = new KeyMID(mid, peer);
 				if (exchangesByMID.putIfAbsent(key, exchange) != null) {
 					throw new IllegalArgumentException(String.format(
-							"generated mid [%d] already in use, cannot register %s", message.getMID(), exchange));
+							"generated mid [%d] already in use, cannot register %s", mid, exchange));
 				}
 				LOGGER.debug("{} added with generated mid {}, {}", exchange, key, message);
+			} else {
+				key = null;
 			}
 		} else {
-			KeyMID key = KeyMID.fromOutboundMessage(message);
+			key = new KeyMID(mid, peer);
 			Exchange existingExchange = exchangesByMID.putIfAbsent(key, exchange);
 			if (existingExchange != null) {
 				if (existingExchange != exchange) {
 					throw new IllegalArgumentException(
-							String.format("mid [%d] already in use, cannot register %s", message.getMID(), exchange));
+							String.format("mid [%d] already in use, cannot register %s", mid, exchange));
 				} else if (exchange.getFailedTransmissionCount() == 0) {
 					throw new IllegalArgumentException(String.format(
 							"message with already registered mid [%d] is not a re-transmission, cannot register %s",
-							message.getMID(), exchange));
+							mid, exchange));
 				}
 			} else {
 				LOGGER.debug("{} added with {}, {}", exchange, key, message);
 			}
 		}
-		return mid;
+		if (key != null) {
+			exchange.setKeyMID(key);
+		}
+		return key;
 	}
 
 	private void registerWithToken(final Exchange exchange) {
 		enableStatus = true;
 		Request request = exchange.getCurrentRequest();
 		exchange.assertIncomplete(request);
+		Object peer = endpointIdentityResolver.getEndpointIdentity(request.getDestinationContext());
+		KeyToken key;
 		Token token = request.getToken();
 		if (token == null) {
+			Scope scope = request.isMulticast() ? Scope.SHORT_TERM : Scope.SHORT_TERM_CLIENT_LOCAL;
 			do {
-				token = tokenGenerator.createToken(false);
+				token = tokenGenerator.createToken(scope);
 				request.setToken(token);
-			} while (exchangesByToken.putIfAbsent(token, exchange) != null);
-			LOGGER.debug("{} added with generated token {}, {}", exchange, token, request);
+				key = tokenGenerator.getKeyToken(token, peer);
+			} while (exchangesByToken.putIfAbsent(key, exchange) != null);
+			LOGGER.debug("{} added with generated token {}, {}", exchange, key, request);
 		} else {
 			// ongoing requests may reuse token
 			if (token.isEmpty() && request.getCode() == null) {
 				// ping, no exchange by token required!
 				return;
 			}
-			Exchange previous = exchangesByToken.put(token, exchange);
+			key = tokenGenerator.getKeyToken(token, peer);
+			Exchange previous = exchangesByToken.put(key, exchange);
 			if (previous == null) {
 				BlockOption block2 = request.getOptions().getBlock2();
 				if (block2 != null) {
-					LOGGER.debug("block2 {} for block {} add with token {}", exchange, block2.getNum(), token);
+					LOGGER.debug("block2 {} for block {} add with token {}", exchange, block2.getNum(), key);
 				} else {
-					LOGGER.debug("{} added with token {}, {}", exchange, token, request);
+					LOGGER.debug("{} added with token {}, {}", exchange, key, request);
 				}
 			} else if (previous != exchange) {
 				if (exchange.getFailedTransmissionCount() == 0 && !request.getOptions().hasBlock1()
 						&& !request.getOptions().hasBlock2() && !request.getOptions().hasObserve()) {
 					LOGGER.warn("{} with manual token overrides existing {} with open request: {}", exchange, previous,
-							token);
+							key);
 				} else {
-					LOGGER.debug("{} replaced with token {}, {}", exchange, token, request);
+					LOGGER.debug("{} replaced with token {}, {}", exchange, key, request);
 				}
 			} else {
-				LOGGER.debug("{} keep for {}, {}", exchange, token, request);
+				LOGGER.debug("{} keep for {}, {}", exchange, key, request);
 			}
+		}
+		if (key != null) {
+			exchange.setKeyToken(key);
 		}
 	}
 
@@ -292,8 +317,8 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 			throw new IllegalArgumentException("exchange does not contain a request");
 		} else {
 			Request currentRequest = exchange.getCurrentRequest();
-			int mid = registerWithMessageId(exchange, currentRequest);
-			if (Message.NONE != mid) {
+			KeyMID key = registerWithMessageId(exchange, currentRequest);
+			if (key != null) {
 				registerWithToken(exchange);
 				if (exchange.getCurrentRequest() != currentRequest) {
 					throw new ConcurrentModificationException("Current request modified!");
@@ -322,7 +347,7 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 	}
 
 	@Override
-	public void remove(final Token token, final Exchange exchange) {
+	public void remove(final KeyToken token, final Exchange exchange) {
 		boolean removed = exchangesByToken.remove(token, exchange);
 		if (removed) {
 			LOGGER.debug("removing {} for token {}", exchange, token);
@@ -346,11 +371,11 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 	}
 
 	@Override
-	public Exchange get(final Token token) {
-		if (token == null) {
+	public Exchange get(final KeyToken keyToken) {
+		if (keyToken == null) {
 			return null;
 		} else {
-			return exchangesByToken.get(token);
+			return exchangesByToken.get(keyToken);
 		}
 	}
 
@@ -371,7 +396,7 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 			throw new IllegalArgumentException("exchange does not contain a response");
 		} else {
 			Response currentResponse = exchange.getCurrentResponse();
-			if (registerWithMessageId(exchange, currentResponse) > Message.NONE) {
+			if (registerWithMessageId(exchange, currentResponse) != null) {
 				if (exchange.getCurrentResponse() != currentResponse) {
 					throw new ConcurrentModificationException("Current response modified!");
 				}
@@ -485,12 +510,17 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 	public List<Exchange> findByToken(Token token) {
 		List<Exchange> result = new ArrayList<>();
 		if (token != null) {
+			if (tokenGenerator.getScope(token) == Scope.SHORT_TERM_CLIENT_LOCAL) {
+				throw new IllegalArgumentException("token must not have client-local scope!");
+			}
 			// TODO: remove the for ...
-			for (Entry<Token, Exchange> entry : exchangesByToken.entrySet()) {
+			for (Entry<KeyToken, Exchange> entry : exchangesByToken.entrySet()) {
 				if (entry.getValue().isOfLocalOrigin()) {
 					Request request = entry.getValue().getRequest();
-					if (request != null && token.equals(request.getToken())) {
-						result.add(entry.getValue());
+					if (request != null) {
+						if (token.equals(request.getToken())) {
+							result.add(entry.getValue());
+						}
 					}
 				}
 			}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/KeyMID.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/KeyMID.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.net.InetSocketAddress;
+
+import org.eclipse.californium.core.coap.Message;
+
+/**
+ * A CoAP message ID scoped to a remote endpoint.
+ * <p>
+ * This class is used by the matcher to correlate messages by MID and
+ * endpoint address.
+ */
+public final class KeyMID {
+
+	private final int mid;
+	private final Object peer;
+	private final int hash;
+
+	/**
+	 * Creates a key based on a message ID and a remote endpoint address.
+	 * 
+	 * @param mid the message ID.
+	 * @param peer peer's identity. Usually that's the peer's
+	 *            {@link InetSocketAddress}.
+	 * @throws NullPointerException if address or origin is {@code null}
+	 * @throws IllegalArgumentException if mid is &lt; 0 or &gt; 65535.
+	 * 
+	 */
+	public KeyMID(int mid,  Object peer) {
+		if (mid < 0 || mid > Message.MAX_MID) {
+			throw new IllegalArgumentException("MID must be a 16 bit unsigned int: " + mid);
+		} else if (peer == null) {
+			throw new NullPointerException("peer must not be null");
+		} else {
+			this.mid = mid;
+			this.peer = peer;
+			this.hash = 31 * mid + peer.hashCode();
+		}
+	}
+
+	public int getMID() {
+		return mid;
+	}
+
+	public Object getPeer() {
+		return peer;
+	}
+
+	@Override
+	public int hashCode() {
+		return hash;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		KeyMID other = (KeyMID) obj;
+		if (mid != other.mid)
+			return false;
+		return peer.equals(other.peer);
+	}
+
+	@Override
+	public String toString() {
+		return new StringBuilder("KeyMID[").append(peer).append(", ").append(mid).append("]").toString();
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/KeyToken.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/KeyToken.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.net.InetSocketAddress;
+
+import org.eclipse.californium.core.coap.Token;
+
+/**
+ * Implementation of client-local and not client-local tokens.
+ */
+public class KeyToken {
+
+	/**
+	 * Precalculated hash.
+	 */
+	private final int hash;
+	/**
+	 * Token.
+	 */
+	private final Token token;
+	/**
+	 * Peer's identity. Usually that's the peer's {@link InetSocketAddress}.
+	 */
+	private final Object peer;
+
+	/**
+	 * Create key token.
+	 * 
+	 * @param token token
+	 * @param peer peer's identity. May be {@code null}, if key token is not
+	 *            client-local. Usually that's the peer's
+	 *            {@link InetSocketAddress}.
+	 */
+	public KeyToken(Token token, Object peer) {
+		this.token = token;
+		this.peer = peer;
+		int hash = token.hashCode();
+		if (peer != null) {
+			hash += peer.hashCode() * 31;
+		}
+		this.hash = hash;
+	}
+
+	/**
+	 * Get token.
+	 * 
+	 * @return token
+	 */
+	public Token getToken() {
+		return token;
+	}
+
+	/**
+	 * Get peer's identity.
+	 * 
+	 * @return peer's identity. Usually that's the peer's
+	 *         {@link InetSocketAddress}.
+	 */
+	public Object getPeer() {
+		return peer;
+	}
+
+	@Override
+	public final int hashCode() {
+		return hash;
+	}
+
+	@Override
+	public final boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		} else if (obj == null) {
+			return false;
+		} else if (getClass() != obj.getClass()) {
+			return false;
+		}
+		KeyToken other = (KeyToken) obj;
+		if (hash != other.hash) {
+			return false;
+		} else if (!token.equals(other.token)) {
+			return false;
+		}
+		if (peer == other.peer) {
+			return true;
+		} else if (peer == null) {
+			return false;
+		}
+		return peer.equals(other.peer);
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder("KeyToken[");
+		if (peer != null) {
+			builder.append(peer).append("-");
+		}
+		builder.append(token.getAsString()).append("]");
+		return builder.toString();
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Matcher.java
@@ -146,10 +146,14 @@ public interface Matcher {
 	void clear();
 
 	/**
-	 * Cancels all pending blockwise requests that have been induced by a notification
-	 * we have received indicating a blockwise transfer of the resource.
+	 * Cancels all pending blockwise requests that have been induced by a
+	 * notification we have received indicating a blockwise transfer of the
+	 * resource.
 	 * 
 	 * @param token the token of the observation.
+	 *            The token must not have client-local scope.
+	 * @return the exchanges.
+	 * @throws IllegalArgumentException if the token has client-local scope.
 	 */
 	void cancelObserve(Token token);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessageExchangeStore.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.Token;
-import org.eclipse.californium.core.network.Exchange.KeyMID;
 
 /**
  * A registry for keeping track of message exchanges with peers.
@@ -128,12 +127,12 @@ public interface MessageExchangeStore {
 	boolean registerOutboundResponse(Exchange exchange);
 
 	/**
-	 * Removes the exchange registered under a given token.
+	 * Removes the exchange registered under a given key token.
 	 * 
-	 * @param token the token of the exchange to remove.
-	 * @param exchange Exchange to be removed, if registered with provided token.
+	 * @param token the key token of the exchange to remove.
+	 * @param exchange Exchange to be removed, if registered with provided key token.
 	 */
-	void remove(Token token, Exchange exchange);
+	void remove(KeyToken token, Exchange exchange);
 
 	/**
 	 * Removes the exchange registered under a given message ID.
@@ -148,12 +147,12 @@ public interface MessageExchangeStore {
 	Exchange remove(KeyMID messageId, Exchange exchange);
 
 	/**
-	 * Gets the exchange registered under a given token.
+	 * Gets the exchange registered under a given key token.
 	 * 
-	 * @param token the token under which the exchange has been registered.
+	 * @param token the key token under which the exchange has been registered.
 	 * @return the exchange or {@code null} if no exchange exists for the given token.
 	 */
-	Exchange get(Token token);
+	Exchange get(KeyToken token);
 
 	/**
 	 * Gets the exchange registered under a given message ID.
@@ -204,8 +203,10 @@ public interface MessageExchangeStore {
 	 * Gets all message exchanges of local origin that contain a request
 	 * with a given token.
 	 * 
-	 * @param token the token to look for.
+	 * @param token token to find exchanges, which are started with.
+	 *            The token must not have client-local scope.
 	 * @return the exchanges.
+	 * @throws IllegalArgumentException if the token has client-local scope.
 	 */
 	List<Exchange> findByToken(Token token);
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/RandomTokenGenerator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/RandomTokenGenerator.java
@@ -18,11 +18,12 @@
 package org.eclipse.californium.core.network;
 
 import java.security.SecureRandom;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@link TokenGenerator} that uses random tokens and set bit 0 of byte
@@ -56,16 +57,52 @@ public class RandomTokenGenerator implements TokenGenerator {
 	}
 
 	@Override
-	public Token createToken(boolean longTermScope) {
+	public Token createToken(Scope scope) {
 		byte[] token = new byte[tokenSize];
 		rng.nextBytes(token);
-		if (longTermScope) {
+		switch (scope) {
+		case LONG_TERM:
 			// set bit 0 to 1
-			token[0] |= 0x1;
-		} else {
-			// set bit 0 to 0
-			token[0] &= 0xfe;
+			token[0] |= 0b1;
+			break;
+		case SHORT_TERM:
+			// set bit 1-0 to 0b10
+			token[0] &= 0b11111100;
+			token[0] |= 0b10;
+			break;
+		case SHORT_TERM_CLIENT_LOCAL:
+			// set bit 1-0 to 0b00
+			token[0] &= 0b11111100;
+			break;
 		}
 		return Token.fromProvider(token);
 	}
+
+	@Override
+	public Scope getScope(Token token) {
+		if (token.length() != tokenSize) {
+			return Scope.SHORT_TERM_CLIENT_LOCAL;
+		}
+		int scope = token.getBytes()[0] & 0b11;
+		switch (scope) {
+		case 0b00:
+			return Scope.SHORT_TERM_CLIENT_LOCAL;
+		case 0b10:
+			return Scope.SHORT_TERM;
+		}
+		return Scope.LONG_TERM;
+	}
+
+	@Override
+	public KeyToken getKeyToken(Token token, Object peer) {
+		if (getScope(token) == Scope.SHORT_TERM_CLIENT_LOCAL) {
+			if (peer == null) {
+				throw new IllegalArgumentException("client-local token requires peer!");
+			}
+			return new KeyToken(token, peer);
+		} else {
+			return new KeyToken(token, null);
+		}
+	}
+
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -55,7 +55,6 @@ import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.Token;
-import org.eclipse.californium.core.network.Exchange.KeyMID;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.observe.ObservationStore;
@@ -158,8 +157,9 @@ public final class TcpMatcher extends BaseMatcher {
 
 	@Override
 	public void receiveResponse(final Response response, final EndpointReceiver receiver) {
+		Object peer = endpointContextMatcher.getEndpointIdentity(response.getSourceContext());
+		final KeyToken idByToken = tokenGenerator.getKeyToken(response.getToken(), peer);
 
-		final Token idByToken = response.getToken();
 		Exchange tempExchange = exchangeStore.get(idByToken);
 
 		if (tempExchange == null) {
@@ -196,6 +196,14 @@ public final class TcpMatcher extends BaseMatcher {
 				}
 				try {
 					if (endpointContextMatcher.isResponseRelatedToRequest(context, response.getSourceContext())) {
+						Request currentRequest = exchange.getCurrentRequest();
+						if (exchange.isNotification() && !currentRequest.isMulticast()
+								&& response.isNotification() && currentRequest.isObserveCancel()) {
+							// overlapping notification for observation cancel
+							// request
+							LOGGER.debug("ignoring notify for pending cancel {}!", response);
+							return;
+						}
 						receiver.receiveResponse(exchange, response);
 					} else {
 						LOGGER.debug(
@@ -218,9 +226,9 @@ public final class TcpMatcher extends BaseMatcher {
 	private class RemoveHandlerImpl implements RemoveHandler {
 
 		@Override
-		public void remove(Exchange exchange, Token token, KeyMID key) {
-			if (token != null) {
-				exchangeStore.remove(token, exchange);
+		public void remove(Exchange exchange, KeyToken keyToken, KeyMID keyMID) {
+			if (keyToken != null) {
+				exchangeStore.remove(keyToken, exchange);
 			}
 			// ignore key, MID is not used for TCP!
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TokenGenerator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TokenGenerator.java
@@ -26,6 +26,13 @@ import org.eclipse.californium.core.coap.Token;
 public interface TokenGenerator {
 
 	/**
+	 * Scope of token
+	 */
+	public enum Scope {
+		LONG_TERM, SHORT_TERM, SHORT_TERM_CLIENT_LOCAL
+	}
+
+	/**
 	 * Creates a token for the provided request.
 	 * 
 	 * Intended to generate tokens with separate scopes for standard- and
@@ -42,11 +49,31 @@ public interface TokenGenerator {
 	 * generated token is already in use, it's intended to create a next token
 	 * calling this method again.
 	 * 
-	 * @param longTermScope {@code true} for observe request within the
-	 *            long-term scope, {@code false} for normal request with
-	 *            short-term scope.
+	 * @param scope {@code LONG_TERM} for observe request within the long-term
+	 *            scope, {@code SHORT_TERM} for multicast request with
+	 *            short-term scope, and {@code SHORT_TERM_CLIENT_LOCAL} for
+	 *            normal requests.
 	 * @return the generated token
 	 */
-	Token createToken(boolean longTermScope);
+	Token createToken(Scope scope);
 
+	/**
+	 * Get scope of token.
+	 * 
+	 * @param token token to determine the scope of
+	 * @return scope of the provided token
+	 */
+	Scope getScope(Token token);
+
+	/**
+	 * Create a key token.
+	 * 
+	 * @param token the message token
+	 * @param peer peer identity. May be {@code null},
+	 *            if the token has a none client-local scope
+	 * @return key token
+	 * @throws IllegalArgumentException if the token has a client-local scope
+	 *             and no peer is provided.
+	 */
+	KeyToken getKeyToken(Token token, Object peer);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/CropRotation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/CropRotation.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.californium.core.network.Exchange;
-import org.eclipse.californium.core.network.Exchange.KeyMID;
+import org.eclipse.californium.core.network.KeyMID;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/Deduplicator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/Deduplicator.java
@@ -23,7 +23,7 @@ package org.eclipse.californium.core.network.deduplication;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.californium.core.network.Exchange;
-import org.eclipse.californium.core.network.Exchange.KeyMID;
+import org.eclipse.californium.core.network.KeyMID;
 
 
 /**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/NoDeduplicator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/NoDeduplicator.java
@@ -23,7 +23,7 @@ package org.eclipse.californium.core.network.deduplication;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.californium.core.network.Exchange;
-import org.eclipse.californium.core.network.Exchange.KeyMID;
+import org.eclipse.californium.core.network.KeyMID;
 
 
 /**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/SweepDeduplicator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/SweepDeduplicator.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.californium.core.network.Exchange;
-import org.eclipse.californium.core.network.Exchange.KeyMID;
+import org.eclipse.californium.core.network.KeyMID;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.elements.util.ClockUtil;
 import org.slf4j.Logger;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
@@ -119,14 +119,6 @@ public class ObserveLayer extends AbstractLayer {
 				relation.setNextControlNotification(null);
 			}
 
-			/*
-			 * The matcher must be able to find the NON notifications to remove
-			 * them from the exchangesByMID hashmap
-			 */
-			if (response.getType() == Type.NON) {
-				relation.addNotification(response);
-			}
-
 		} // else no observe was requested or the resource does not allow it
 		lower().sendResponse(exchange, response);
 	}
@@ -198,13 +190,6 @@ public class ObserveLayer extends AbstractLayer {
 			relation.setNextControlNotification(null);
 			if (next != null) {
 				LOGGER.debug("notification has been acknowledged, send the next one");
-				/*
-				 * The matcher must be able to find the NON notifications to
-				 * remove them from the exchangesByMID hashmap
-				 */
-				if (next.getType() == Type.NON) {
-					relation.addNotification(next);
-				}
 				// Create a new task for sending next response so that we
 				// can leave the sync-block
 				exchange.execute(new Runnable() {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
@@ -81,8 +81,8 @@ public class ReliabilityLayer extends AbstractLayer {
 		ack_timeout_scale = config.getFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE);
 		max_retransmit = config.getInt(NetworkConfig.Keys.MAX_RETRANSMIT);
 
-		LOGGER.info("ReliabilityLayer uses ACK_TIMEOUT={}, ACK_RANDOM_FACTOR={}, and ACK_TIMEOUT_SCALE={}",
-				new Object[] { ack_timeout, ack_random_factor, ack_timeout_scale });
+		LOGGER.info("ReliabilityLayer uses ACK_TIMEOUT={}, ACK_RANDOM_FACTOR={}, and ACK_TIMEOUT_SCALE={}", ack_timeout,
+				ack_random_factor, ack_timeout_scale);
 	}
 
 	/**
@@ -273,7 +273,6 @@ public class ReliabilityLayer extends AbstractLayer {
 
 		exchange.setFailedTransmissionCount(0);
 		exchange.setRetransmissionHandle(null);
-		exchange.getCurrentRequest().setAcknowledged(true);
 
 		if (response.getType() == Type.CON && !exchange.getRequest().isCanceled()) {
 			LOGGER.debug("{} acknowledging CON response", exchange);
@@ -284,6 +283,7 @@ public class ReliabilityLayer extends AbstractLayer {
 		if (response.isDuplicate()) {
 			LOGGER.debug("{} ignoring duplicate response", exchange);
 		} else {
+			exchange.getCurrentRequest().setAcknowledged(true);
 			upper().receiveResponse(exchange, response);
 		}
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
@@ -27,8 +27,6 @@
 package org.eclipse.californium.core.observe;
 
 import java.net.InetSocketAddress;
-import java.util.Iterator;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,9 +73,6 @@ public class ObserveRelation {
 	private long interestCheckTimer = System.currentTimeMillis();
 	private int interestCheckCounter = 1;
 
-	/** The notifications that have been sent, so they can be removed from the Matcher */
-	private ConcurrentLinkedQueue<Response> notifications = new ConcurrentLinkedQueue<Response>();
-	
 	/**
 	 * Constructs a new observe relation.
 	 * 
@@ -229,16 +224,7 @@ public class ObserveRelation {
 		}
 		this.nextControlNotification = nextControlNotification;
 	}
-	
-	public void addNotification(Response notification) {
-		notifications.add(notification);
-		LOGGER.trace("{} add notification MID {} (size {}).", resource.getURI(), notification.getMID(), notifications.size());
-	}
-	
-	public Iterator<Response> getNotificationIterator() {
-		return notifications.iterator();
-	}
-	
+
 	public String getKey() {
 		return this.key;
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
@@ -152,7 +152,7 @@ public class ServerMessageDeliverer implements MessageDeliverer {
 
 			if (request.isObserve()) {
 				// Requests wants to observe and resource allows it :-)
-				LOGGER.debug("initiating an observe relation between {} and resource {}", source, resource.getURI());
+				LOGGER.debug("initiating an observe relation between {} and resource {}, {}", source, resource.getURI(), exchange);
 				ObservingEndpoint remote = observeManager.findObservingEndpoint(source);
 				ObserveRelation relation = new ObserveRelation(remote, resource, exchange);
 				remote.addObserveRelation(relation);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
@@ -27,7 +27,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.eclipse.californium.TestTools;
 import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.coap.Request;
-import org.eclipse.californium.core.network.Exchange.KeyMID;
 import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.elements.util.ExecutorsUtil;
@@ -80,7 +79,8 @@ public class InMemoryMessageExchangeStoreTest {
 
 		// THEN the request gets assigned an MID and is put to the store
 		assertNotNull(exchange.getCurrentRequest().getMID());
-		KeyMID key = KeyMID.fromOutboundMessage(exchange.getCurrentRequest());
+		KeyMID key = new KeyMID(exchange.getCurrentRequest().getMID(),
+				exchange.getCurrentRequest().getDestinationContext().getPeerAddress());
 		assertThat(store.get(key), is(exchange));
 	}
 
@@ -98,7 +98,8 @@ public class InMemoryMessageExchangeStoreTest {
 			fail("should have thrown IllegalArgumentException");
 		} catch (IllegalArgumentException e) {
 			// THEN the newExchange is not put to the store
-			KeyMID key = KeyMID.fromOutboundMessage(exchange.getCurrentRequest());
+			KeyMID key = new KeyMID(exchange.getCurrentRequest().getMID(),
+					exchange.getCurrentRequest().getDestinationContext().getPeerAddress());
 			Exchange exchangeFromStore = store.get(key);
 			assertThat(exchangeFromStore, is(exchange));
 			assertThat(exchangeFromStore, is(not(newExchange)));
@@ -119,16 +120,19 @@ public class InMemoryMessageExchangeStoreTest {
 			// THEN the store rejects the re-registration
 		}
 	}
-	
-	@Test
+
+	@Test(expected = NullPointerException.class)
 	public void testShouldNotCreateInMemoryMessageExchangeStoreWithoutTokenProvider() {
-		//WHEN trying to create new InMemoryMessageExchangeStore without TokenProvider
-		try {
-			store = new InMemoryMessageExchangeStore(config, null);
-			fail("should have thrown NullPointerException");
-		} catch (NullPointerException e) {
-			//THEN NullPointerException is thrown 
-		}
+		// WHEN trying to create new InMemoryMessageExchangeStore without TokenProvider
+		store = new InMemoryMessageExchangeStore(config, null, null);
+		fail("should have thrown NullPointerException");
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testShouldNotCreateInMemoryMessageExchangeStoreWithoutResolver() {
+		// WHEN trying to create new InMemoryMessageExchangeStore without TokenProvider
+		store = new InMemoryMessageExchangeStore(config, new RandomTokenGenerator(config), null);
+		fail("should have thrown NullPointerException");
 	}
 
 	public void testRegisterOutboundRequestAcceptsRetransmittedRequest() {
@@ -141,7 +145,8 @@ public class InMemoryMessageExchangeStoreTest {
 		store.registerOutboundRequest(exchange);
 
 		// THEN the store contains the re-transmitted request
-		KeyMID key = KeyMID.fromOutboundMessage(exchange.getCurrentRequest());
+		KeyMID key = new KeyMID(exchange.getCurrentRequest().getMID(),
+				exchange.getCurrentRequest().getDestinationContext().getPeerAddress());
 		Exchange exchangeFromStore = store.get(key);
 		assertThat(exchangeFromStore, is(exchange));
 		assertThat(exchangeFromStore.getFailedTransmissionCount(), is(1));

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTestUtils.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTestUtils.java
@@ -36,6 +36,7 @@ import org.eclipse.californium.core.observe.ObservationStore;
 import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.EndpointContextMatcher;
+import org.eclipse.californium.elements.util.Bytes;
 import org.eclipse.californium.elements.util.ExecutorsUtil;
 import org.eclipse.californium.elements.util.TestThreadFactory;
 
@@ -75,10 +76,12 @@ public final class MatcherTestUtils {
 		return newUdpMatcher(config, new InMemoryMessageExchangeStore(config), new InMemoryObservationStore(config), correlationContextMatcher, scheduler);
 	}
 
-	static UdpMatcher newUdpMatcher(NetworkConfig config, MessageExchangeStore exchangeStore, ObservationStore observationStore,
-			EndpointContextMatcher correlationContextMatcher, ScheduledExecutorService scheduler) {
+	static UdpMatcher newUdpMatcher(NetworkConfig config, MessageExchangeStore exchangeStore,
+			ObservationStore observationStore, EndpointContextMatcher correlationContextMatcher,
+			ScheduledExecutorService scheduler) {
 		UdpMatcher matcher = new UdpMatcher(config, notificationListener, new RandomTokenGenerator(config),
-				observationStore, exchangeStore, TEST_EXCHANGE_EXECUTOR, correlationContextMatcher);
+				observationStore, exchangeStore, TEST_EXCHANGE_EXECUTOR,
+				correlationContextMatcher);
 		exchangeStore.setExecutor(scheduler);
 		matcher.start();
 		return matcher;
@@ -121,7 +124,7 @@ public final class MatcherTestUtils {
 		Response response = new Response(ResponseCode.CONTENT);
 		response.setMID(request.getMID());
 		response.setToken(request.getToken());
-		response.setBytes(new byte[]{});
+		response.setBytes(Bytes.EMPTY);
 		response.setSourceContext(sourceContext);
 		return response;
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/TcpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/TcpMatcherTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -75,6 +76,7 @@ public class TcpMatcherTest {
 		endpointContextMatcher = mock(EndpointContextMatcher.class);
 		when(exchangeEndpointContext.getPeerAddress()).thenReturn(dest);
 		when(responseEndpointContext.getPeerAddress()).thenReturn(dest);
+		when(endpointContextMatcher.getEndpointIdentity((EndpointContext)notNull())).thenReturn(dest);
 	}
 
 	@Test

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherMulticastTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherMulticastTest.java
@@ -76,6 +76,7 @@ public class UdpMatcherMulticastTest {
 		endpointContextMatcher = mock(EndpointContextMatcher.class);
 		when(endpointContextMatcher.isResponseRelatedToRequest(exchangeEndpointContext, responseEndpointContext)).thenReturn(true);
 		when(responseEndpointContext.getPeerAddress()).thenReturn(dest);
+		when(endpointContextMatcher.getEndpointIdentity(responseEndpointContext)).thenReturn(dest);
 		when(exchangeEndpointContext.getPeerAddress()).thenReturn(multicast_dest);
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -43,6 +43,7 @@ import org.eclipse.californium.core.observe.InMemoryObservationStore;
 import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.EndpointContextMatcher;
+import org.eclipse.californium.elements.UdpEndpointContextMatcher;
 import org.eclipse.californium.rule.CoapNetworkRule;
 import org.eclipse.californium.rule.CoapThreadsRule;
 import org.junit.Before;
@@ -81,7 +82,7 @@ public class UdpMatcherTest {
 		scheduler = MatcherTestUtils.newScheduler();
 		cleanup.add(scheduler);
 		tokenProvider = new RandomTokenGenerator(config);
-		messageExchangeStore = new InMemoryMessageExchangeStore(config, tokenProvider);
+		messageExchangeStore = new InMemoryMessageExchangeStore(config, tokenProvider, new UdpEndpointContextMatcher());
 		observationStore =  new InMemoryObservationStore(config);
 		exchangeEndpointContext = mock(EndpointContext.class);
 		responseEndpointContext = mock(EndpointContext.class);
@@ -90,6 +91,7 @@ public class UdpMatcherTest {
 		endpointContextOperator = mock(EndpointContextOperator.class);
 		when(exchangeEndpointContext.getPeerAddress()).thenReturn(dest);
 		when(responseEndpointContext.getPeerAddress()).thenReturn(dest);
+		when(endpointContextMatcher.getEndpointIdentity((EndpointContext)notNull())).thenReturn(dest);
 		when(endpointContextOperator.apply(preEndpointContext)).thenReturn(exchangeEndpointContext);
 	}
 
@@ -144,8 +146,10 @@ public class UdpMatcherTest {
 		exchange.setComplete();
 
 		// THEN assert that token got released in both stores
-		Token token = exchange.getCurrentRequest().getToken();
-		assertThat(messageExchangeStore.get(token), is(nullValue()));
+		Request request = exchange.getCurrentRequest();
+		Token token = request.getToken();
+		KeyToken keyToken = tokenProvider.getKeyToken(token,  request.getDestinationContext().getPeerAddress());
+		assertThat(messageExchangeStore.get(keyToken), is(nullValue()));
 		assertThat(observationStore.get(token), is(nullValue()));
 	}
 
@@ -160,8 +164,10 @@ public class UdpMatcherTest {
 
 		// THEN assert that token got released in message exchange store
 		// THEN assert that token got not released in observation store
-		Token token = exchange.getCurrentRequest().getToken();
-		assertThat(messageExchangeStore.get(token), is(nullValue()));
+		Request request = exchange.getCurrentRequest();
+		Token token = request.getToken();
+		KeyToken keyToken = tokenProvider.getKeyToken(token,  request.getDestinationContext().getPeerAddress());
+		assertThat(messageExchangeStore.get(keyToken), is(nullValue()));
 		assertThat(observationStore.get(token), is(notNullValue()));
 	}
 
@@ -173,11 +179,13 @@ public class UdpMatcherTest {
 		Exchange exchange = sendObserveRequest(dest, matcher, exchangeEndpointContext);
 
 		// WHEN canceling any observe relations for the exchange's token
-		matcher.cancelObserve(exchange.getCurrentRequest().getToken());
+		matcher.cancelObserve(exchange.getRequest().getToken());
 
 		// THEN the token has been released for re-use
-		Token token = exchange.getCurrentRequest().getToken();
-		assertThat(messageExchangeStore.get(token), is(nullValue()));
+		Request request = exchange.getCurrentRequest();
+		Token token = request.getToken();
+		KeyToken keyToken = tokenProvider.getKeyToken(token,  request.getDestinationContext().getPeerAddress());
+		assertThat(messageExchangeStore.get(keyToken), is(nullValue()));
 		assertThat(observationStore.get(token), is(nullValue()));
 	}
 

--- a/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureNatTest.java
+++ b/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureNatTest.java
@@ -43,6 +43,7 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.PrincipalEndpointContextMatcher;
 import org.eclipse.californium.elements.rule.TestNameLoggerRule;
 import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.examples.NatUtil;
@@ -87,6 +88,7 @@ public class SecureNatTest {
 	private DebugConnectionStore serverConnections;
 	private List<DebugConnectionStore> clientConnections = new ArrayList<DebugConnectionStore>();
 	private TestUtilPskStore pskStore;
+	private MatcherMode mode;
 	private NetworkConfig config;
 	private CoapEndpoint serverEndpoint;
 	private List<CoapEndpoint> clientEndpoints = new ArrayList<>();
@@ -393,6 +395,7 @@ public class SecureNatTest {
 	}
 
 	private void setupNetworkConfig(MatcherMode mode) {
+		this.mode = mode;
 		config = network.getStandardTestConfig()
 				// retransmit starting with 200 milliseconds
 				.setInt(Keys.ACK_TIMEOUT, 200)
@@ -426,6 +429,9 @@ public class SecureNatTest {
 		Connector serverConnector = new MyDtlsConnector(dtlsConfig, serverConnections);
 		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setConnector(serverConnector);
+		if (mode == MatcherMode.PRINCIPAL) {
+			builder.setEndpointContextMatcher(new PrincipalEndpointContextMatcher(true));
+		}
 		builder.setNetworkConfig(config);
 		serverEndpoint = builder.build();
 

--- a/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureObserveTest.java
+++ b/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureObserveTest.java
@@ -33,7 +33,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.eclipse.californium.core.network.EndpointContextMatcherFactory.MatcherMode;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
@@ -51,6 +50,7 @@ import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.EndpointManager;
+import org.eclipse.californium.core.network.EndpointContextMatcherFactory.MatcherMode;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.eclipse.californium.core.server.resources.CoapExchange;
@@ -58,6 +58,7 @@ import org.eclipse.californium.core.test.CountingCoapHandler;
 import org.eclipse.californium.elements.exception.ConnectorException;
 import org.eclipse.californium.elements.DtlsEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
+import org.eclipse.californium.elements.PrincipalEndpointContextMatcher;
 import org.eclipse.californium.elements.exception.EndpointMismatchException;
 import org.eclipse.californium.elements.rule.TestNameLoggerRule;
 import org.eclipse.californium.examples.NatUtil;
@@ -519,6 +520,9 @@ public class SecureObserveTest {
 		serverConnector = new DTLSConnector(dtlsConfig);
 		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setConnector(serverConnector);
+		if (mode == MatcherMode.PRINCIPAL) {
+			builder.setEndpointContextMatcher(new PrincipalEndpointContextMatcher(true));
+		}
 		builder.setNetworkConfig(config);
 		serverEndpoint = builder.build();
 

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreTest.java
@@ -33,6 +33,7 @@ import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.RandomTokenGenerator;
 import org.eclipse.californium.core.network.TokenGenerator;
+import org.eclipse.californium.core.network.TokenGenerator.Scope;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.oscore.Encryptor;
 import org.eclipse.californium.oscore.HashMapCtxDB;
@@ -576,7 +577,7 @@ public class OSCoreTest {
 	public Token generateToken() {
 		Token token;
 		do {
-			token = tokenGenerator.createToken(false);
+			token = tokenGenerator.createToken(Scope.SHORT_TERM);
 		} while (tokenExist(token));
 		return token;
 	}

--- a/cf-pubsub/src/main/java/org/eclipse/californium/pubsub/PubSub.java
+++ b/cf-pubsub/src/main/java/org/eclipse/californium/pubsub/PubSub.java
@@ -31,6 +31,7 @@ import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.RandomTokenGenerator;
+import org.eclipse.californium.core.network.TokenGenerator.Scope;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.elements.exception.ConnectorException;
 import java.io.IOException;
@@ -321,7 +322,7 @@ public class PubSub {
 
             config.set(NetworkConfig.Keys.TOKEN_SIZE_LIMIT, 4);
             RandomTokenGenerator rand = new RandomTokenGenerator(config);
-            Token token = rand.createToken(false);
+            Token token = rand.createToken(Scope.SHORT_TERM_CLIENT_LOCAL);
             req.setToken(token);
 
             relation = client.observe(req, handler);

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
@@ -33,8 +33,10 @@ import javax.net.ssl.SSLSessionContext;
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.EndpointManager;
+import org.eclipse.californium.core.network.EndpointContextMatcherFactory.MatcherMode;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
+import org.eclipse.californium.elements.PrincipalEndpointContextMatcher;
 import org.eclipse.californium.elements.tcp.TcpServerConnector;
 import org.eclipse.californium.elements.tcp.TlsServerConnector;
 import org.eclipse.californium.elements.tcp.TlsServerConnector.ClientAuthMode;
@@ -282,6 +284,9 @@ public abstract class AbstractTestServer extends CoapServer {
 					DTLSConnector connector = new DTLSConnector(dtlsConfigBuilder.build());
 					CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 					builder.setConnector(connector);
+					if (MatcherMode.PRINCIPAL.name().equals(dtlsConfig.getString(Keys.RESPONSE_MATCHING))) {
+						builder.setEndpointContextMatcher(new PrincipalEndpointContextMatcher(true));
+					}
 					builder.setNetworkConfig(dtlsConfig);
 					CoapEndpoint endpoint = builder.build();
 					addEndpoint(endpoint);

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContextMatcher.java
@@ -24,7 +24,7 @@ package org.eclipse.californium.elements;
  * 
  * Enable implementor to flexible decide on endpoint context information.
  */
-public interface EndpointContextMatcher {
+public interface EndpointContextMatcher extends EndpointIdentityResolver {
 
 	/**
 	 * Return matcher name. Used for logging.

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointIdentityResolver.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointIdentityResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,22 +11,28 @@
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  * 
  * Contributors:
- *    Bosch Software Innovations GmbH - replace ExchangeObserver.
+ *    Bosch Software Innovations GmbH - initial implementation
  ******************************************************************************/
-package org.eclipse.californium.core.network;
+package org.eclipse.californium.elements;
 
 /**
- * The remove handler can be set to an {@link Exchange} and will be invoked
- * for release the exchange from the exchange store.
+ * Interface for resolving the endpoint identity from an endpoint context.
  */
-public interface RemoveHandler {
+public interface EndpointIdentityResolver {
 
 	/**
-	 * Remove exchange from store.
+	 * Return resolver name. Used for logging.
 	 * 
-	 * @param exchange exchange to remove from store
-	 * @param keyToken token to remove exchange. Maybe {@code null}.
-	 * @param keyMID mid key to remove exchange. Maybe {@code null}.
+	 * @return name of resolver.
 	 */
-	void remove(Exchange exchange, KeyToken keyToken, KeyMID keyMID);
+	String getName();
+
+	/**
+	 * Get the endpoint identity object.
+	 * 
+	 * @param context endpoint context
+	 * @return endpoint identity object.
+	 */
+	Object getEndpointIdentity(EndpointContext context);
+
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/KeySetEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/KeySetEndpointContextMatcher.java
@@ -30,7 +30,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 /**
  * Key set based endpoint context matcher.
  */
-public class KeySetEndpointContextMatcher implements EndpointContextMatcher {
+public abstract class KeySetEndpointContextMatcher implements EndpointContextMatcher {
 
 	/**
 	 * Name of matcher. Used for logging.
@@ -75,6 +75,11 @@ public class KeySetEndpointContextMatcher implements EndpointContextMatcher {
 	@Override
 	public String getName() {
 		return name;
+	}
+
+	@Override
+	public Object getEndpointIdentity(EndpointContext context) {
+		return context.getPeerAddress();
 	}
 
 	@Override

--- a/element-connector/src/main/java/org/eclipse/californium/elements/PrincipalEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/PrincipalEndpointContextMatcher.java
@@ -24,12 +24,32 @@ import java.security.Principal;
  */
 public class PrincipalEndpointContextMatcher implements EndpointContextMatcher {
 
+	private final boolean usePrincipalAsIdentity;
+
 	public PrincipalEndpointContextMatcher() {
+		this(false);
+	}
+
+	public PrincipalEndpointContextMatcher(boolean usePrincipalAsIdentity) {
+		this.usePrincipalAsIdentity = usePrincipalAsIdentity;
 	}
 
 	@Override
 	public String getName() {
 		return "principal correlation";
+	}
+
+	@Override
+	public Object getEndpointIdentity(EndpointContext context) {
+		if (usePrincipalAsIdentity) {
+			Principal identity = context.getPeerIdentity();
+			if (identity == null) {
+				throw new IllegalArgumentException("Principal identity missing in provided endpoint context!");
+			}
+			return identity;
+		} else {
+			return context.getPeerAddress();
+		}
 	}
 
 	@Override
@@ -79,4 +99,5 @@ public class PrincipalEndpointContextMatcher implements EndpointContextMatcher {
 	protected boolean matchPrincipals(Principal requestedPrincipal, Principal availablePrincipal) {
 		return requestedPrincipal.equals(availablePrincipal);
 	}
+
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/UDPConnectorTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/UDPConnectorTest.java
@@ -244,6 +244,11 @@ public class UDPConnectorTest {
 		}
 
 		@Override
+		public Object getEndpointIdentity(EndpointContext context) {
+			return context.getPeerAddress();
+		}
+
+		@Override
 		public boolean isResponseRelatedToRequest(EndpointContext requestContext, EndpointContext responseContext) {
 			return false;
 		}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
@@ -313,6 +313,11 @@ public class DTLSEndpointContextTest {
 		}
 
 		@Override
+		public Object getEndpointIdentity(EndpointContext context) {
+			return context.getPeerAddress();
+		}
+
+		@Override
 		public boolean isResponseRelatedToRequest(EndpointContext requestContext, EndpointContext responseContext) {
 			return false;
 		}


### PR DESCRIPTION
Replaces PR #1066 as fix for issue #1064

Move KeyMID into outer class.
Add EndpointContextResolver and use it for KeyToken and KeyMID.
Keep KeyToken and KeyMID in Exchange.
Replace response in observe relation by KeyMID.
Add test with principal based peer identity.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>