### PR TITLE
Check for emtpy server certificate.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -1304,6 +1304,12 @@ public abstract class Handshaker implements Destroyable {
 	 */
 	public void verifyCertificate(CertificateMessage message) throws HandshakeException {
 		if (message.getCertificateChain() != null) {
+			if (isClient && message.getCertificateChain().getCertificates().isEmpty()) {
+				LOGGER.debug("Certificate validation failed: empty server certificate!");
+				AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.BAD_CERTIFICATE,
+						session.getPeer());
+				throw new HandshakeException("Empty server certificate!", alert);
+			}
 			if (certificateVerifier != null) {
 				certificateVerifier.verifyCertificate(message, session);
 			} else {


### PR DESCRIPTION
Fail handshake, if server doesn't provide a certificate.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>