### PR TITLE
Move Mac.reset() call.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CbcBlockCipher.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CbcBlockCipher.java
@@ -220,7 +220,9 @@ public class CbcBlockCipher {
 		hmac.init(macKey);
 		hmac.update(additionalData);
 		hmac.update(content, 0, length);
-		return hmac.doFinal();
+		byte[] mac = hmac.doFinal();
+		hmac.reset();
+		return mac;
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
@@ -328,8 +328,6 @@ public enum CipherSuite {
 	/**
 	 * Gets the thread local MAC used by this cipher suite.
 	 * 
-	 * Calls {@link Mac#reset()} on access.
-	 * 
 	 * @return mac, or {@code null}, if not supported by vm.
 	 */
 	public Mac getThreadLocalMac() {
@@ -872,14 +870,11 @@ public enum CipherSuite {
 		/**
 		 * Gets the thread local MAC used by this MAC algorithm.
 		 * 
-		 * Calls {@link Mac#reset()} on access.
-		 * 
 		 * @return mac, or {@code null}, if not supported by vm.
 		 */
 		public Mac getMac() {
 			if (mac != null) {
 				Mac current = mac.current();
-				current.reset();
 				return current;
 			} else {
 				return null;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/PseudoRandomFunction.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/PseudoRandomFunction.java
@@ -76,7 +76,9 @@ public final class PseudoRandomFunction {
 	static byte[] doPRF(Mac hmac, byte[] secret, byte[] label, byte[] seed, int length) {
 		try {
 			hmac.init(new SecretKeySpec(secret, "MAC"));
-			return doExpansion(hmac, label, seed, length);
+			byte[] prf = doExpansion(hmac, label, seed, length);
+			hmac.reset();
+			return prf;
 		} catch (InvalidKeyException e) {
 			// according to http://www.ietf.org/rfc/rfc2104 (HMAC) section 3
 			// keys can be of arbitrary length
@@ -124,7 +126,7 @@ public final class PseudoRandomFunction {
 	 * @param length the number of bytes to expand the data to.
 	 * @return the expanded data.
 	 */
-	public static final byte[] doExpansion(Mac hmac, byte[] label, byte[] seed, int length) {
+	static final byte[] doExpansion(Mac hmac, byte[] label, byte[] seed, int length) {
 		/*
 		 * RFC 5246, chapter 5, page 15
 		 * 


### PR DESCRIPTION
Caused NullPointerException in Android 4.4, if called without prior
init. Though the logic of such a MAC is to provide a secret and a
message, to miss the secret is not very probable. Therefore I moved the
reset to the using parts.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>