### PR TITLE
Message interceptor based health

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
@@ -960,7 +960,9 @@ public abstract class Message {
 
 	/**
 	 * Checks if this message is a duplicate.
-	 *
+	 * 
+	 * Since 2.1 this also reflects, if the message is resent.
+	 * 
 	 * @return true, if is a duplicate
 	 */
 	public boolean isDuplicate() {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpointHealth.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpointHealth.java
@@ -15,9 +15,15 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
+import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
+
 /**
  * Health interface for {@link CoapEndpoint}
+ * 
+ * @deprecated use {@link MessageInterceptor} and
+ *             {@link CoapEndpoint#addPostProcessInterceptor(MessageInterceptor)}
  */
+@Deprecated
 public interface CoapEndpointHealth {
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpointHealthLogger.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpointHealthLogger.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
+import org.eclipse.californium.core.network.interceptors.HealthStatisticLogger;
 import org.eclipse.californium.elements.util.SimpleCounterStatistic;
 import org.eclipse.californium.elements.util.StringUtil;
 import org.slf4j.Logger;
@@ -22,7 +23,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Health implementation using counter and logging for result.
+ * 
+ * @deprecated use {@link HealthStatisticLogger}
  */
+@Deprecated
 public class CoapEndpointHealthLogger implements CoapEndpointHealth {
 
 	/** the logger. */

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
@@ -34,6 +34,7 @@ import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
 import org.eclipse.californium.core.observe.NotificationListener;
 import org.eclipse.californium.core.server.MessageDeliverer;
+import org.eclipse.californium.elements.Connector;
 
 /**
  * A communication endpoint multiplexing CoAP message exchanges between (potentially multiple) clients and servers.
@@ -129,7 +130,20 @@ public interface Endpoint {
 	void removeNotificationListener(NotificationListener lis);
 
 	/**
-	 * Adds a message interceptor to this endpoint.
+	 * Adds a message interceptor to this endpoint to be called, when messages
+	 * are passed between the {@link Connector} and this endpoint. When messages
+	 * arrive from the connector, the corresponding receive-method is called.
+	 * When a message is about to be sent over a connector, the corresponding
+	 * send method is called. The interceptor can be thought of being placed
+	 * inside an {@code CoapEndpoint} just between the message
+	 * {@code Serializer} and the {@code Matcher}.
+	 * <p>
+	 * A {@code MessageInterceptor} registered here can cancel a message to stop
+	 * it. If it is an outgoing message that traversed down through the
+	 * {@code CoapStack} to the {@code Matcher} and is now intercepted and
+	 * canceled, will not reach the {@code Connector}. If it is an incoming
+	 * message coming from the {@code Connector} to the {@code DataParser} and
+	 * is now intercepted and canceled, will not reach the {@code Matcher}.
 	 *
 	 * @param interceptor the interceptor
 	 */

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessagePostProcessInterceptors.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessagePostProcessInterceptors.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.util.List;
+
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
+import org.eclipse.californium.core.network.stack.CoapStack;
+import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.util.PublicAPIExtension;
+
+/**
+ * Extension interface for {@link Endpoint} to add {@link MessageInterceptor} to be
+ * called, when the messages are fully processed. Will be merged into
+ * {@link Endpoint} with the next major release.
+ */
+@PublicAPIExtension(type = Endpoint.class)
+public interface MessagePostProcessInterceptors {
+
+	/**
+	 * Adds a message interceptor to this endpoint to be called, when messages
+	 * are fully processed. The send methods are called, when a {@link Message}
+	 * was successful sent by the {@link Connector}, or the sending failed. The
+	 * receive methods are called, when the message, received by the
+	 * {@link Connector}, was fully processed by the {@link Matcher} and the
+	 * {@link CoapStack}.
+	 * <p>
+	 * A {@code MessageInterceptor} registered here must not cancel the message.
+	 * </p>
+	 *
+	 * @param interceptor the interceptor
+	 */
+	void addPostProcessInterceptor(MessageInterceptor interceptor);
+
+	/**
+	 * Removes the interceptor.
+	 *
+	 * @param interceptor the interceptor
+	 */
+	void removePostProcessInterceptor(MessageInterceptor interceptor);
+
+	/**
+	 * Gets all registered message post process interceptor.
+	 *
+	 * @return an immutable list of the registered message post process interceptors.
+	 */
+	List<MessageInterceptor> getPostProcessInterceptors();
+
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/HealthStatisticLogger.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/HealthStatisticLogger.java
@@ -1,0 +1,231 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network.interceptors;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.elements.util.CounterStatisticManager;
+import org.eclipse.californium.elements.util.SimpleCounterStatistic;
+import org.eclipse.californium.elements.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Health implementation using counter and logging for result.
+ */
+public class HealthStatisticLogger extends CounterStatisticManager implements MessageInterceptor {
+
+	/** the logger. */
+	private static final Logger LOGGER = LoggerFactory.getLogger(HealthStatisticLogger.class);
+
+	private final SimpleCounterStatistic sentRequests = new SimpleCounterStatistic("requests", align);
+	private final SimpleCounterStatistic sentResponses = new SimpleCounterStatistic("responses", align);
+	private final SimpleCounterStatistic sentRejects = new SimpleCounterStatistic("rejects", align);
+	private final SimpleCounterStatistic sentAcknowledges = new SimpleCounterStatistic("acks", align);
+	private final SimpleCounterStatistic resentRequests = new SimpleCounterStatistic("request retransmissions", align);
+	private final SimpleCounterStatistic resentResponses = new SimpleCounterStatistic("response retransmissions",
+			align);
+	private final SimpleCounterStatistic sendErrors = new SimpleCounterStatistic("errors", align);
+
+	private final SimpleCounterStatistic receivedRequests = new SimpleCounterStatistic("requests", align);
+	private final SimpleCounterStatistic receivedResponses = new SimpleCounterStatistic("responses", align);
+	private final SimpleCounterStatistic receivedRejects = new SimpleCounterStatistic("rejects", align);
+	private final SimpleCounterStatistic receivedAcknowledges = new SimpleCounterStatistic("acks", align);
+	private final SimpleCounterStatistic duplicateRequests = new SimpleCounterStatistic("duplicate requests", align);
+	private final SimpleCounterStatistic duplicateResponses = new SimpleCounterStatistic("duplicate responses", align);
+	private final SimpleCounterStatistic ignoredMessages = new SimpleCounterStatistic("ignored", align);
+
+	/**
+	 * {@code true} dump statistic for udp, {@code false}, dump statistic for
+	 * tcp.
+	 */
+	private final boolean udp;
+
+	/**
+	 * Create passive health logger.
+	 * 
+	 * {@link #dump()} is intended to be called externally.
+	 * 
+	 * @param tag logging tag
+	 * @param udp {@code true} dump statistic for udp, {@code false}, dump
+	 *            statistic for tcp.
+	 */
+	public HealthStatisticLogger(String tag, boolean udp) {
+		super(tag);
+		this.udp = udp;
+		init();
+	}
+
+	/**
+	 * Create active health logger.
+	 * 
+	 * {@link #dump()} is called repeated with configurable interval.
+	 * 
+	 * @param tag logging tag
+	 * @param udp {@code true} dump statistic for udp, {@code false}, dump
+	 *            statistic for tcp.
+	 * @param interval interval in seconds. {@code 0} to disable active logging.
+	 * @param executor executor executor to schedule active logging.
+	 * @throws NullPointerException if executor is {@code null}
+	 */
+	public HealthStatisticLogger(String tag, boolean udp, int interval, ScheduledExecutorService executor) {
+		super(tag, interval, executor);
+		this.udp = udp;
+		init();
+	}
+
+	private void init() {
+		add("send-", sentRequests);
+		add("send-", sentResponses);
+		add("send-", sentAcknowledges);
+		add("send-", sentRejects);
+		add("send-", resentRequests);
+		add("send-", resentResponses);
+		add("send-", sendErrors);
+
+		add("recv-", receivedRequests);
+		add("recv-", receivedResponses);
+		add("recv-", receivedAcknowledges);
+		add("recv-", receivedRejects);
+		add("recv-", duplicateRequests);
+		add("recv-", duplicateResponses);
+		add("recv-", ignoredMessages);
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return LOGGER.isDebugEnabled();
+	}
+
+	@Override
+	public void dump() {
+		try {
+			if (receivedRequests.isUsed() || sentRequests.isUsed() || sendErrors.isUsed()) {
+				String eol = StringUtil.lineSeparator();
+				String head = "   " + tag;
+				StringBuilder log = new StringBuilder();
+				log.append(tag).append("endpoint statistic:").append(eol);
+				log.append(tag).append("send statistic:").append(eol);
+				log.append(head).append(sentRequests).append(eol);
+				log.append(head).append(sentResponses).append(eol);
+				if (udp) {
+					log.append(head).append(sentAcknowledges).append(eol);
+					log.append(head).append(sentRejects).append(eol);
+					log.append(head).append(resentRequests).append(eol);
+					log.append(head).append(resentResponses).append(eol);
+				}
+				log.append(head).append(sendErrors).append(eol);
+				log.append(tag).append("receive statistic:").append(eol);
+				log.append(head).append(receivedRequests).append(eol);
+				log.append(head).append(receivedResponses).append(eol);
+				if (udp) {
+					log.append(head).append(receivedAcknowledges).append(eol);
+					log.append(head).append(receivedRejects).append(eol);
+					log.append(head).append(duplicateRequests).append(eol);
+					log.append(head).append(duplicateResponses).append(eol);
+				}
+				log.append(head).append(ignoredMessages).append(eol);
+				long sent = getSentCounters();
+				long processed = getProcessedCounters();
+				log.append(tag).append("sent ").append(sent).append(", received ").append(processed);
+				LOGGER.debug("{}", log);
+			}
+		} catch (Throwable e) {
+			LOGGER.error("{}", tag, e);
+		}
+	}
+
+	public long getSentCounters() {
+		long sent = sentRequests.getCounter() + sentResponses.getCounter() + sentAcknowledges.getCounter()
+				+ sentRejects.getCounter() + resentRequests.getCounter() + resentResponses.getCounter();
+		return sent;
+	}
+
+	public long getProcessedCounters() {
+		long processed = receivedRequests.getCounter() + receivedResponses.getCounter()
+				+ receivedAcknowledges.getCounter() + receivedRejects.getCounter() + duplicateRequests.getCounter()
+				+ duplicateResponses.getCounter() + ignoredMessages.getCounter();
+		return processed;
+	}
+
+	@Override
+	public void sendRequest(Request request) {
+		if (request.getSendError() != null) {
+			sendErrors.increment();
+		} else if (request.isDuplicate()) {
+			resentRequests.increment();
+		} else {
+			sentRequests.increment();
+		}
+	}
+
+	@Override
+	public void sendResponse(Response response) {
+		if (response.getSendError() != null) {
+			sendErrors.increment();
+		} else if (response.isDuplicate()) {
+			resentResponses.increment();
+		} else {
+			sentResponses.increment();
+		}
+	}
+
+	@Override
+	public void sendEmptyMessage(EmptyMessage message) {
+		if (message.getSendError() != null) {
+			sendErrors.increment();
+		} else if (message.getType() == CoAP.Type.ACK) {
+			sentAcknowledges.increment();
+		} else {
+			sentRejects.increment();
+		}
+	}
+
+	@Override
+	public void receiveRequest(Request request) {
+		if (request.isDuplicate()) {
+			duplicateRequests.increment();
+		} else {
+			receivedRequests.increment();
+		}
+	}
+
+	@Override
+	public void receiveResponse(Response response) {
+		if (response.isCanceled()) {
+			ignoredMessages.increment();
+		} else if (response.isDuplicate()) {
+			duplicateResponses.increment();
+		} else {
+			receivedResponses.increment();
+		}
+	}
+
+	@Override
+	public void receiveEmptyMessage(EmptyMessage message) {
+		if (message.isCanceled()) {
+			ignoredMessages.increment();
+		} else if (message.getType() == CoAP.Type.ACK) {
+			receivedAcknowledges.increment();
+		} else {
+			receivedRejects.increment();
+		}
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/MessageInterceptor.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/MessageInterceptor.java
@@ -24,62 +24,66 @@ package org.eclipse.californium.core.network.interceptors;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Endpoint;
 
 /**
- * MessageInterceptors register at an endpoint. When messages arrive from the
- * connector, the corresponding receive-method is called. When a message is
- * about to be sent over a connector, the corresponding send method is called.
- * The interceptor can be thought of being placed inside an <code>CoapEndpoint</code>
- * just between the message <code>Serializer</code> and the <code>Matcher</code>.
- * <p>
- * A <code>MessageInterceptor</code> can cancel a message to stop it. If it is
- * an outgoing message that traversed down through the <code>CoapStack</code> to the
- * <code>Matcher</code> and is now intercepted and canceled, will not reach the
- * <code>Connector</code>. If it is an incoming message coming from the
- * <code>Connector</code> to the <code>DataParser</code> and is now intercepted and
- * canceled, will not reach the <code>Matcher</code>.
+ * MessageInterceptors will be called by a {@link Endpoint} at specific
+ * processing stage defined by the method to register it at the
+ * {@link Endpoint}.
+ * 
+ * In difference to the Californium API version 2.0.0, where such
+ * MessageInterceptors are only intended to be called, when messages arrive from
+ * the connector, or when a message is about to be sent over a connector, the
+ * processing stage for the callback is now defined by the method to register
+ * the interceptor at the {@link Endpoint}. Using
+ * {@link Endpoint#addInterceptor(MessageInterceptor)} to register a interceptor
+ * results in the exact same behaviour specified as the only scenario supported
+ * for 2.0.0.
+ * 
+ * The callbacks are only supported to cancel a message to stop it, if that is
+ * documented at the method to register.
+ * {@link Endpoint#addInterceptor(MessageInterceptor)} permits that, and
+ * therefore results in the exact same behaviour as for 2.0.0.
  */
 public interface MessageInterceptor {
 
 	/**
-	 * Override this method to be notified when a request is about to be sent.
+	 * Override this method to be notified when a request is send.
 	 *
 	 * @param request the request
 	 */
 	void sendRequest(Request request);
 
 	/**
-	 * Override this method to be notified when a response is about to be sent.
+	 * Override this method to be notified when a response is send.
 	 *
 	 * @param response the response
 	 */
 	void sendResponse(Response response);
 
 	/**
-	 * Override this method to be notified when an empty message is about to be
-	 * sent.
+	 * Override this method to be notified when an empty message is send.
 	 * 
 	 * @param message the empty message
 	 */
 	void sendEmptyMessage(EmptyMessage message);
 
 	/**
-	 * Override this method to be notified when request has been received.
+	 * Override this method to be notified when request is received.
 	 *
 	 * @param request the request
 	 */
 	void receiveRequest(Request request);
 
 	/**
-	 * Override this method to be notified when response has been received.
+	 * Override this method to be notified when response is received.
 	 *
 	 * @param response the response
 	 */
 	void receiveResponse(Response response);
 
 	/**
-	 * Override this method to be notified when an empty message has been
-	 * received.
+	 * Override this method to be notified when an empty message is received.
 	 * 
 	 * @param message the message
 	 */

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MessageExchangeStoreTool.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MessageExchangeStoreTool.java
@@ -205,7 +205,7 @@ public class MessageExchangeStoreTool {
 				InMemoryObservationStore observationStore, InMemoryMessageExchangeStore exchangeStore,
 				EndpointContextMatcher matcher) {
 			super(connector, applyConfiguration, config, new RandomTokenGenerator(config), observationStore,
-					exchangeStore, matcher, null, null, COAP_STACK_TEST_FACTORY, null);
+					exchangeStore, matcher, null, COAP_STACK_TEST_FACTORY, null);
 			this.exchangeStore = exchangeStore;
 			this.observationStore = observationStore;
 			this.requestChecker = new RequestEventChecker();

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ResponseRetransmissionTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ResponseRetransmissionTest.java
@@ -21,7 +21,9 @@ import static org.eclipse.californium.core.coap.CoAP.Type.ACK;
 import static org.eclipse.californium.core.coap.CoAP.Type.CON;
 import static org.eclipse.californium.core.test.MessageExchangeStoreTool.assertAllExchangesAreCompleted;
 import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.*;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 import java.util.concurrent.TimeUnit;
 
@@ -31,6 +33,7 @@ import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.interceptors.HealthStatisticLogger;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.core.test.MessageExchangeStoreTool.CoapTestEndpoint;
 import org.eclipse.californium.core.test.MessageExchangeStoreTool.UDPTestConnector;
@@ -51,6 +54,7 @@ import org.junit.experimental.categories.Category;
 @Category(Medium.class)
 public class ResponseRetransmissionTest {
 
+	private static final String PIGGYBACKED = "ack";
 	private static final String SEPARATE = "con";
 	private static final int TEST_EXCHANGE_LIFETIME = 247; // milliseconds
 	private static final int TEST_SWEEP_DEDUPLICATOR_INTERVAL = 100; // milliseconds
@@ -76,6 +80,7 @@ public class ResponseRetransmissionTest {
 	private CoapTestEndpoint serverEndpoint;
 	private UDPTestConnector serverConnector;
 	private ServerBlockwiseInterceptor serverInterceptor = new ServerBlockwiseInterceptor();
+	private HealthStatisticLogger health = new HealthStatisticLogger("server", true);
 
 	@Before
 	public void setup() throws Exception {
@@ -88,9 +93,11 @@ public class ResponseRetransmissionTest {
 		serverConnector = new UDPTestConnector(TestTools.LOCALHOST_EPHEMERAL);
 		serverEndpoint = new CoapTestEndpoint(serverConnector, config, false);
 		serverEndpoint.addInterceptor(serverInterceptor);
+		serverEndpoint.addPostProcessInterceptor(health);
 		server = new CoapServer(config);
 		server.addEndpoint(serverEndpoint);
 		server.add(new TestResource(SEPARATE, true));
+		server.add(new TestResource(PIGGYBACKED, false));
 		server.start();
 		cleanup.add(server);
 
@@ -119,6 +126,75 @@ public class ResponseRetransmissionTest {
 		client.goMultiExpectation();
 
 		client.sendEmpty(ACK).loadMID("M").go();
+
+		assertAllExchangesAreCompleted(serverEndpoint, time);
+
+		assertThat(health.getCounter("send-responses"), is(1L));
+		assertThat(health.getCounter("send-response retransmissions"), is(0L));
+		assertThat(health.getCounter("send-acks"), is(1L));
+		assertThat(health.getCounter("send-rejects"), is(0L));
+		assertThat(health.getCounter("send-errors"), is(0L));
+		assertThat(health.getCounter("recv-requests"), is(1L));
+		assertThat(health.getCounter("recv-duplicate requests"), is(0L));
+		assertThat(health.getCounter("recv-acks"), is(1L));
+		assertThat(health.getCounter("recv-rejects"), is(0L));
+		assertThat(health.getCounter("recv-ignored"), is(0L));
+	}
+
+	@Test
+	public void testGETRequestRetransmittedConResponse() throws Exception {
+		Token tok = generateNextToken();
+
+		client.sendRequest(CON, GET, tok, ++mid).path(SEPARATE).go();
+		client.startMultiExpectation();
+		client.expectEmpty(ACK, mid).go();
+		client.expectResponse().type(CON).code(CONTENT).token(tok).storeMID("M").go();
+		client.goMultiExpectation();
+
+		client.sendRequest(CON, GET, tok, mid).path(SEPARATE).go();
+		client.startMultiExpectation();
+		client.expectEmpty(ACK, mid).go();
+		client.expectResponse().type(CON).code(CONTENT).token(tok).sameMID("M").go();
+		client.goMultiExpectation();
+
+		client.sendEmpty(ACK).loadMID("M").go();
+
+		assertAllExchangesAreCompleted(serverEndpoint, time);
+
+		assertThat(health.getCounter("send-responses"), is(1L));
+		assertThat(health.getCounter("send-response retransmissions"), is(1L));
+		assertThat(health.getCounter("send-acks"), is(2L));
+		assertThat(health.getCounter("send-rejects"), is(0L));
+		assertThat(health.getCounter("send-errors"), is(0L));
+		assertThat(health.getCounter("recv-requests"), is(1L));
+		assertThat(health.getCounter("recv-duplicate requests"), is(1L));
+		assertThat(health.getCounter("recv-acks"), is(1L));
+		assertThat(health.getCounter("recv-rejects"), is(0L));
+		assertThat(health.getCounter("recv-ignored"), is(0L));
+	}
+
+	@Test
+	public void testGETRequestRetransmittedAckResponse() throws Exception {
+		Token tok = generateNextToken();
+
+		client.sendRequest(CON, GET, tok, ++mid).path(PIGGYBACKED).go();
+		client.expectResponse().type(ACK).code(CONTENT).token(tok).mid(mid).go();
+
+		client.sendRequest(CON, GET, tok, mid).path(PIGGYBACKED).go();
+		client.expectResponse().type(ACK).code(CONTENT).token(tok).mid(mid).go();
+
+		assertAllExchangesAreCompleted(serverEndpoint, time);
+
+		assertThat(health.getCounter("send-responses"), is(1L));
+		assertThat(health.getCounter("send-response retransmissions"), is(1L));
+		assertThat(health.getCounter("send-acks"), is(0L));
+		assertThat(health.getCounter("send-rejects"), is(0L));
+		assertThat(health.getCounter("send-errors"), is(0L));
+		assertThat(health.getCounter("recv-requests"), is(1L));
+		assertThat(health.getCounter("recv-duplicate requests"), is(1L));
+		assertThat(health.getCounter("recv-acks"), is(0L));
+		assertThat(health.getCounter("recv-rejects"), is(0L));
+		assertThat(health.getCounter("recv-ignored"), is(0L));
 	}
 
 	@Test
@@ -134,6 +210,19 @@ public class ResponseRetransmissionTest {
 		client.expectResponse().type(CON).code(CONTENT).token(tok).sameMID("M").go();
 
 		client.sendEmpty(ACK).loadMID("M").go();
+
+		assertAllExchangesAreCompleted(serverEndpoint, time);
+
+		assertThat(health.getCounter("send-responses"), is(1L));
+		assertThat(health.getCounter("send-response retransmissions"), is(1L));
+		assertThat(health.getCounter("send-acks"), is(1L));
+		assertThat(health.getCounter("send-rejects"), is(0L));
+		assertThat(health.getCounter("send-errors"), is(0L));
+		assertThat(health.getCounter("recv-requests"), is(1L));
+		assertThat(health.getCounter("recv-duplicate requests"), is(0L));
+		assertThat(health.getCounter("recv-acks"), is(1L));
+		assertThat(health.getCounter("recv-rejects"), is(0L));
+		assertThat(health.getCounter("recv-ignored"), is(0L));
 	}
 
 	@Test
@@ -148,6 +237,18 @@ public class ResponseRetransmissionTest {
 
 		client.expectResponse().type(CON).code(CONTENT).token(tok).sameMID("M").go();
 		assertNull(client.receiveNextMessage(TEST_ACK_TIMEOUT * 2, TimeUnit.MILLISECONDS));
+
+		assertAllExchangesAreCompleted(serverEndpoint, time);
+		assertThat(health.getCounter("send-responses"), is(1L));
+		assertThat(health.getCounter("send-response retransmissions"), is(1L));
+		assertThat(health.getCounter("send-acks"), is(1L));
+		assertThat(health.getCounter("send-rejects"), is(0L));
+		assertThat(health.getCounter("send-errors"), is(0L));
+		assertThat(health.getCounter("recv-requests"), is(1L));
+		assertThat(health.getCounter("recv-duplicate requests"), is(0L));
+		assertThat(health.getCounter("recv-acks"), is(0L));
+		assertThat(health.getCounter("recv-rejects"), is(0L));
+		assertThat(health.getCounter("recv-ignored"), is(0L));
 	}
 
 	@Test
@@ -159,6 +260,18 @@ public class ResponseRetransmissionTest {
 		client.sendRequest(CON, GET, tok, ++mid).path(SEPARATE).go();
 		client.expectEmpty(ACK, mid).go();
 		assertNull(client.receiveNextMessage(TEST_ACK_TIMEOUT * 2, TimeUnit.MILLISECONDS));
+
+		assertAllExchangesAreCompleted(serverEndpoint, time);
+		assertThat(health.getCounter("send-responses"), is(0L));
+		assertThat(health.getCounter("send-response retransmissions"), is(0L));
+		assertThat(health.getCounter("send-acks"), is(1L));
+		assertThat(health.getCounter("send-rejects"), is(0L));
+		assertThat(health.getCounter("send-errors"), is(1L));
+		assertThat(health.getCounter("recv-requests"), is(1L));
+		assertThat(health.getCounter("recv-duplicate requests"), is(0L));
+		assertThat(health.getCounter("recv-acks"), is(0L));
+		assertThat(health.getCounter("recv-rejects"), is(0L));
+		assertThat(health.getCounter("recv-ignored"), is(0L));
 	}
 
 	private class TestResource extends CoapResource {

--- a/californium-core/src/test/resources/logback-test.xml
+++ b/californium-core/src/test/resources/logback-test.xml
@@ -16,6 +16,10 @@
 		<appender-ref ref="STDOUT" />
 	</logger>
 
+	<logger name="org.eclipse.californium.core.network.interceptors.HealthStatisticLogger" level="DEBUG" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+
 	<root level="WARN">
 		<appender-ref ref="STDOUT" />
 	</root>

--- a/demo-apps/cf-extplugtest-client/src/main/resources/logback.xml
+++ b/demo-apps/cf-extplugtest-client/src/main/resources/logback.xml
@@ -41,6 +41,10 @@
 		<appender-ref ref="STDOUT_SIMPLE" />
 	</logger>
 
+	<logger name="org.eclipse.californium.core.network.interceptors.HealthStatisticLogger" level="DEBUG" additivity="false">
+		<appender-ref ref="STDOUT_SIMPLE" />
+	</logger>
+
 	<logger name="org.eclipse.californium.plugtests.ClientInitializer" level="INFO" additivity="false" >
 		<appender-ref ref="STDOUT_SIMPLE" />
 	</logger>

--- a/demo-apps/cf-extplugtest-server/src/main/resources/logback.xml
+++ b/demo-apps/cf-extplugtest-server/src/main/resources/logback.xml
@@ -74,7 +74,7 @@
 	<logger name="org.eclipse.californium.extplugtests.resources.ReverseObserve.health" level="DEBUG" additivity="false">
 		<appender-ref ref="STDOUT" />
 	</logger>
-	<logger name="org.eclipse.californium.core.network.CoapEndpoint.health" level="DEBUG" additivity="false">
+	<logger name="org.eclipse.californium.core.network.interceptors.HealthStatisticLogger" level="DEBUG" additivity="false">
 		<appender-ref ref="STDOUT" />
 	</logger>
 	<logger name="org.eclipse.californium.scandium.DTLSConnector.health" level="DEBUG" additivity="false">

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/CounterStatisticManager.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/CounterStatisticManager.java
@@ -1,0 +1,204 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Counter statistic manager.
+ * 
+ * Manage {@link SimpleCounterStatistic} and support timer interval based and
+ * external triggered processing.
+ */
+abstract public class CounterStatisticManager {
+
+	/**
+	 * Align group for {@link SimpleCounterStatistic}.
+	 */
+	protected final SimpleCounterStatistic.AlignGroup align = new SimpleCounterStatistic.AlignGroup();
+
+	/**
+	 * Map of statistics.
+	 */
+	private final Map<String, SimpleCounterStatistic> statistics = new HashMap<>();
+
+	/**
+	 * Tag to describe the information.
+	 */
+	protected final String tag;
+	/**
+	 * Executor for active repeated {@link #dump()}. {@code null}, if
+	 * {@link #dump()} is called externally.
+	 */
+	private final ScheduledExecutorService executor;
+	/**
+	 * Interval to call {@link #dump()} in seconds. {@code 0} to disable active
+	 * calls of {@link #dump()}.
+	 */
+	private final int interval;
+	/**
+	 * Handle of scheduled task.
+	 */
+	private ScheduledFuture<?> taskHandle;
+
+	/**
+	 * Create passive statistic manager.
+	 * 
+	 * {@link #dump()} is intended to be called externally.
+	 * 
+	 * @param tag describing information
+	 */
+	protected CounterStatisticManager(String tag) {
+		this.tag = StringUtil.normalizeLoggingTag(tag);
+		this.interval = 0;
+		this.executor = null;
+	}
+
+	/**
+	 * Create active statistic manager.
+	 * 
+	 * {@link #dump()} is called repeated with configurable interval.
+	 * 
+	 * @param tag describing information
+	 * @param interval interval in seconds. {@code 0} to disable active calling
+	 *            {@link #dump()}.
+	 * @param executor executor to schedule active calls of {@link #dump()}.
+	 * @throws NullPointerException if executor is {@code null}
+	 */
+	protected CounterStatisticManager(String tag, int interval, ScheduledExecutorService executor) {
+		if (executor == null) {
+			throw new NullPointerException("executor must not be null!");
+		}
+		this.tag = StringUtil.normalizeLoggingTag(tag);
+		if (isEnabled()) {
+			this.interval = interval;
+			this.executor = interval > 0 ? executor : null;
+		} else {
+			this.interval = 0;
+			this.executor = null;
+		}
+	}
+
+	/**
+	 * Add {@link SimpleCounterStatistic} to {@link #statistics} map by head and
+	 * name.
+	 * 
+	 * @param head head appended with {@link SimpleCounterStatistic#getName()}
+	 *            to build the key for the map.
+	 * @param statistic statistic to be added.
+	 * @see #getCounter(String)
+	 */
+	protected void add(String head, SimpleCounterStatistic statistic) {
+		statistics.put(head + statistic.getName(), statistic);
+	}
+
+	/**
+	 * Add {@link SimpleCounterStatistic} to {@link #statistics} map by name.
+	 * 
+	 * @param statistic statistic to be added by name.
+	 * @see #getCounter(String)
+	 */
+	protected void add(SimpleCounterStatistic statistic) {
+		statistics.put(statistic.getName(), statistic);
+	}
+
+	/**
+	 * Add {@link SimpleCounterStatistic} to {@link #statistics} map by key.
+	 * 
+	 * @param key the key for the map.
+	 * @param statistic statistic to be added.
+	 * @see #getCounter(String)
+	 */
+	protected void addByKey(String key, SimpleCounterStatistic statistic) {
+		statistics.put(key, statistic);
+	}
+
+	/**
+	 * Get {@link SimpleCounterStatistic} by name.
+	 * 
+	 * @param name name of counter statistic
+	 * @return the counter statistic, or {@link null}, if not availabel.
+	 */
+	protected SimpleCounterStatistic get(String name) {
+		return statistics.get(name);
+	}
+
+	/**
+	 * Check, if statistic manager is enabled.
+	 * 
+	 * @return {@code true}, if statistic logger is enabled, {@code false},
+	 *         otherwise.
+	 */
+	public abstract boolean isEnabled();
+
+	/**
+	 * Start active calls of {@link #dump()}.
+	 */
+	public synchronized void start() {
+		if (executor != null && taskHandle == null) {
+			taskHandle = executor.scheduleAtFixedRate(new Runnable() {
+
+				@Override
+				public void run() {
+					dump();
+				}
+
+			}, interval, interval, TimeUnit.SECONDS);
+		}
+	}
+
+	/**
+	 * Stop active calls of {@link #dump()}.
+	 */
+	public synchronized void stop() {
+		if (taskHandle != null) {
+			taskHandle.cancel(false);
+			taskHandle = null;
+		}
+	}
+
+	/**
+	 * Dump statistic. Either called active, for
+	 * {@link #CounterStatisticLogger(String, int, ScheduledExecutorService)},
+	 * or externally.
+	 */
+	public abstract void dump();
+
+	/**
+	 * Resets all {@link SimpleCounterStatistic}.
+	 */
+	public void reset() {
+		for (SimpleCounterStatistic statistic : statistics.values()) {
+			statistic.reset();
+		}
+	}
+
+	/**
+	 * Get counter of {@link SimpleCounterStatistic}.
+	 * 
+	 * @param name name to lookup. Created using {@code head} and append
+	 *            {@link SimpleCounterStatistic#getName()}.
+	 * @return counter of {@link SimpleCounterStatistic}.
+	 * @see #add(String, SimpleCounterStatistic)
+	 */
+	public long getCounter(String name) {
+		return get(name).getCounter();
+	}
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/PublicAPIExtension.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/PublicAPIExtension.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+/**
+ * Mark interfaces, which are extension to public API interfaces. These
+ * functions are intended to be merged into the public API interface with the
+ * next major version. Migration will then be replace just the usage of this
+ * interface with the public API interface.
+ */
+public @interface PublicAPIExtension {
+
+	/**
+	 * Type of the public APi interface.
+	 * 
+	 * @return representing class of the public APi interface.
+	 */
+	Class<?> type();
+}

--- a/pom.xml
+++ b/pom.xml
@@ -555,6 +555,18 @@
 								</classes-->
 							</filter>
 						</revapi.java>
+						<revapi.ignore>
+							<item>
+								<regex>true</regex>
+								<code>java\.class\.externalClassExposedInAPI</code>
+								<package>org\.eclipse\.californium\..*</package>
+								<justification>
+									Californium uses classes of other californium modules very
+									frequently in the APIs. It's considered, that always all
+									used californium modules must have the same version!
+								</justification>
+							</item>
+						</revapi.ignore>
 					</analysisConfiguration>
 					<failOnMissingConfigurationFiles>false</failOnMissingConfigurationFiles>
 					<analysisConfigurationFiles>


### PR DESCRIPTION
Add `HealthStatisticLogger` and `MessagePostInterceptor` and use it in benchmark and extended-plugtest-server. Deprecate `CoapEndpointHealth` and `CoapEndpointHealthLogger`.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>