### PR TITLE
Use message timestamp for receive time.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
@@ -61,6 +61,7 @@ import org.eclipse.californium.core.Utils;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.observe.ObserveManager;
 import org.eclipse.californium.elements.EndpointContext;
+import org.eclipse.californium.elements.util.ClockUtil;
 
 /**
  * The class Message models the base class of all CoAP messages. CoAP messages
@@ -171,10 +172,9 @@ public abstract class Message {
 	private volatile List<MessageObserver> unmodifiableMessageObserversFacade = null;
 
 	/**
-	 * The timestamp when this message has been received, sent, or 0, if neither
-	 * has happened yet. The {@link Matcher} sets the timestamp.
+	 * The nano-timestamp when this message has been received, or {@code 0} for outgoing messages.
 	 */
-	private volatile long timestamp;
+	private volatile long receiveNanoTimestamp;
 
 	/**
 	 * Creates a new message with no specified message type.
@@ -935,23 +935,25 @@ public abstract class Message {
 	}
 
 	/**
-	 * Gets the timestamp.
+	 * Gets the nano timestamp of receiving this message.
 	 *
-	 * @return the timestamp
+	 * @return the nano timestamp
+	 * @see ClockUtil#nanoRealtime()
 	 */
-	public long getTimestamp() {
-		return timestamp;
+	public long getReceiveNanoTimestamp() {
+		return receiveNanoTimestamp;
 	}
 
 	/**
-	 * Sets the timestamp.
+	 * Sets nano timestamp of receiving this message.
 	 * 
 	 * Not part of the fluent API.
 	 *
-	 * @param timestamp the new timestamp
+	 * @param nano timestamp the nano timestamp when receiving this message.
+	 * @see ClockUtil#nanoRealtime()
 	 */
-	public void setTimestamp(long timestamp) {
-		this.timestamp = timestamp;
+	public void setReceiveNanoTimestamp(long timestamp) {
+		this.receiveNanoTimestamp = timestamp;
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataParser.java
@@ -54,6 +54,7 @@ public abstract class DataParser {
 		}
 		Message message = parseMessage(raw.getBytes());
 		message.setSourceContext(raw.getEndpointContext());
+		message.setReceiveNanoTimestamp(raw.getReceiveNanoTimestamp());
 		return message;
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
@@ -146,7 +146,7 @@ public class CoapEndpointTest {
 		};
 
 		
-		RawData inboundRequest = RawData.inbound(getSerializedRequest(), new AddressEndpointContext(SOURCE_ADDRESS, clientId), false);
+		RawData inboundRequest = RawData.inbound(getSerializedRequest(), new AddressEndpointContext(SOURCE_ADDRESS, clientId), false, System.nanoTime());
 		connector.receiveMessage(inboundRequest);
 		assertTrue(latch.await(2, TimeUnit.SECONDS));
 		assertThat(receivedRequests.get(0).getSourceContext().getPeerIdentity(), is(clientId));
@@ -154,7 +154,7 @@ public class CoapEndpointTest {
 
 	@Test
 	public void testStandardSchemeIsSetOnIncomingRequest() throws Exception {
-		RawData inboundRequest = RawData.inbound(getSerializedRequest(), new AddressEndpointContext(SOURCE_ADDRESS), false);
+		RawData inboundRequest = RawData.inbound(getSerializedRequest(), new AddressEndpointContext(SOURCE_ADDRESS), false, System.nanoTime());
 		connector.receiveMessage(inboundRequest);
 		assertTrue(latch.await(2, TimeUnit.SECONDS));
 		assertThat(receivedRequests.get(0).getScheme(), is(CoAP.COAP_URI_SCHEME));
@@ -185,7 +185,7 @@ public class CoapEndpointTest {
 		cleanup.add(endpoint);
 		
 		EndpointContext secureCtx = new DtlsEndpointContext(SOURCE_ADDRESS, null, "session", "1", "CIPHER", "100");
-		RawData inboundRequest = RawData.inbound(getSerializedRequest(), secureCtx, false);
+		RawData inboundRequest = RawData.inbound(getSerializedRequest(), secureCtx, false, System.nanoTime());
 		connector.receiveMessage(inboundRequest);
 		assertTrue(latch.await(2, TimeUnit.SECONDS));
 		assertThat(receivedRequests.get(0).getScheme(), is(CoAP.COAP_SECURE_URI_SCHEME));
@@ -200,7 +200,7 @@ public class CoapEndpointTest {
 				0x00, 0x10, // message ID
 				(byte) 0xFF // payload marker
 		};
-		RawData inboundMessage = RawData.inbound(malformedGetRequest, new AddressEndpointContext(SOURCE_ADDRESS), false);
+		RawData inboundMessage = RawData.inbound(malformedGetRequest, new AddressEndpointContext(SOURCE_ADDRESS), false, System.nanoTime());
 
 		// WHEN the incoming message is processed by the Inbox
 		connector.receiveMessage(inboundMessage);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapTranslator.java
@@ -159,8 +159,8 @@ public final class CoapTranslator {
 		outgoingResponse.setPayload(payload);
 
 		// copy the timestamp
-		long timestamp = incomingResponse.getTimestamp();
-		outgoingResponse.setTimestamp(timestamp);
+		long timestamp = incomingResponse.getReceiveNanoTimestamp();
+		outgoingResponse.setReceiveNanoTimestamp(timestamp);
 
 		// copy every option
 		outgoingResponse.setOptions(new OptionSet(

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCacheResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCacheResource.java
@@ -153,12 +153,12 @@ public class ProxyCacheResource extends CoapResource implements CacheResource {
 					Response cachedResponse = responseCache.getUnchecked(cacheKey);
 
 					// calculate the new parameters
-					long newCurrentTime = response.getTimestamp();
+					long newCurrentTime = response.getReceiveNanoTimestamp();
 					long newMaxAge = maxAgeOption.longValue();
 
 					// set the new parameters
 					cachedResponse.getOptions().setMaxAge(newMaxAge);
-					cachedResponse.setTimestamp(newCurrentTime);
+					cachedResponse.setReceiveNanoTimestamp(newCurrentTime);
 
 					LOGGER.debug("Updated cached response");
 				} else {
@@ -246,7 +246,7 @@ public class ProxyCacheResource extends CoapResource implements CacheResource {
 				// consider the aging of the response while in the cache
 				response.getOptions().setMaxAge(nanosLeft);
 				// set the current time as the response timestamp
-				response.setTimestamp(currentTime);
+				response.setReceiveNanoTimestamp(currentTime);
 			} else {
 				LOGGER.debug("Expired response");
 
@@ -317,7 +317,7 @@ public class ProxyCacheResource extends CoapResource implements CacheResource {
 	 */
 	private long getRemainingLifetime(Response response, long currentTime) {
 		// get the timestamp
-		long arriveTime = response.getTimestamp();
+		long arriveTime = response.getReceiveNanoTimestamp();
 		
 		Long maxAgeOption = response.getOptions().getMaxAge();
 		long oldMaxAge = OptionNumberRegistry.Defaults.MAX_AGE;

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyHttpClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyHttpClientResource.java
@@ -126,7 +126,7 @@ public class ProxyHttpClientResource extends ForwardingResource {
 				// translate the received http response in a coap response
 				try {
 					Response coapResponse = new HttpTranslator().getCoapResponse(result, incomingCoapRequest);
-					coapResponse.setTimestamp(timestamp);
+					coapResponse.setReceiveNanoTimestamp(timestamp);
 
 					future.complete(coapResponse);
 				} catch (InvalidFieldException e) {

--- a/element-connector-tcp/src/main/java/org/eclipse/californium/elements/tcp/DatagramFramer.java
+++ b/element-connector-tcp/src/main/java/org/eclipse/californium/elements/tcp/DatagramFramer.java
@@ -24,6 +24,7 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.RawData;
+import org.eclipse.californium.elements.util.ClockUtil;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -65,7 +66,7 @@ public class DatagramFramer extends ByteToMessageDecoder {
 			
 			Channel channel = ctx.channel();
 			EndpointContext endpointContext = contextUtil.buildEndpointContext(channel);
-			RawData rawData = RawData.inbound(data, endpointContext, false);
+			RawData rawData = RawData.inbound(data, endpointContext, false, ClockUtil.nanoRealtime());
 			out.add(rawData);
 		}
 	}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/RawData.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/RawData.java
@@ -31,10 +31,13 @@
  ******************************************************************************/
 package org.eclipse.californium.elements;
 
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.Principal;
-import java.util.Arrays;
+
+import org.eclipse.californium.elements.util.ClockUtil;
 
 /**
  * A container object for the data received or sent via a {@link Connector}.
@@ -55,6 +58,11 @@ public final class RawData {
 
 	/** The raw message. */
 	public final byte[] bytes;
+
+	/**
+	 * Nano timestamp of receive time.
+	 */
+	private final long receiveNanoTimestamp;
 
 	/** Indicates if this message is a multicast message */
 	private final boolean multicast;
@@ -80,9 +88,11 @@ public final class RawData {
 	 * @param endpointContext remote peers endpoint context.
 	 * @param multicast indicates whether the data represents a multicast
 	 *            message
+	 * @param nanoTimestamp nano-timestamp for received messages. {@code 0}
+	 *            for outgoing messages.
 	 * @throws NullPointerException if data or address is {@code null}
 	 */
-	private RawData(byte[] data, EndpointContext peerEndpointContext, MessageCallback callback, boolean multicast) {
+	private RawData(byte[] data, EndpointContext peerEndpointContext, MessageCallback callback, boolean multicast, long nanoTimestamp) {
 		if (data == null) {
 			throw new NullPointerException("Data must not be null");
 		} else if (peerEndpointContext == null) {
@@ -92,6 +102,7 @@ public final class RawData {
 			this.peerEndpointContext = peerEndpointContext;
 			this.callback = callback;
 			this.multicast = multicast;
+			this.receiveNanoTimestamp = nanoTimestamp;
 		}
 	}
 
@@ -105,12 +116,15 @@ public final class RawData {
 	 *            the message has been received in, and can be used to correlate
 	 *            this message with another (previously sent) message.
 	 * @param isMulticast indicates whether the data has been received as a
-	 *            multicast message.
+	 *            multicast message. (Currently {@link DatagramPacket} nor
+	 *            {@link DatagramSocket} offers this information!)
+	 * @param nanoTimestamp nano-timestamp for received messages.
 	 * @return the raw data object containing the inbound message.
 	 * @throws NullPointerException if data or address is {@code null}.
+	 * @see ClockUtil#nanoRealtime()
 	 */
-	public static RawData inbound(byte[] data, EndpointContext peerEndpointContext, boolean isMulticast) {
-		return new RawData(data, peerEndpointContext, null, isMulticast);
+	public static RawData inbound(byte[] data, EndpointContext peerEndpointContext, boolean isMulticast, long timestamp) {
+		return new RawData(data, peerEndpointContext, null, isMulticast, timestamp);
 	}
 
 	/**
@@ -142,16 +156,16 @@ public final class RawData {
 	 */
 	public static RawData outbound(byte[] data, EndpointContext peerEndpointContext, MessageCallback callback,
 			boolean useMulticast) {
-		return new RawData(data, peerEndpointContext, callback, useMulticast);
+		return new RawData(data, peerEndpointContext, callback, useMulticast, 0);
 	}
 
 	/**
 	 * Gets the raw message.
 	 *
-	 * @return a copy of the raw message bytes
+	 * @return raw message bytes
 	 */
 	public byte[] getBytes() {
-		return Arrays.copyOf(bytes, bytes.length);
+		return bytes;
 	}
 
 	/**
@@ -179,6 +193,17 @@ public final class RawData {
 	 */
 	public int getPort() {
 		return peerEndpointContext.getPeerAddress().getPort();
+	}
+
+	/**
+	 * Get nano receive timestamp.
+	 * 
+	 * @return nano-time of receiving this message. {@code 0} for outgoing
+	 *         messages.
+	 * @see ClockUtil#nanoRealtime()
+	 */
+	public long getReceiveNanoTimestamp() {
+		return receiveNanoTimestamp;
 	}
 
 	/**

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
@@ -50,6 +50,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import org.eclipse.californium.elements.exception.EndpointMismatchException;
 import org.eclipse.californium.elements.util.Bytes;
+import org.eclipse.californium.elements.util.ClockUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -369,12 +370,13 @@ public class UDPConnector implements Connector {
 							"UDPConnector ({}) received truncated UDP datagram from {}:{}. Maximum size allowed {}. Discarding ...",
 							effectiveAddr, datagram.getAddress(), datagram.getPort(), size - 1);
 				} else {
+					long timestamp = ClockUtil.nanoRealtime();
 					LOGGER.debug("UDPConnector ({}) received {} bytes from {}:{}", effectiveAddr, datagram.getLength(),
 							datagram.getAddress(), datagram.getPort());
 					byte[] bytes = Arrays.copyOfRange(datagram.getData(), datagram.getOffset(), datagram.getLength());
 					RawData msg = RawData.inbound(bytes,
 							new UdpEndpointContext(new InetSocketAddress(datagram.getAddress(), datagram.getPort())),
-							false);
+							false, timestamp);
 					receiver.receiveData(msg);
 				}
 			}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -1289,7 +1289,7 @@ public class DTLSConnector implements Connector, RecordLayer {
 					context = session.getConnectionWriteContext();
 				}
 				LOGGER.debug("Received APPLICATION_DATA for {}", context);
-				RawData receivedApplicationMessage = RawData.inbound(message.getData(), context, false);
+				RawData receivedApplicationMessage = RawData.inbound(message.getData(), context, false, record.getReceiveNanos());
 				channel.receiveData(receivedApplicationMessage);
 			}
 		} else if (ongoingHandshake != null) {


### PR DESCRIPTION
Use it for improved deduplication by suppress duplicated request
received before the last response was sent out.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>