### PR TITLE
Use "classic" way to initialize logger.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
@@ -80,7 +80,7 @@ import org.eclipse.californium.elements.util.NamedThreadFactory;
 public class CoapClient {
 
 	/** The logger. */
-	private static final Logger LOGGER = LoggerFactory.getLogger(CoapClient.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(CoapClient.class);
 
 	/** The timeout. 
 	 * 

--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
 public class CoapObserveRelation {
 
 	/** The logger. */
-	private static final Logger LOGGER = LoggerFactory.getLogger(CoapObserveRelation.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(CoapObserveRelation.class);
 
 	/** A executor service to schedule re-registrations */
 	private final ScheduledThreadPoolExecutor scheduler;

--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
@@ -140,7 +140,7 @@ import org.eclipse.californium.core.server.resources.ResourceObserver;
 public  class CoapResource implements Resource {
 
 	/** The logger. */
-	protected final static Logger LOGGER = LoggerFactory.getLogger(CoapResource.class.getCanonicalName());
+	protected final static Logger LOGGER = LoggerFactory.getLogger(CoapResource.class);
 
 	/* The attributes of this resource. */
 	private final ResourceAttributes attributes;

--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
@@ -97,7 +97,7 @@ import org.eclipse.californium.elements.util.NamedThreadFactory;
 public class CoapServer implements ServerInterface {
 
 	/** The logger. */
-	private static final Logger LOGGER = LoggerFactory.getLogger(CoapServer.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(CoapServer.class);
 
 	/** The root resource. */
 	private final Resource root;

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
@@ -89,7 +89,7 @@ import org.eclipse.californium.elements.util.ClockUtil;
  */
 public abstract class Message {
 
-	protected final static Logger LOGGER = LoggerFactory.getLogger(Message.class.getCanonicalName());
+	protected final static Logger LOGGER = LoggerFactory.getLogger(Message.class);
 
 	/** The Constant NONE in case no MID has been set. */
 	public static final int NONE = -1;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
@@ -89,7 +89,7 @@ import org.eclipse.californium.elements.EndpointContext;
  */
 public abstract class BaseMatcher implements Matcher {
 
-	private static final Logger LOG = LoggerFactory.getLogger(BaseMatcher.class.getName());
+	private static final Logger LOG = LoggerFactory.getLogger(BaseMatcher.class);
 	protected final NetworkConfig config;
 	protected final ObservationStore observationStore;
 	protected final MessageExchangeStore exchangeStore;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -194,7 +194,7 @@ import org.slf4j.LoggerFactory;
 public class CoapEndpoint implements Endpoint {
 
 	/** the logger. */
-	private static final Logger LOGGER = LoggerFactory.getLogger(CoapEndpoint.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(CoapEndpoint.class);
 
 	/** The stack of layers that make up the CoAP protocol */
 	protected final CoapStack coapstack;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/EndpointManager.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/EndpointManager.java
@@ -80,7 +80,7 @@ import org.eclipse.californium.elements.util.NetworkInterfacesUtil;
 public class EndpointManager {
 
 	/** The logger */
-	private static final Logger LOGGER = LoggerFactory.getLogger(EndpointManager.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(EndpointManager.class);
 
 	/** The singleton manager instance */
 	private static final EndpointManager manager = new EndpointManager();

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -127,7 +127,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Exchange {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(Exchange.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(Exchange.class);
 	
 	static final boolean DEBUG = LOGGER.isTraceEnabled();
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
@@ -76,7 +76,7 @@ import org.eclipse.californium.elements.util.StringUtil;
  */
 public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryMessageExchangeStore.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryMessageExchangeStore.class);
 	private static final Logger HEALTH_LOGGER = LoggerFactory.getLogger(LOGGER.getName() + ".health");
 	// for all
 	private final ConcurrentMap<KeyMID, Exchange> exchangesByMID = new ConcurrentHashMap<>();

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageIdProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageIdProvider.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  */
 public class InMemoryMessageIdProvider implements MessageIdProvider {
 
-	private static final Logger LOG = LoggerFactory.getLogger(InMemoryMessageIdProvider.class.getName());
+	private static final Logger LOG = LoggerFactory.getLogger(InMemoryMessageIdProvider.class);
 
 	public enum TrackerMode {
 		NULL, GROUPED, MAPBASED

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/RandomTokenGenerator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/RandomTokenGenerator.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RandomTokenGenerator implements TokenGenerator {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(RandomTokenGenerator.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(RandomTokenGenerator.class);
 	private static final int DEFAULT_TOKEN_LENGTH = 8; // bytes
 
 	private final int tokenSize;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -70,7 +70,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class TcpMatcher extends BaseMatcher {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(TcpMatcher.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(TcpMatcher.class);
 	private final RemoveHandler exchangeRemoveHandler = new RemoveHandlerImpl();
 	private final EndpointContextMatcher endpointContextMatcher;
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -82,7 +82,7 @@ import org.eclipse.californium.elements.EndpointContextMatcher;
  */
 public final class UdpMatcher extends BaseMatcher {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(UdpMatcher.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(UdpMatcher.class);
 
 	private final RemoveHandler exchangeRemoveHandler = new RemoveHandlerImpl();
 	private final EndpointContextMatcher endpointContextMatcher;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class NetworkConfig {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(NetworkConfig.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(NetworkConfig.class);
 
 	/** The default name for the configuration. */
 	public static final String DEFAULT_FILE_NAME = "Californium.properties";

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/CropRotation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/CropRotation.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CropRotation implements Deduplicator {
 
-	private final static Logger LOGGER = LoggerFactory.getLogger(CropRotation.class.getCanonicalName());
+	private final static Logger LOGGER = LoggerFactory.getLogger(CropRotation.class);
 	private volatile ScheduledFuture<?> jobStatus;
 
 	private final ExchangeMap maps[];

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/DeduplicatorFactory.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/DeduplicatorFactory.java
@@ -36,7 +36,7 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
 public class DeduplicatorFactory {
 
 	/** The logger. */
-	private static final Logger LOGGER = LoggerFactory.getLogger(DeduplicatorFactory.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(DeduplicatorFactory.class);
 
 	/** The factory. */
 	private static DeduplicatorFactory factory;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/SweepDeduplicator.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/deduplication/SweepDeduplicator.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class SweepDeduplicator implements Deduplicator {
 
-	private final static Logger LOGGER = LoggerFactory.getLogger(SweepDeduplicator.class.getName());
+	private final static Logger LOGGER = LoggerFactory.getLogger(SweepDeduplicator.class);
 
 	/**
 	 * Add timestamp for deduplication to Exchange.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/MessageTracer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/MessageTracer.java
@@ -36,7 +36,7 @@ import org.eclipse.californium.core.coap.Response;
  */
 public class MessageTracer implements MessageInterceptor {
 
-	private final static Logger LOGGER = LoggerFactory.getLogger(MessageTracer.class.getCanonicalName());
+	private final static Logger LOGGER = LoggerFactory.getLogger(MessageTracer.class);
 
 	@Override
 	public void sendRequest(Request request) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/AbstractLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/AbstractLayer.java
@@ -50,7 +50,7 @@ import org.eclipse.californium.core.network.Exchange;
 public abstract class AbstractLayer implements Layer {
 
 	/** The logger. */
-	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractLayer.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractLayer.class);
 
 	/** The upper layer. */
 	private Layer upperLayer = LogOnlyLayer.getInstance();

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
@@ -48,7 +48,7 @@ import org.eclipse.californium.core.server.MessageDeliverer;
  */
 public abstract class BaseCoapStack implements CoapStack {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(BaseCoapStack.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(BaseCoapStack.class);
 
 	private List<Layer> layers;
 	private final Outbox outbox;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
@@ -44,7 +44,7 @@ import org.eclipse.californium.core.observe.NotificationOrder;
  */
 public final class Block2BlockwiseStatus extends BlockwiseStatus {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(Block2BlockwiseStatus.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(Block2BlockwiseStatus.class);
 
 	/**
 	 * Order for notifications according RFC 7641, 4-4.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -152,7 +152,7 @@ public class BlockwiseLayer extends AbstractLayer {
 	 * matches the example in the draft.
 	 */
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(BlockwiseLayer.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(BlockwiseLayer.class);
 	private static final Logger HEALTH_LOGGER = LoggerFactory.getLogger(LOGGER.getName() + ".health");
 	private final LeastRecentlyUsedCache<KeyUri, Block1BlockwiseStatus> block1Transfers;
 	private final LeastRecentlyUsedCache<KeyUri, Block2BlockwiseStatus> block2Transfers;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseStatus.java
@@ -43,7 +43,7 @@ import org.eclipse.californium.core.network.Exchange;
  */
 public abstract class BlockwiseStatus {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(BlockwiseStatus.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(BlockwiseStatus.class);
 
 	private final int contentFormat;
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CleanupMessageObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CleanupMessageObserver.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CleanupMessageObserver extends MessageObserverAdapter {
 
-	protected static final Logger LOGGER = LoggerFactory.getLogger(CleanupMessageObserver.class.getName());
+	protected static final Logger LOGGER = LoggerFactory.getLogger(CleanupMessageObserver.class);
 
 	protected final Exchange exchange;
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapUdpStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapUdpStack.java
@@ -78,7 +78,7 @@ import org.eclipse.californium.elements.Connector;
 public class CoapUdpStack extends BaseCoapStack {
 
 	/** The LOGGER. */
-	private final static Logger LOGGER = LoggerFactory.getLogger(CoapStack.class.getCanonicalName());
+	private final static Logger LOGGER = LoggerFactory.getLogger(CoapStack.class);
 
 	/**
 	 * Creates a new stack for UDP as the transport.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ExchangeCleanupLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ExchangeCleanupLayer.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ExchangeCleanupLayer extends AbstractLayer {
 
-	static final Logger LOGGER = LoggerFactory.getLogger(ExchangeCleanupLayer.class.getName());
+	static final Logger LOGGER = LoggerFactory.getLogger(ExchangeCleanupLayer.class);
 
 	/**
 	 * Multicast lifetime in milliseconds.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/MulticastCleanupMessageObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/MulticastCleanupMessageObserver.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MulticastCleanupMessageObserver extends CleanupMessageObserver {
 
-	static final Logger LOGGER = LoggerFactory.getLogger(MulticastCleanupMessageObserver.class.getName());
+	static final Logger LOGGER = LoggerFactory.getLogger(MulticastCleanupMessageObserver.class);
 
 	/**
 	 * Scheduler for time based exchange completion.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ObserveLayer.java
@@ -54,7 +54,7 @@ import org.eclipse.californium.core.observe.ObserveRelation;
  */
 public class ObserveLayer extends AbstractLayer {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(ObserveLayer.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ObserveLayer.class);
 
 	/**
 	 * Creates a new observe layer for a configuration.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
 public class ReliabilityLayer extends AbstractLayer {
 
 	/** The logger. */
-	protected final static Logger LOGGER = LoggerFactory.getLogger(ReliabilityLayer.class.getCanonicalName());
+	protected final static Logger LOGGER = LoggerFactory.getLogger(ReliabilityLayer.class);
 
 	/** The random numbers generator for the back-off timer */
 	private final Random rand = new Random();

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpAdaptionLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpAdaptionLayer.java
@@ -29,7 +29,7 @@ import org.eclipse.californium.core.network.Exchange;
  */
 public class TcpAdaptionLayer extends AbstractLayer {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(TcpAdaptionLayer.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(TcpAdaptionLayer.class);
 
 	@Override
 	public void sendEmptyMessage(final Exchange exchange, final EmptyMessage message) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpExchangeCleanupLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpExchangeCleanupLayer.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TcpExchangeCleanupLayer extends AbstractLayer {
 
-	static final Logger LOGGER = LoggerFactory.getLogger(TcpExchangeCleanupLayer.class.getName());
+	static final Logger LOGGER = LoggerFactory.getLogger(TcpExchangeCleanupLayer.class);
 
 	/**
 	 * Adds a message observer to the request to be sent which completes the

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpObserveLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/TcpObserveLayer.java
@@ -34,7 +34,7 @@ import org.eclipse.californium.core.observe.ObserveRelation;
  */
 public class TcpObserveLayer extends AbstractLayer {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(TcpObserveLayer.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(TcpObserveLayer.class);
 
 	private static final Integer CANCEL = 1;
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/InMemoryObservationStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/InMemoryObservationStore.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class InMemoryObservationStore implements ObservationStore {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryObservationStore.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(InMemoryObservationStore.class);
 	private static final Logger HEALTH_LOGGER = LoggerFactory.getLogger(LOGGER.getName() + ".health");
 	private final ConcurrentMap<Token, Observation> map = new ConcurrentHashMap<>();
 	private volatile boolean enableStatus;

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
@@ -43,7 +43,7 @@ import org.eclipse.californium.core.server.resources.Resource;
 public class ObserveRelation {
 
 	/** The logger. */
-	private final static Logger LOGGER = LoggerFactory.getLogger(ObserveRelation.class.getCanonicalName());
+	private final static Logger LOGGER = LoggerFactory.getLogger(ObserveRelation.class);
 	
 	private final long checkIntervalTime;
 	private final int checkIntervalCount;

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ServerMessageDeliverer implements MessageDeliverer {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(ServerMessageDeliverer.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ServerMessageDeliverer.class);
 
 	/* The root of all resources */
 	private final Resource root;

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/CountingCoapHandler.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/CountingCoapHandler.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CountingCoapHandler implements CoapHandler {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(CountingCoapHandler.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(CountingCoapHandler.class);
 
 	/**
 	 * Current read index for {@link #waitOnLoad(long)}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MemoryLeakingHashMapTest.java
@@ -114,7 +114,7 @@ public class MemoryLeakingHashMapTest {
 	// The name of the resource of the server
 	private static final String URI = "test";
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(MemoryLeakingHashMapTest.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(MemoryLeakingHashMapTest.class);
 	private static Endpoint serverEndpoint;
 
 	// The server endpoint that we test

--- a/californium-core/src/test/java/org/eclipse/californium/rule/CoapNetworkRule.java
+++ b/californium-core/src/test/java/org/eclipse/californium/rule/CoapNetworkRule.java
@@ -86,7 +86,7 @@ import org.eclipse.californium.elements.util.DatagramFormatter;
  */
 public class CoapNetworkRule extends NetworkRule {
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(CoapNetworkRule.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(CoapNetworkRule.class);
 	private static final int DEFAULT_MESSAGE_THREADS = 1;
 	/**
 	 * CoAP datagram formatter. Used for logging.

--- a/californium-core/src/test/java/org/eclipse/californium/rule/CoapThreadsRule.java
+++ b/californium-core/src/test/java/org/eclipse/californium/rule/CoapThreadsRule.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CoapThreadsRule extends ThreadsRule {
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(CoapThreadsRule.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(CoapThreadsRule.class);
 
 	/**
 	 * List of resource objects to cleanup.

--- a/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/util/CoapsNetworkRule.java
+++ b/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/util/CoapsNetworkRule.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CoapsNetworkRule extends CoapNetworkRule {
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(CoapsNetworkRule.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(CoapsNetworkRule.class);
 
 	/**
 	 * Null formatter, data is encrypted, so nothign useful for logging.

--- a/californium-osgi/src/main/java/org/eclipse/californium/osgi/ManagedServer.java
+++ b/californium-osgi/src/main/java/org/eclipse/californium/osgi/ManagedServer.java
@@ -62,7 +62,7 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
  */
 public class ManagedServer implements ManagedService, ServiceTrackerCustomizer<Resource, Resource>, ServerEndpointRegistry {
 
-	private final static Logger LOGGER = LoggerFactory.getLogger(ManagedServer.class.getCanonicalName());
+	private final static Logger LOGGER = LoggerFactory.getLogger(ManagedServer.class);
 	
 	private ServerInterface managedServer;
 	private boolean running = false;

--- a/californium-osgi/src/main/java/org/eclipse/californium/osgi/SimpleServerEndpointFactory.java
+++ b/californium-osgi/src/main/java/org/eclipse/californium/osgi/SimpleServerEndpointFactory.java
@@ -36,7 +36,7 @@ import org.osgi.service.io.ConnectionFactory;
  */
 public class SimpleServerEndpointFactory implements EndpointFactory {
 
-	private final Logger log = LoggerFactory.getLogger(SimpleServerEndpointFactory.class.getName());
+	private final Logger log = LoggerFactory.getLogger(SimpleServerEndpointFactory.class);
 
 	private ConnectorFactory secureConnectorFactory;
 

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapTranslator.java
@@ -40,7 +40,7 @@ import org.eclipse.californium.core.coap.Response;
 public final class CoapTranslator {
 
 	/** The Constant LOG. */
-	private static final Logger LOGGER = LoggerFactory.getLogger(CoapTranslator.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(CoapTranslator.class);
 
 	/**
 	 * Property file containing the mappings between coap messages and http

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/DirectProxyCoapResolver.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/DirectProxyCoapResolver.java
@@ -27,7 +27,7 @@ import org.eclipse.californium.proxy.resources.ForwardingResource;
 
 public class DirectProxyCoapResolver implements ProxyCoapResolver {
 
-	private final static Logger LOGGER = LoggerFactory.getLogger(DirectProxyCoapResolver.class.getCanonicalName());
+	private final static Logger LOGGER = LoggerFactory.getLogger(DirectProxyCoapResolver.class);
 	
 	private ForwardingResource proxyCoapClientResource;
 	

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
@@ -75,7 +75,7 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
  */
 public class HttpStack {
 	
-	private static final Logger LOGGER = LoggerFactory.getLogger(HttpStack.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(HttpStack.class);
 	
 	private static final Response Response_NULL = new Response(null); // instead of Response.NULL // TODO
 	

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
@@ -104,7 +104,7 @@ public final class HttpTranslator {
 	public static final int STATUS_URI_MALFORMED = HttpStatus.SC_BAD_REQUEST;
 	public static final int STATUS_WRONG_METHOD = HttpStatus.SC_NOT_IMPLEMENTED;
 
-	protected static final Logger LOGGER = LoggerFactory.getLogger(HttpTranslator.class.getName());
+	protected static final Logger LOGGER = LoggerFactory.getLogger(HttpTranslator.class);
 	
 	public HttpTranslator(String mappingPropertiesFileName) {
 		httpTranslationProperties = new MappingProperties(mappingPropertiesFileName);

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/MappingProperties.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/MappingProperties.java
@@ -35,7 +35,7 @@ import org.eclipse.californium.core.coap.OptionNumberRegistry;
  */
 public class MappingProperties extends java.util.Properties {
 
-	private static final Logger LOG = LoggerFactory.getLogger(MappingProperties.class.getName());
+	private static final Logger LOG = LoggerFactory.getLogger(MappingProperties.class);
 
 	/**
 	 * auto-generated to eliminate warning

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/ProxyHttpServer.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/ProxyHttpServer.java
@@ -44,7 +44,7 @@ import org.eclipse.californium.proxy.resources.StatsResource;
  */
 public class ProxyHttpServer {
 
-	private final static Logger LOGGER = LoggerFactory.getLogger(ProxyHttpServer.class.getCanonicalName());
+	private final static Logger LOGGER = LoggerFactory.getLogger(ProxyHttpServer.class);
 	
 	private static final String PROXY_COAP_CLIENT = "proxy/coapClient";
 	private static final String PROXY_HTTP_CLIENT = "proxy/httpClient";

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/ProxyProperties.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/ProxyProperties.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ProxyProperties extends java.util.Properties {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(ProxyProperties.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ProxyProperties.class);
 
 	/**
 	 * auto-generated to eliminate warning

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/CoapOSExceptionHandler.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/CoapOSExceptionHandler.java
@@ -39,7 +39,7 @@ public class CoapOSExceptionHandler {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(CoapOSExceptionHandler.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(CoapOSExceptionHandler.class);
 
 	/**
 	 * 

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
@@ -63,7 +63,7 @@ public class ContextRederivation {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(ContextRederivation.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ContextRederivation.class);
 
 	/**
 	 * Method to indicate that the mutable parts of an OSCORE context has been

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/Decryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/Decryptor.java
@@ -52,7 +52,7 @@ public abstract class Decryptor {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(Decryptor.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(Decryptor.class);
 
 	/**
 	 * Empty option set

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/Encryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/Encryptor.java
@@ -48,7 +48,7 @@ public abstract class Encryptor {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(Encryptor.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(Encryptor.class);
 
 	/**
 	 * Encrypt the COSE message using the OSCore context.

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/HashMapCtxDB.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/HashMapCtxDB.java
@@ -44,7 +44,7 @@ public class HashMapCtxDB implements OSCoreCtxDB {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(HashMapCtxDB.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(HashMapCtxDB.class);
 
 	private HashMap<ByteId, OSCoreCtx> ridMap;
 	private HashMap<Token, OSCoreCtx> tokenMap;

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtx.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtx.java
@@ -47,7 +47,7 @@ public class OSCoreCtx {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(OSCoreCtx.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(OSCoreCtx.class);
 
 	private AlgorithmID common_alg;
 	private byte[] common_master_secret;

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreStack.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreStack.java
@@ -40,7 +40,7 @@ public class OSCoreStack extends BaseCoapStack {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(OSCoreStack.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(OSCoreStack.class);
 
 	/**
 	 * Creates a new stack for UDP as the transport.

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSSerializer.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSSerializer.java
@@ -46,7 +46,7 @@ public class OSSerializer {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(OSSerializer.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(OSSerializer.class);
 
 	/**
 	 * Prepare options and payload for encrypting.

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
@@ -41,7 +41,7 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(ObjectSecurityContextLayer.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ObjectSecurityContextLayer.class);
 
 	private final OSCoreCtxDB ctxDb;
 

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityLayer.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityLayer.java
@@ -44,7 +44,7 @@ public class ObjectSecurityLayer extends AbstractLayer {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(ObjectSecurityLayer.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ObjectSecurityLayer.class);
 
 	private final OSCoreCtxDB ctxDb;
 

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OptionJuggle.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OptionJuggle.java
@@ -47,7 +47,7 @@ public class OptionJuggle {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(OptionJuggle.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(OptionJuggle.class);
 	
 	private static List<Integer> allEOptions = populateAllEOptions();
 

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestDecryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestDecryptor.java
@@ -51,7 +51,7 @@ public class RequestDecryptor extends Decryptor {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(RequestDecryptor.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(RequestDecryptor.class);
 
 	/**
 	 * @param db the context database used

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestEncryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestEncryptor.java
@@ -35,7 +35,7 @@ public class RequestEncryptor extends Encryptor {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(RequestEncryptor.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(RequestEncryptor.class);
 
 	/**
 	 * @param request the request

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseDecryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseDecryptor.java
@@ -43,7 +43,7 @@ public class ResponseDecryptor extends Decryptor {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(ResponseDecryptor.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ResponseDecryptor.class);
 
 	/**
 	 * Decrypt the response.

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseEncryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseEncryptor.java
@@ -35,7 +35,7 @@ public class ResponseEncryptor extends Encryptor {
 	/**
 	 * The logger
 	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(ResponseEncryptor.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ResponseEncryptor.class);
 
 	/**
 	 * @param response the response

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
@@ -85,7 +85,7 @@ import org.slf4j.LoggerFactory;
 public class BenchmarkClient {
 
 	/** The logger. */
-	private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkClient.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(BenchmarkClient.class);
 
 	private static final Logger STATISTIC_LOGGER = LoggerFactory.getLogger("org.eclipse.californium.extplugtests.statistics");
 

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/resources/Feed.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/resources/Feed.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Feed extends CoapResource {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(Feed.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(Feed.class);
 	/**
 	 * Resource name.
 	 */

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseObserve.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseObserve.java
@@ -87,7 +87,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ReverseObserve extends CoapResource implements NotificationListener {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(ReverseObserve.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ReverseObserve.class);
 	private static final Logger HEALTH_LOGGER = LoggerFactory.getLogger(LOGGER.getName() + ".health");
 
 	private static final String RESOURCE_NAME = "reverse-observe";

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseRequest.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseRequest.java
@@ -73,7 +73,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ReverseRequest extends CoapResource {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(ReverseRequest.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ReverseRequest.class);
 	private static final Logger HEALTH_LOGGER = LoggerFactory.getLogger(LOGGER.getName() + ".health");
 
 	private static final String RESOURCE_NAME = "reverse-request";

--- a/demo-apps/cf-helloworld-server/src/main/java/org/eclipse/californium/examples/MulticastTestServer.java
+++ b/demo-apps/cf-helloworld-server/src/main/java/org/eclipse/californium/examples/MulticastTestServer.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * Test server using {@link UdpMulticastConnector}.
  */
 public class MulticastTestServer {
-	private static final Logger LOGGER = LoggerFactory.getLogger(MulticastTestServer.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(MulticastTestServer.class);
 
 	public static void main(String[] args) throws UnknownHostException {
 

--- a/demo-apps/cf-nat/src/main/java/org/eclipse/californium/examples/NatUtil.java
+++ b/demo-apps/cf-nat/src/main/java/org/eclipse/californium/examples/NatUtil.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  */
 public class NatUtil implements Runnable {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(NatUtil.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(NatUtil.class);
 	/**
 	 * Supported maximum message size.
 	 */

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/LinkParser.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/LinkParser.java
@@ -34,7 +34,7 @@ import org.eclipse.californium.core.server.resources.Resource;
  */
 public class LinkParser {
 
-	protected static final Logger LOG = LoggerFactory.getLogger(LinkParser.class.getName());
+	protected static final Logger LOG = LoggerFactory.getLogger(LinkParser.class);
 	
 	public static Resource parseTree(String linkFormat) {
 

--- a/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/ClientInitializer.java
+++ b/demo-apps/cf-plugtest-client/src/main/java/org/eclipse/californium/plugtests/ClientInitializer.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ClientInitializer {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(ClientInitializer.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ClientInitializer.class);
 
 	public static final String PSK_IDENTITY_PREFIX = "cali.";
 

--- a/demo-apps/cf-simplefile-server/src/main/java/org/eclipse/californium/examples/SimpleFileServer.java
+++ b/demo-apps/cf-simplefile-server/src/main/java/org/eclipse/californium/examples/SimpleFileServer.java
@@ -44,7 +44,7 @@ import org.eclipse.californium.plugtests.AbstractTestServer;
 
 public class SimpleFileServer extends AbstractTestServer {
 
-	private static final Logger LOG = LoggerFactory.getLogger(SimpleFileServer.class.getName());
+	private static final Logger LOG = LoggerFactory.getLogger(SimpleFileServer.class);
 
 	private static final File CONFIG_FILE = new File("Californium.properties");
 	private static final String CONFIG_HEADER = "Californium CoAP Properties file for Fileserver";

--- a/demo-apps/sc-dtls-example-client/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSClient.java
+++ b/demo-apps/sc-dtls-example-client/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSClient.java
@@ -51,7 +51,7 @@ public class ExampleDTLSClient {
 
 	private static final int DEFAULT_PORT = 5684;
 	private static final long DEFAULT_TIMEOUT_NANOS = TimeUnit.MILLISECONDS.toNanos(10000);
-	private static final Logger LOG = LoggerFactory.getLogger(ExampleDTLSClient.class.getName());
+	private static final Logger LOG = LoggerFactory.getLogger(ExampleDTLSClient.class);
 	private static final char[] KEY_STORE_PASSWORD = "endPass".toCharArray();
 	private static final String KEY_STORE_LOCATION = "certs/keyStore.jks";
 	private static final char[] TRUST_STORE_PASSWORD = "rootPass".toCharArray();

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/CloseOnErrorHandler.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/CloseOnErrorHandler.java
@@ -38,7 +38,7 @@ import javax.net.ssl.SSLException;
  */
 class CloseOnErrorHandler extends ChannelHandlerAdapter {
 
-	private final static Logger LOGGER = LoggerFactory.getLogger(CloseOnErrorHandler.class.getName());
+	private final static Logger LOGGER = LoggerFactory.getLogger(CloseOnErrorHandler.class);
 
 	@Override
 	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/CloseOnIdleHandler.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/CloseOnIdleHandler.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 class CloseOnIdleHandler extends ChannelDuplexHandler {
 
-	private final static Logger LOGGER = LoggerFactory.getLogger(CloseOnIdleHandler.class.getName());
+	private final static Logger LOGGER = LoggerFactory.getLogger(CloseOnIdleHandler.class);
 
 	@Override public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
 		if (evt instanceof IdleStateEvent) {

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpClientConnector.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpClientConnector.java
@@ -78,7 +78,7 @@ import org.slf4j.LoggerFactory;
 public class TcpClientConnector implements Connector {
 	private static final boolean USE_FIXED_CONNECTION_POOL = false;
 
-	protected final Logger LOGGER = LoggerFactory.getLogger(getClass().getName());
+	protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
 	private final int numberOfThreads;
 	private final int connectionIdleTimeoutSeconds;

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpContextUtil.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpContextUtil.java
@@ -30,7 +30,7 @@ import io.netty.channel.Channel;
  */
 public class TcpContextUtil {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(TcpContextUtil.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(TcpContextUtil.class);
 
 	/**
 	 * Build endpoint context related to the provided channel.

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpServerConnector.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpServerConnector.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TcpServerConnector implements Connector {
 
-	protected final Logger LOGGER = LoggerFactory.getLogger(getClass().getName());
+	protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
 	private final int numberOfThreads;
 	private final int connectionIdleTimeoutSeconds;

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsContextUtil.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsContextUtil.java
@@ -40,7 +40,7 @@ import io.netty.handler.ssl.SslHandler;
  */
 public class TlsContextUtil extends TcpContextUtil {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(TlsContextUtil.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(TlsContextUtil.class);
 
 	/**
 	 * Log warn messages, if remote peer's principal is not valid.

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContextUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContextUtil.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public class EndpointContextUtil {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(EndpointContextUtil.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(EndpointContextUtil.class);
 
 	/**
 	 * Match endpoint contexts based on a set of keys.

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UDPConnector.java
@@ -73,7 +73,7 @@ import org.slf4j.LoggerFactory;
  */
 public class UDPConnector implements Connector {
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(UDPConnector.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(UDPConnector.class);
 
 	public static final int UNDEFINED = 0;
 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UdpEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UdpEndpointContextMatcher.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 public class UdpEndpointContextMatcher extends KeySetEndpointContextMatcher {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(UdpEndpointContextMatcher.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(UdpEndpointContextMatcher.class);
 
 	private static final String KEYS[] = { UdpEndpointContext.KEY_PLAIN };
 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UdpMulticastConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UdpMulticastConnector.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * Protocol (CoAP) to the registered multicast group.
  */
 public class UdpMulticastConnector extends UDPConnector {
-	public static final Logger LOGGER = LoggerFactory.getLogger(UdpMulticastConnector.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(UdpMulticastConnector.class);
 
 	/**
 	 * Address of network interface to be used to receive multicast packets

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/Base64.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/Base64.java
@@ -221,7 +221,7 @@ public class Base64
 	
 	/* ********  P R I V A T E   F I E L D S  ******** */  
 
-	private final static Logger LOG = LoggerFactory.getLogger(Base64.class.getName());
+	private final static Logger LOG = LoggerFactory.getLogger(Base64.class);
 
 	/** Maximum line length (76) of Base64 output. */
 	private final static int MAX_LINE_LENGTH = 76;

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/CertPathUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/CertPathUtil.java
@@ -85,7 +85,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CertPathUtil {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(CertPathUtil.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(CertPathUtil.class);
 
 	private static final String TYPE_X509 = "X.509";
 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramWriter.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramWriter.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * on bit-level.
  */
 public final class DatagramWriter {
-	private static final Logger LOGGER = LoggerFactory.getLogger(DatagramWriter.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(DatagramWriter.class);
 
 	// Attributes //////////////////////////////////////////////////////////////
 	private final ByteArrayOutputStream byteStream;

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/ExecutorsUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/ExecutorsUtil.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 public class ExecutorsUtil {
 
 	/** the logger. */
-	private static final Logger LOGGER = LoggerFactory.getLogger(ExecutorsUtil.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ExecutorsUtil.class);
 
 	private static final Runnable WARMUP = new Runnable() {
 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/NetworkInterfacesUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/NetworkInterfacesUtil.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 public class NetworkInterfacesUtil {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(NetworkInterfacesUtil.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(NetworkInterfacesUtil.class);
 
 	/**
 	 * Maximum UDP MTU.

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/PemReader.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/PemReader.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PemReader {
-	public static final Logger LOGGER = LoggerFactory.getLogger(PemReader.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(PemReader.class);
 
 	private static final Pattern BEGIN_PATTERN = Pattern.compile("^\\-+BEGIN\\s+([\\w\\s]+)\\-+$");
 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/SerialExecutor.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/SerialExecutor.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SerialExecutor extends AbstractExecutorService {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(SerialExecutor.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(SerialExecutor.class);
 
 	/**
 	 * Target executor to execute job serially.

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
@@ -104,7 +104,7 @@ import org.slf4j.LoggerFactory;
  * @see #configure(String, InputStreamFactory)
  */
 public class SslContextUtil {
-	public static final Logger LOGGER = LoggerFactory.getLogger(SslContextUtil.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(SslContextUtil.class);
 
 	/**
 	 * Scheme for key store URI. Used to load the key stores from classpath.

--- a/element-connector/src/test/java/org/eclipse/californium/elements/UDPConnectorTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/UDPConnectorTest.java
@@ -48,7 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UDPConnectorTest {
-	public static final Logger LOGGER = LoggerFactory.getLogger(UDPConnectorTest.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(UDPConnectorTest.class);
 
 	@ClassRule
 	public static NetworkRule network = new NetworkRule(NetworkRule.Mode.DIRECT, NetworkRule.Mode.NATIVE);

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/NetworkRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/NetworkRule.java
@@ -81,7 +81,7 @@ import org.junit.runners.model.Statement;
  */
 public class NetworkRule implements TestRule {
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(NetworkRule.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(NetworkRule.class);
 	/**
 	 * Name of configuration property. Supported values of property "NATIVE" and
 	 * "DIRECT".

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestNameLoggerRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestNameLoggerRule.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TestNameLoggerRule extends TestWatcher {
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(TestNameLoggerRule.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(TestNameLoggerRule.class);
 
 	@Override
 	protected void starting(Description description) {

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestTimeRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestTimeRule.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TestTimeRule extends TestWatcher {
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(TestTimeRule.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(TestTimeRule.class);
 
 	/**
 	 * Realtime handler applying the {@link #timeShiftNanos}.

--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/ThreadsRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/ThreadsRule.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ThreadsRule implements TestRule {
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(ThreadsRule.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(ThreadsRule.class);
 
 	/**
 	 * Description of current test.

--- a/element-connector/src/test/java/org/eclipse/californium/elements/runner/TestRepeater.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/runner/TestRepeater.java
@@ -38,7 +38,7 @@ import org.junit.runner.notification.RunNotifier;
  */
 public class TestRepeater {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(TestRepeater.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(TestRepeater.class);
 
 	/**
 	 * Final divisor for logging memory in mega bytes.

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/DirectDatagramSocketImpl.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/DirectDatagramSocketImpl.java
@@ -105,7 +105,7 @@ public class DirectDatagramSocketImpl extends AbstractDatagramSocketImpl {
 	 */
 	public static final int AUTO_PORT_RANGE_SIZE = AUTO_PORT_RANGE_MAX - AUTO_PORT_RANGE_MIN + 1;
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(DirectDatagramSocketImpl.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(DirectDatagramSocketImpl.class);
 
 	/**
 	 * Default factory, if {@code null} is provided for

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -228,7 +228,7 @@ public class DTLSConnector implements Connector, RecordLayer {
 	public static final int DEFAULT_IPV6_MTU = 1280;
 	public static final int DEFAULT_IPV4_MTU = 576;
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(DTLSConnector.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(DTLSConnector.class);
 	private static final int MAX_PLAINTEXT_FRAGMENT_LENGTH = 16384; // max. DTLSPlaintext.length (2^14 bytes)
 	private static final int MAX_CIPHERTEXT_EXPANSION = CipherSuite.getOverallMaxCiphertextExpansion();
 	private static final int MAX_DATAGRAM_BUFFER_SIZE = MAX_PLAINTEXT_FRAGMENT_LENGTH

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
@@ -62,7 +62,7 @@ public final class CertificateMessage extends HandshakeMessage {
 
 	private static final String CERTIFICATE_TYPE_X509 = "X.509";
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(CertificateMessage.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(CertificateMessage.class);
 
 	// DTLS-specific constants ///////////////////////////////////////////
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
 @NoPublicAPI
 public final class CertificateRequest extends HandshakeMessage {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(CertificateRequest.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(CertificateRequest.class);
 
 	// DTLS-specific constants ////////////////////////////////////////
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateTypeExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateTypeExtension.java
@@ -36,7 +36,7 @@ import org.eclipse.californium.scandium.util.ListUtils;
  */
 public abstract class CertificateTypeExtension extends HelloExtension {
 
-	private static final Logger LOG = LoggerFactory.getLogger(CertificateTypeExtension.class.getName());
+	private static final Logger LOG = LoggerFactory.getLogger(CertificateTypeExtension.class);
 	
 	// DTLS-specific constants ////////////////////////////////////////
 	

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateVerify.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateVerify.java
@@ -49,7 +49,7 @@ public final class CertificateVerify extends HandshakeMessage {
 	
 	// Logging ///////////////////////////////////////////////////////////
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(CertificateVerify.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(CertificateVerify.class);
 
 	// DTLS-specific constants ////////////////////////////////////////
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CompressionMethod.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CompressionMethod.java
@@ -48,7 +48,7 @@ public enum CompressionMethod {
 
 	// Logging ////////////////////////////////////////////////////////
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(CompressionMethod.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(CompressionMethod.class);
 
 	// Members ////////////////////////////////////////////////////////
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class Connection {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(Connection.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(Connection.class);
 
 	private final AtomicReference<Handshaker> ongoingHandshake = new AtomicReference<Handshaker>();
 	private final SessionListener sessionListener = new ConnectionSessionListener();

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -89,7 +89,7 @@ public final class DTLSSession implements Destroyable {
 								+ 36 // bytes optional IP options
 								+ 8 // bytes UDP headers
 								+ 20; // bytes IP headers
-	private static final Logger LOGGER = LoggerFactory.getLogger(DTLSSession.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(DTLSSession.class);
 	private static final long RECEIVE_WINDOW_SIZE = 64;
 	private static final long MAX_SEQUENCE_NO = 281474976710655L; // 2^48 - 1
 	private static final int MAX_FRAGMENT_LENGTH_DEFAULT = 16384; // 2^14 bytes as defined by DTLS 1.2 spec, Section 4.1

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DebugConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DebugConnectionStore.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  * Intended to be used for unit tests.
  */
 public final class DebugConnectionStore extends InMemoryConnectionStore {
-	private static final Logger LOG = LoggerFactory.getLogger(DebugConnectionStore.class.getName());
+	private static final Logger LOG = LoggerFactory.getLogger(DebugConnectionStore.class);
 
 	/**
 	 * Creates a store based on given configuration parameters.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DtlsAeadConnectionState.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DtlsAeadConnectionState.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DtlsAeadConnectionState extends DTLSConnectionState {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(DtlsAeadConnectionState.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(DtlsAeadConnectionState.class);
 
 	private final SecretKey encryptionKey;
 	private final SecretIvParameterSpec iv;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchange.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 public final class ECDHServerKeyExchange extends ServerKeyExchange {
 
 	private static final String MSG_UNKNOWN_CURVE_TYPE = "Unknown curve type [{}]";
-	private static final Logger LOGGER = LoggerFactory.getLogger(ECDHServerKeyExchange.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ECDHServerKeyExchange.class);
 
 	// DTLS-specific constants ////////////////////////////////////////
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchange.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class EcdhPskServerKeyExchange extends ServerKeyExchange {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(EcdhPskServerKeyExchange.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(EcdhPskServerKeyExchange.class);
 
 	private static final int IDENTITY_HINT_LENGTH_BITS = 16;
 	private static final String MSG_UNKNOWN_CURVE_TYPE = "Unknown curve type [{}]";

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Finished.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Finished.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class Finished extends HandshakeMessage {
 
-	private static final Logger LOG = LoggerFactory.getLogger(Finished.class.getName());
+	private static final Logger LOG = LoggerFactory.getLogger(Finished.class);
 
 	// Members ////////////////////////////////////////////////////////
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeMessage.java
@@ -63,7 +63,7 @@ public abstract class HandshakeMessage extends AbstractMessage {
 
 	// Logging ////////////////////////////////////////////////////////
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(HandshakeMessage.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(HandshakeMessage.class);
 
 	// Members ////////////////////////////////////////////////////////
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -115,7 +115,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class Handshaker implements Destroyable {
 
-	protected final Logger LOGGER = LoggerFactory.getLogger(getClass().getName());
+	protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
 	/**
 	 * Indicates whether this handshaker performs the client or server part of

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtensions.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtensions.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 public final class HelloExtensions {
 	// Logging ////////////////////////////////////////////////////////
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(HelloExtensions.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(HelloExtensions.class);
 
 	// DTLS-specific constants ////////////////////////////////////////
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -85,7 +85,7 @@ import org.slf4j.LoggerFactory;
  */
 public class InMemoryConnectionStore implements ResumptionSupportingConnectionStore, CloseSupportingConnectionStore {
 
-	private static final Logger LOG = LoggerFactory.getLogger(InMemoryConnectionStore.class.getName());
+	private static final Logger LOG = LoggerFactory.getLogger(InMemoryConnectionStore.class);
 	private static final int DEFAULT_SMALL_EXTRA_CID_LENGTH = 2; // extra cid bytes additionally to required bytes for small capacity.
 	private static final int DEFAULT_LARGE_EXTRA_CID_LENGTH = 3; // extra cid bytes additionally to required bytes for large capacity.
 	private static final int DEFAULT_CACHE_SIZE = 150000;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PskUtil.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PskUtil.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PskUtil implements Destroyable {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(PskUtil.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(PskUtil.class);
 
 	private final SecretKey pskSecret;
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Record.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Record.java
@@ -55,7 +55,7 @@ public class Record {
 
 	// Logging ////////////////////////////////////////////////////////
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(Record.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(Record.class);
 
 	// DTLS specific constants/////////////////////////////////////////
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
@@ -123,7 +123,7 @@ public enum CipherSuite {
 	public static final int CIPHER_SUITE_BITS = 16;
 
 	// Logging ////////////////////////////////////////////////////////
-	private static final Logger LOGGER = LoggerFactory.getLogger(CipherSuite.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(CipherSuite.class);
 
 	// Members ////////////////////////////////////////////////////////
 	private static int overallMaxCipherTextExpansion = 0;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/ECDHECryptography.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/ECDHECryptography.java
@@ -58,7 +58,7 @@ public final class ECDHECryptography {
 
 	// Logging ////////////////////////////////////////////////////////
 
-	protected static final Logger LOGGER = LoggerFactory.getLogger(ECDHECryptography.class.getCanonicalName());
+	protected static final Logger LOGGER = LoggerFactory.getLogger(ECDHECryptography.class);
 
 	// Static members /////////////////////////////////////////////////
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticCertificateVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticCertificateVerifier.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StaticCertificateVerifier implements AdvancedCertificateVerifier {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(StaticCertificateVerifier.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(StaticCertificateVerifier.class);
 
 	/**
 	 * Array of root certificates.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/util/SecretUtil.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/util/SecretUtil.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  * Utility to use {@link Destroyable} {@link SecretKey} for java before 1.8.
  */
 public class SecretUtil {
-	private static final Logger LOGGER = LoggerFactory.getLogger(SecretUtil.class.getCanonicalName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(SecretUtil.class);
 
 	/**
 	 * Destroy secret key.

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
@@ -93,7 +93,7 @@ import org.slf4j.LoggerFactory;
 @Category(Medium.class)
 public class DTLSConnectorAdvancedTest {
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(DTLSConnectorAdvancedTest.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(DTLSConnectorAdvancedTest.class);
 
 	@ClassRule
 	public static DtlsNetworkRule network = new DtlsNetworkRule(DtlsNetworkRule.Mode.DIRECT,

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
@@ -84,7 +84,7 @@ import org.slf4j.LoggerFactory;
 @Category(Medium.class)
 public class DTLSConnectorResumeTest {
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(DTLSConnectorResumeTest.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(DTLSConnectorResumeTest.class);
 
 	@ClassRule
 	public static DtlsNetworkRule network = new DtlsNetworkRule(DtlsNetworkRule.Mode.DIRECT,

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorStartStopTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorStartStopTest.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
 @Category(Large.class)
 public class DTLSConnectorStartStopTest {
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(DTLSConnectorStartStopTest.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(DTLSConnectorStartStopTest.class);
 
 	@ClassRule
 	public static DtlsNetworkRule network = new DtlsNetworkRule(DtlsNetworkRule.Mode.DIRECT, DtlsNetworkRule.Mode.NATIVE);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -121,7 +121,7 @@ import org.slf4j.LoggerFactory;
  */
 @Category(Medium.class)
 public class DTLSConnectorTest {
-	public static final Logger LOGGER = LoggerFactory.getLogger(DTLSConnectorTest.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(DTLSConnectorTest.class);
 
 	@ClassRule
 	public static DtlsNetworkRule network = new DtlsNetworkRule(DtlsNetworkRule.Mode.DIRECT, DtlsNetworkRule.Mode.NATIVE);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/AdversaryClientHandshaker.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/AdversaryClientHandshaker.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AdversaryClientHandshaker extends ClientHandshaker {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(AdversaryClientHandshaker.class.getName());
+	private static final Logger LOGGER = LoggerFactory.getLogger(AdversaryClientHandshaker.class);
 
 	// Constructors ///////////////////////////////////////////////////
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ReassemblingHandshakeMessageTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ReassemblingHandshakeMessageTest.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 @Category(Small.class)
 public class ReassemblingHandshakeMessageTest {
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(ReassemblingHandshakeMessageTest.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(ReassemblingHandshakeMessageTest.class);
 
 	private static final int MAX_FRAGMENT_SIZE = 100;
 	private static final int MESSAGE_SIZE = 3000;

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/rule/DtlsNetworkRule.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/rule/DtlsNetworkRule.java
@@ -44,7 +44,7 @@ import org.eclipse.californium.scandium.dtls.Record;
  */
 public class DtlsNetworkRule extends NetworkRule {
 
-	public static final Logger LOGGER = LoggerFactory.getLogger(DtlsNetworkRule.class.getName());
+	public static final Logger LOGGER = LoggerFactory.getLogger(DtlsNetworkRule.class);
 
 	private static final InetSocketAddress ADDRESS = new InetSocketAddress(0) {
 


### PR DESCRIPTION
This PR was triggered by https://github.com/eclipse/californium/pull/1171#discussion_r362503747.

Reading the [SLF4J manual](http://www.slf4j.org/manual.html) this sounds to be the "normal" way.

AFAIK, the only benefits is that this is more concise.

(I do this quickly with a find/replace, then review the diff, so if this is not accepted this is not a big deal :-) )