### PR TITLE
Preserve ACK/RST for CON responses.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -307,6 +307,10 @@ public final class UdpMatcher extends BaseMatcher {
 										response.getSourceContext())) {
 									LOGGER.trace("received response for already completed {}: {}", prev, response);
 									response.setDuplicate(true);
+									Response prevResponse = prev.getCurrentResponse();
+									if (prevResponse != null) {
+										response.setRejected(prevResponse.isRejected());
+									}
 									receiver.receiveResponse(prev, response);
 									return;
 								}
@@ -391,9 +395,14 @@ public final class UdpMatcher extends BaseMatcher {
 						// deduplication is relevant only for CON and NON messages
 						if (type == Type.CON || type == Type.NON) {
 							KeyMID idByMID = new KeyMID(response.getMID(), peer);
-							if (exchangeStore.findPrevious(idByMID, exchange) != null) {
+							Exchange prev = exchangeStore.findPrevious(idByMID, exchange);
+							if (prev != null) {
 								LOGGER.trace("received duplicate response for open {}: {}", exchange, response);
 								response.setDuplicate(true);
+								Response prevResponse = prev.getCurrentResponse();
+								if (prevResponse != null) {
+									response.setRejected(prevResponse.isRejected());
+								}
 							}
 						}
 						receiver.receiveResponse(exchange, response);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
@@ -68,7 +68,7 @@ public class ReliabilityLayer extends AbstractLayer {
 	private final ReliabilityLayerParameters defaultReliabilityLayerParameters;
 
 	private final AtomicInteger counter = new AtomicInteger();
-	
+
 	/**
 	 * Constructs a new reliability layer. Changes to the configuration are
 	 * observed and automatically applied.
@@ -284,24 +284,55 @@ public class ReliabilityLayer extends AbstractLayer {
 		exchange.setFailedTransmissionCount(0);
 		exchange.setRetransmissionHandle(null);
 
-		if (response.getType() == Type.CON && !exchange.getRequest().isCanceled()) {
-			if (exchange.getSendNanoTimestamp() > response.getNanoTimestamp()) {
-				// received before ACK/RST was sent
-				int count = counter.incrementAndGet();
-				LOGGER.debug("{}: {} duplicate response {}, server sent ACK delayed, ignore response", count,
-						exchange, response);
-				return;
+		if (response.getType() == Type.CON) {
+			boolean ack = true;
+			if (response.isDuplicate()) {
+				if (response.getNanoTimestamp() < exchange.getSendNanoTimestamp()) {
+					// received response duplicate before ACK/RST
+					// or last request retransmission was sent
+					// => drop response
+					// Note: if the response is received the 1. time, no ACK nor RST was sent
+					// so far. Therefore the send timestamp is related to the request
+					// retransmission only. In that case always ACK/RST to try stopping future
+					// response retransmissions.
+					int count = counter.incrementAndGet();
+					LOGGER.info("{}: {} duplicate response {}, server sent ACK delayed, ignore response", count,
+							exchange, response);
+					return;
+				}
+				// resend last ack or rst, don't update, request state may have changed!
+				if (response.isRejected()) {
+					ack = false;
+					LOGGER.debug("{} reject duplicate CON response, request canceled.", exchange);
+				} else {
+					LOGGER.debug("{} acknowledging duplicate CON response", exchange);
+				}
 			} else {
-				LOGGER.debug("{} acknowledging CON response", exchange);
-				EmptyMessage ack = EmptyMessage.newACK(response);
-				sendEmptyMessage(exchange, ack);
+				if (exchange.getRequest().isCanceled()) {
+					ack = false;
+					LOGGER.debug("{} reject CON response, request canceled.", exchange);
+				} else {
+					LOGGER.debug("{} acknowledging CON response", exchange);
+				}
 			}
+			EmptyMessage empty;
+			if (ack) {
+				empty = EmptyMessage.newACK(response);
+				response.setAcknowledged(true);
+			} else {
+				empty = EmptyMessage.newRST(response);
+				response.setRejected(true);
+			}
+			sendEmptyMessage(exchange, empty);
 		}
 
 		if (response.isDuplicate()) {
-			LOGGER.debug("{} ignoring duplicate response", exchange);
+			if (response.getType() != Type.CON) {
+				LOGGER.debug("{} ignoring duplicate response", exchange);
+			}
 		} else {
 			exchange.getCurrentRequest().setAcknowledged(true);
+			exchange.setCurrentResponse(response);
 			upper().receiveResponse(exchange, response);
 		}
 	}


### PR DESCRIPTION
Send-/Receive-timefilter drops only retransmitted responses.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>