### PR TITLE
Revapi ignores 

### DIFF
--- a/cf-pubsub/pom.xml
+++ b/cf-pubsub/pom.xml
@@ -42,6 +42,14 @@
 					</descriptorRefs>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.revapi</groupId>
+				<artifactId>revapi-maven-plugin</artifactId>
+				<configuration>
+					<!-- not depolyed to repos -->
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/element-connector/api-changes.json
+++ b/element-connector/api-changes.json
@@ -1,0 +1,23 @@
+{
+	"2.1.0-SNAPSHOT": {
+		"revapi": {
+			"ignore": [
+				{
+					"code": "java.field.visibilityReduced",
+					"old": "field org.eclipse.californium.elements.util.Asn1DerDecoder.OID",
+					"new": "field org.eclipse.californium.elements.util.Asn1DerDecoder.OID",
+					"justification": "APIfix - public scope was not intended",
+					"oldVisibility": "public",
+					"newVisibility": "private",
+					"package": "org.eclipse.californium.elements.util",
+					"classQualifiedName": "org.eclipse.californium.elements.util.Asn1DerDecoder",
+					"classSimpleName": "Asn1DerDecoder",
+					"fieldName": "OID",
+					"oldArchive": "org.eclipse.californium:element-connector:jar:2.0.0",
+					"newArchive": "org.eclipse.californium:element-connector:jar:2.1.0-SNAPSHOT",
+					"elementKind": "field"
+				}
+			]
+		}
+	}
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/Asn1DerDecoder.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/Asn1DerDecoder.java
@@ -120,7 +120,7 @@ public class Asn1DerDecoder {
 	/**
 	 * ASN.1 entity definition for OID.
 	 */
-	public static final OidEntityDefinition OID = new OidEntityDefinition();
+	private static final OidEntityDefinition OID = new OidEntityDefinition();
 	/**
 	 * ASN.1 entity definition for INTEGER.
 	 */

--- a/pom.xml
+++ b/pom.xml
@@ -530,7 +530,7 @@
 						<revapi.java>
 							<checks>
 								<nonPublicPartOfAPI>
-									<reportUnchanged>false</reportUnchanged>
+									<reportUnchanged>true</reportUnchanged>
 								</nonPublicPartOfAPI>
 							</checks>
 							<filter>
@@ -549,6 +549,15 @@
 							</filter>
 						</revapi.java>
 					</analysisConfiguration>
+					<failOnMissingConfigurationFiles>false</failOnMissingConfigurationFiles>
+					<analysisConfigurationFiles>
+						<configurationFile>
+							<path>api-changes.json</path>
+							<roots>
+								<root>${project.version}</root>
+							</roots>
+						</configurationFile>
+					</analysisConfigurationFiles>
 				</configuration>
 				<executions>
 					<execution>

--- a/scandium-core/api-changes.json
+++ b/scandium-core/api-changes.json
@@ -1,0 +1,23 @@
+{
+	"2.1.0-SNAPSHOT": {
+		"revapi": {
+			"ignore": [
+				{
+					"code": "java.field.visibilityReduced",
+					"old": "field org.eclipse.californium.scandium.dtls.Handshaker.inboundMessageBuffer",
+					"new": "field org.eclipse.californium.scandium.dtls.Handshaker.inboundMessageBuffer",
+					"justification": "APIfix - protected scope was not intended and only used for unit test. Added isInboundMessageProcessed for unit tests instead.",
+					"oldVisibility": "protected",
+					"newVisibility": "private",
+					"package": "org.eclipse.californium.scandium.dtls",
+					"classQualifiedName": "org.eclipse.californium.scandium.dtls.Handshaker",
+					"classSimpleName": "Handshaker",
+					"fieldName": "inboundMessageBuffer",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.0.0",
+					"newArchive": "org.eclipse.californium:scandium:jar:2.1.0-SNAPSHOT",
+					"elementKind": "field"
+				}
+			]
+		}
+	}
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
@@ -44,7 +44,7 @@ import org.eclipse.californium.scandium.util.SecretIvParameterSpec;
  * This class is immutable and thus only appropriate to reflect a <em>current</em> read or
  * write state whose properties have been negotiated/established already.
  */
-abstract class DTLSConnectionState implements Destroyable {
+public abstract class DTLSConnectionState implements Destroyable {
 
 	public static final DTLSConnectionState NULL = new DTLSConnectionState(CipherSuite.TLS_NULL_WITH_NULL_NULL,
 			CompressionMethod.NULL) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -201,7 +201,8 @@ public abstract class Handshaker implements Destroyable {
 	private final Connection connection;
 
 	/** Buffer for received records that can not be processed immediately. */
-	protected InboundMessageBuffer inboundMessageBuffer;
+	private InboundMessageBuffer inboundMessageBuffer;
+
 	/** List of handshake messages */
 	protected final List<HandshakeMessage> handshakeMessages = new ArrayList<HandshakeMessage>();
 
@@ -306,7 +307,7 @@ public abstract class Handshaker implements Destroyable {
 	/**
 	 * A queue for buffering inbound handshake records.
 	 */
-	class InboundMessageBuffer {
+	private class InboundMessageBuffer {
 
 		private Record changeCipherSpec = null;
 
@@ -484,6 +485,16 @@ public abstract class Handshaker implements Destroyable {
 				return 0;
 			}
 		}
+	}
+
+	/**
+	 * Check, if inbound messages are all processed.
+	 * 
+	 * @return {@code true}, all inbound messages are processed, {@code false},
+	 *         some inbound messages are pending.
+	 */
+	public boolean isInboundMessageProcessed() {
+		return inboundMessageBuffer.isEmpty();
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/ThreadLocalCrypto.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/ThreadLocalCrypto.java
@@ -102,7 +102,7 @@ public class ThreadLocalCrypto<CryptoFunction> {
 	/**
 	 * Factory to create instances of crypto functions.
 	 */
-	static interface Factory<CryptoFunction> {
+	public static interface Factory<CryptoFunction> {
 
 		/**
 		 * Create instance of crypto function.

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
@@ -229,7 +229,7 @@ public class HandshakerTest {
 		// the future sequence no has been processed
 		assertThat(receivedMessages[nextSeqNo], is(1));
 		assertThat(receivedMessages[futureSeqNo], is(1));
-		assertTrue(handshaker.inboundMessageBuffer.isEmpty());
+		assertTrue(handshaker.isInboundMessageProcessed());
 	}
 
 	private void givenAHandshakerWithAQueuedFragmentedMessage(int seqNo) throws HandshakeException, GeneralSecurityException {
@@ -242,7 +242,7 @@ public class HandshakerTest {
 			handshaker.decryptAndProcessMessage(record);
 		}
 		assertThat(receivedMessages[seqNo], is(0));
-		assertFalse(handshaker.inboundMessageBuffer.isEmpty());
+		assertFalse(handshaker.isInboundMessageProcessed());
 	}
 
 	@Test

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
@@ -393,7 +393,7 @@ public class ServerHandshakerTest {
 		
 		assertThat(handshaker.handshakeMessages.size(), is(6));
 		assertFalse("Client's KEY_EXCHANGE message should have been queued",
-				handshaker.inboundMessageBuffer.isEmpty());
+				handshaker.isInboundMessageProcessed());
 
 		return certificateMsgRecord;
 	}
@@ -405,7 +405,7 @@ public class ServerHandshakerTest {
 		assertThat("Client's KEY_EXCHANGE message should have been processed",
 				getHandshakeMessage(7, HandshakeType.CLIENT_KEY_EXCHANGE), notNullValue());
 		assertTrue("All (processed) messages should have been removed from inbound messages queue",
-				handshaker.inboundMessageBuffer.isEmpty());
+				handshaker.isInboundMessageProcessed());
 
 	}
 


### PR DESCRIPTION
Fix inconsistent API scopes.
Add "api-changes.json" to ignore APIfixes.
Skip revapi for module cf-pubsub, not deployed for 2.0.0.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>