### PR TITLE
Add revapi ignore annotations.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/NoPublicAPI.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/NoPublicAPI.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+/**
+ * Methods or classes marked by this annotation are not intended to be part of
+ * the public API. They may change without major version change!
+ */
+public @interface NoPublicAPI {
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -527,6 +527,13 @@
 								<patch>equivalent</patch>
 							</versionIncreaseAllows>
 						</revapi.semver.ignore>
+						<revapi.java.filter.annotated>
+							<regex>false</regex>
+							<exclude>
+								<item>@org.eclipse.californium.elements.util.NoPublicAPI</item>
+								<item>@java.lang.Deprecated</item>
+							</exclude>
+						</revapi.java.filter.annotated>
 						<revapi.java>
 							<checks>
 								<nonPublicPartOfAPI>


### PR DESCRIPTION
Introduce @NoPublicAPI annotation and add that and the @Deprecated to be
ignored by revapi.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>