### PR TITLE
Fix race conditions in unit tests.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/TestTools.java
+++ b/californium-core/src/test/java/org/eclipse/californium/TestTools.java
@@ -17,6 +17,8 @@
  ******************************************************************************/
 package org.eclipse.californium;
 
+import static org.junit.Assert.assertThat;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -28,7 +30,9 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.MessageObserver;
 import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.elements.util.CounterStatisticManager;
 import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 
 /**
  * A collection of utility methods for implementing tests.
@@ -253,5 +257,24 @@ public final class TestTools {
 			description.appendText(max.toString());
 			description.appendText(")");
 		}
+	}
+
+	public static void assertCounter(final CounterStatisticManager manager, final String name,
+			final Matcher<? super Long> matcher, long timeout) throws InterruptedException {
+		if (timeout > 0) {
+			TestTools.waitForCondition(timeout, timeout / 10l, TimeUnit.MILLISECONDS, new CheckCondition() {
+
+				@Override
+				public boolean isFulFilled() throws IllegalStateException {
+					return matcher.matches(manager.getCounter(name));
+				}
+			});
+		}
+		assertThat(name, manager.getCounter(name), matcher);
+	}
+
+	public static void assertCounter(CounterStatisticManager manager, String name,
+			Matcher<? super Long> matcher) {
+		assertThat(name, manager.getCounter(name), matcher);
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ResponseRetransmissionTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ResponseRetransmissionTest.java
@@ -23,7 +23,6 @@ import static org.eclipse.californium.core.test.MessageExchangeStoreTool.assertA
 import static org.eclipse.californium.core.test.lockstep.IntegrationTestTools.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 import java.util.concurrent.TimeUnit;
 
@@ -41,6 +40,7 @@ import org.eclipse.californium.elements.rule.TestNameLoggerRule;
 import org.eclipse.californium.elements.rule.TestTimeRule;
 import org.eclipse.californium.rule.CoapNetworkRule;
 import org.eclipse.californium.rule.CoapThreadsRule;
+import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -129,16 +129,18 @@ public class ResponseRetransmissionTest {
 
 		assertAllExchangesAreCompleted(serverEndpoint, time);
 
-		assertThat(health.getCounter("send-responses"), is(1L));
-		assertThat(health.getCounter("send-response retransmissions"), is(0L));
-		assertThat(health.getCounter("send-acks"), is(1L));
-		assertThat(health.getCounter("send-rejects"), is(0L));
-		assertThat(health.getCounter("send-errors"), is(0L));
-		assertThat(health.getCounter("recv-requests"), is(1L));
-		assertThat(health.getCounter("recv-duplicate requests"), is(0L));
-		assertThat(health.getCounter("recv-acks"), is(1L));
-		assertThat(health.getCounter("recv-rejects"), is(0L));
-		assertThat(health.getCounter("recv-ignored"), is(0L));
+		// may be on the way
+		assertHealthCounter("recv-acks", is(1L), 1000);
+
+		assertHealthCounter("send-responses", is(1L));
+		assertHealthCounter("send-response retransmissions", is(0L));
+		assertHealthCounter("send-acks", is(1L));
+		assertHealthCounter("send-rejects", is(0L));
+		assertHealthCounter("send-errors", is(0L));
+		assertHealthCounter("recv-requests", is(1L));
+		assertHealthCounter("recv-duplicate requests", is(0L));
+		assertHealthCounter("recv-rejects", is(0L));
+		assertHealthCounter("recv-ignored", is(0L));
 	}
 
 	@Test
@@ -161,16 +163,18 @@ public class ResponseRetransmissionTest {
 
 		assertAllExchangesAreCompleted(serverEndpoint, time);
 
-		assertThat(health.getCounter("send-responses"), is(1L));
-		assertThat(health.getCounter("send-response retransmissions"), is(1L));
-		assertThat(health.getCounter("send-acks"), is(2L));
-		assertThat(health.getCounter("send-rejects"), is(0L));
-		assertThat(health.getCounter("send-errors"), is(0L));
-		assertThat(health.getCounter("recv-requests"), is(1L));
-		assertThat(health.getCounter("recv-duplicate requests"), is(1L));
-		assertThat(health.getCounter("recv-acks"), is(1L));
-		assertThat(health.getCounter("recv-rejects"), is(0L));
-		assertThat(health.getCounter("recv-ignored"), is(0L));
+		// may be on the way
+		assertHealthCounter("recv-acks", is(1L), 1000);
+
+		assertHealthCounter("send-responses", is(1L));
+		assertHealthCounter("send-response retransmissions", is(1L));
+		assertHealthCounter("send-acks", is(2L));
+		assertHealthCounter("send-rejects", is(0L));
+		assertHealthCounter("send-errors", is(0L));
+		assertHealthCounter("recv-requests", is(1L));
+		assertHealthCounter("recv-duplicate requests", is(1L));
+		assertHealthCounter("recv-rejects", is(0L));
+		assertHealthCounter("recv-ignored", is(0L));
 	}
 
 	@Test
@@ -185,16 +189,18 @@ public class ResponseRetransmissionTest {
 
 		assertAllExchangesAreCompleted(serverEndpoint, time);
 
-		assertThat(health.getCounter("send-responses"), is(1L));
-		assertThat(health.getCounter("send-response retransmissions"), is(1L));
-		assertThat(health.getCounter("send-acks"), is(0L));
-		assertThat(health.getCounter("send-rejects"), is(0L));
-		assertThat(health.getCounter("send-errors"), is(0L));
-		assertThat(health.getCounter("recv-requests"), is(1L));
-		assertThat(health.getCounter("recv-duplicate requests"), is(1L));
-		assertThat(health.getCounter("recv-acks"), is(0L));
-		assertThat(health.getCounter("recv-rejects"), is(0L));
-		assertThat(health.getCounter("recv-ignored"), is(0L));
+		// may be on the way
+		assertHealthCounter("recv-duplicate requests", is(1L), 1000);
+
+		assertHealthCounter("send-responses", is(1L));
+		assertHealthCounter("send-response retransmissions", is(1L));
+		assertHealthCounter("send-acks", is(0L));
+		assertHealthCounter("send-rejects", is(0L));
+		assertHealthCounter("send-errors", is(0L));
+		assertHealthCounter("recv-requests", is(1L));
+		assertHealthCounter("recv-acks", is(0L));
+		assertHealthCounter("recv-rejects", is(0L));
+		assertHealthCounter("recv-ignored", is(0L));
 	}
 
 	@Test
@@ -213,16 +219,18 @@ public class ResponseRetransmissionTest {
 
 		assertAllExchangesAreCompleted(serverEndpoint, time);
 
-		assertThat(health.getCounter("send-responses"), is(1L));
-		assertThat(health.getCounter("send-response retransmissions"), is(1L));
-		assertThat(health.getCounter("send-acks"), is(1L));
-		assertThat(health.getCounter("send-rejects"), is(0L));
-		assertThat(health.getCounter("send-errors"), is(0L));
-		assertThat(health.getCounter("recv-requests"), is(1L));
-		assertThat(health.getCounter("recv-duplicate requests"), is(0L));
-		assertThat(health.getCounter("recv-acks"), is(1L));
-		assertThat(health.getCounter("recv-rejects"), is(0L));
-		assertThat(health.getCounter("recv-ignored"), is(0L));
+		// may be on the way
+		assertHealthCounter("recv-acks", is(1L), 1000);
+
+		assertHealthCounter("send-responses", is(1L));
+		assertHealthCounter("send-response retransmissions", is(1L));
+		assertHealthCounter("send-acks", is(1L));
+		assertHealthCounter("send-rejects", is(0L));
+		assertHealthCounter("send-errors", is(0L));
+		assertHealthCounter("recv-requests", is(1L));
+		assertHealthCounter("recv-duplicate requests", is(0L));
+		assertHealthCounter("recv-rejects", is(0L));
+		assertHealthCounter("recv-ignored", is(0L));
 	}
 
 	@Test
@@ -239,16 +247,16 @@ public class ResponseRetransmissionTest {
 		assertNull(client.receiveNextMessage(TEST_ACK_TIMEOUT * 2, TimeUnit.MILLISECONDS));
 
 		assertAllExchangesAreCompleted(serverEndpoint, time);
-		assertThat(health.getCounter("send-responses"), is(1L));
-		assertThat(health.getCounter("send-response retransmissions"), is(1L));
-		assertThat(health.getCounter("send-acks"), is(1L));
-		assertThat(health.getCounter("send-rejects"), is(0L));
-		assertThat(health.getCounter("send-errors"), is(0L));
-		assertThat(health.getCounter("recv-requests"), is(1L));
-		assertThat(health.getCounter("recv-duplicate requests"), is(0L));
-		assertThat(health.getCounter("recv-acks"), is(0L));
-		assertThat(health.getCounter("recv-rejects"), is(0L));
-		assertThat(health.getCounter("recv-ignored"), is(0L));
+		assertHealthCounter("send-responses", is(1L));
+		assertHealthCounter("send-response retransmissions", is(1L));
+		assertHealthCounter("send-acks", is(1L));
+		assertHealthCounter("send-rejects", is(0L));
+		assertHealthCounter("send-errors", is(0L));
+		assertHealthCounter("recv-requests", is(1L));
+		assertHealthCounter("recv-duplicate requests", is(0L));
+		assertHealthCounter("recv-acks", is(0L));
+		assertHealthCounter("recv-rejects", is(0L));
+		assertHealthCounter("recv-ignored", is(0L));
 	}
 
 	@Test
@@ -262,16 +270,25 @@ public class ResponseRetransmissionTest {
 		assertNull(client.receiveNextMessage(TEST_ACK_TIMEOUT * 2, TimeUnit.MILLISECONDS));
 
 		assertAllExchangesAreCompleted(serverEndpoint, time);
-		assertThat(health.getCounter("send-responses"), is(0L));
-		assertThat(health.getCounter("send-response retransmissions"), is(0L));
-		assertThat(health.getCounter("send-acks"), is(1L));
-		assertThat(health.getCounter("send-rejects"), is(0L));
-		assertThat(health.getCounter("send-errors"), is(1L));
-		assertThat(health.getCounter("recv-requests"), is(1L));
-		assertThat(health.getCounter("recv-duplicate requests"), is(0L));
-		assertThat(health.getCounter("recv-acks"), is(0L));
-		assertThat(health.getCounter("recv-rejects"), is(0L));
-		assertThat(health.getCounter("recv-ignored"), is(0L));
+		assertHealthCounter("send-responses", is(0L));
+		assertHealthCounter("send-response retransmissions", is(0L));
+		assertHealthCounter("send-acks", is(1L));
+		assertHealthCounter("send-rejects", is(0L));
+		assertHealthCounter("send-errors", is(1L));
+		assertHealthCounter("recv-requests", is(1L));
+		assertHealthCounter("recv-duplicate requests", is(0L));
+		assertHealthCounter("recv-acks", is(0L));
+		assertHealthCounter("recv-rejects", is(0L));
+		assertHealthCounter("recv-ignored", is(0L));
+	}
+
+	private void assertHealthCounter(final String name, final Matcher<? super Long> matcher, long timeout)
+			throws InterruptedException {
+		TestTools.assertCounter(health, name, matcher, timeout);
+	}
+
+	private void assertHealthCounter(String name, Matcher<? super Long> matcher) {
+		TestTools.assertCounter(health, name, matcher);
 	}
 
 	private class TestResource extends CoapResource {


### PR DESCRIPTION
"recv-ignored" or some other callbacks maybe delayed.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>