### PR TITLE
Proxy: Use Exchange asynchrone.

### DIFF
--- a/californium-proxy/src/main/java/org/eclipse/californium/compat/CompletableFuture.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/compat/CompletableFuture.java
@@ -16,10 +16,15 @@
 
 package org.eclipse.californium.compat;
 
+import org.eclipse.californium.core.network.Exchange;
+
 /**
  * Backport of the class introduced in Java java.util.concurrent.CompletableFuture<T>.
  * @param <T> Type of the result the future shall complete with.
+ * 
+ * @deprecated not required. {@link Exchange} already support asynchronous processing.
  */
+@Deprecated
 public class CompletableFuture<T> {
     private T result;
     private Consumer<T> consumer;

--- a/californium-proxy/src/main/java/org/eclipse/californium/compat/Consumer.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/compat/Consumer.java
@@ -16,10 +16,14 @@
 
 package org.eclipse.californium.compat;
 
+import org.eclipse.californium.core.network.Exchange;
+
 /**
  * Backport of the class java.util.function.Consumer<T>
  * @param <T> Type that the consumer will receives.
- */
+* @deprecated not required. {@link Exchange} already support asynchronous processing.
+*/
+@Deprecated
 public interface Consumer<T> {
     /**
      * Executed when a said action is sent to the consumer.

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ForwardingResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ForwardingResource.java
@@ -24,7 +24,11 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange;
 
-
+/**
+ * @deprecated {@link Exchange} is already asynchronous. Use base-class
+ *             {@link CoapResource} instead.
+ */
+@Deprecated
 public abstract class ForwardingResource extends CoapResource {
 
 	public ForwardingResource(String resourceIdentifier) {

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyHttpClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyHttpClientResource.java
@@ -34,6 +34,8 @@ import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.elements.util.ClockUtil;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.proxy.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,15 +67,14 @@ public class ProxyHttpClientResource extends ForwardingResource {
 	}
 
 	@Override
-	public CompletableFuture<Response> forwardRequest(Request request) {
-		final CompletableFuture<Response> future = new CompletableFuture<>();
-		final Request incomingCoapRequest = request;
-		
+	public void handleRequest(final Exchange exchange) {
+		final Request incomingCoapRequest = exchange.getRequest();
+
 		// check the invariant: the request must have the proxy-uri set
 		if (!incomingCoapRequest.getOptions().hasProxyUri()) {
-			LOGGER.warn("Proxy-uri option not set.");
-			future.complete(new Response(ResponseCode.BAD_OPTION));
-			return future;
+			LOGGER.debug("Proxy-uri option not set.");
+			exchange.sendResponse(new Response(ResponseCode.BAD_OPTION));
+			return;
 		}
 
 		// remove the fake uri-path // TODO: why? still necessary in new Cf?
@@ -86,13 +87,13 @@ public class ProxyHttpClientResource extends ForwardingResource {
 					incomingCoapRequest.getOptions().getProxyUri(), "UTF-8");
 			proxyUri = new URI(proxyUriString);
 		} catch (UnsupportedEncodingException e) {
-			LOGGER.warn("Proxy-uri option malformed: {}", e.getMessage());
-			future.complete(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
-			return future;
+			LOGGER.debug("Proxy-uri option malformed: {}", e.getMessage());
+			exchange.sendResponse(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
+			return;
 		} catch (URISyntaxException e) {
-			LOGGER.warn("Proxy-uri option malformed: {}", e.getMessage());
-			future.complete(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
-			return future;
+			LOGGER.debug("Proxy-uri option malformed: {}", e.getMessage());
+			exchange.sendResponse(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
+			return;
 		}
 
 		// get the requested host, if the port is not specified, the constructor
@@ -105,13 +106,13 @@ public class ProxyHttpClientResource extends ForwardingResource {
 			httpRequest = new HttpTranslator().getHttpRequest(incomingCoapRequest);
 			LOGGER.debug("Outgoing http request: {}", httpRequest.getRequestLine());
 		} catch (InvalidFieldException e) {
-			LOGGER.warn("Problems during the http/coap translation: {}", e.getMessage());
-			future.complete(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
-			return future;
+			LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
+			exchange.sendResponse(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
+			return;
 		} catch (TranslationException e) {
-			LOGGER.warn("Problems during the http/coap translation: {}", e.getMessage());
-			future.complete(new Response(CoapTranslator.STATUS_TRANSLATION_ERROR));
-			return future;
+			LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
+			exchange.sendResponse(new Response(CoapTranslator.STATUS_TRANSLATION_ERROR));
+			return;
 		}
 
 		asyncClient.execute(httpHost, httpRequest, new BasicHttpContext(), new FutureCallback<HttpResponse>() {
@@ -128,29 +129,53 @@ public class ProxyHttpClientResource extends ForwardingResource {
 					Response coapResponse = new HttpTranslator().getCoapResponse(result, incomingCoapRequest);
 					coapResponse.setNanoTimestamp(timestamp);
 
-					future.complete(coapResponse);
+					exchange.sendResponse(coapResponse);
 				} catch (InvalidFieldException e) {
-					LOGGER.warn("Problems during the http/coap translation: {}", e.getMessage());
-					future.complete(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
+					LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
+					exchange.sendResponse(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
 				} catch (TranslationException e) {
-					LOGGER.warn("Problems during the http/coap translation: {}", e.getMessage());
-					future.complete(new Response(CoapTranslator.STATUS_TRANSLATION_ERROR));
+					LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
+					exchange.sendResponse(new Response(CoapTranslator.STATUS_TRANSLATION_ERROR));
 				}
 			}
 
 			@Override
 			public void failed(Exception ex) {
-				LOGGER.warn("Failed to get the http response: {}", ex.getMessage());
-				future.complete(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
+				LOGGER.debug("Failed to get the http response: {}", ex.getMessage());
+				exchange.sendResponse(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
 			}
 
 			@Override
 			public void cancelled() {
-				LOGGER.warn("Request canceled");
-				future.complete(new Response(ResponseCode.SERVICE_UNAVAILABLE));
+				LOGGER.debug("Request canceled");
+				exchange.sendResponse(new Response(ResponseCode.SERVICE_UNAVAILABLE));
 			}
 		});
 
+	}
+
+	@Deprecated
+	@Override
+	public CompletableFuture<Response> forwardRequest(final Request incomingRequest) {
+		final CompletableFuture<Response> future = new CompletableFuture<>();
+		Exchange exchange = new Exchange(incomingRequest, Origin.REMOTE, null) {
+
+			@Override
+			public void sendAccept() {
+				// has no meaning for HTTP: do nothing
+			}
+
+			@Override
+			public void sendReject() {
+				future.complete(new Response(ResponseCode.SERVICE_UNAVAILABLE));
+			}
+
+			@Override
+			public void sendResponse(Response response) {
+				future.complete(response);
+			}
+		};
+		handleRequest(exchange);
 		return future;
 	}
 }


### PR DESCRIPTION
Deprecate addition asynchronous Consumer, CompletableFuture and
ForwardingResource.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>