### PR TITLE
Add revapi maven plugin to build system to check API.

### DIFF
--- a/demo-apps/pom.xml
+++ b/demo-apps/pom.xml
@@ -116,6 +116,13 @@
 					</descriptorRefs>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.revapi</groupId>
+				<artifactId>revapi-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -430,6 +430,18 @@
 					<artifactId>license-maven-plugin</artifactId>
 					<version>1.16</version>
 				</plugin>
+				<plugin>
+					<groupId>org.revapi</groupId>
+					<artifactId>revapi-maven-plugin</artifactId>
+					<version>0.11.2</version>
+					<dependencies>
+						<dependency>
+							<groupId>org.revapi</groupId>
+							<artifactId>revapi-java</artifactId>
+							<version>0.20.0</version>
+						</dependency>
+					</dependencies>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
@@ -500,6 +512,51 @@
 					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
 					<autoReleaseAfterClose>false</autoReleaseAfterClose>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.revapi</groupId>
+				<artifactId>revapi-maven-plugin</artifactId>
+				<configuration>
+					<oldVersion>2.0.0</oldVersion>
+					<analysisConfiguration>
+						<revapi.semver.ignore>
+							<enabled>true</enabled>
+							<versionIncreaseAllows>
+								<major>breaking</major>
+								<minor>nonBreaking</minor>
+								<patch>equivalent</patch>
+							</versionIncreaseAllows>
+						</revapi.semver.ignore>
+						<revapi.java>
+							<checks>
+								<nonPublicPartOfAPI>
+									<reportUnchanged>false</reportUnchanged>
+								</nonPublicPartOfAPI>
+							</checks>
+							<filter>
+								<!--packages>
+									<regex>true</regex>
+									<exclude>
+										<item>org\.eclipse\.californium\.scandium\.dtls.*</item>
+									</exclude>
+								</packages-->
+								<!--classes>
+									<regex>false</regex>
+									<exclude>
+										<item>org.eclipse.californium.scandium.dtls.Handshaker</item>
+									</exclude>
+								</classes-->
+							</filter>
+						</revapi.java>
+					</analysisConfiguration>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
The idea is to add tooling to check API break using [revapi](https://revapi.org/modules/revapi-maven-plugin/index.html).

For now I only push this modification in master (2.1?) branch.
If we agree about using this tool, we should also include this in the future 2.0.x branch.

**revapi** will fail the build if API break is detected.
I configure it to :
 -  uses [semantic versioning](https://revapi.org/modules/revapi-basic-features/extensions/semver-ignore.html).
 - compare against 2.0.0 version.
 - excludes all the `demo-apps` projects.
 - ignore unchanged [Non-Public Part of API](https://revapi.org/modules/revapi-java/index.html#class_is_non_public_part_of_api)

About the last point, I think this is not good practice and we should fix this `Non-Public Part of API` instead. Here 1 example :
```
The following API problems caused the build to fail:
[ERROR] java.class.nonPublicPartOfAPI: class org.eclipse.californium.elements.util.Asn1DerDecoder.OidEntityDefinition: 
Class 'org.eclipse.californium.elements.util.Asn1DerDecoder.OidEntityDefinition'
is indirectly included in the API (by the means of method return type for example) 
but the class is not accessible (neither public nor protected). 
(breaks semantic versioning)
```
I also add some commented samples about  classes or packages filtering but I still think that the right way is to defined a package naming convention. This will make the configuration simpler and will allow us to have a simple claim about what is API or not.

If you cherry pick this commit on [Check key usage and adapt certificate validation](e4ee05dc44a584bfcbb2446c1d3504c6c756124b) commit, you should see something like this : 
```
The following API problems caused the build to fail:
[ERROR] java.method.removed:
method boolean org.eclipse.californium.scandium.dtls.CertificateRequest::addCertificateAuthorities(java.security.cert.X509Certificate[]):
Method was removed. (breaks semantic versioning)

[ERROR] java.method.removed:
method java.util.List<java.security.cert.X509Certificate> org.eclipse.californium.scandium.dtls.CertificateRequest::removeTrustedCertificates(java.util.List<java.security.cert.X509Certificate>):
Method was removed. (breaks semantic versioning)

[ERROR] java.field.nowFinal:
field org.eclipse.californium.scandium.dtls.ClientHandshaker.maxFragmentLengthCode:
Field is now final. (breaks semantic versioning)
[ERROR] java.field.nowFinal:
field org.eclipse.californium.scandium.dtls.Handshaker.certificateChain:
Field is now final. (breaks semantic versioning)
[ERROR] java.field.nowFinal:
field org.eclipse.californium.scandium.dtls.Handshaker.privateKey: 
Field is now final. (breaks semantic versioning)
[ERROR] java.field.nowFinal:
field org.eclipse.californium.scandium.dtls.Handshaker.publicKey: 
Field is now final. (breaks semantic versioning)
[ERROR] java.field.nowFinal:
field org.eclipse.californium.scandium.dtls.Handshaker.sniEnabled: 
Field is now final. (breaks semantic versioning)
[ERROR] java.field.nowFinal:
field org.eclipse.californium.scandium.dtls.Handshaker.useStateValidation: 
Field is now final. (breaks semantic versioning)
```
(At first sight, all this breaks seems easy to avoid)



