### PR TITLE
Add handshake probe.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
@@ -69,6 +69,11 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 	 */
 	public static final String HANDSHAKE_MODE_FORCE = "force";
 	/**
+	 * Force handshake probe before send this message. Doesn't start a
+	 * handshake, if the connector is configured to act as server only.
+	 */
+	public static final String HANDSHAKE_MODE_PROBE = "probe";
+	/**
 	 * Don't start a handshake, even, if no session is available.
 	 */
 	public static final String HANDSHAKE_MODE_NONE = "none";

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -1300,6 +1300,31 @@ public abstract class Handshaker implements Destroyable {
 	}
 
 	/**
+	 * Test, if handshake was started in probing mode.
+	 * 
+	 * Usually a resuming client handshake removes the session from the
+	 * connection store with the start. Probing removes the session only with
+	 * the first data received back.
+	 * 
+	 * @return {@code true}, if handshake is in probing mode, {@code false},
+	 *         otherwise.
+	 * @see ResumingClientHandshaker
+	 */
+	public boolean isProbing() {
+		// intended to be overriden by the ResumingClientHandshaker
+		return false;
+	}
+
+	/**
+	 * Reset probing mode, when data is received during.
+	 * 
+	 * @see ResumingClientHandshaker
+	 */
+	public void resetProbing() {
+		// intended to be overriden by the ResumingClientHandshaker
+	}
+
+	/**
 	 * Test, if handshake is expired according nano realtime.
 	 * 
 	 * Used to mitigate deep sleep during handhsakes.


### PR DESCRIPTION
Intended to be used, if connectivity may be the cause for missing responses.
If the 1. handshake flight is not responded, the handshake is cancelled and the session still kept.
(Stop handshake after "deep sleep").

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>