### PR TITLE
Fix 1101

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -1934,7 +1934,7 @@ public class DTLSConnector implements Connector, RecordLayer {
 			Handshaker handshaker = connection.getOngoingHandshake();
 			if (handshaker == null) {
 				session = new DTLSSession(peerAddress);
-				session.setVirtualHost(message.getEndpointContext().getVirtualHost());
+				session.setHostName(message.getEndpointContext().getVirtualHost());
 				// no session with peer established nor handshaker started yet,
 				// create new empty session & start handshake
 				handshaker = new ClientHandshaker(session, this, connection, config, maximumTransmissionUnit);
@@ -1980,12 +1980,12 @@ public class DTLSConnector implements Connector, RecordLayer {
 					// that resumption is not supported
 					// https://tools.ietf.org/html/rfc5246#section-7.4.1.3
 					DTLSSession newSession = new DTLSSession(peerAddress);
-					newSession.setVirtualHost(message.getEndpointContext().getVirtualHost());
+					newSession.setHostName(message.getEndpointContext().getVirtualHost());
 					handshaker = new ClientHandshaker(newSession, this, connection, config, maximumTransmissionUnit);
 				} else {
 					DTLSSession resumableSession = new DTLSSession(sessionId, peerAddress, ticket, 0);
 					SecretUtil.destroy(ticket);
-					resumableSession.setVirtualHost(message.getEndpointContext().getVirtualHost());
+					resumableSession.setHostName(message.getEndpointContext().getVirtualHost());
 					handshaker = new ResumingClientHandshaker(resumableSession, this, connection, config,
 							maximumTransmissionUnit);
 				}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -694,9 +694,9 @@ public class ClientHandshaker extends Handshaker {
 
 	protected void addServerNameIndication(final ClientHello helloMessage) {
 
-		if (sniEnabled && session.getVirtualHost() != null) {
-			LOGGER.debug("adding SNI extension to CLIENT_HELLO message [{}]", session.getVirtualHost());
-			helloMessage.addExtension(ServerNameExtension.forHostName(session.getVirtualHost()));
+		if (sniEnabled && session.getServerNames() != null) {
+			LOGGER.debug("adding SNI extension to CLIENT_HELLO message [{}]", session.getHostName());
+			helloMessage.addExtension(ServerNameExtension.forServerNames(session.getServerNames()));
 		}
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -186,7 +186,7 @@ public final class DTLSSession implements Destroyable {
 	private volatile long receiveWindowLowerBoundary = 0;
 	private volatile long receivedRecordsVector = 0;
 	private long creationTime;
-	private String virtualHost;
+	private String hostName;
 	private ServerNames serverNames;
 	private boolean peerSupportsSni;
 
@@ -376,21 +376,23 @@ public final class DTLSSession implements Destroyable {
 	 * 
 	 * @return the host name or {@code null} if this session has not
 	 *         been established for a virtual host.
+	 * @see #getServerNames()
 	 */
-	public String getVirtualHost() {
-		return virtualHost;
+	public String getHostName() {
+		return hostName;
 	}
 
 	/**
 	 * Set the (virtual) host name for the server that this session has been
 	 * established for.
 	 * <p>
+	 * Sets the {@link #setServerNames(ServerNames)} accordingly.
 	 * 
 	 * @param hostname the virtual host name at the peer (may be {@code null}).
 	 */
-	public void setVirtualHost(String hostname) {
+	public void setHostName(String hostname) {
 		this.serverNames = null;
-		this.virtualHost = hostname;
+		this.hostName = hostname;
 		if (hostname != null) {
 			this.serverNames = ServerNames
 					.newInstance(ServerName.from(NameType.HOST_NAME, hostname.getBytes(ServerName.CHARSET)));
@@ -402,6 +404,7 @@ public final class DTLSSession implements Destroyable {
 	 * has been established for.
 	 * 
 	 * @return server names, or {@code null}, if not used.
+	 * @see #getHostName()
 	 */
 	public ServerNames getServerNames() {
 		return serverNames;
@@ -411,16 +414,17 @@ public final class DTLSSession implements Destroyable {
 	 * Set the server names for the server that this session has been
 	 * established for.
 	 * <p>
+	 * Sets the {@link #setHostName(String)} accordingly.
 	 * 
 	 * @param serverNames the server names (may be {@code null}).
 	 */
 	public void setServerNames(ServerNames serverNames) {
-		this.virtualHost = null;
+		this.hostName = null;
 		this.serverNames = serverNames;
 		if (serverNames != null) {
 			ServerName serverName = serverNames.getServerName(NameType.HOST_NAME);
 			if (serverName != null) {
-				virtualHost = serverName.getNameAsString();
+				hostName = serverName.getNameAsString();
 			}
 		}
 	}
@@ -443,13 +447,13 @@ public final class DTLSSession implements Destroyable {
 
 	public DtlsEndpointContext getConnectionWriteContext() {
 		String id = sessionIdentifier.isEmpty() ? "TIME:" + Long.toString(creationTime) : sessionIdentifier.toString();
-		return new DtlsEndpointContext(peer, virtualHost, peerIdentity, id, Integer.toString(writeEpoch),
+		return new DtlsEndpointContext(peer, hostName, peerIdentity, id, Integer.toString(writeEpoch),
 				cipherSuite.name(), handshakeTimeTag);
 	}
 
 	public DtlsEndpointContext getConnectionReadContext() {
 		String id = sessionIdentifier.isEmpty() ? "TIME:" + Long.toString(creationTime) : sessionIdentifier.toString();
-		return new DtlsEndpointContext(peer, virtualHost, peerIdentity, id, Integer.toString(readEpoch),
+		return new DtlsEndpointContext(peer, hostName, peerIdentity, id, Integer.toString(readEpoch),
 				cipherSuite.name(), handshakeTimeTag);
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerNameExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerNameExtension.java
@@ -21,8 +21,6 @@ import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
-import org.eclipse.californium.scandium.util.ServerName;
-import org.eclipse.californium.scandium.util.ServerName.NameType;
 import org.eclipse.californium.scandium.util.ServerNames;
 
 /**
@@ -66,22 +64,6 @@ public final class ServerNameExtension extends HelloExtension {
 	 */
 	public static ServerNameExtension emptyServerNameIndication() {
 		return new ServerNameExtension();
-	}
-
-	/**
-	 * Creates a new instance for a single server's host name.
-	 * <p>
-	 * This method should be used by a client that wants to include the <em>Server Name Indication</em>
-	 * extension in its <em>CLIENT_HELLO</em> handshake message.
-	 * 
-	 * @param hostName The host name of the server. NB: The host name MUST only contain ASCII characters,
-	 *                 non-ASCII characters will be replaced by {@code StandardCharsets.US_ASCII}'s default
-	 *                 replacement byte.
-	 * @return The new instance.
-	 * @throws NullPointerException if the host name is {@code null}.
-	 */
-	public static ServerNameExtension forHostName(final String hostName) {
-		return new ServerNameExtension(ServerNames.newInstance(ServerName.from(NameType.HOST_NAME, hostName.getBytes(ServerName.CHARSET))));
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/pskstore/InMemoryPskStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/pskstore/InMemoryPskStore.java
@@ -95,7 +95,10 @@ public class InMemoryPskStore implements PskStore {
 		} else {
 			synchronized (scopedKeys) {
 				for (ServerName serverName : serverNames) {
-					return getKeyFromMapAndNormalizeIdentity(identity, scopedKeys.get(serverName));
+					SecretKey secretKey = getKeyFromMapAndNormalizeIdentity(identity, scopedKeys.get(serverName));
+					if (secretKey != null) {
+						return secretKey;
+					}
 				}
 				return null;
 			}
@@ -420,7 +423,7 @@ public class InMemoryPskStore implements PskStore {
 		} else if (peerAddress == null) {
 			throw new NullPointerException("address must not be null");
 		} else {
-			synchronized (scopedKeys) {
+			synchronized (scopedIdentities) {
 				for (ServerName serverName : virtualHost) {
 					PskPublicInformation identity = getIdentityFromMap(serverName, scopedIdentities.get(peerAddress));
 					if (identity != null) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/util/ServerName.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/util/ServerName.java
@@ -34,10 +34,16 @@ public class ServerName {
 
 	private final NameType type;
 	private final byte[] name;
+	private final int hashCode;
 
 	private ServerName(final NameType type, final byte[] name) {
+		if (type == null) {
+			throw new NullPointerException("Name type must be provided!");
+		}
 		this.type = type;
 		this.name = name;
+		this.hashCode = 31 * Arrays.hashCode(name) + type.hashCode();
+		
 	}
 
 	/**
@@ -113,11 +119,7 @@ public class ServerName {
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + Arrays.hashCode(name);
-		result = prime * result + ((type == null) ? 0 : type.hashCode());
-		return result;
+		return hashCode;
 	}
 
 	/**
@@ -164,7 +166,7 @@ public class ServerName {
 		 */
 		UNDEFINED((byte) 0xFF);
 
-		private byte code;
+		private final byte code;
 
 		private NameType(final byte code) {
 			this.code = code;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/util/ServerNames.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/util/ServerNames.java
@@ -60,9 +60,23 @@ public final class ServerNames implements Iterable<ServerName> {
 	 */
 	public static ServerNames newInstance(final ServerName serverName) {
 		if (serverName == null) {
-			throw new NullPointerException("name must not be null");
+			throw new NullPointerException("server name must not be null");
 		} else {
 			return new ServerNames(serverName);
+		}
+	}
+
+	/**
+	 * Creates a new server name list from an initial host name.
+	 * 
+	 * @param hostName The host name to add as {@link NameType#HOST_NAME}.
+	 * @return The new instance.
+	 */
+	public static ServerNames newInstance(final String hostName) {
+		if (hostName == null) {
+			throw new NullPointerException("host name must not be null");
+		} else {
+			return new ServerNames(ServerName.from(NameType.HOST_NAME, hostName.getBytes(ServerName.CHARSET)));
 		}
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -92,6 +92,7 @@ public class ConnectorHelper {
 
 	static final String SERVERNAME							= "my.test.server";
 	static final String	SCOPED_CLIENT_IDENTITY				= "My_client_identity";
+	static final String	SCOPED_CLIENT_IDENTITY_SECRET		= "mySecretPSK";
 	static final String	CLIENT_IDENTITY						= "Client_identity";
 	static final String	CLIENT_IDENTITY_SECRET				= "secretPSK";
 	static final int	MAX_TIME_TO_WAIT_SECS				= 2;
@@ -153,7 +154,7 @@ public class ConnectorHelper {
 
 		InMemoryPskStore pskStore = new InMemoryPskStore();
 		pskStore.setKey(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes());
-		pskStore.setKey(SCOPED_CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes(), SERVERNAME);
+		pskStore.setKey(SCOPED_CLIENT_IDENTITY, SCOPED_CLIENT_IDENTITY_SECRET.getBytes(), SERVERNAME);
 
 		builder.setAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0))
 				.setIdentity(DtlsTestTools.getPrivateKey(), DtlsTestTools.getServerCertificateChain(), CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509)

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorHandshakeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorHandshakeTest.java
@@ -22,6 +22,7 @@ import static org.eclipse.californium.scandium.ConnectorHelper.CLIENT_IDENTITY;
 import static org.eclipse.californium.scandium.ConnectorHelper.CLIENT_IDENTITY_SECRET;
 import static org.eclipse.californium.scandium.ConnectorHelper.MAX_TIME_TO_WAIT_SECS;
 import static org.eclipse.californium.scandium.ConnectorHelper.SCOPED_CLIENT_IDENTITY;
+import static org.eclipse.californium.scandium.ConnectorHelper.SCOPED_CLIENT_IDENTITY_SECRET;
 import static org.eclipse.californium.scandium.ConnectorHelper.SERVERNAME;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -332,7 +333,7 @@ public class DTLSConnectorHandshakeTest {
 	@Test
 	public void testPskHandshakeWithServernameClientWithSniAndServerWithSni() throws Exception {
 		startServer(true, true, false, null);
-		startClientPsk(true, SERVERNAME, null, new StaticPskStore(SCOPED_CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes()));
+		startClientPsk(true, SERVERNAME, null, new StaticPskStore(SCOPED_CLIENT_IDENTITY, SCOPED_CLIENT_IDENTITY_SECRET.getBytes()));
 		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
 		Principal principal = endpointContext.getPeerIdentity();
 		assertThat(principal, is(notNullValue()));

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
@@ -244,7 +244,7 @@ public class ClientHandshakerTest {
 		}
 		Connection connection = new Connection(peer, new SyncSerialExecutor());
 		DTLSSession session = new DTLSSession(peer);
-		session.setVirtualHost(virtualHost);
+		session.setHostName(virtualHost);
 		handshaker = new ClientHandshaker(
 				session,
 				recordLayer,

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DTLSSessionTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DTLSSessionTest.java
@@ -239,7 +239,7 @@ public class DTLSSessionTest {
 	public void testSessionWithServerNamesCanBeResumedFromSessionTicket() throws GeneralSecurityException {
 		// GIVEN a session ticket for an established server session
 		session = newEstablishedServerSession(PEER_ADDRESS, CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8, true);
-		session.setVirtualHost("test");
+		session.setHostName("test");
 		SessionTicket ticket = session.getSessionTicket();
 
 		// WHEN creating a new session to be resumed from the ticket
@@ -266,7 +266,7 @@ public class DTLSSessionTest {
 	public void testSessionWithServerNamesCanBeResumedFromSerializedSessionTicket() throws GeneralSecurityException {
 		// GIVEN a session ticket for an established server session
 		session = newEstablishedServerSession(PEER_ADDRESS, CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8, true);
-		session.setVirtualHost("test");
+		session.setHostName("test");
 		SessionTicket ticket = serialize(session.getSessionTicket());
 
 		// WHEN creating a new session to be resumed from the ticket

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/PskUtilTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/PskUtilTest.java
@@ -64,7 +64,7 @@ public class PskUtilTest {
 
 		session = new DTLSSession(LOCALHOST);
 		sessionWithVirtualServer = new DTLSSession(LOCALHOST);
-		sessionWithVirtualServer.setVirtualHost(VIRTUAL_HOST);
+		sessionWithVirtualServer.setHostName(VIRTUAL_HOST);
 		sessionWithVirtualServer.setSniSupported(true);
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/PskUtilTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/PskUtilTest.java
@@ -1,0 +1,196 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation
+ *******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+
+import javax.crypto.SecretKey;
+
+import org.eclipse.californium.scandium.category.Small;
+import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
+import org.eclipse.californium.scandium.util.SecretUtil;
+import org.eclipse.californium.scandium.util.ServerName;
+import org.eclipse.californium.scandium.util.ServerName.NameType;
+import org.eclipse.californium.scandium.util.ServerNames;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Small.class)
+public class PskUtilTest {
+
+	private static final String VIRTUAL_HOST = "californium";
+	private static final InetSocketAddress LOCALHOST = new InetSocketAddress(InetAddress.getLoopbackAddress(), 5684);
+	private static final ServerNames SERVER_NAMES = ServerNames
+			.newInstance(ServerName.from(NameType.HOST_NAME, VIRTUAL_HOST.getBytes(ServerName.CHARSET)));
+	private static final PskPublicInformation IDENTITY = new PskPublicInformation("me");
+	private static final PskPublicInformation SCOPED_IDENTITY = new PskPublicInformation("cali.me");
+	private static final SecretKey KEY = SecretUtil.create("secret".getBytes(), "PSK");
+	private static final SecretKey SCOPED_KEY = SecretUtil.create("cali.secret".getBytes(), "PSK");
+
+	private DTLSSession session;
+	private DTLSSession sessionWithVirtualServer;
+	private PskStore pskStore;
+	private PskUtil util;
+
+	@Before
+	public void init() {
+		pskStore = mock(PskStore.class);
+
+		when(pskStore.getIdentity(LOCALHOST)).thenReturn(IDENTITY);
+		when(pskStore.getKey(IDENTITY)).thenReturn(SecretUtil.create(KEY));
+		when(pskStore.getIdentity(LOCALHOST, SERVER_NAMES)).thenReturn(SCOPED_IDENTITY);
+		when(pskStore.getKey(SERVER_NAMES, SCOPED_IDENTITY)).thenReturn(SecretUtil.create(SCOPED_KEY));
+
+		session = new DTLSSession(LOCALHOST);
+		sessionWithVirtualServer = new DTLSSession(LOCALHOST);
+		sessionWithVirtualServer.setVirtualHost(VIRTUAL_HOST);
+		sessionWithVirtualServer.setSniSupported(true);
+	}
+
+	@After
+	public void cleanup() {
+		SecretUtil.destroy(util);
+	}
+
+	@Test
+	public void testClientGetPlainIdentity() throws HandshakeException {
+		util = new PskUtil(false, session, pskStore);
+		assertThat(util.getPskPublicIdentity(), is(IDENTITY));
+		verify(pskStore, times(1)).getIdentity(LOCALHOST);
+		verify(pskStore, never()).getIdentity((InetSocketAddress) anyObject(), (ServerNames) anyObject());
+		verify(pskStore, times(1)).getKey(IDENTITY);
+		verify(pskStore, never()).getKey((ServerNames) anyObject(), (PskPublicInformation) anyObject());
+		SecretKey premasterSecret = util.generatePremasterSecretFromPSK(null);
+		assertThat(premasterSecret, is(notNullValue()));
+	}
+
+	@Test
+	public void testClientGetPlainIdentityWithVirtualServer() throws HandshakeException {
+		util = new PskUtil(false, sessionWithVirtualServer, pskStore);
+		assertThat(util.getPskPublicIdentity(), is(IDENTITY));
+		verify(pskStore, times(1)).getIdentity(LOCALHOST);
+		verify(pskStore, never()).getIdentity((InetSocketAddress) anyObject(), (ServerNames) anyObject());
+		verify(pskStore, times(1)).getKey(IDENTITY);
+		verify(pskStore, never()).getKey((ServerNames) anyObject(), (PskPublicInformation) anyObject());
+		SecretKey premasterSecret = util.generatePremasterSecretFromPSK(null);
+		assertThat(premasterSecret, is(notNullValue()));
+	}
+
+	@Test
+	public void testClientGetSniIdentity() throws HandshakeException {
+		util = new PskUtil(true, session, pskStore);
+		assertThat(util.getPskPublicIdentity(), is(IDENTITY));
+		verify(pskStore, times(1)).getIdentity(LOCALHOST);
+		verify(pskStore, never()).getIdentity((InetSocketAddress) anyObject(), (ServerNames) anyObject());
+		verify(pskStore, times(1)).getKey(IDENTITY);
+		verify(pskStore, never()).getKey((ServerNames) anyObject(), (PskPublicInformation) anyObject());
+		SecretKey premasterSecret = util.generatePremasterSecretFromPSK(null);
+		assertThat(premasterSecret, is(notNullValue()));
+	}
+
+	@Test
+	public void testClientGetSniIdentityWithVirtualServer() throws HandshakeException {
+		util = new PskUtil(true, sessionWithVirtualServer, pskStore);
+		assertThat(util.getPskPublicIdentity(), is(SCOPED_IDENTITY));
+		verify(pskStore, times(1)).getIdentity(LOCALHOST, SERVER_NAMES);
+		verify(pskStore, never()).getIdentity((InetSocketAddress) anyObject());
+		verify(pskStore, times(1)).getKey(SERVER_NAMES, SCOPED_IDENTITY);
+		verify(pskStore, never()).getKey((PskPublicInformation) anyObject());
+		SecretKey premasterSecret = util.generatePremasterSecretFromPSK(null);
+		assertThat(premasterSecret, is(notNullValue()));
+	}
+
+	@Test
+	public void testServerGetPlainIdentity() throws HandshakeException {
+		util = new PskUtil(false, session, pskStore, IDENTITY);
+		assertThat(util.getPskPublicIdentity(), is(IDENTITY));
+		verify(pskStore, never()).getIdentity((InetSocketAddress) anyObject());
+		verify(pskStore, never()).getIdentity((InetSocketAddress) anyObject(), (ServerNames) anyObject());
+		verify(pskStore, times(1)).getKey(IDENTITY);
+		verify(pskStore, never()).getKey((ServerNames) anyObject(), (PskPublicInformation) anyObject());
+		SecretKey premasterSecret = util.generatePremasterSecretFromPSK(null);
+		assertThat(premasterSecret, is(notNullValue()));
+	}
+
+	@Test
+	public void testServerGetPlainIdentityWithVirtualServer() throws HandshakeException {
+		util = new PskUtil(false, sessionWithVirtualServer, pskStore, IDENTITY);
+		assertThat(util.getPskPublicIdentity(), is(IDENTITY));
+		verify(pskStore, never()).getIdentity((InetSocketAddress) anyObject());
+		verify(pskStore, never()).getIdentity((InetSocketAddress) anyObject(), (ServerNames) anyObject());
+		verify(pskStore, times(1)).getKey(IDENTITY);
+		verify(pskStore, never()).getKey((ServerNames) anyObject(), (PskPublicInformation) anyObject());
+		SecretKey premasterSecret = util.generatePremasterSecretFromPSK(null);
+		assertThat(premasterSecret, is(notNullValue()));
+	}
+
+	@Test
+	public void testServerGetSniIdentity() throws HandshakeException {
+		util = new PskUtil(true, session, pskStore, IDENTITY);
+		assertThat(util.getPskPublicIdentity(), is(IDENTITY));
+		verify(pskStore, never()).getIdentity((InetSocketAddress) anyObject());
+		verify(pskStore, never()).getIdentity((InetSocketAddress) anyObject(), (ServerNames) anyObject());
+		verify(pskStore, times(1)).getKey(IDENTITY);
+		verify(pskStore, never()).getKey((ServerNames) anyObject(), (PskPublicInformation) anyObject());
+		SecretKey premasterSecret = util.generatePremasterSecretFromPSK(null);
+		assertThat(premasterSecret, is(notNullValue()));
+	}
+
+	@Test
+	public void testServerGetSniIdentityWithVirtualServer() throws HandshakeException {
+		util = new PskUtil(true, sessionWithVirtualServer, pskStore, SCOPED_IDENTITY);
+		assertThat(util.getPskPublicIdentity(), is(SCOPED_IDENTITY));
+		verify(pskStore, never()).getIdentity((InetSocketAddress) anyObject());
+		verify(pskStore, never()).getIdentity((InetSocketAddress) anyObject(), (ServerNames) anyObject());
+		verify(pskStore, never()).getKey((PskPublicInformation) anyObject());
+		verify(pskStore, times(1)).getKey(SERVER_NAMES, SCOPED_IDENTITY);
+		SecretKey premasterSecret = util.generatePremasterSecretFromPSK(null);
+		assertThat(premasterSecret, is(notNullValue()));
+	}
+
+	@Test
+	public void testGeneratePremasterSecret() throws HandshakeException {
+		util = new PskUtil(false, session, pskStore, IDENTITY);
+		SecretKey premasterSecret = util.generatePremasterSecretFromPSK(null);
+		assertThat(premasterSecret, is(notNullValue()));
+		SecretKey premasterSecret2 = util.generatePremasterSecretFromPSK(null);
+		assertThat(premasterSecret2, is(notNullValue()));
+		assertArrayEquals(premasterSecret.getEncoded(), premasterSecret2.getEncoded());
+
+		SecretKey premasterSecret3 = util.generatePremasterSecretFromPSK(KEY);
+		assertThat(premasterSecret3, is(notNullValue()));
+		SecretKey premasterSecret4 = util.generatePremasterSecretFromPSK(KEY);
+		assertThat(premasterSecret4, is(notNullValue()));
+		assertArrayEquals(premasterSecret3.getEncoded(), premasterSecret4.getEncoded());
+		assertFalse(Arrays.equals(premasterSecret2.getEncoded(), premasterSecret4.getEncoded()));
+
+		SecretKey premasterSecret5 = util.generatePremasterSecretFromPSK(SCOPED_KEY);
+		assertThat(premasterSecret5, is(notNullValue()));
+		SecretKey premasterSecret6 = util.generatePremasterSecretFromPSK(SCOPED_KEY);
+		assertThat(premasterSecret6, is(notNullValue()));
+		assertArrayEquals(premasterSecret5.getEncoded(), premasterSecret6.getEncoded());
+		assertFalse(Arrays.equals(premasterSecret2.getEncoded(), premasterSecret6.getEncoded()));
+		assertFalse(Arrays.equals(premasterSecret4.getEncoded(), premasterSecret6.getEncoded()));
+	}
+}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerNameExtensionTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerNameExtensionTest.java
@@ -26,6 +26,7 @@ import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.scandium.category.Small;
 import org.eclipse.californium.scandium.dtls.HelloExtension.ExtensionType;
 import org.eclipse.californium.scandium.util.ServerName;
+import org.eclipse.californium.scandium.util.ServerNames;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -86,7 +87,7 @@ public class ServerNameExtensionTest {
 	public void testToByteArrayResultCanBeParsedIntoExtensionAgain() throws HandshakeException {
 
 		// GIVEN a serialized server name extension object
-		ServerNameExtension ext = ServerNameExtension.forHostName("iot.eclipse.org");
+		ServerNameExtension ext = ServerNameExtension.forServerNames(ServerNames.newInstance("iot.eclipse.org"));
 		ByteBuffer b = ByteBuffer.allocate(1024);
 		writeLength(ext.getLength(), b); //extension length
 		b.put(ext.toByteArray());


### PR DESCRIPTION
Fix issue #1101 

Cleanup naming virtualhost/servernames

Add ServerNames.newInstance(final String hostName) and remove
ServerNameExtension.forHostName(final String hostName).

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>
