### PR TITLE
Add a default handshake mode to the dtls connector

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
@@ -230,6 +230,7 @@ public  class CoapResource implements Resource {
 			case FETCH: handleFETCH(new CoapExchange(exchange, this)); break;
 			case PATCH: handlePATCH(new CoapExchange(exchange, this)); break;
 			case IPATCH: handleIPATCH(new CoapExchange(exchange, this)); break;
+			default: exchange.sendResponse(new Response(ResponseCode.METHOD_NOT_ALLOWED)); break;
 		}
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/EmptyMessage.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/EmptyMessage.java
@@ -23,6 +23,7 @@
 package org.eclipse.californium.core.coap;
 
 import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.elements.EndpointContext;
 
 /**
  * EmptyMessage represents an empty CoAP message. An empty message has either
@@ -90,8 +91,19 @@ public class EmptyMessage extends Message {
 	 * @return the acknowledgment
 	 */
 	public static EmptyMessage newACK(Message message) {
+		return newACK(message, message.getSourceContext());
+
+	}
+	/**
+	 * Create a new acknowledgment for the specified message.
+	 *
+	 * @param message the message to acknowledge
+	 * @param destination destination context
+	 * @return the acknowledgment
+	 */
+	public static EmptyMessage newACK(Message message, EndpointContext destination) {
 		EmptyMessage ack = new EmptyMessage(Type.ACK);
-		ack.setDestinationContext(message.getSourceContext());
+		ack.setDestinationContext(destination);
 		ack.setMID(message.getMID());
 		return ack;
 	}
@@ -103,8 +115,19 @@ public class EmptyMessage extends Message {
 	 * @return the reset
 	 */
 	public static EmptyMessage newRST(Message message) {
+		return newRST(message, message.getSourceContext());
+	}
+
+	/**
+	 * Create a new reset message for the specified message.
+	 *
+	 * @param message the message to reject
+	 * @param destination destination context
+	 * @return the reset
+	 */
+	public static EmptyMessage newRST(Message message, EndpointContext destination) {
 		EmptyMessage rst = new EmptyMessage(Type.RST);
-		rst.setDestinationContext(message.getSourceContext());
+		rst.setDestinationContext(destination);
 		rst.setMID(message.getMID());
 		return rst;
 	}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
@@ -74,6 +74,10 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 	 */
 	public static final String HANDSHAKE_MODE_PROBE = "probe";
 	/**
+	 * Start a handshake, if no session is available.
+	 */
+	public static final String HANDSHAKE_MODE_AUTO = "auto";
+	/**
 	 * Don't start a handshake, even, if no session is available.
 	 */
 	public static final String HANDSHAKE_MODE_NONE = "none";


### PR DESCRIPTION
Add a default handshake mode to the dtls connector.
Add the handshake mode "auto".
Expose destination endpoint context for responses, ack and rst.
Intended to provide a specific handshake mode different from the dtls
connector's default handshake mode.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>
