### PR TITLE
Fix close notify processing.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CloseSupportingConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CloseSupportingConnectionStore.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+/**
+ * A connection store which adds support of close notify.
+ */
+public interface CloseSupportingConnectionStore {
+
+	/**
+	 * Remove a connection in the address-table in the store.
+	 * 
+	 * @param connection the connection to update.
+	 * @return {@code true}, if removed, {@code false}, otherwise.
+	 */
+	boolean removeFromAddress(Connection connection);
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
@@ -282,14 +282,17 @@ public final class Connection {
 			this.peerAddress = peerAddress;
 			if (establishedSession != null) {
 				establishedSession.setPeer(peerAddress);
-			} else if (peerAddress == null) {
+			} else if (peerAddress != null) {
+				throw new IllegalArgumentException("Address change without established sesson is not supported!");
+			}
+			if (peerAddress == null) {
 				final Handshaker pendingHandshaker = getOngoingHandshake();
 				if (pendingHandshaker != null) {
-					// this will only call the listener, if no other cause was set before!
-					pendingHandshaker.handshakeFailed(new IOException("address changed!"));
+					if (establishedSession == null || pendingHandshaker.getSession() != establishedSession) {
+						// this will only call the listener, if no other cause was set before!
+						pendingHandshaker.handshakeFailed(new IOException("address changed!"));
+					}
 				}
-			} else {
-				throw new IllegalArgumentException("Address change without established sesson is not supported!");
 			}
 		}
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -1273,10 +1273,10 @@ public abstract class Handshaker implements Destroyable {
 				for (SessionListener sessionListener : sessionListeners) {
 					sessionListener.handshakeFailed(this, cause);
 				}
+				SecretUtil.destroy(session);
 			}
+			SecretUtil.destroy(this);
 		}
-		SecretUtil.destroy(session);
-		SecretUtil.destroy(this);
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -83,7 +83,7 @@ import org.slf4j.LoggerFactory;
  * Storing and reading to/from the store is thread safe.
  * </p>
  */
-public class InMemoryConnectionStore implements ResumptionSupportingConnectionStore {
+public class InMemoryConnectionStore implements ResumptionSupportingConnectionStore, CloseSupportingConnectionStore {
 
 	private static final Logger LOG = LoggerFactory.getLogger(InMemoryConnectionStore.class.getName());
 	private static final int DEFAULT_SMALL_EXTRA_CID_LENGTH = 2; // extra cid bytes additionally to required bytes for small capacity.
@@ -345,6 +345,20 @@ public class InMemoryConnectionStore implements ResumptionSupportingConnectionSt
 			LOG.debug("{}connection: {} - {} update failed!", tag, connection.getConnectionId(), newPeerAddress);
 			return false;
 		}
+	}
+
+	@Override
+	public synchronized boolean removeFromAddress(final Connection connection) {
+		if (connection != null) {
+			InetSocketAddress peerAddress = connection.getPeerAddress();
+			if (peerAddress != null) {
+				LOG.debug("{}connection: {} removed from address {}!", tag, connection.getConnectionId(), peerAddress);
+				connectionsByAddress.remove(peerAddress, connection);
+				connection.updatePeerAddress(null);
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
Remove connection from address table, but keep the session on the server
side. Mark the connection for resumption on the client side.

Fix issue #1163 
Fix issue #948

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>