### PR TITLE
Prepare proxy update

### DIFF
--- a/californium-core/api-changes.json
+++ b/californium-core/api-changes.json
@@ -1,0 +1,118 @@
+{
+	"2.1.0-SNAPSHOT": {
+		"revapi": {
+			"ignore": [
+				{
+					"code": "java.method.removed",
+					"old": "method java.net.InetAddress org.eclipse.californium.core.coap.Message::getDestination()",
+					"justification": "already deprecated - use getDestinationContext().getPeerAddress().getAddress()",
+					"package": "org.eclipse.californium.core.coap",
+					"classQualifiedName": "org.eclipse.californium.core.coap.Message",
+					"classSimpleName": "Message",
+					"methodName": "getDestination",
+					"oldArchive": "org.eclipse.californium:californium-core:jar:2.0.0",
+					"elementKind": "method"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method int org.eclipse.californium.core.coap.Message::getDestinationPort()",
+					"justification": "already deprecated - use getDestinationContext().getPeerAddress().getPort()",
+					"package": "org.eclipse.californium.core.coap",
+					"classQualifiedName": "org.eclipse.californium.core.coap.Message",
+					"classSimpleName": "Message",
+					"methodName": "getDestinationPort",
+					"oldArchive": "org.eclipse.californium:californium-core:jar:2.0.0",
+					"elementKind": "method"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method java.net.InetAddress org.eclipse.californium.core.coap.Message::getSource()",
+					"justification": "already deprecated - use getSourceContext().getPeerAddress().getAddress()",
+					"package": "org.eclipse.californium.core.coap",
+					"classQualifiedName": "org.eclipse.californium.core.coap.Message",
+					"classSimpleName": "Message",
+					"methodName": "getSource",
+					"oldArchive": "org.eclipse.californium:californium-core:jar:2.0.0",
+					"elementKind": "method"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method int org.eclipse.californium.core.coap.Message::getSourcePort()",
+					"justification": "already deprecated - use getSourceContext().getPeerAddress().getPort()",
+					"package": "org.eclipse.californium.core.coap",
+					"classQualifiedName": "org.eclipse.californium.core.coap.Message",
+					"classSimpleName": "Message",
+					"methodName": "getSourcePort",
+					"oldArchive": "org.eclipse.californium:californium-core:jar:2.0.0",
+					"elementKind": "method"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method java.net.InetAddress org.eclipse.californium.core.coap.Request::getDestination()",
+					"justification": "already deprecated - use getDestinationContext().getPeerAddress().getAddress()",
+					"package": "org.eclipse.californium.core.coap",
+					"classQualifiedName": "org.eclipse.californium.core.coap.Request",
+					"classSimpleName": "Request",
+					"methodName": "getDestination",
+					"oldArchive": "org.eclipse.californium:californium-core:jar:2.0.0",
+					"elementKind": "method"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method int org.eclipse.californium.core.coap.Request::getDestinationPort()",
+					"justification": "already deprecated - use getDestinationContext().getPeerAddress().getPort()",
+					"package": "org.eclipse.californium.core.coap",
+					"classQualifiedName": "org.eclipse.californium.core.coap.Request",
+					"classSimpleName": "Request",
+					"methodName": "getDestinationPort",
+					"oldArchive": "org.eclipse.californium:californium-core:jar:2.0.0",
+					"elementKind": "method"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method java.security.Principal org.eclipse.californium.core.coap.Request::getSenderIdentity()",
+					"justification": "already deprecated - use getSourceContext().getPeerIdentity()",
+					"package": "org.eclipse.californium.core.coap",
+					"classQualifiedName": "org.eclipse.californium.core.coap.Request",
+					"classSimpleName": "Request",
+					"methodName": "getSenderIdentity",
+					"oldArchive": "org.eclipse.californium:californium-core:jar:2.0.0",
+					"elementKind": "method"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method void org.eclipse.californium.core.coap.Request::prepareDestinationContext()",
+					"justification": "already deprecated - not longer required!",
+					"package": "org.eclipse.californium.core.coap",
+					"classQualifiedName": "org.eclipse.californium.core.coap.Request",
+					"classSimpleName": "Request",
+					"methodName": "prepareDestinationContext",
+					"oldArchive": "org.eclipse.californium:californium-core:jar:2.0.0",
+					"elementKind": "method"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method org.eclipse.californium.core.coap.Message org.eclipse.californium.core.coap.Request::setDestination(java.net.InetAddress)",
+					"justification": "already deprecated - use setDestinationContext()",
+					"package": "org.eclipse.californium.core.coap",
+					"classQualifiedName": "org.eclipse.californium.core.coap.Request",
+					"classSimpleName": "Request",
+					"methodName": "setDestination",
+					"oldArchive": "org.eclipse.californium:californium-core:jar:2.0.0",
+					"elementKind": "method"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method org.eclipse.californium.core.coap.Message org.eclipse.californium.core.coap.Request::setDestinationPort(int)",
+					"justification": "already deprecated - use setDestinationContext()",
+					"package": "org.eclipse.californium.core.coap",
+					"classQualifiedName": "org.eclipse.californium.core.coap.Request",
+					"classSimpleName": "Request",
+					"methodName": "setDestinationPort",
+					"oldArchive": "org.eclipse.californium:californium-core:jar:2.0.0",
+					"elementKind": "method"
+				}
+			]
+		}
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
@@ -1359,7 +1359,7 @@ public class CoapClient {
 		if (context != null && request.getDestinationContext() == null) {
 			request.setDestinationContext(context);
 			request.setURI(uri);
-		} else if (request.getDestination() == null) {
+		} else if (!request.hasURI()) {
 			// request.getUri() is a computed getter and never returns null
 			// so destination is checked
 			request.setURI(uri);

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/EmptyMessage.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/EmptyMessage.java
@@ -23,6 +23,7 @@
 package org.eclipse.californium.core.coap;
 
 import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.elements.EndpointContext;
 
 /**
  * EmptyMessage represents an empty CoAP message. An empty message has either
@@ -38,7 +39,27 @@ public class EmptyMessage extends Message {
 	public EmptyMessage(Type type) {
 		super(type);
 	}
-	
+
+	/**
+	 * Set destination endpoint context.
+	 * 
+	 * Multicast addresses are not supported.
+	 * 
+	 * Provides a fluent API to chain setters.
+	 * 
+	 * @param peerContext destination endpoint context
+	 * @return this EmptyMessage
+	 * @throws IllegalArgumentException if destination address is multicast
+	 *             address
+	 */
+	public Message setDestinationContext(EndpointContext peerContext) {
+		if (peerContext != null && peerContext.getPeerAddress().getAddress().isMulticastAddress()) {
+			throw new IllegalArgumentException("Multicast destination is not supported for empty messages!");
+		}
+		setInternalDestinationContext(peerContext);
+		return this;
+	}
+
 	/* (non-Javadoc)
 	 * @see java.lang.Object#toString()
 	 */

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
@@ -43,7 +43,6 @@
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
-import java.net.InetAddress;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
@@ -593,62 +592,6 @@ public abstract class Message {
 	}
 
 	/**
-	 * Gets the destination address.
-	 *
-	 * @return the destination
-	 * @deprecated use {@link #getDestinationContext()}
-	 */
-	public InetAddress getDestination() {
-		EndpointContext destinationContext = this.destinationContext;
-		if (destinationContext == null) {
-			return null;
-		}
-		return destinationContext.getPeerAddress().getAddress();
-	}
-
-	/**
-	 * Gets the destination port.
-	 *
-	 * @return the destination port
-	 * @deprecated use {@link #getDestinationContext()}
-	 */
-	public int getDestinationPort() {
-		EndpointContext destinationContext = this.destinationContext;
-		if (destinationContext == null) {
-			return -1;
-		}
-		return destinationContext.getPeerAddress().getPort();
-	}
-
-	/**
-	 * Gets the source address.
-	 *
-	 * @return the source
-	 * @deprecated use {@link #getSourceContext()}
-	 */
-	public InetAddress getSource() {
-		EndpointContext sourceContext = this.sourceContext;
-		if (sourceContext == null) {
-			return null;
-		}
-		return sourceContext.getPeerAddress().getAddress();
-	}
-
-	/**
-	 * Gets the source port.
-	 *
-	 * @return the source port
-	 * @deprecated use {@link #getSourceContext()}
-	 */
-	public int getSourcePort() {
-		EndpointContext sourceContext = this.sourceContext;
-		if (sourceContext == null) {
-			return -1;
-		}
-		return sourceContext.getPeerAddress().getPort();
-	}
-
-	/**
 	 * Get destination endpoint context.
 	 * 
 	 * May be {@code null} for {@link Request} during it's construction.
@@ -671,24 +614,22 @@ public abstract class Message {
 	/**
 	 * Set destination endpoint context.
 	 * 
-	 * Multicast addresses are not supported.
+	 * Multicast addresses are only supported for {@link Request}s.
 	 * 
 	 * Provides a fluent API to chain setters.
 	 * 
 	 * @param peerContext destination endpoint context
 	 * @return this Message
 	 * @throws IllegalArgumentException if destination address is multicast
-	 *             address
+	 *             address, but message is no {@link Request}
 	 * @see #setRequestDestinationContext(EndpointContext)
+	 * @deprecated use {@link #setDestinationContext(EndpointContext)} of
+	 *             {@link Request}, {@link Response}, or {@link EmptyMessage}
+	 *             instead. The parameter validation depends too much on the
+	 *             context to use this function on the base-class.
 	 */
-	public Message setDestinationContext(EndpointContext peerContext) {
-		// requests calls setRequestDestinationContext instead
-		if (peerContext != null && peerContext.getPeerAddress().getAddress().isMulticastAddress()) {
-			throw new IllegalArgumentException("Multicast destination is only supported for request!");
-		}
-		this.destinationContext = peerContext;
-		return this;
-	}
+	@Deprecated
+	public abstract Message setDestinationContext(EndpointContext peerContext);
 
 	/**
 	 * Set destination endpoint context for requests.
@@ -696,8 +637,19 @@ public abstract class Message {
 	 * 
 	 * @param peerContext destination endpoint context
 	 * @see #setDestinationContext(EndpointContext)
+	 * @deprecated use {@link #setInternalDestinationContext(EndpointContext)}
 	 */
+	@Deprecated
 	protected void setRequestDestinationContext(EndpointContext peerContext) {
+		this.destinationContext = peerContext;
+	}
+
+	/**
+	 * Set destination endpoint context.
+	 * 
+	 * @param peerContext destination endpoint context
+	 */
+	protected void setInternalDestinationContext(EndpointContext peerContext) {
 		this.destinationContext = peerContext;
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -46,12 +46,10 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
-import java.security.Principal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.californium.core.coap.CoAP.Code;
@@ -122,7 +120,7 @@ import org.eclipse.californium.elements.util.StringUtil;
 public class Request extends Message {
 
 	private static final Pattern IP_PATTERN = Pattern
-			.compile("(\\[[0-9a-f:]+(%\\w+)?\\]|[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})");
+			.compile("(\\[[0-9a-fA-F:]+(%\\w+)?\\]|[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})");
 
 	/** The request code. */
 	private final CoAP.Code code;
@@ -133,15 +131,23 @@ public class Request extends Message {
 	/** The current response for the request. */
 	private Response response;
 
+	/**
+	 * Request's scheme.
+	 * 
+	 * @see CoAP#COAP_URI_SCHEME
+	 * @see CoAP#COAP_SECURE_URI_SCHEME
+	 * @see CoAP#COAP_TCP_URI_SCHEME
+	 * @see CoAP#COAP_SECURE_TCP_URI_SCHEME
+	 */
 	private String scheme;
 
-	/** The destination address of this message. */
-	@Deprecated
-	private InetAddress destination;
-
-	/** The destination port of this message. */
-	@Deprecated
-	private int destinationPort;
+	/**
+	 * Indicates, that the URI is already set and parts of the URI are converted
+	 * into options. Though the usage of the
+	 * {@link OptionSet#setUriHost(String)} depends on the destination, it's not
+	 * supported to change the destination afterwards.
+	 */
+	private boolean uri;
 
 	/** Contextual information about this request */
 	private Map<String, String> userContext;
@@ -237,6 +243,14 @@ public class Request extends Message {
 
 	/**
 	 * Sets this request's CoAP URI.
+	 * <p>
+	 * if the destination is not already set this method sets the
+	 * <em>destination</em> to the IP address that the host part of the URI has
+	 * been resolved to. Other parts of the URI are also used to populate the
+	 * request's options. If a different destination is required, that must be
+	 * set ahead. Calling {@link #setDestinationContext(EndpointContext)} after
+	 * this will throw an {@link IllegalStateException}.
+	 * </p>
 	 * 
 	 * @param uri A CoAP URI as specified by
 	 *            <a href="https://tools.ietf.org/html/rfc7252#section-6">
@@ -246,6 +260,7 @@ public class Request extends Message {
 	 * @throws IllegalArgumentException if the given string is not a valid CoAP
 	 *             URI, contains a non-resolvable host name, an unsupported
 	 *             scheme or a fragment.
+	 * @see #setURI(URI)
 	 */
 	public Request setURI(final String uri) {
 
@@ -268,10 +283,13 @@ public class Request extends Message {
 	/**
 	 * Sets the destination address and port and options from a given URI.
 	 * <p>
-	 * This method sets the <em>destination</em> to the IP address that the host
-	 * part of the URI has been resolved to and then delegates to the
-	 * {@link #setOptions(URI)} method in order to populate the request's
-	 * options.
+	 * if the destination is not already set this method sets the
+	 * <em>destination</em> to the IP address that the host part of the URI has
+	 * been resolved to. Other parts of the URI are also used to populate the
+	 * request's options. If a different destination is required, that must be
+	 * set ahead. Calling {@link #setDestinationContext(EndpointContext)} after
+	 * this will throw an {@link IllegalStateException}.
+	 * </p>
 	 * 
 	 * @param uri The target URI.
 	 * @return This request for command chaining.
@@ -280,29 +298,34 @@ public class Request extends Message {
 	 *             host name, an unsupported scheme or a fragment.
 	 */
 	public Request setURI(final URI uri) {
-
-		if (uri == null) {
-			throw new NullPointerException("URI must not be null");
-		}
+		checkURI(uri);
 
 		final String host = uri.getHost() == null ? "localhost" : uri.getHost();
+		final String uriScheme = uri.getScheme();
+		final boolean literalIp = IP_PATTERN.matcher(host).matches();
 
 		try {
-			if (getDestinationContext() == null) {
+			InetSocketAddress destinationAdress;
+			EndpointContext destinationContext = getDestinationContext();
+			if (destinationContext == null) {
+				final int port = uri.getPort();
 				InetAddress destAddress = InetAddress.getByName(host);
-				setDestinationContext(new AddressEndpointContext(new InetSocketAddress(destAddress, 0), null));
+				String destHost = literalIp ? null : host;
+				int destPort = port <= 0 ? CoAP.getDefaultPort(uriScheme) : port;
+				destinationAdress = new InetSocketAddress(destAddress, destPort);
+				destinationContext = new AddressEndpointContext(destinationAdress, destHost, null);
+			} else {
+				destinationAdress = destinationContext.getPeerAddress();
 			}
 
-			return setOptions(new URI(uri.getScheme(), uri.getUserInfo(), host, uri.getPort(), uri.getPath(), uri.getQuery(),
-					uri.getFragment()));
+			setOptionsInternal(uri, destinationAdress, literalIp);
+			setDestinationContext(destinationContext);
+			this.scheme = uriScheme.toLowerCase();
+			this.uri = true;
+			return this;
 
 		} catch (UnknownHostException e) {
 			throw new IllegalArgumentException("cannot resolve host name: " + host);
-		} catch (URISyntaxException e) {
-			// should not happen because we are creating the URI from an
-			// existing URI object
-			LOGGER.warn("cannot set URI on request", e);
-			throw new IllegalArgumentException(e);
 		}
 	}
 
@@ -315,7 +338,9 @@ public class Request extends Message {
 	 * it does not try to resolve a host name that is part of the given URI.
 	 * Therefore, this method can be used as an alternative to the
 	 * {@link #setURI(String)} and {@link #setURI(URI)} methods when DNS is not
-	 * available.
+	 * available. Calling {@link #setDestinationContext(EndpointContext)} after
+	 * this will throw an {@link IllegalStateException}.
+	 * </p>
 	 * 
 	 * @param uri The URI to set the options from.
 	 * @return This request for command chaining.
@@ -325,84 +350,112 @@ public class Request extends Message {
 	 * @throws IllegalStateException if the destination is not set.
 	 */
 	public Request setOptions(final URI uri) {
-		InetAddress destination = getDestination();
+		checkURI(uri);
+		EndpointContext destinationContext = getDestinationContext();
+		if (destinationContext == null) {
+			throw new IllegalStateException("destination must be set ahead!");
+		}
+		setOptionsInternal(uri, destinationContext.getPeerAddress(), IP_PATTERN.matcher(uri.getHost()).matches());
+		this.uri = true;
+		return this;
+	}
+
+	/**
+	 * Check URI.
+	 * 
+	 * @param uri URI to check
+	 * @throws NullPointerException if the URI is {@code null}.
+	 * @throws IllegalArgumentException if the URI contains an unsupported
+	 *             scheme or contains a fragment.
+	 */
+	private void checkURI(final URI uri) {
 		if (uri == null) {
 			throw new NullPointerException("URI must not be null");
 		} else if (!CoAP.isSupportedScheme(uri.getScheme())) {
-			throw new IllegalArgumentException("unsupported URI scheme: " + uri.getScheme());
+			throw new IllegalArgumentException("URI scheme '" + uri.getScheme() + "' is not supported!");
 		} else if (uri.getFragment() != null) {
 			throw new IllegalArgumentException("URI must not contain a fragment");
-		} else if (destination == null) {
-			throw new IllegalStateException("destination address must be set");
+		}
+	}
+
+	/**
+	 * Internal set options from URI.
+	 * 
+	 * @param uri The URI to set the options from.
+	 * @param destination The destination of the request.
+	 * @param literalIp {@code true}, if the host part of the URI is a literal
+	 *            address, {@code false}, if it's a DNS name.
+	 * @return This request for command chaining.
+	 * @throws NullPointerException if the destination is {@code null}
+	 * @throws IllegalArgumentException if the URI contains an unsupported
+	 *             scheme or contains a fragment. Also thrown, if a literal
+	 *             address doesn't match the provided destination.
+	 */
+	private void setOptionsInternal(URI uri, InetSocketAddress destination, boolean literalIp) {
+		if (destination == null) {
+			throw new NullPointerException("destination address must not be null!");
 		}
 
-		if (uri.getHost() != null) {
-			String host = uri.getHost().toLowerCase();
-			Matcher matcher = IP_PATTERN.matcher(host);
-			if (matcher.matches()) {
+		String host = uri.getHost();
+
+		if (host != null) {
+			if (literalIp) {
 				try {
 					// host is a literal IP address, so we should be able
 					// to "wrap" it without invoking the resolver
 					InetAddress hostAddress = InetAddress.getByName(host);
-					if (!hostAddress.equals(destination)) {
+					InetAddress destinationAddress = destination.getAddress();
+					if (!hostAddress.equals(destinationAddress)) {
 						throw new IllegalArgumentException("URI's literal host IP address '" + hostAddress
-								+ "' does not match request's destination address '" + destination + "'");
+								+ "' does not match request's destination address '" + destinationAddress + "'");
 					}
+					// literal IP => no Uri-Host option
+					host = null;
 				} catch (UnknownHostException e) {
 					// this should not happen because we do not need to resolve
 					// a host name
 					LOGGER.warn("could not parse IP address of URI despite successful IP address pattern matching");
 				}
 			} else {
-				// host contains a host name, put it into Uri-Host option to
-				// enable virtual hosts (multiple names, same IP address)
-				if (StringUtil.isValidHostName(host)) {
-					getOptions().setUriHost(host);
-				} else {
+				if (!StringUtil.isValidHostName(host)) {
 					throw new IllegalArgumentException("URI's hostname '" + host + "' is invalid!'");
 				}
+				// host contains a host name, keep it to put it into Uri-Host option
+				// to enable virtual hosts (multiple names, same IP address)
+				host = host.toLowerCase();
 			}
 		}
 
-		String uriScheme = uri.getScheme().toLowerCase();
 		// The Uri-Port is only for special cases where it differs from
 		// the UDP port, usually when Proxy-Scheme is used.
 		int port = uri.getPort();
 		if (port <= 0) {
-			port = CoAP.getDefaultPort(uriScheme);
+			port = CoAP.getDefaultPort(uri.getScheme());
+		}
+		int destPort = destination.getPort();
+		if (destPort != port) {
+			throw new IllegalArgumentException(
+					"URI's port '" + port + "' does not match request's destination port '" + destPort + "'");
 		}
 
-		EndpointContext destinationContext = getDestinationContext();
-		if (destinationContext != null) {
-			int destPort = destinationContext.getPeerAddress().getPort();
-			if (destPort == 0) {
-				destinationContext = null;
-			} else if (destPort != port) {
-				throw new IllegalArgumentException(
-						"URI's port '" + port + "' does not match request's destination port '" + destPort + "'");
-			}
+		OptionSet options = getOptions();
+		if (host != null) {
+			options.setUriHost(host);
 		}
-
-		if (destinationContext == null) {
-			setDestinationContext(new AddressEndpointContext(new InetSocketAddress(destination, port), getOptions().getUriHost(), null));
-		}
-		this.scheme = uriScheme;
-		// do not set the Uri-Port option unless it is used for proxying
-		// (setting Uri-Scheme option)
-
 		// set Uri-Path options
 		String path = uri.getPath();
 		if (path != null && path.length() > 1) {
-			getOptions().setUriPath(path);
+			options.setUriPath(path);
 		}
-
 		// set Uri-Query options
 		String query = uri.getQuery();
 		if (query != null) {
-			getOptions().setUriQuery(query);
+			options.setUriQuery(query);
 		}
+	}
 
-		return this;
+	public boolean hasURI() {
+		return uri;
 	}
 
 	/**
@@ -420,20 +473,22 @@ public class Request extends Message {
 	 *             properties which cannot be parsed into a URI.
 	 */
 	public String getURI() {
-
 		String host = getOptions().getUriHost();
+		Integer port = getOptions().getUriPort();
 		if (host == null) {
-			if (getDestination() != null) {
-				host = getDestination().getHostAddress();
+			if (getDestinationContext() != null) {
+				host = getDestinationContext().getPeerAddress().getAddress().getHostAddress();
 			} else {
 				// used during construction or when receiving
 				host = "localhost";
 			}
 		}
-
-		Integer port = getOptions().getUriPort();
 		if (port == null) {
-			port = getDestinationPort();
+			if (getDestinationContext() != null) {
+				port = getDestinationContext().getPeerAddress().getPort();
+			} else {
+				port = -1;
+			}
 		}
 		if (port > 0) {
 			if (CoAP.isSupportedScheme(getScheme())) {
@@ -458,126 +513,20 @@ public class Request extends Message {
 	}
 
 	/**
-	 * Gets the destination address.
-	 *
-	 * @return the destination
-	 * @deprecated
-	 */
-	public InetAddress getDestination() {
-		EndpointContext context = getDestinationContext();
-		if (context != null) {
-			return context.getPeerAddress().getAddress();
-		}
-		return destination;
-	}
-
-	/**
-	 * Sets the destination address.
-	 *
+	 * Set destination endpoint context.
+	 * 
+	 * Multicast addresses are supported. Assumed to be called before setting
+	 * the URI. The {@link OptionSet#setUriHost(String)} depends on the
+	 * destination. Setting the destination after the URI doesn't adjust the
+	 * option and is only useful, if proxies are addressed.
+	 * 
 	 * Provides a fluent API to chain setters.
-	 *
-	 * @param destination the new destination
-	 * @return this Message
-	 * @throws IllegalStateException if destination context is already set.
-	 * @deprecated
-	 * Note: intended to be removed with {@link #setDestinationPort(int)} and 
-	 * {@link Request#prepareDestinationContext()}
-	 */
-	public Message setDestination(InetAddress destination) {
-		if (getDestinationContext() != null) {
-			throw new IllegalStateException("destination context already set!");
-		}
-		this.destination = destination;
-		multicast = destination != null && destination.isMulticastAddress();
-		return this;
-	}
-
-	/**
-	 * Gets the destination port.
-	 *
-	 * @return the destination port
-	 * @deprecated
-	 */
-	public int getDestinationPort() {
-		EndpointContext context = getDestinationContext();
-		if (context != null) {
-			return context.getPeerAddress().getPort();
-		}
-		return destinationPort;
-	}
-
-	/**
-	 * Sets the destination port.
-	 *
-	 * Provides a fluent API to chain setters.
-	 *
-	 * @param destinationPort the new destination port
-	 * @return this Message
-	 * @throws IllegalStateException if destination context is already set.
-	 * @deprecated
-	 * Note: intended to be removed with {@link #setDestination(InetAddress)} and 
-	 * {@link Request#prepareDestinationContext()}
-	 */
-	public Message setDestinationPort(int destinationPort) {
-		if (getDestinationContext() != null) {
-			throw new IllegalStateException("destination context already set!");
-		}
-		this.destinationPort = destinationPort;
-		return this;
-	}
-
-
-	/**
-	 * Gets the authenticated (remote) sender's identity.
 	 * 
-	 * @return the identity or {@code null} if the sender has not been
-	 *         authenticated
-	 * @see #getSourceContext()
-	 * @deprecated
+	 * @param peerContext destination endpoint context
+	 * @return this Request
 	 */
-	public Principal getSenderIdentity() {
-		return getSourceContext().getPeerIdentity();
-	}
-
-	/**
-	 * Prepare destination endpoint context. If not already available, create it
-	 * from the {@link #destination} and {@link #destinationPort}.
-	 * 
-	 * @throws IllegalStateException if no destination endpoint context is
-	 *             available and the destination is missing
-	 * @deprecated intended to be removed with {@link #setDestination(InetAddress)} and 
-	 * {@link #setDestinationPort(int)}
-	 */
-	public void prepareDestinationContext() {
-		EndpointContext context = getDestinationContext();
-		if (context == null) {
-			if (destination == null) {
-				throw new IllegalStateException("missing destination!");
-			}
-			context = new AddressEndpointContext(
-					new InetSocketAddress(destination, destinationPort),
-					getOptions().getUriHost(),
-					null);
-			super.setDestinationContext(context);
-		}
-		multicast = context.getPeerAddress().getAddress().isMulticastAddress();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 * 
-	 * Check, if {@link #destination} is different.
-	 * 
-	 * @throws IllegalStateException if destination differs.
-	 */
-	@Override
 	public Request setDestinationContext(EndpointContext peerContext) {
-		if (destination != null) {
-			if (!destination.equals(peerContext.getPeerAddress().getAddress())) {
-				throw new IllegalStateException("different destination!");
-			}
-		}
-		super.setRequestDestinationContext(peerContext);
+		super.setInternalDestinationContext(peerContext);
 		multicast = peerContext != null && peerContext.getPeerAddress().getAddress().isMulticastAddress();
 		return this;
 	}
@@ -613,10 +562,10 @@ public class Request extends Message {
 	 * Validate before sending that there is a destination set.
 	 */
 	private void validateBeforeSending() {
-		if (getDestination() == null) {
-			throw new NullPointerException("Destination is null");
+		if (getDestinationContext() == null) {
+			throw new IllegalStateException("Destination is null");
 		}
-		if (getDestinationPort() == 0) {
+		if (getDestinationContext().getPeerAddress().getPort() == 0) {
 			throw new NullPointerException("Destination port is 0");
 		}
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Response.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Response.java
@@ -30,6 +30,7 @@ package org.eclipse.californium.core.coap;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.network.Matcher;
 import org.eclipse.californium.core.network.stack.ReliabilityLayer;
+import org.eclipse.californium.elements.EndpointContext;
 
 /**
  * Response represents a CoAP response to a CoAP request.
@@ -133,6 +134,26 @@ public class Response extends Message {
 		} else if (!current.equals(token)) {
 			throw new IllegalArgumentException("token mismatch! (" + current + "!=" + token + ")");
 		}
+	}
+
+	/**
+	 * Set destination endpoint context.
+	 * 
+	 * Multicast addresses are not supported.
+	 * 
+	 * Provides a fluent API to chain setters.
+	 * 
+	 * @param peerContext destination endpoint context
+	 * @return this Response
+	 * @throws IllegalArgumentException if destination address is multicast
+	 *             address
+	 */
+	public Message setDestinationContext(EndpointContext peerContext) {
+		if (peerContext != null && peerContext.getPeerAddress().getAddress().isMulticastAddress()) {
+			throw new IllegalArgumentException("Multicast destination is not supported for responses!");
+		}
+		setInternalDestinationContext(peerContext);
+		return this;
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -724,8 +724,6 @@ public class CoapEndpoint implements Endpoint, MessagePostProcessInterceptors {
 			request.cancel();
 			return;
 		}
-		// create context, if not already set
-		request.prepareDestinationContext();
 
 		InetSocketAddress destinationAddress = request.getDestinationContext().getPeerAddress();
 		if (request.isMulticast()) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
@@ -21,6 +21,7 @@
 package org.eclipse.californium.core.server.resources;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -84,6 +85,15 @@ public class CoapExchange {
 		} else {
 			queryParameters.put(param, Boolean.TRUE.toString());
 		}
+	}
+
+	/**
+	 * Gets the source socket address of the request.
+	 *
+	 * @return the source socket address
+	 */
+	public InetSocketAddress getSourceSocketAddress() {
+		return exchange.getRequest().getSourceContext().getPeerAddress();
 	}
 
 	/**

--- a/californium-core/src/test/java/org/eclipse/californium/core/coap/RequestTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/coap/RequestTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import org.eclipse.californium.category.Small;
 import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.rule.TestNameLoggerRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -69,12 +70,13 @@ public class RequestTest {
 				"coap://EXAMPLE.com/%7Esensors/temp.xml",
 				"coap://EXAMPLE.com:/%7esensors/temp.xml"
 		};
+		InetSocketAddress destination = new InetSocketAddress(InetAddress.getLoopbackAddress(), 5683);
 
 		for (String uriString : exampleUris) {
 			URI uri = new URI(uriString);
 			Request req = Request.newGet();
 			// explicitly set destination address so that we do not rely on working DNS
-			req.setDestination(InetAddress.getLoopbackAddress());
+			req.setDestinationContext(new AddressEndpointContext(destination));
 			req.setOptions(uri);
 			assertThat(req.getOptions().getUriHost(), is("example.com"));
 			assertThat(req.getDestinationContext().getPeerAddress().getPort(), is(5683));
@@ -246,9 +248,10 @@ public class RequestTest {
 
 	@Test
 	public void testSetOptionsSetsUriHostOption() {
+		InetSocketAddress destination = new InetSocketAddress(InetAddress.getLoopbackAddress(), 5683);
 
 		Request req = Request.newGet();
-		req.setDestination(InetAddress.getLoopbackAddress());
+		req.setDestinationContext(new AddressEndpointContext(destination));
 		req.setOptions(URI.create("coap://iot.eclipse.org"));
 		assertThat(req.getDestinationContext().getPeerAddress().getPort(), is(CoAP.DEFAULT_COAP_PORT));
 		assertThat(req.getOptions().getUriHost(), is("iot.eclipse.org"));

--- a/californium-osgi/pom.xml
+++ b/californium-osgi/pom.xml
@@ -76,6 +76,20 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.revapi</groupId>
+				<artifactId>revapi-maven-plugin</artifactId>
+				<configuration>
+					<analysisConfigurationFiles combine.children="append">
+						<configurationFile>
+							<path>../californium-core/api-changes.json</path>
+							<roots>
+								<root>${project.version}</root>
+							</roots>
+						</configurationFile>
+					</analysisConfigurationFiles>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
 				<extensions>true</extensions>

--- a/californium-proxy/pom.xml
+++ b/californium-proxy/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>californium-core</artifactId>
-		</dependency>		
+		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
@@ -88,6 +88,20 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.revapi</groupId>
+				<artifactId>revapi-maven-plugin</artifactId>
+				<configuration>
+					<analysisConfigurationFiles combine.children="append">
+						<configurationFile>
+							<path>../californium-core/api-changes.json</path>
+							<roots>
+								<root>${project.version}</root>
+							</roots>
+						</configurationFile>
+					</analysisConfigurationFiles>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpTranslator.java
@@ -23,11 +23,9 @@ import static org.eclipse.californium.elements.util.StandardCharsets.ISO_8859_1;
 import static org.eclipse.californium.elements.util.StandardCharsets.UTF_8;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
-import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
@@ -474,16 +472,6 @@ public final class HttpTranslator {
 				coapRequest.setURI(uriString);
 			}
 
-			// set the proxy as the sender to receive the response correctly
-			try {
-				// TODO check with multihomed hosts
-				InetAddress localHostAddress = InetAddress.getLocalHost();
-				coapRequest.setDestination(localHostAddress);
-				// TODO: setDestinationPort???
-			} catch (UnknownHostException e) {
-				LOGGER.warn("Cannot get the localhost address", e);
-				throw new TranslationException("Cannot get the localhost address: " + e.getMessage());
-			}
 		} else {
 			// if the uri does not contains the proxy resource, it means the
 			// request is local to the proxy and it shouldn't be forwarded
@@ -802,6 +790,9 @@ public final class HttpTranslator {
 		case POST: coapMethod = "POST"; break;
 		case PUT: coapMethod = "PUT"; break;
 		case DELETE: coapMethod = "DELETE"; break;
+		default:
+			LOGGER.warn("Method {} not supported!", coapRequest.getCode());
+			throw new TranslationException("Method " +  coapRequest.getCode() + " not supported!");
 		}
 
 		// get the proxy-uri

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
@@ -121,11 +121,8 @@ public class ProxyCoapClientResource extends ForwardingResource {
 			// execute the request
 			LOGGER.debug("Sending proxied CoAP request.");
 
-			if (outgoingRequest.getDestination() == null) {
+			if (outgoingRequest.getDestinationContext() == null) {
 				throw new NullPointerException("Destination is null");
-			}
-			if (outgoingRequest.getDestinationPort() == 0) {
-				throw new NullPointerException("Destination port is 0");
 			}
 
 			endpointManager.getDefaultEndpoint().sendRequest(outgoingRequest);

--- a/cf-oscore/pom.xml
+++ b/cf-oscore/pom.xml
@@ -44,6 +44,20 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.revapi</groupId>
+				<artifactId>revapi-maven-plugin</artifactId>
+				<configuration>
+					<analysisConfigurationFiles combine.children="append">
+						<configurationFile>
+							<path>../californium-core/api-changes.json</path>
+							<roots>
+								<root>${project.version}</root>
+							</roots>
+						</configurationFile>
+					</analysisConfigurationFiles>
+				</configuration>
+			</plugin>
+			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<descriptorRefs>


### PR DESCRIPTION
Prepare Request for adaption of proxy-functionality.

Remove deprecated source and destination functions.
Deprecated setDestinationContext in the base-class Message and move it
into the Request, Response and EmptyMessage.

Cleanup already deprecated usage of source- and destination address without context.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>