### PR TITLE
Http proxy support

### DIFF
--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
@@ -130,6 +130,22 @@ public class HttpStack {
 	}
 
 	/**
+	 * Register http-proxy request handlers.
+	 * 
+	 * Enables to catch calls, if this http server is configures as http-proxy
+	 * for the client. In that case, the http-request contains the URI
+	 * (including destination host).
+	 * 
+	 * Handles proxy requests for
+	 * "http:/<destination>:<port>/<destination-uri>/<destination-scheme>:".
+	 */
+	void registerHttpProxyRequestHandler() {
+		UriHttpAsyncRequestHandlerMapper registry = server.getRequestHandlerMapper();
+		// register the handler for proxy coap resources
+		registry.register("http*", new ProxyAsyncRequestHandler(PROXY_RESOURCE_NAME, true));
+	}
+
+	/**
 	 * Start http server.
 	 * 
 	 * @throws IOException in case if a non-recoverable I/O error.
@@ -254,6 +270,9 @@ public class HttpStack {
 			} catch (TranslationException e) {
 				LOGGER.warn("Failed to translate the http request in a valid coap request", e);
 				httpRequestContext.sendSimpleHttpResponse(HttpTranslator.STATUS_TRANSLATION_ERROR, e.getMessage());
+			} catch (Throwable e) {
+				LOGGER.error("Unexpected error", e);
+				httpRequestContext.sendSimpleHttpResponse(HttpTranslator.STATUS_INTERNAL_SERVER_ERROR, e.getMessage());
 			}
 		}
 

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/ProxyHttpServer.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/ProxyHttpServer.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 
 import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange;
@@ -104,6 +105,7 @@ public class ProxyHttpServer {
 		if (!handlerRegistered) {
 			if (proxyCoapDeliverer != null || proxyCoapResolver != null) {
 				httpStack.registerProxyRequestHandler();
+				httpStack.registerHttpProxyRequestHandler();
 			}
 			if (localCoapDeliverer != null || proxyCoapResolver != null) {
 				httpStack.registerLocalRequestHandler();
@@ -205,8 +207,8 @@ public class ProxyHttpServer {
 	/**
 	 * Set deliverer for forward proxy.
 	 * 
-	 * Register {@link HttpStack#registerProxyRequestHandler()} on
-	 * {@link #start()}.
+	 * Register {@link HttpStack#registerProxyRequestHandler()} and
+	 * {@link HttpStack#registerHttpProxyRequestHandler()} on {@link #start()}.
 	 * 
 	 * @param deliverer mesage deliverer for proxy-requests
 	 */

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
@@ -131,7 +131,7 @@ public class ProxyCoapClientResource extends ForwardingResource {
 				pool.release(endpoint);
 				throw new NullPointerException("Destination is null");
 			}
-			LOGGER.debug("Sending proxied CoAP request.");
+			LOGGER.debug("Sending proxied CoAP request to {}", outgoingRequest.getDestinationContext());
 			endpoint.sendRequest(outgoingRequest);
 		} catch (TranslationException e) {
 			LOGGER.debug("Proxy-uri option malformed: {}", e.getMessage());

--- a/californium-proxy/src/test/java/org/eclipse/californium/proxy/HttpTranslatorTest.java
+++ b/californium-proxy/src/test/java/org/eclipse/californium/proxy/HttpTranslatorTest.java
@@ -15,21 +15,37 @@
  ******************************************************************************/
 package org.eclipse.californium.proxy;
 
+import static org.hamcrest.core.StringContains.*;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestFactory;
 import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.DefaultHttpRequestFactory;
+import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.elements.util.StandardCharsets;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class HttpTranslatorTest {
+	/**
+	 * No exception expected by default
+	 */
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
 
 	@Test
 	public void testPutHttpEntity() throws Exception {
@@ -51,10 +67,85 @@ public class HttpTranslatorTest {
 		validateCharset(req, StandardCharsets.UTF_8);
 	}
 
+//	public Request getCoapRequest(HttpRequest httpRequest, String httpResource, boolean proxyingEnabled) throws TranslationException {
+
+	@Test
+	public void testHttp2CoapLocalUri() throws Exception {
+		HttpRequestFactory factory = new DefaultHttpRequestFactory();
+		HttpRequest request = factory.newHttpRequest("GET", "/local/l-target?para1=1&para2=t");
+
+		Request coapRequest = new HttpTranslator().getCoapRequest(request, "local", false);
+		assertThat(coapRequest.getCode(), is(CoAP.Code.GET));
+		assertThat(coapRequest.getURI(), is("coap://localhost/l-target?para1=1&para2=t"));
+	}
+
+	@Test
+	public void testHttp2CoapLocalMalformedUri() throws Exception {
+		exception.expect(TranslationException.class);
+		exception.expectMessage(containsString("scheme"));
+		HttpRequestFactory factory = new DefaultHttpRequestFactory();
+		HttpRequest request = factory.newHttpRequest("GET", "/local/coap://destination/target?para1=1&para2=t");
+
+		new HttpTranslator().getCoapRequest(request, "local", false);
+	}
+
+	@Test
+	public void testHttp2CoapProxyUri() throws Exception {
+		HttpRequestFactory factory = new DefaultHttpRequestFactory();
+		HttpRequest request = factory.newHttpRequest("PUT", "/proxy/coap://destination:5683/target?para1=1&para2=t");
+		addEntity(request, "put");
+
+		Request coapRequest = new HttpTranslator().getCoapRequest(request, "proxy", true);
+		assertThat(coapRequest.getCode(), is(CoAP.Code.PUT));
+		assertThat(coapRequest.getOptions().getProxyUri(), is("coap://destination:5683/target?para1=1&para2=t"));
+		assertThat(coapRequest.getPayloadString(), is("put"));
+	}
+
+	@Test
+	public void testHttp2CoapProxyMalformedUri() throws Exception {
+		exception.expect(TranslationException.class);
+		exception.expectMessage(containsString("scheme"));
+		HttpRequestFactory factory = new DefaultHttpRequestFactory();
+		HttpRequest request = factory.newHttpRequest("PUT", "/proxy/coap//destination:5683/target?para1=1&para2=t");
+		addEntity(request, "put");
+
+		new HttpTranslator().getCoapRequest(request, "proxy", true);
+	}
+
+	@Test
+	public void testHttp2CoapHttpProxyUri() throws Exception {
+		HttpRequestFactory factory = new DefaultHttpRequestFactory();
+		HttpRequest request = factory.newHttpRequest("POST", "http://destination:5683/target/coap:?para1=1&para2=t");
+		addEntity(request, "post");
+
+		Request coapRequest = new HttpTranslator().getCoapRequest(request, "proxy", true);
+		assertThat(coapRequest.getCode(), is(CoAP.Code.POST));
+		assertThat(coapRequest.getOptions().getProxyUri(), is("coap://destination:5683/target?para1=1&para2=t"));
+		assertThat(coapRequest.getPayloadString(), is("post"));
+	}
+
+	@Test
+	public void testHttp2CoapHttpProxyMalformedUri() throws Exception {
+		exception.expect(TranslationException.class);
+		exception.expectMessage(containsString("scheme"));
+		HttpRequestFactory factory = new DefaultHttpRequestFactory();
+		HttpRequest request = factory.newHttpRequest("POST", "http://destination:5683/target?para1=1&para2=t");
+		addEntity(request, "post");
+
+		new HttpTranslator().getCoapRequest(request, "proxy", true);
+	}
+
 	private void validateCharset(Message request, Charset charset) throws TranslationException {
 		HttpEntity httpEntity = new HttpTranslator().getHttpEntity(request);
 		Charset httpEntityCharset = ContentType.parse(httpEntity.getContentType().getValue()).getCharset();
 
 		assertThat(httpEntityCharset, equalTo(charset));
+	}
+
+	private void addEntity(HttpRequest request, String message) throws UnsupportedEncodingException {
+		if (request instanceof HttpEntityEnclosingRequest) {
+			HttpEntity entity = new StringEntity(message);
+			((HttpEntityEnclosingRequest)request).setEntity(entity);
+		}
 	}
 }

--- a/demo-apps/cf-proxy/src/main/resources/logback.xml
+++ b/demo-apps/cf-proxy/src/main/resources/logback.xml
@@ -8,9 +8,13 @@
 		</encoder>
 	</appender>
 
+	<logger name="org.eclipse.californium.proxy" level="DEBUG" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+
 	<!-- Strictly speaking, the level attribute is not necessary since -->
 	<!-- the level of the root level is set to DEBUG by default. -->
-	<root level="INFO">
+	<root level="WARN">
 		<appender-ref ref="STDOUT" />
 	</root>
 


### PR DESCRIPTION
Add http-proxy support for http-server.

If http-server is use as http-proxy in the web-browser, the URL contains
also the destination and port of the outgoing request. Add
request-handler and adapt http-translator accordingly.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>
