### PR TITLE
OSCORE: Update JUnit test for secure re-generation of contexts

### DIFF
--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
@@ -329,13 +329,9 @@ public class ContextRederivation {
 			OSCoreCtx newCtx = rederiveWithContextID(ctx, protectContextID);
 			newCtx.setReceiverSeq(0);
 
-			// In outgoing response from this context, only use R2 as
-			// Context ID (not concatenated one used to generate the
-			// context)
+			// Outgoing response from this context only uses R2 as
+			// Context ID (not concatenated one used to generate the context)
 			newCtx.setIncludeContextId(contextR2);
-
-			// Retain the context re-derivation key
-			newCtx.setContextRederivationKey(ctx.getContextRederivationKey());
 
 			// Respond with new partial IV
 			newCtx.setResponsesIncludePartialIV(true);
@@ -353,14 +349,17 @@ public class ContextRederivation {
 
 	/**
 	 * Re-derive a context with the same input parameters except Context ID.
+	 * Also retain the same context re-derivation key.
 	 * 
 	 * @param ctx the OSCORE context to re-derive
 	 * @param contextID the new context ID to use
 	 * @return the new re-derived context
 	 */
 	private static OSCoreCtx rederiveWithContextID(OSCoreCtx ctx, byte[] contextID) throws OSException {
-		return new OSCoreCtx(ctx.getMasterSecret(), true, ctx.getAlg(), ctx.getSenderId(), ctx.getRecipientId(),
-				ctx.getKdf(), ctx.getRecipientReplaySize(), ctx.getSalt(), contextID);
+		OSCoreCtx newCtx = new OSCoreCtx(ctx.getMasterSecret(), true, ctx.getAlg(), ctx.getSenderId(),
+				ctx.getRecipientId(), ctx.getKdf(), ctx.getRecipientReplaySize(), ctx.getSalt(), contextID);
+		newCtx.setContextRederivationKey(ctx.getContextRederivationKey());
+		return newCtx;
 	}
 
 	/**

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
@@ -140,6 +140,8 @@ public class ContextRederivationTest {
 		// Length of Context ID in context
 		int contextIdLen = currCtx.getIdContext().length;
 		assertEquals(3 * SEGMENT_LENGTH, contextIdLen);
+		// Check length of Context ID in the request
+		assertEquals(3 * SEGMENT_LENGTH, requestTestObserver.requestIdContext.length);
 
 		// Check R2 value derived by server using its key with received one
 		// The R2 value is composed of S2 || HMAC(K_HMAC, S2).
@@ -179,13 +181,12 @@ public class ContextRederivationTest {
 	 */
 	private static class RequestTestObserver extends MessageObserverAdapter {
 
+		public byte[] requestIdContext;
+
 		@Override
 		public void onContextEstablished(EndpointContext endpointContext) {
-			byte[] requestIdContext = StringUtil
+			requestIdContext = StringUtil
 					.hex2ByteArray(endpointContext.get(OSCoreEndpointContextInfo.OSCORE_CONTEXT_ID));
-
-			// Check length of Context ID in the request
-			assertEquals(3 * SEGMENT_LENGTH, requestIdContext.length);
 		}
 	}
 

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
@@ -21,15 +21,20 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
+import java.util.Arrays;
+
 import org.eclipse.californium.TestTools;
 import org.eclipse.californium.core.CoapClient;
 import org.eclipse.californium.core.CoapResponse;
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.Utils;
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.exception.ConnectorException;
 import org.eclipse.californium.elements.util.Bytes;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.oscore.ContextRederivation.PHASE;
 import org.eclipse.californium.rule.CoapNetworkRule;
 import org.junit.After;
@@ -44,15 +49,16 @@ import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.EndpointManager;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.cose.AlgorithmID;
+import org.eclipse.californium.cose.CoseException;
 
 /**
- * Class that implements test of functionality for re-derivation of contexts.
- * As detailed in Appendix B.2. of the OSCORE draft:
- * https://tools.ietf.org/html/draft-ietf-core-object-security-16#appendix-B.2
+ * Class that implements test of functionality for re-derivation of contexts. As
+ * detailed in Appendix B.2. of the OSCORE RFC:
+ * https://tools.ietf.org/html/rfc8613#appendix-B.2
  *
  * This can for instance be used when one device has lost power and information
- * about the mutable parts of a context (e.g. sequence number) but retains information
- * about static parts (e.g. master secret)
+ * about the mutable parts of a context (e.g. sequence number) but retains
+ * information about static parts (e.g. master secret)
  * 
  */
 public class ContextRederivationTest {
@@ -79,6 +85,7 @@ public class ContextRederivationTest {
 	private final static byte[] rid = new byte[] { 0x01 };
 
 	private static int SEGMENT_LENGTH = ContextRederivation.SEGMENT_LENGTH;
+	private static byte[] requestIdContext;
 
 	@Before
 	public void initLogger() {
@@ -106,9 +113,10 @@ public class ContextRederivationTest {
 	 * @throws OSException
 	 * @throws ConnectorException
 	 * @throws IOException
+	 * @throws CoseException
 	 */
 	@Test
-	public void rederivationTest() throws OSException, ConnectorException, IOException {
+	public void rederivationTest() throws OSException, ConnectorException, IOException, CoseException {
 		
 		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, null);
 		String serverUri = serverEndpoint.getUri().toASCIIString();
@@ -120,6 +128,8 @@ public class ContextRederivationTest {
 		CoapClient c = new CoapClient(serverUri + hello1);
 		Request r = new Request(Code.GET);
 		r.getOptions().setOscore(Bytes.EMPTY);
+		RequestTestObserver requestTestObserver = new RequestTestObserver();
+		r.addMessageObserver(requestTestObserver);
 		CoapResponse resp = c.advanced(r);
 
 		System.out.println((Utils.prettyPrint(resp)));
@@ -127,15 +137,24 @@ public class ContextRederivationTest {
 		OSCoreCtx currCtx = dbClient.getContext(serverUri);
 		assertEquals(ContextRederivation.PHASE.INACTIVE, currCtx.getContextRederivationPhase()); // Phase
 		assertFalse(currCtx.getIncludeContextId()); // Do not include Context ID
-		int contextIDLen = currCtx.getIdContext().length;
-		// Length of Context ID in context
-		assertEquals(3 * SEGMENT_LENGTH, contextIDLen);
-//		byte[] oscoreOption = resp.getOptions().getOscore();
-		// OSCORE option in response is 2 * SEGMENT_LENGTH (R2 as Context ID) +
-		// 2 additional bytes
-//		assertEquals(2 * SEGMENT_LENGTH + 2, oscoreOption.length);
 
-		// Empty OSCORE option
+		// Length of Context ID in context
+		int contextIdLen = currCtx.getIdContext().length;
+		assertEquals(3 * SEGMENT_LENGTH, contextIdLen);
+		// Length of Context ID in context in the request
+		assertEquals(3 * SEGMENT_LENGTH, requestIdContext.length);
+
+		// Check R2 value derived by server using its key with received one
+		// The R2 value is composed of S2 || HMAC(K_HMAC, S2).
+		OSCoreCtx serverCtx = dbServer.getContext(sid);
+		byte[] srvContextRederivationKey = serverCtx.getContextRederivationKey();
+		byte[] contextS2 = Arrays.copyOfRange(currCtx.getIdContext(), 0, SEGMENT_LENGTH);
+		byte[] hmacOutput = OSCoreCtx.deriveKey(srvContextRederivationKey, srvContextRederivationKey, SEGMENT_LENGTH,
+				"SHA256", contextS2);
+		byte[] messageHmacValue = Arrays.copyOfRange(currCtx.getIdContext(), SEGMENT_LENGTH, SEGMENT_LENGTH * 2);
+		assertArrayEquals(hmacOutput, messageHmacValue);
+
+		// Empty OSCORE option in response
 		assertArrayEquals(Bytes.EMPTY, resp.getOptions().getOscore());
 
 		assertEquals(ResponseCode.CONTENT, resp.getCode());
@@ -154,6 +173,20 @@ public class ContextRederivationTest {
 		System.out.println((Utils.prettyPrint(resp)));
 
 		c.shutdown();
+	}
+
+	/**
+	 * Message observer that will save the ID Context used in the outgoing
+	 * request from the client for comparison.
+	 *
+	 */
+	private static class RequestTestObserver extends MessageObserverAdapter {
+
+		@Override
+		public void onContextEstablished(EndpointContext endpointContext) {
+			requestIdContext = StringUtil
+					.hex2ByteArray(endpointContext.get(OSCoreEndpointContextInfo.OSCORE_CONTEXT_ID));
+		}
 	}
 
 	/**

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
@@ -85,7 +85,6 @@ public class ContextRederivationTest {
 	private final static byte[] rid = new byte[] { 0x01 };
 
 	private static int SEGMENT_LENGTH = ContextRederivation.SEGMENT_LENGTH;
-	private static byte[] requestIdContext;
 
 	@Before
 	public void initLogger() {
@@ -141,8 +140,6 @@ public class ContextRederivationTest {
 		// Length of Context ID in context
 		int contextIdLen = currCtx.getIdContext().length;
 		assertEquals(3 * SEGMENT_LENGTH, contextIdLen);
-		// Length of Context ID in context in the request
-		assertEquals(3 * SEGMENT_LENGTH, requestIdContext.length);
 
 		// Check R2 value derived by server using its key with received one
 		// The R2 value is composed of S2 || HMAC(K_HMAC, S2).
@@ -184,8 +181,11 @@ public class ContextRederivationTest {
 
 		@Override
 		public void onContextEstablished(EndpointContext endpointContext) {
-			requestIdContext = StringUtil
+			byte[] requestIdContext = StringUtil
 					.hex2ByteArray(endpointContext.get(OSCoreEndpointContextInfo.OSCORE_CONTEXT_ID));
+
+			// Check length of Context ID in the request
+			assertEquals(3 * SEGMENT_LENGTH, requestIdContext.length);
 		}
 	}
 


### PR DESCRIPTION
This pull request updates the JUnit test for the functionality in Appendix B.2. of the OSCORE RFC which describes how to securely re-generate contexts.
https://tools.ietf.org/html/rfc8613#appendix-B.2

It also makes a small update to the context re-derivation procedure to make sure the context rederivation key is kept when contexts are re-generated.
