### PR TITLE
Adapt logging for message tracking.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -572,6 +572,10 @@ public class Exchange {
 		}
 	}
 
+	public KeyToken getKeyToken() {
+		return currentKeyToken;
+	}
+
 	/**
 	 * Returns the block option of the last block of a blockwise sent request.
 	 * When the server sends the response, this block option has to be

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/KeyMID.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/KeyMID.java
@@ -83,7 +83,10 @@ public final class KeyMID {
 
 	@Override
 	public String toString() {
-		String peerAsString = peer instanceof InetSocketAddress ? StringUtil.toString((InetSocketAddress)peer) : peer.toString();
-		return new StringBuilder("KeyMID[").append(peerAsString).append('-').append(mid).append(']').toString();
+		Object peer = this.peer;
+		if (peer instanceof InetSocketAddress) {
+			peer = StringUtil.toDisplayString((InetSocketAddress) peer);
+		}
+		return new StringBuilder("KeyMID[").append(peer).append('-').append(mid).append(']').toString();
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/KeyToken.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/KeyToken.java
@@ -107,8 +107,11 @@ public class KeyToken {
 	public String toString() {
 		StringBuilder builder = new StringBuilder("KeyToken[");
 		if (peer != null) {
-			String peerAsString = peer instanceof InetSocketAddress ? StringUtil.toString((InetSocketAddress)peer) : peer.toString();
-			builder.append(peerAsString).append('-');
+			Object peer = this.peer;
+			if (peer instanceof InetSocketAddress) {
+				peer = StringUtil.toDisplayString((InetSocketAddress) peer);
+			}
+			builder.append(peer).append('-');
 		}
 		builder.append(token.getAsString()).append(']');
 		return builder.toString();

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -107,7 +107,7 @@ public final class TcpMatcher extends BaseMatcher {
 		}
 		exchange.setRemoveHandler(exchangeRemoveHandler);
 		exchangeStore.registerOutboundRequestWithTokenOnly(exchange);
-		LOGGER.debug("tracking open request using {}", request.getTokenString());
+		LOGGER.debug("tracking open request using [{}]", exchange.getKeyToken());
 	}
 
 	@Override
@@ -170,7 +170,8 @@ public final class TcpMatcher extends BaseMatcher {
 
 		if (tempExchange == null) {
 			// There is no exchange with the given token - ignore response
-			LOGGER.trace("discarding unmatchable response from [{}]: {}", response.getSourceContext(), response);
+			LOGGER.trace("discarding by [{}] unmatchable response from [{}]: {}", idByToken,
+					response.getSourceContext(), response);
 			cancel(response, receiver);
 			return;
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -129,7 +129,7 @@ public final class UdpMatcher extends BaseMatcher {
 		try {
 			if (exchangeStore.registerOutboundRequest(exchange)) {
 				exchange.setRemoveHandler(exchangeRemoveHandler);
-				LOGGER.debug("tracking open request [MID: {}, Token: {}]", request.getMID(), request.getToken());
+				LOGGER.debug("tracking open request [{}, {}]", exchange.getKeyMID(), exchange.getKeyToken());
 			} else {
 				LOGGER.warn("message IDs exhausted, could not register outbound request for tracking");
 				request.setSendError(new IllegalStateException("automatic message IDs exhausted"));
@@ -153,6 +153,7 @@ public final class UdpMatcher extends BaseMatcher {
 			// all previous NON notifications
 			exchange.removeNotifications();
 			exchangeStore.registerOutboundResponse(exchange);
+			LOGGER.debug("tracking open response [{}]", exchange.getKeyMID());
 			ready = false;
 		} else if (response.getType() == Type.NON) {
 			if (response.isNotification()) {
@@ -273,7 +274,7 @@ public final class UdpMatcher extends BaseMatcher {
 
 		final Object peer = endpointContextMatcher.getEndpointIdentity( response.getSourceContext());
 		final KeyToken idByToken = tokenGenerator.getKeyToken(response.getToken(), peer);
-		LOGGER.trace("received response {}", response);
+		LOGGER.trace("received response {} from {}", response, response.getSourceContext());
 		Exchange tempExchange = exchangeStore.get(idByToken);
 
 		if (tempExchange == null) {
@@ -325,8 +326,8 @@ public final class UdpMatcher extends BaseMatcher {
 					reject(response, receiver);
 				}
 			} else {
-				LOGGER.trace("discarding unmatchable piggy-backed response from [{}]: {}", response.getSourceContext(),
-						response);
+				LOGGER.trace("discarding by [{}] unmatchable piggy-backed response from [{}]: {}", idByToken,
+						response.getSourceContext(), response);
 				cancel(response, receiver);
 			}
 			return;
@@ -437,7 +438,7 @@ public final class UdpMatcher extends BaseMatcher {
 		final Exchange exchange = exchangeStore.get(idByMID);
 
 		if (exchange == null) {
-			LOGGER.debug("ignoring unmatchable empty message from {}: {}", message.getSourceContext(), message);
+			LOGGER.debug("ignoring by [{}] unmatchable empty message from {}: {}", idByMID, message.getSourceContext(), message);
 			cancel(message, receiver);
 			return;
 		}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/AddressEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/AddressEndpointContext.java
@@ -137,6 +137,6 @@ public class AddressEndpointContext implements EndpointContext {
 	}
 
 	protected final String getPeerAddressAsString() {
-		return StringUtil.toString(peerAddress);
+		return StringUtil.toDisplayString(peerAddress);
 	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/KeySetEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/KeySetEndpointContextMatcher.java
@@ -22,10 +22,13 @@
  ******************************************************************************/
 package org.eclipse.californium.elements;
 
+import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+
+import org.eclipse.californium.elements.util.StringUtil;
 
 /**
  * Key set based endpoint context matcher.
@@ -79,7 +82,11 @@ public abstract class KeySetEndpointContextMatcher implements EndpointContextMat
 
 	@Override
 	public Object getEndpointIdentity(EndpointContext context) {
-		return context.getPeerAddress();
+		InetSocketAddress address = context.getPeerAddress();
+		if (address.isUnresolved()) {
+			throw new IllegalArgumentException(StringUtil.toDisplayString(address) + " must be resolved!");
+		}
+		return address;
 	}
 
 	@Override

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/StringUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/StringUtil.java
@@ -268,12 +268,44 @@ public class StringUtil {
 		if (SUPPORT_HOST_STRING) {
 			host = toHostString(address);
 		} else {
-			host = toString(address.getAddress());
+			InetAddress addr = address.getAddress();
+			if (addr != null) {
+				host = toString(addr);
+			} else {
+				host = "<unresolved>";
+			}
 		}
 		if (address.getAddress() instanceof Inet6Address) {
 			return "[" + host + "]:" + address.getPort();
 		} else {
 			return host + ":" + address.getPort();
+		}
+	}
+
+	/**
+	 * Get socket address as string for logging.
+	 * 
+	 * @param address socket address to be converted to string
+	 * @return the host string, if available, separated by "/", appended by the
+	 *         host address, ":" and the port. Or {@code null}, if address is
+	 *         {@code null}.
+	 */
+	public static String toDisplayString(InetSocketAddress address) {
+		if (address == null) {
+			return null;
+		}
+		String name = SUPPORT_HOST_STRING ? toHostString(address) : "";
+		InetAddress addr = address.getAddress();
+		String host = (addr != null) ? toString(addr) : "<unresolved>";
+		if (name.equals(host)) {
+			name = "";
+		} else {
+			name += "/";
+		}
+		if (address.getAddress() instanceof Inet6Address) {
+			return name + "[" + host + "]:" + address.getPort();
+		} else {
+			return name + host + ":" + address.getPort();
 		}
 	}
 


### PR DESCRIPTION
This is intended for analyzing ignored messages without matching exchange.
Thought the matching is done on the address (and not the dns-name), that message is now included together with dns-name. 

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>