### PR TITLE
Use scheme specific endpoint pool.

### DIFF
--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/EndpointPool.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/EndpointPool.java
@@ -15,43 +15,128 @@
  ******************************************************************************/
 package org.eclipse.californium.proxy;
 
-import org.eclipse.californium.core.network.CoapEndpoint;
-import org.eclipse.californium.core.network.Endpoint;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.util.DaemonThreadFactory;
+import org.eclipse.californium.elements.util.ExecutorsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
- * A pool of Endpoints to avoid concurrency issues across concurrent requests.
+ * A pool of Endpoints.
  */
 public class EndpointPool {
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(EndpointPool.class);
 
+	/**
+	 * Shutdown executors on {@link #destroy()}
+	 */
+	private final boolean shutdown;
+	/**
+	 * Size of pool.
+	 */
 	private final int size;
+	/**
+	 * Network configuration for new endpoints.
+	 */
+	protected final NetworkConfig config;
+	/**
+	 * Scheme of endpoints.
+	 */
+	private final String scheme;
+	/**
+	 * Pool of endpoints.
+	 */
 	private final Queue<Endpoint> pool;
-	private final ScheduledExecutorService mainExecutor;
-	private final ScheduledExecutorService secondaryExecutor;
+	/**
+	 * Main executor for endpoints.
+	 * 
+	 * @see Endpoint#setExecutors(ScheduledExecutorService,
+	 *      ScheduledExecutorService)
+	 */
+	protected final ScheduledExecutorService mainExecutor;
+	/**
+	 * Secondary executor for endpoints.
+	 * 
+	 * @see Endpoint#setExecutors(ScheduledExecutorService,
+	 *      ScheduledExecutorService)
+	 */
+	protected final ScheduledExecutorService secondaryExecutor;
 
-	public EndpointPool(int size, int init, ScheduledExecutorService mainExecutor,
+	/**
+	 * Create default endpoint pool.
+	 */
+	public EndpointPool() {
+		this.shutdown = true;
+		this.size = 128;
+		this.config = new NetworkConfig(NetworkConfig.getStandard());
+		int threads = this.config.getInt(NetworkConfig.Keys.PROTOCOL_STAGE_THREAD_COUNT);
+		this.config.setInt(NetworkConfig.Keys.NETWORK_STAGE_RECEIVER_THREAD_COUNT, 1);
+		this.config.setInt(NetworkConfig.Keys.NETWORK_STAGE_SENDER_THREAD_COUNT, 1);
+		this.mainExecutor = ExecutorsUtil.newScheduledThreadPool(threads, new DaemonThreadFactory("Proxy#"));
+		this.secondaryExecutor = ExecutorsUtil.newDefaultSecondaryScheduler("ProxyTimer#");
+		this.pool = new ArrayDeque<>(size);
+		this.scheme = init(size);
+	}
+
+	/**
+	 * Create endpoint pool with specific network configuration and executors.
+	 * 
+	 * @param size size of pool
+	 * @param init initial size of pool
+	 * @param config network configuration to create endpoints.
+	 * @param mainExecutor main executor for endpoints
+	 * @param secondaryExecutor secondary executor for endpoints
+	 */
+	public EndpointPool(int size, int init, NetworkConfig config, ScheduledExecutorService mainExecutor,
 			ScheduledExecutorService secondaryExecutor) {
+		this.shutdown = false;
 		this.size = size;
 		this.pool = new ArrayDeque<>(size);
+		this.config = config;
 		this.mainExecutor = mainExecutor;
 		this.secondaryExecutor = secondaryExecutor;
 		if (init > size) {
 			init = size;
 		}
+		this.scheme = init(init);
+	}
+
+	/**
+	 * Initialize pool with endpoints.
+	 * 
+	 * @param init number of initial endpoints.
+	 * @return scheme of endpoints
+	 */
+	private String init(int init) {
+		String scheme = null;
 		try {
-			for (int i = 0; i < init; i++) {
+			Endpoint endpoint = createEndpoint();
+			scheme = endpoint.getUri().getScheme();
+			pool.add(endpoint);
+			for (int i = 1; i < init; i++) {
 				pool.add(createEndpoint());
 			}
 		} catch (IOException ex) {
 			LOGGER.warn("endpoint pool could not be filled!", ex);
 		}
+		return scheme;
+	}
+
+	/**
+	 * Returns scheme of endpoint.
+	 * 
+	 * @return scheme of endpoint
+	 */
+	public String getScheme() {
+		return scheme;
 	}
 
 	/**
@@ -70,8 +155,16 @@ public class EndpointPool {
 		return createEndpoint();
 	}
 
-	private Endpoint createEndpoint() throws IOException {
-		Endpoint endpoint = new CoapEndpoint.Builder().build();
+	/**
+	 * Create new endpoint.
+	 * 
+	 * Maybe overriden to create endpoints using other schemes and protocols.
+	 * 
+	 * @return new created endpoint.
+	 * @throws IOException
+	 */
+	protected Endpoint createEndpoint() throws IOException {
+		Endpoint endpoint = new CoapEndpoint.Builder().setNetworkConfig(config).build();
 		endpoint.setExecutors(mainExecutor, secondaryExecutor);
 		try {
 			endpoint.start();
@@ -85,7 +178,8 @@ public class EndpointPool {
 	/**
 	 * Release a Endpoint so that other requests can use it.
 	 * 
-	 * @param endpoint Endpoint to free. {@code null} will return without releasing it.
+	 * @param endpoint Endpoint to free. {@code null} will return without
+	 *            releasing it.
 	 */
 	public void release(final Endpoint endpoint) {
 		if (endpoint == null) {
@@ -100,11 +194,20 @@ public class EndpointPool {
 		endpoint.destroy();
 	}
 
+	/**
+	 * Destroy endpoints in pool.
+	 * 
+	 * Shutdown executor, if not passed in as argument.
+	 */
 	public void destroy() {
 		synchronized (pool) {
 			for (Endpoint endpoint : pool) {
 				endpoint.destroy();
 			}
+		}
+		if (shutdown) {
+			ExecutorsUtil.shutdownExecutorGracefully(1000, mainExecutor);
+			ExecutorsUtil.shutdownExecutorGracefully(1000, secondaryExecutor);
 		}
 	}
 }

--- a/demo-apps/cf-proxy/src/main/java/org/eclipse/californium/examples/ExampleCrossProxy.java
+++ b/demo-apps/cf-proxy/src/main/java/org/eclipse/californium/examples/ExampleCrossProxy.java
@@ -32,6 +32,7 @@ import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.core.server.resources.Resource;
 import org.eclipse.californium.elements.util.DaemonThreadFactory;
 import org.eclipse.californium.elements.util.ExecutorsUtil;
+import org.eclipse.californium.proxy.EndpointPool;
 import org.eclipse.californium.proxy.ProxyHttpServer;
 import org.eclipse.californium.proxy.resources.ProxyCoapClientResource;
 import org.eclipse.californium.proxy.resources.ProxyHttpClientResource;
@@ -72,7 +73,11 @@ public class ExampleCrossProxy {
 		ScheduledExecutorService mainExecutor = ExecutorsUtil.newScheduledThreadPool(threads,
 				new DaemonThreadFactory("Proxy#"));
 		ScheduledExecutorService secondaryExecutor = ExecutorsUtil.newDefaultSecondaryScheduler("ProxyTimer#");
-		CoapResource coap2coap = new ProxyCoapClientResource(config, COAP2COAP, mainExecutor, secondaryExecutor);
+		NetworkConfig outgoingConfig = new NetworkConfig(config);
+		outgoingConfig.setInt(NetworkConfig.Keys.NETWORK_STAGE_RECEIVER_THREAD_COUNT, 1);
+		outgoingConfig.setInt(NetworkConfig.Keys.NETWORK_STAGE_SENDER_THREAD_COUNT, 1);
+		EndpointPool pool = new EndpointPool(1000, 250, outgoingConfig, mainExecutor, secondaryExecutor);
+		CoapResource coap2coap = new ProxyCoapClientResource(COAP2COAP, pool);
 		CoapResource coap2http = new ProxyHttpClientResource(COAP2HTTP);
 
 		// Create CoAP Server on PORT with proxy resources form CoAP to CoAP and HTTP


### PR DESCRIPTION
Enables to use encryption for outgoing requests.
Pass network config to endpoint pool.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>