### PR TITLE
Fix unknown signature- and hashalgorithms

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
@@ -37,11 +37,8 @@ import javax.security.auth.x500.X500Principal;
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.elements.util.StringUtil;
-import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm.HashAlgorithm;
-import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm.SignatureAlgorithm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * A non-anonymous server can optionally request a certificate from the client,
@@ -219,8 +216,7 @@ public final class CertificateRequest extends HandshakeMessage {
 		while (rangeReader.bytesAvailable()) {
 			int codeHash = rangeReader.read(SUPPORTED_SIGNATURE_BITS);
 			int codeSignature = rangeReader.read(SUPPORTED_SIGNATURE_BITS);
-			supportedSignatureAlgorithms.add(new SignatureAndHashAlgorithm(HashAlgorithm.getAlgorithmByCode(codeHash),
-					SignatureAlgorithm.getAlgorithmByCode(codeSignature)));
+			supportedSignatureAlgorithms.add(new SignatureAndHashAlgorithm(codeHash, codeSignature));
 		}
 
 		List<X500Principal> certificateAuthorities = new ArrayList<>();

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -527,7 +527,7 @@ public class ServerHandshaker extends Handshaker {
 
 			// TODO make this variable, reasonable values
 			certificateRequest.addCertificateType(ClientCertificateType.ECDSA_SIGN);
-			certificateRequest.addSignatureAlgorithm(new SignatureAndHashAlgorithm(signatureAndHashAlgorithm.getHash(), signatureAndHashAlgorithm.getSignature()));
+			certificateRequest.addSignatureAlgorithm(signatureAndHashAlgorithm);
 			if (certificateVerifier != null) {
 				certificateRequest.addCertificateAuthorities(certificateVerifier.getAcceptedIssuers());
 			}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SignatureAndHashAlgorithm.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SignatureAndHashAlgorithm.java
@@ -117,17 +117,28 @@ public final class SignatureAndHashAlgorithm {
 
 	private final HashAlgorithm hash;
 	private final SignatureAlgorithm signature;
+	private final int hashAlgorithmCode;
+	private final int signatureAlgorithmCode;
 
 	/**
 	 * Creates an instance for a hash and signature algorithm.
 	 * 
 	 * @param hashAlgorithm The hash algorithm.
 	 * @param signatureAlgorithm The signature algorithm.
+	 * @throws NullPointerException if one of the provided arguments was
+	 *             {@code null}
 	 */
 	public SignatureAndHashAlgorithm(HashAlgorithm hashAlgorithm, SignatureAlgorithm signatureAlgorithm) {
-
-		this.signature = signatureAlgorithm;
+		if (hashAlgorithm == null) {
+			throw new NullPointerException("Hash Algorithm must not be null!");
+		}
+		if (signatureAlgorithm == null) {
+			throw new NullPointerException("Signature Algorithm must not be null!");
+		}
 		this.hash = hashAlgorithm;
+		this.signature = signatureAlgorithm;
+		this.hashAlgorithmCode = hashAlgorithm.getCode();
+		this.signatureAlgorithmCode = signatureAlgorithm.getCode();
 	}
 
 	/**
@@ -139,6 +150,8 @@ public final class SignatureAndHashAlgorithm {
 	 *            the signature algorithm's code.
 	 */
 	public SignatureAndHashAlgorithm(int hashAlgorithmCode, int signatureAlgorithmCode) {
+		this.hashAlgorithmCode = hashAlgorithmCode;
+		this.signatureAlgorithmCode = signatureAlgorithmCode;
 		this.signature = SignatureAlgorithm.getAlgorithmByCode(signatureAlgorithmCode);
 		this.hash = HashAlgorithm.getAlgorithmByCode(hashAlgorithmCode);
 	}
@@ -175,6 +188,18 @@ public final class SignatureAndHashAlgorithm {
 	 * @return The name.
 	 */
 	public String jcaName() {
-		return hash.toString() + "with" + signature.toString();
+		StringBuilder name = new StringBuilder();
+		if (hash != null) {
+			name.append(hash);
+		} else {
+			name.append(String.format("0x%02x", hashAlgorithmCode));
+		}
+		name.append("with");
+		if (signature != null) {
+			name.append(signature);
+		} else {
+			name.append(String.format("0x%02x", signatureAlgorithmCode));
+		}
+		return name.toString();
 	}
 }


### PR DESCRIPTION
Fix NullPointerExceptions caused by unknown signature- and hashalgorithms during logging. Extending openssl interoperability tests uncovered this issue. 

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>