### PR TITLE
Add maven assembly descriptor module for improved submodule support.

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.californium</groupId>
+		<artifactId>parent</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>californium-assembly</artifactId>
+	<name>Custom Assembly Descriptors</name>
+	<description>The set of custom assembly descriptors used for Californium.</description>
+
+</project>

--- a/assembly/src/main/resources/assemblies/enhanced-jar-with-dependencies.xml
+++ b/assembly/src/main/resources/assemblies/enhanced-jar-with-dependencies.xml
@@ -1,7 +1,23 @@
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
-	<id>jar-with-dependencies</id>
+
+	<!--
+	 * Copyright (c) 2019  Sierra Wireless and others.
+	 *
+	 * All rights reserved. This program and the accompanying materials
+	 * are made available under the terms of the Eclipse Public License v1.0
+	 * and Eclipse Distribution License v1.0 which accompany this distribution.
+	 *
+	 * The Eclipse Public License is available at
+	 *    http://www.eclipse.org/legal/epl-v10.html
+	 * and the Eclipse Distribution License is available at
+	 *    http://www.eclipse.org/org/documents/edl-v10.html.
+	 *
+	 * Contributors:
+	 *     Sierra Wireless - initial implementation
+	-->
+    <id>jar-with-dependencies</id>
 
 	<!-- This descriptor behave like maven "jar-with-dependency" except it ensure 
 		that current module files have always priority on dependency files in case 

--- a/assembly/src/main/resources/assemblies/enhanced-jar-with-licenses.xml
+++ b/assembly/src/main/resources/assemblies/enhanced-jar-with-licenses.xml
@@ -3,6 +3,23 @@
 	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
 	<id>jar-with-dependencies</id>
 
+	<!--
+	 * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+	 *
+	 * All rights reserved. This program and the accompanying materials
+	 * are made available under the terms of the Eclipse Public License v1.0
+	 * and Eclipse Distribution License v1.0 which accompany this distribution.
+	 *
+	 * The Eclipse Public License is available at
+	 *    http://www.eclipse.org/legal/epl-v10.html
+	 * and the Eclipse Distribution License is available at
+	 *    http://www.eclipse.org/org/documents/edl-v10.html.
+	 *
+	 * Contributors:
+	 *    Bosch Software Innovations GmbH - initial implementation
+	 *                                      derived from enhanced-jar-with-dependencies.xml
+	-->
+
 	<!-- This descriptor behave like maven "jar-without-dependency" except the 
 		californium-legal dependency and it ensure that current module files
 		have always priority on dependency files in case of duplicate.

--- a/californium-core/pom.xml
+++ b/californium-core/pom.xml
@@ -171,9 +171,9 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptors>
-						<descriptor>${project.parent.basedir}/enhanced-jar-with-licenses.xml</descriptor>
-					</descriptors>
+					<descriptorRefs>
+						<descriptorRef>enhanced-jar-with-licenses</descriptorRef>
+					</descriptorRefs>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 					</archive>

--- a/californium-integration-tests/pom.xml
+++ b/californium-integration-tests/pom.xml
@@ -114,9 +114,9 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptors>
-						<descriptor>enhanced-jar-with-licenses.xml</descriptor>
-					</descriptors>
+					<descriptorRefs>
+						<descriptorRef>enhanced-jar-with-licenses</descriptorRef>
+					</descriptorRefs>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/californium-osgi/pom.xml
+++ b/californium-osgi/pom.xml
@@ -96,9 +96,9 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptors>
-						<descriptor>${project.parent.basedir}/enhanced-jar-with-licenses.xml</descriptor>
-					</descriptors>
+					<descriptorRefs>
+						<descriptorRef>enhanced-jar-with-licenses</descriptorRef>
+					</descriptorRefs>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 					</archive>

--- a/californium-proxy/pom.xml
+++ b/californium-proxy/pom.xml
@@ -127,9 +127,9 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptors>
-						<descriptor>enhanced-jar-with-licenses.xml</descriptor>
-					</descriptors>
+					<descriptorRefs>
+						<descriptorRef>enhanced-jar-with-licenses</descriptorRef>
+					</descriptorRefs>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 					</archive>

--- a/cf-oscore/pom.xml
+++ b/cf-oscore/pom.xml
@@ -57,9 +57,9 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptors>
-						<descriptor>enhanced-jar-with-licenses.xml</descriptor>
-					</descriptors>
+					<descriptorRefs>
+						<descriptorRef>enhanced-jar-with-licenses</descriptorRef>
+					</descriptorRefs>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/cf-pubsub/pom.xml
+++ b/cf-pubsub/pom.xml
@@ -1,48 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <artifactId>parent</artifactId>
-        <groupId>org.eclipse.californium</groupId>
-        <version>2.0.0-SNAPSHOT</version>
-    </parent>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<artifactId>parent</artifactId>
+		<groupId>org.eclipse.californium</groupId>
+		<version>2.0.0-SNAPSHOT</version>
+	</parent>
 
-    <artifactId>cf-pubsub</artifactId>
-    <packaging>jar</packaging>
+	<artifactId>cf-pubsub</artifactId>
+	<packaging>jar</packaging>
 
-    <name>Cf-PubSub</name>
-    <description>Californium (Cf) PubSub, CoAP Publish-Subscribe implementation</description>
+	<name>Cf-PubSub</name>
+	<description>Californium (Cf) PubSub, CoAP Publish-Subscribe implementation</description>
 
-    <properties>
+	<properties>
 
-    </properties>
+	</properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>californium-legal</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.californium</groupId>
-            <artifactId>californium-core</artifactId>
-        </dependency>
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>californium-legal</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.californium</groupId>
+			<artifactId>californium-core</artifactId>
+		</dependency>
 
-        <!-- test dependencies -->
-    </dependencies>
+		<!-- test dependencies -->
+	</dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <descriptors>
-                        <descriptor>enhanced-jar-with-licenses.xml</descriptor>
-                    </descriptors>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>enhanced-jar-with-licenses</descriptorRef>
+					</descriptorRefs>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/element-connector-tcp/pom.xml
+++ b/element-connector-tcp/pom.xml
@@ -124,9 +124,9 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptors>
-						<descriptor>enhanced-jar-with-licenses.xml</descriptor>
-					</descriptors>
+					<descriptorRefs>
+						<descriptorRef>enhanced-jar-with-licenses</descriptorRef>
+					</descriptorRefs>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 					</archive>

--- a/element-connector/pom.xml
+++ b/element-connector/pom.xml
@@ -92,9 +92,9 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptors>
-						<descriptor>enhanced-jar-with-licenses.xml</descriptor>
-					</descriptors>
+					<descriptorRefs>
+						<descriptorRef>enhanced-jar-with-licenses</descriptorRef>
+					</descriptorRefs>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 					</archive>

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,8 @@
 	</dependencyManagement>
 
 	<modules>
+		<module>assembly</module>
+		<module>legal</module>
 		<module>element-connector</module>
 		<module>scandium-core</module>
 		<module>element-connector-tcp</module>
@@ -239,10 +241,9 @@
 		<module>californium-osgi</module>
 		<module>demo-apps</module>
 		<module>demo-certs</module>
-		<module>legal</module>
 		<module>cf-oscore</module>
-        <module>cf-pubsub</module>
-    </modules>
+		<module>cf-pubsub</module>
+	</modules>
 
 	<build>
 		<pluginManagement>
@@ -344,6 +345,13 @@
 					<artifactId>maven-assembly-plugin</artifactId>
 					<version>3.1.1</version>
 					<inherited>true</inherited>
+					<dependencies>
+						<dependency>
+							<groupId>${project.groupId}</groupId>
+							<artifactId>californium-assembly</artifactId>
+							<version>${project.version}</version>
+						</dependency>
+					</dependencies>
 					<configuration>
 						<appendAssemblyId>false</appendAssemblyId>
 						<attach>false</attach>
@@ -353,9 +361,9 @@
 								<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
 							</manifest>
 						</archive>
-						<descriptors>
-							<descriptor>enhanced-jar-with-dependencies.xml</descriptor>
-						</descriptors>
+						<descriptorRefs>
+							<descriptorRef>enhanced-jar-with-dependencies</descriptorRef>
+						</descriptorRefs>
 					</configuration>
 					<executions>
 						<execution>

--- a/scandium-core/pom.xml
+++ b/scandium-core/pom.xml
@@ -157,9 +157,9 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
-					<descriptors>
-						<descriptor>${project.parent.basedir}/enhanced-jar-with-licenses.xml</descriptor>
-					</descriptors>
+					<descriptorRefs>
+						<descriptorRef>enhanced-jar-with-licenses</descriptorRef>
+					</descriptorRefs>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 					</archive>


### PR DESCRIPTION
Supports starting of  maven builds from submodule folders.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>