### PR TITLE
Fix ignored block2

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -182,7 +182,7 @@ public final class TcpMatcher extends BaseMatcher {
 				boolean checkResponseToken = !exchange.isNotification() || exchange.getRequest() != exchange.getCurrentRequest();
 				if (checkResponseToken && exchangeStore.get(idByToken) != exchange) {
 					if (running) {
-						LOGGER.error("ignoring response {}, exchange not longer matching!", response);
+						LOGGER.debug("ignoring response {}, exchange not longer matching!", response);
 					}
 					return;
 				}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -664,37 +664,8 @@ public class BlockwiseLayer extends AbstractLayer {
 			}
 
 			KeyUri key = getKey(exchange, response);
-			BlockOption block = response.getOptions().getBlock2();
 			Block2BlockwiseStatus status = getBlock2Status(key);
-			if (status != null) {
-				// ongoing blockwise transfer
-				boolean starting = (block == null) || (block.getNum() == 0);
-				if (starting) {
-					if (status.isNew(response)) {
-						LOGGER.debug("discarding outdated block2 transfer {}, current is [{}]", status.getObserve(),
-								response);
-						clearBlock2Status(key, status);
-						status.completeOldTransfer(exchange);
-					} else {
-						LOGGER.debug("discarding old block2 transfer [{}], received during ongoing block2 transfer {}",
-								response, status.getObserve());
-						status.completeNewTranfer(exchange);
-						return;
-					}
-				}
-				else if (!status.matchTransfer(exchange)) {
-					LOGGER.debug(
-							"discarding outdate block2 response [{}, {}] received during ongoing block2 transfer {}",
-							exchange.getNotificationNumber(), response, status.getObserve());
-					status.completeNewTranfer(exchange);
-					return;
-				}
-			}
-			else if (block != null && block.getNum() != 0) {
-				LOGGER.debug(
-						"discarding stale block2 response [{}, {}] received without ongoing block2 transfer for {}",
-						exchange.getNotificationNumber(), response, key);
-				exchange.setComplete();
+			if (discardBlock2(key, status, exchange, response)) {
 				return;
 			}
 
@@ -840,6 +811,50 @@ public class BlockwiseLayer extends AbstractLayer {
 	}
 
 	/**
+	 * Check, if response is to be discarded caused by the block2 status. Clears
+	 * also the block status for new block transfers
+	 * 
+	 * @param key uri key for blocktransfer
+	 * @param status status of blocktransfer
+	 * @param exchange exchange of blocktransfer
+	 * @param response current response
+	 * @return {@code true}, if reponse is to be ignored, {@code false},
+	 *         otherwise
+	 */
+	private boolean discardBlock2(KeyUri key, Block2BlockwiseStatus status, Exchange exchange, Response response) {
+		BlockOption block = response.getOptions().getBlock2();
+		boolean starting = (block == null) || (block.getNum() == 0);
+		if (status != null) {
+			// ongoing blockwise transfer
+			if (starting) {
+				if (status.isNew(response)) {
+					LOGGER.debug("discarding outdated block2 transfer {}, current is [{}]", status.getObserve(),
+							response);
+					clearBlock2Status(key, status);
+					status.completeOldTransfer(exchange);
+				} else {
+					LOGGER.debug("discarding old block2 transfer [{}], received during ongoing block2 transfer {}",
+							response, status.getObserve());
+					status.completeNewTranfer(exchange);
+					return true;
+				}
+			} else if (!status.matchTransfer(exchange)) {
+				LOGGER.debug("discarding outdate block2 response [{}, {}] received during ongoing block2 transfer {}",
+						exchange.getNotificationNumber(), response, status.getObserve());
+				status.completeNewTranfer(exchange);
+				return true;
+			}
+		} else if (block != null && block.getNum() != 0) {
+			LOGGER.debug("discarding stale block2 response [{}, {}] received without ongoing block2 transfer for {}",
+					exchange.getNotificationNumber(), response, key);
+			exchange.setComplete();
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Checks if a response contains a single block of a large payload only and
 	 * retrieves the remaining blocks if applicable.
 	 * 
@@ -874,12 +889,15 @@ public class BlockwiseLayer extends AbstractLayer {
 			exchange.getRequest().cancel();
 
 		} else {
-
-			Block2BlockwiseStatus status = getInboundBlock2Status(key, exchange, response);
-
-			if (block2.getNum() == status.getCurrentNum() && (block2.getNum() == 0 || response.getToken().equals(exchange.getCurrentRequest().getToken()))) {
-
-				// check token to avoid mixed blockwise transfers (possible with observe) 
+			Block2BlockwiseStatus status;
+			synchronized (block2Transfers) {
+				status = getBlock2Status(key);
+				if (discardBlock2(key, status, exchange, response)) {
+					return;
+				}
+				status = getInboundBlock2Status(key, exchange, response);
+			}
+			if (block2.getNum() == status.getCurrentNum()) {
 
 				// We got the block we expected :-)
 				LOGGER.debug("processing incoming block2 response [num={}]: {}", block2.getNum(), response);
@@ -927,10 +945,11 @@ public class BlockwiseLayer extends AbstractLayer {
 
 			} else {
 				// ERROR, wrong block number (server error)
-				// Canceling the request would interfere with Observe, so just ignore it
+				// Canceling the request would interfere with Observe,
+				// so just ignore it
 				ignoredBlock2.incrementAndGet();
-				LOGGER.warn("ignoring block2 response with wrong block number {} (expected {}): {}",
-						block2.getNum(), status.getCurrentNum(), response);
+				LOGGER.warn("ignoring block2 response with wrong block number {} (expected {}) - {}: {}",
+						block2.getNum(), status.getCurrentNum(), exchange.getCurrentRequest().getToken(), response);
 			}
 		}
 	}
@@ -990,10 +1009,14 @@ public class BlockwiseLayer extends AbstractLayer {
 
 			status.setCurrentNum(nextNum);
 
-			LOGGER.debug("requesting next Block2 [num={}]: {}", nextNum, block);
-			exchange.setCurrentRequest(block);
-			prepareBlock2Cleanup(status, key);
-			lower().sendRequest(exchange, block);
+			if (status.isComplete()) {
+				LOGGER.debug("stopped block2 transfer, droping response.");
+			} else {
+				LOGGER.debug("requesting next Block2 [num={}]: {}", nextNum, block);
+				exchange.setCurrentRequest(block);
+				prepareBlock2Cleanup(status, key);
+				lower().sendRequest(exchange, block);
+			}
 		} catch (RuntimeException ex) {
 			LOGGER.warn("cannot process next block request, aborting request!", ex);
 			block.setSendError(ex);
@@ -1104,14 +1127,15 @@ public class BlockwiseLayer extends AbstractLayer {
 	private KeyUri addRandomAccessBlock2Status(final Exchange exchange, final Request request) {
 
 		KeyUri key = getKey(exchange, request);
+		int size;
 		Block2BlockwiseStatus status = Block2BlockwiseStatus.forRandomAccessRequest(exchange, request);
 		synchronized (block2Transfers) {
 			block2Transfers.put(key, status);
+			size = block1Transfers.size();
 		}
 		enableStatus = true;
 		addBlock2CleanUpObserver(request, key, status);
-		LOGGER.debug("created tracker for random access block2 retrieval {}, transfers in progress: {}", status,
-				block2Transfers.size());
+		LOGGER.debug("created tracker for random access block2 retrieval {}, transfers in progress: {}", status, size);
 		return key;
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/NotificationOrder.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/NotificationOrder.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial API and implementation
+ *                                      split from ObserveNotificationOrderer
+ *******************************************************************************/
+package org.eclipse.californium.core.observe;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.elements.util.ClockUtil;
+
+/**
+ * The NotificationOrderer holds the state of an observe relation such as the
+ * timeout of the last notification and the current number.
+ */
+public class NotificationOrder {
+
+	/** The observe number */
+	protected final Integer number;
+
+	/** The timestamp of the response */
+	protected final long nanoTimestamp;
+
+	/**
+	 * Creates a new notification order for a given notification.
+	 * 
+	 * @param observe observe of the notification, or {@code null}, if order is
+	 *            not related to a notification.
+	 */
+	public NotificationOrder(Integer observe) {
+		this(observe, ClockUtil.nanoRealtime());
+	}
+
+	/**
+	 * Creates a new notification order for a given notification.
+	 * 
+	 * @param observe observe of the notification, or {@code null}, if order is
+	 *            not related to a notification.
+	 * @param nanoTime receive time of notification
+	 */
+	public NotificationOrder(Integer observe, long nanoTime) {
+		number = observe;
+		nanoTimestamp = nanoTime;
+	}
+
+	/**
+	 * Returns the notification number.
+	 * 
+	 * @return the notification number, or {@code null}, if order is not related
+	 *         to a notification.
+	 */
+	public Integer getObserve() {
+		return number;
+	}
+
+	/**
+	 * Test, if the provided notification is newer than the current one.
+	 * 
+	 * @param response the notification
+	 * @return {@code true} if the notification is new
+	 */
+	public synchronized boolean isNew(Response response) {
+
+		Integer observe = response.getOptions().getObserve();
+		if (observe == null) {
+			// this is a final response, e.g. error or proactive cancellation
+			return true;
+		}
+
+		return isNew(nanoTimestamp, number, ClockUtil.nanoRealtime(), observe);
+	}
+
+	/**
+	 * Compare order of notifications.
+	 * 
+	 * @param T1 nano realtimestamp of first notification
+	 * @param V1 observe number of first notification
+	 * @param T2 nano realtimestamp of second notification
+	 * @param V2 observe number of second notification
+	 * @return {@code true}, if second notification is newer.
+	 */
+	public static boolean isNew(long T1, int V1, long T2, int V2) {
+		// Multiple responses with different notification numbers might
+		// arrive and be processed by different threads. We have to
+		// ensure that only the most fresh one is being delivered.
+		// We use the notation from the observe draft-08.
+		if (V1 < V2 && (V2 - V1) < (1L << 23) || V1 > V2 && (V1 - V2) > (1L << 23)
+				|| T2 > (T1 + TimeUnit.SECONDS.toNanos(128))) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveNotificationOrderer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveNotificationOrderer.java
@@ -21,12 +21,10 @@
  ******************************************************************************/
 package org.eclipse.californium.core.observe;
 
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.elements.util.ClockUtil;
-
 
 /**
  * The ObservingNotificationOrderer holds the state of an observe relation such
@@ -36,10 +34,10 @@ public class ObserveNotificationOrderer {
 
 	/** The counter for observe numbers */
 	private final AtomicInteger number = new AtomicInteger();
-	
+
 	/** The timestamp of the last response */
 	private long nanoTimestamp;
-	
+
 	/**
 	 * Creates a new notification orderer.
 	 */
@@ -58,7 +56,7 @@ public class ObserveNotificationOrderer {
 		number.set(observe);
 		nanoTimestamp = ClockUtil.nanoRealtime();
 	}
-	
+
 	/**
 	 * Return a new observe option number. This method is thread-safe as it
 	 * increases the option number atomically.
@@ -67,49 +65,45 @@ public class ObserveNotificationOrderer {
 	 */
 	public int getNextObserveNumber() {
 		int next = number.incrementAndGet();
-		while (next >= 1<<24) {
+		while (next >= 1 << 24) {
 			number.compareAndSet(next, 0);
 			next = number.incrementAndGet();
 		}
 		// assert 0 <= next && next < 1<<24;
 		return next;
 	}
-	
+
 	/**
 	 * Returns the current notification number.
+	 * 
 	 * @return the current notification number
 	 */
 	public int getCurrent() {
 		return number.get();
 	}
-	
+
 	/**
 	 * Returns true if the specified notification is newer than the current one.
+	 * 
 	 * @param response the notification
 	 * @return true if the notification is new
 	 */
 	public synchronized boolean isNew(Response response) {
-		
+
 		Integer observe = response.getOptions().getObserve();
 		if (observe == null) {
 			// this is a final response, e.g., error or proactive cancellation
 			return true;
 		}
-		
+
 		// Multiple responses with different notification numbers might
 		// arrive and be processed by different threads. We have to
 		// ensure that only the most fresh one is being delivered.
 		// We use the notation from the observe draft-08.
-		long T1 = nanoTimestamp;
-		int V1 = number.get();
 		long T2 = ClockUtil.nanoRealtime();
-		int V2 = observe;
-		if (V1 < V2 && (V2 - V1) < (1L<<23)
-				|| V1 > V2 && (V1 - V2) > (1L<<23)
-				|| T2 > (T1 + TimeUnit.SECONDS.toNanos(128))) {
-
+		if (NotificationOrder.isNew(nanoTimestamp, number.get(), T2, observe)) {
 			nanoTimestamp = T2;
-			number.set(V2);
+			number.set(observe);
 			return true;
 		} else {
 			return false;

--- a/demo-apps/cf-extplugtest-client/benchmark.sh
+++ b/demo-apps/cf-extplugtest-client/benchmark.sh
@@ -32,12 +32,15 @@ CF_OPT="-d64 -XX:+UseG1GC -Xmx6g -Dcalifornium.statistic=M17"
 CF_HOST=localhost
 
 # adjust the multiplier according the speed of your CPU
-USE_TCP=0
+USE_TCP=1
 MULTIPLIER=10
 REQS=$((500 * $MULTIPLIER))
 REQS_EXTRA=$(($REQS + ($REQS/10)))
 REV_REQS=$((2 * $REQS))
 NOTIFIES=$((100 * $MULTIPLIER))
+
+PAYLOAD=40
+PAYLOAD_LARGE=400
 
 echo ${REV_REQS2}
 
@@ -83,18 +86,18 @@ benchmark()
 }
 
 # GET
-benchmark_udp "benchmark?rlen=40" ${UDP_CLIENTS} ${REQS}
-benchmark_tcp "benchmark?rlen=40" ${TCP_CLIENTS} ${REQS}
+benchmark_udp "benchmark?rlen=${PAYLOAD}" ${UDP_CLIENTS} ${REQS}
+benchmark_tcp "benchmark?rlen=${PAYLOAD}" ${TCP_CLIENTS} ${REQS}
 
 # reverse GET
-benchmark_udp "reverse-request?req=${REQS_EXTRA}&res=feed-CON&rlen=40" ${UDP_CLIENTS} 2 stop ${REV_REQS}
-benchmark_tcp "reverse-request?req=${REQS_EXTRA}&res=feed-CON&rlen=40" ${TCP_CLIENTS} 2 stop ${REV_REQS}
+benchmark_udp "reverse-request?req=${REQS_EXTRA}&res=feed-CON&rlen=${PAYLOAD}" ${UDP_CLIENTS} 2 stop ${REV_REQS}
+benchmark_tcp "reverse-request?req=${REQS_EXTRA}&res=feed-CON&rlen=${PAYLOAD}" ${TCP_CLIENTS} 2 stop ${REV_REQS}
 
 # observe CON 
-benchmark "reverse-observe?obs=25000&res=feed-CON&rlen=400" ${OBS_CLIENTS} 1 stop ${NOTIFIES} 20 100
+benchmark "reverse-observe?obs=25000&res=feed-CON&rlen=${PAYLOAD_LARGE}" ${OBS_CLIENTS} 1 stop ${NOTIFIES} 20 100
 
 # observe NON
-benchmark_udp "reverse-observe?obs=25000&res=feed-NON&rlen=400" ${OBS_CLIENTS} 1 stop ${NOTIFIES} 20 100
+benchmark_udp "reverse-observe?obs=25000&res=feed-NON&rlen=${PAYLOAD_LARGE}" ${OBS_CLIENTS} 1 stop ${NOTIFIES} 20 100
 
 END_BENCHMARK=`date +%s`
 


### PR DESCRIPTION
Fix block2 warnings.

Add synch section to recheck blockstatus.
Use unmodifiable NotificationOrder to check for new notifies,
fix unintended updates of the orderer by new notifications.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>