### PR TITLE
Support compliant coap-proxy.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -831,27 +831,14 @@ public class CoapEndpoint implements Endpoint, MessagePostProcessInterceptors {
 
 	@Override
 	public URI getUri() {
-		URI uri = null;
 		try {
-			InetSocketAddress socketAddress = getAddress();
-			String host = socketAddress.getAddress().getHostAddress();
-			try {
-				uri = new URI(scheme, null, host, socketAddress.getPort(), null, null, null);
-			} catch (URISyntaxException e) {
-				try {
-					// workaround for openjdk bug JDK-8199396.
-					// some characters are not supported for the ipv6 scope.
-					host = host.replaceAll("[-._~]", "");
-					uri = new URI(scheme, null, host, socketAddress.getPort(), null, null, null);
-				} catch (URISyntaxException e2) {
-					// warn with the original violation
-					LOGGER.warn("{}URI", tag, e);
-				}
-			}
-		} catch (IllegalArgumentException e) {
+			InetSocketAddress address = getAddress();
+			String hostname = StringUtil.getUriHostname(address.getAddress());
+			return new URI(scheme, null, hostname, address.getPort(), null, null, null);
+		} catch (URISyntaxException e) {
 			LOGGER.warn("{}URI", tag, e);
 		}
-		return uri;
+		return null;
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
@@ -89,8 +89,7 @@ public class ServerMessageDeliverer implements MessageDeliverer {
 		}
 		boolean processed = preDeliverRequest(exchange);
 		if (!processed) {
-			Request request = exchange.getRequest();
-			final Resource resource = findResource(request);
+			final Resource resource = findResource(exchange);
 			if (resource != null) {
 				checkForObserveOption(exchange, resource);
 
@@ -108,6 +107,7 @@ public class ServerMessageDeliverer implements MessageDeliverer {
 				}
 			} else {
 				if (LOGGER.isInfoEnabled()) {
+					Request request = exchange.getRequest();
 					LOGGER.info("did not find resource /{} requested by {}", request.getOptions().getUriPathString(),
 							request.getSourceContext().getPeerAddress());
 				}
@@ -188,11 +188,12 @@ public class ServerMessageDeliverer implements MessageDeliverer {
 	 * may accept requests to subresources, e.g., to allow addresses with
 	 * wildcards like <code>coap://example.com:5683/devices/*</code>
 	 * 
-	 * @param request request including the path of resource names
+	 * @param exchange The exchange containing the inbound request including the
+	 *            path of resource names
 	 * @return the resource or {@code null}, if not found
 	 */
-	protected Resource findResource(Request request) {
-		return findResource(request.getOptions().getUriPath());
+	protected Resource findResource(Exchange exchange) {
+		return findResource(exchange.getRequest().getOptions().getUriPath());
 	}
 
 	/**

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/Coap2CoapTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/Coap2CoapTranslator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Institute for Pervasive Computing, ETH Zurich and others.
+ * Copyright (c) 2020 Bosch IO GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -11,19 +11,12 @@
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  * 
  * Contributors:
- *    Matthias Kovatsch - creator and main architect
- *    Martin Lanter - architect and re-implementation
- *    Francesco Corazza - HTTP cross-proxy
- *    Bosch Software Innovations GmbH - migrate to SLF4J
+ *    Bosch IO GmbH - initial implementation
  ******************************************************************************/
+
 package org.eclipse.californium.proxy;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URLDecoder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
@@ -31,30 +24,17 @@ import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Static class that provides the translations between the messages from the
  * internal CoAP nodes and external ones.
- * 
- * @deprecated use {@link Coap2CoapTranslator} instead
  */
-@Deprecated
-public final class CoapTranslator {
+public class Coap2CoapTranslator extends CoapUriTranslator {
 
 	/** The Constant LOG. */
-	private static final Logger LOGGER = LoggerFactory.getLogger(CoapTranslator.class);
-
-	/**
-	 * Property file containing the mappings between coap messages and http
-	 * messages.
-	 */
-//	public static final Properties COAP_TRANSLATION_PROPERTIES = new Properties("Proxy.properties");
-
-	// Error constants
-	public static final ResponseCode STATUS_FIELD_MALFORMED = ResponseCode.BAD_OPTION;
-	public static final ResponseCode STATUS_TIMEOUT = ResponseCode.GATEWAY_TIMEOUT;
-	public static final ResponseCode STATUS_TRANSLATION_ERROR = ResponseCode.BAD_GATEWAY;
+	private static final Logger LOGGER = LoggerFactory.getLogger(Coap2CoapTranslator.class);
 
 	/**
 	 * Starting from an external CoAP request, the method fills a new request
@@ -62,19 +42,18 @@ public final class CoapTranslator {
 	 * of the new request and simply copies the options and the payload from the
 	 * original request to the new one.
 	 * 
-	 * @param incomingRequest
-	 *            the original request
-	 * 
-	 * 
-	 * 
-	 * @return Request
-	 * @throws TranslationException
-	 *             the translation exception
+	 * @param destination destination for outgoing request
+	 * @param incomingRequest the original incoming request
+	 * @return Request the created outgoing request
+	 * @throws TranslationException the translation exception
 	 */
-	public static Request getRequest(final Request incomingRequest) throws TranslationException {
+	public Request getRequest(URI destination, Request incomingRequest) throws TranslationException {
 		// check parameters
+		if (destination == null) {
+			throw new NullPointerException("destination == null");
+		}
 		if (incomingRequest == null) {
-			throw new IllegalArgumentException("incomingRequest == null");
+			throw new NullPointerException("incomingRequest == null");
 		}
 
 		// get the code
@@ -91,24 +70,6 @@ public final class CoapTranslator {
 		byte[] payload = incomingRequest.getPayload();
 		outgoingRequest.setPayload(payload);
 
-		// get the uri address from the proxy-uri option
-		URI serverUri;
-		try {
-			/*
-			 * The new draft (14) only allows one proxy-uri option. Thus, this
-			 * code segment has changed.
-			 */
-			String proxyUriString = URLDecoder.decode(
-					incomingRequest.getOptions().getProxyUri(), "UTF-8");
-			serverUri = new URI(proxyUriString);
-		} catch (UnsupportedEncodingException e) {
-			LOGGER.warn("UTF-8 do not support this encoding", e);
-			throw new TranslationException("UTF-8 do not support this encoding", e);
-		} catch (URISyntaxException e) {
-			LOGGER.warn("Cannot translate the server uri", e);
-			throw new TranslationException("Cannot translate the server uri", e);
-		}
-
 		// copy every option from the original message
 		// do not copy the proxy-uri option because it is not necessary in
 		// the new message
@@ -119,34 +80,32 @@ public final class CoapTranslator {
 		// do not copy the uri-* options because they are already filled in
 		// the new message
 		OptionSet options = new OptionSet(incomingRequest.getOptions());
+		options.removeProxyScheme();
 		options.removeProxyUri();
 		options.removeBlock1();
 		options.removeBlock2();
+		options.removeUriHost();
+		options.removeUriPort();
 		options.clearUriPath();
 		options.clearUriQuery();
 		outgoingRequest.setOptions(options);
-		
+
 		// set the proxy-uri as the outgoing uri
-		if (serverUri != null) {
-			outgoingRequest.setURI(serverUri);
-		}
+		outgoingRequest.setURI(destination);
 
 		LOGGER.debug("Incoming request translated correctly");
 		return outgoingRequest;
 	}
-	
+
 	/**
 	 * Fills the new response with the response received from the internal CoAP
 	 * node. Simply copies the options and the payload from the forwarded
 	 * response to the new one.
 	 * 
-	 * @param incomingResponse
-	 *            the forwarded request
-	 * 
-	 * 
-	 * @return the response
+	 * @param incomingResponse the incoming response
+	 * @return the response to outgoing response
 	 */
-	public static Response getResponse(final Response incomingResponse) {
+	public Response getResponse(Response incomingResponse) {
 		if (incomingResponse == null) {
 			throw new IllegalArgumentException("incomingResponse == null");
 		}
@@ -167,15 +126,8 @@ public final class CoapTranslator {
 
 		// copy every option
 		outgoingResponse.setOptions(incomingResponse.getOptions());
-		
+
 		LOGGER.debug("Incoming response translated correctly");
 		return outgoingResponse;
-	}
-
-	/**
-	 * The Constructor is private because the class is an helper class and
-	 * cannot be instantiated.
-	 */
-	private CoapTranslator() {
 	}
 }

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapUriTranslator.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/CoapUriTranslator.java
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+
+package org.eclipse.californium.proxy;
+
+import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.OptionSet;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.elements.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Static class that provides the translations between the messages from the
+ * internal CoAP nodes and external ones.
+ */
+public class CoapUriTranslator {
+
+	/** The Constant LOG. */
+	private static final Logger LOGGER = LoggerFactory.getLogger(CoapUriTranslator.class);
+
+	/**
+	 * Property file containing the mappings between coap messages and http
+	 * messages.
+	 */
+
+	// Error constants
+	public static final ResponseCode STATUS_FIELD_MALFORMED = ResponseCode.BAD_OPTION;
+	public static final ResponseCode STATUS_TIMEOUT = ResponseCode.GATEWAY_TIMEOUT;
+	public static final ResponseCode STATUS_TRANSLATION_ERROR = ResponseCode.BAD_GATEWAY;
+
+	/**
+	 * Get destination schem for request.
+	 * 
+	 * If a Proxy-URI is provided, that is used to determine the scheme.
+	 * Otherwise the {@link OptionSet#getProxyScheme()} is, if available, or the
+	 * scheme of the request in absence of the other schemes.
+	 * 
+	 * @param incomingRequest the original request
+	 * @return scheme destination scheme
+	 * @throws TranslationException the translation exception
+	 */
+	public String getDestinationScheme(Request incomingRequest) throws TranslationException {
+		if (incomingRequest == null) {
+			throw new NullPointerException("incomingRequest == null");
+		}
+		OptionSet options = incomingRequest.getOptions();
+		if (options.hasProxyUri()) {
+			try {
+				String proxyUriString = URLDecoder.decode(options.getProxyUri(), "UTF-8");
+				return new URI(proxyUriString).getScheme();
+			} catch (UnsupportedEncodingException e) {
+				LOGGER.warn("UTF-8 do not support this encoding", e);
+				throw new TranslationException("UTF-8 do not support this encoding", e);
+			} catch (URISyntaxException e) {
+				LOGGER.warn("Cannot translate the server uri", e);
+				throw new TranslationException("Cannot translate the server uri", e);
+			}
+		} else if (options.hasProxyScheme()) {
+			return options.getProxyScheme();
+		} else {
+			return incomingRequest.getScheme();
+		}
+	}
+
+	/**
+	 * Return the exposed interface the request is received.
+	 * 
+	 * In cloud deployments the receiving interface may differ from the exposed
+	 * one. This default implementation returns the address contained in the
+	 * destination context, which must be set in the request by the used
+	 * MessageDeliverer.
+	 * 
+	 * @param incomingRequest the received request.
+	 * @return exposed interface. {@code null}, if not available.
+	 */
+	public InetSocketAddress getExposedInterface(Request incomingRequest) {
+		if (incomingRequest.getDestinationContext() == null) {
+			return null;
+		} else {
+			return incomingRequest.getDestinationContext().getPeerAddress();
+		}
+	}
+
+	/**
+	 * Get "final" destination URI from request.
+	 * 
+	 * If a Proxy-URI is provided, that is used. Otherwise the "final
+	 * destination" is constructed using the options
+	 * {@link OptionSet#getProxyScheme()}, {@link OptionSet#getUriHost()},
+	 * {@link OptionSet#getUriPort()}, {@link OptionSet#getUriPath()}, and
+	 * {@link OptionSet#getUriQuery()}.
+	 * 
+	 * @param incomingRequest the original request
+	 * @param exposed the exposed interface of this request. {@code null}, if
+	 *            unknown.
+	 * @return "final destination" URI
+	 * @throws TranslationException the translation exception
+	 */
+	public URI getDestinationURI(Request incomingRequest, InetSocketAddress exposed) throws TranslationException {
+		// check parameters
+		if (incomingRequest == null) {
+			throw new NullPointerException("incomingRequest == null");
+		}
+		try {
+			OptionSet options = incomingRequest.getOptions();
+			if (options.hasProxyUri()) {
+				String proxyUriString = URLDecoder.decode(options.getProxyUri(), "UTF-8");
+				return new URI(proxyUriString);
+			} else {
+				String scheme = options.hasProxyScheme() ? options.getProxyScheme() : incomingRequest.getScheme();
+				String host = options.getUriHost();
+				if (host == null) {
+					if (exposed == null) {
+						throw new TranslationException("Destination host missing!");
+					}
+					host = StringUtil.getUriHostname(exposed.getAddress());
+				}
+				Integer port = options.getUriPort();
+				if (port == null) {
+					if (exposed == null) {
+						throw new TranslationException("Destination port missing!");
+					}
+					port = exposed.getPort();
+				}
+				String path = "/" + options.getUriPathString();
+				String query = options.getURIQueryCount() > 0 ? options.getUriQueryString() : null;
+				return new URI(scheme, null, host, port, path, query, null);
+			}
+		} catch (UnsupportedEncodingException e) {
+			LOGGER.warn("UTF-8 do not support this encoding", e);
+			throw new TranslationException("UTF-8 do not support this encoding", e);
+		} catch (URISyntaxException e) {
+			LOGGER.warn("Cannot translate the server uri", e);
+			throw new TranslationException("Cannot translate the server uri", e);
+		}
+	}
+}

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/EndpointPool.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/EndpointPool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Bosch IO GmbH and others.
+ * Copyright (c) 2020 Bosch IO GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/Proxy2CoapClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/Proxy2CoapClientResource.java
@@ -1,0 +1,195 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2017 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Matthias Kovatsch - creator and main architect
+ *    Martin Lanter - architect and re-implementation
+ *    Francesco Corazza - HTTP cross-proxy
+ *    Bosch Software Innovations GmbH - migrate to SLF4J
+ ******************************************************************************/
+package org.eclipse.californium.proxy.resources;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.proxy.Coap2CoapTranslator;
+import org.eclipse.californium.proxy.EndpointPool;
+import org.eclipse.californium.proxy.TranslationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resource that forwards a coap request with the proxy-uri option set to the
+ * desired coap server.
+ */
+public class Proxy2CoapClientResource extends CoapResource {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(Proxy2CoapClientResource.class);
+
+	/**
+	 * Destroy endpoint pools.
+	 */
+	private boolean destroyPool;
+	/**
+	 * Accept CON request before forwarding it.
+	 */
+	private boolean accept;
+	/**
+	 * Maps scheme to endpoint pool.
+	 */
+	private Map<String, EndpointPool> mapSchemeToPool = new HashMap<>();
+	/**
+	 * Coap2Coap translator.
+	 */
+	private Coap2CoapTranslator translator;
+
+	public Proxy2CoapClientResource() {
+		this("coapClient", true, new Coap2CoapTranslator(), new EndpointPool());
+		destroyPool = true;
+	}
+
+	public Proxy2CoapClientResource(String name) {
+		this(name, true, new Coap2CoapTranslator(), new EndpointPool());
+		destroyPool = true;
+	}
+
+	/**
+	 * Create proxy resource.
+	 * 
+	 * @param name name of the resource
+	 * @param accept accept CON request befor forwarding the request
+	 * @param translator translater for coap2coap messages. {@code null} to sue
+	 *            default implementation {@link Coap2CoapTranslator}.
+	 * @param pools list of endpoint pools for outgoing requests
+	 */
+	public Proxy2CoapClientResource(String name, boolean accept, Coap2CoapTranslator translator, EndpointPool... pools) {
+		// set the resource hidden
+		super(name, true);
+		getAttributes().setTitle("Forward the requests to a CoAP server.");
+		this.accept = accept;
+		this.translator = translator;
+		for (EndpointPool pool : pools) {
+			this.mapSchemeToPool.put(pool.getScheme(), pool);
+		}
+	}
+
+	public void destroy() {
+		if (destroyPool) {
+			for (EndpointPool pool : mapSchemeToPool.values()) {
+				pool.destroy();
+			}
+		}
+	}
+
+	@Override
+	public void handleRequest(final Exchange exchange) {
+		Request incomingRequest = exchange.getRequest();
+		LOGGER.debug("ProxyCoapClientResource forwards {}", incomingRequest);
+
+		EndpointPool pool = null;
+		Endpoint outgoingEndpoint = null;
+
+		try {
+			// create the new request from the original
+			InetSocketAddress exposedInterface = translator.getExposedInterface(incomingRequest);
+			URI destination = translator.getDestinationURI(incomingRequest, exposedInterface);
+			Request outgoingRequest = translator.getRequest(destination, incomingRequest);
+			pool = mapSchemeToPool.get(outgoingRequest.getScheme());
+			outgoingEndpoint = pool.getEndpoint();
+
+			// prepare to process the outcome
+			outgoingRequest.addMessageObserver(new ProxyMessageObserver(pool, translator, exchange, outgoingEndpoint));
+
+			// execute the request
+			if (outgoingRequest.getDestinationContext() == null) {
+				exchange.sendResponse(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
+				pool.release(outgoingEndpoint);
+				throw new NullPointerException("Destination is null");
+			}
+			LOGGER.debug("Sending proxied CoAP request to {}", outgoingRequest.getDestinationContext());
+			if (accept) {
+				exchange.sendAccept();
+			}
+			outgoingEndpoint.sendRequest(outgoingRequest);
+		} catch (TranslationException e) {
+			LOGGER.debug("Proxy-uri option malformed: {}", e.getMessage());
+			exchange.sendResponse(new Response(Coap2CoapTranslator.STATUS_FIELD_MALFORMED));
+		} catch (Exception e) {
+			LOGGER.warn("Failed to execute request: {}", e.getMessage(), e);
+			exchange.sendResponse(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
+			if (pool != null) {
+				pool.release(outgoingEndpoint);
+			}
+		}
+	}
+
+	private static class ProxyMessageObserver extends MessageObserverAdapter {
+
+		private final EndpointPool pool;
+		private final Coap2CoapTranslator translator;
+		private final Exchange incomingExchange;
+		private final Endpoint outgoingEndpoint;
+
+		private ProxyMessageObserver(EndpointPool pool, Coap2CoapTranslator translator, Exchange incomingExchange,
+				Endpoint outgoingEndpoint) {
+			this.pool = pool;
+			this.translator = translator;
+			this.incomingExchange = incomingExchange;
+			this.outgoingEndpoint = outgoingEndpoint;
+		}
+
+		@Override
+		public void onResponse(Response incomingResponse) {
+			LOGGER.debug("ProxyCoapClientResource received {}", incomingResponse);
+			incomingExchange.sendResponse(translator.getResponse(incomingResponse));
+			pool.release(outgoingEndpoint);
+		}
+
+		@Override
+		public void onReject() {
+			fail(ResponseCode.SERVICE_UNAVAILABLE);
+			LOGGER.debug("Request rejected");
+		}
+
+		@Override
+		public void onTimeout() {
+			fail(ResponseCode.GATEWAY_TIMEOUT);
+			LOGGER.debug("Request timed out.");
+		}
+
+		@Override
+		public void onCancel() {
+			fail(ResponseCode.SERVICE_UNAVAILABLE);
+			LOGGER.debug("Request canceled");
+		}
+
+		@Override
+		public void onSendError(Throwable e) {
+			fail(ResponseCode.SERVICE_UNAVAILABLE);
+			LOGGER.warn("Send error", e);
+		}
+
+		private void fail(ResponseCode response) {
+			incomingExchange.sendResponse(new Response(response));
+			pool.release(outgoingEndpoint);
+		}
+	}
+}

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/Proxy2HttpClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/Proxy2HttpClientResource.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2017 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Matthias Kovatsch - creator and main architect
+ *    Martin Lanter - architect and re-implementation
+ *    Francesco Corazza - HTTP cross-proxy
+ *    Bosch Software Innovations GmbH - migrate to SLF4J
+ ******************************************************************************/
+package org.eclipse.californium.proxy.resources;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.protocol.BasicHttpContext;
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.elements.util.ClockUtil;
+import org.eclipse.californium.proxy.Coap2CoapTranslator;
+import org.eclipse.californium.proxy.HttpClientFactory;
+import org.eclipse.californium.proxy.HttpTranslator;
+import org.eclipse.californium.proxy.InvalidFieldException;
+import org.eclipse.californium.proxy.TranslationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Proxy2HttpClientResource extends CoapResource {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(Proxy2HttpClientResource.class);
+
+	/**
+	 * Accept CON request before forwarding it.
+	 */
+	private boolean accept;
+
+	private HttpTranslator translator;
+
+	/**
+	 * DefaultHttpClient is thread safe. It is recommended that the same
+	 * instance of this class is reused for multiple request executions.
+	 */
+	private static final CloseableHttpAsyncClient asyncClient = HttpClientFactory.createClient();
+
+	public Proxy2HttpClientResource() {
+		this("httpClient", true, new HttpTranslator());
+	}
+
+	public Proxy2HttpClientResource(String name) {
+		this(name, true, new HttpTranslator());
+	}
+
+	public Proxy2HttpClientResource(String name, boolean accept, HttpTranslator translator) {
+		// set the resource hidden
+		super(name, true);
+		getAttributes().setTitle("Forward the requests to a HTTP client.");
+		this.accept = accept;
+		this.translator = translator;
+	}
+
+	@Override
+	public void handleRequest(final Exchange exchange) {
+		final Request incomingCoapRequest = exchange.getRequest();
+
+		URI uri;
+		try {
+			InetSocketAddress exposedInterface = translator.getExposedInterface(incomingCoapRequest);
+			uri = translator.getDestinationURI(incomingCoapRequest, exposedInterface);
+		} catch (TranslationException ex) {
+			LOGGER.debug("URI error.", ex);
+			exchange.sendResponse(new Response(Coap2CoapTranslator.STATUS_FIELD_MALFORMED));
+			return;
+		}
+
+		// get the requested host, if the port is not specified, the constructor
+		// sets it to -1
+		HttpHost httpHost = new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());
+
+		HttpRequest httpRequest = null;
+		try {
+			// get the mapping to http for the incoming coap request
+			httpRequest = translator.getHttpRequest(uri, incomingCoapRequest);
+			LOGGER.debug("Outgoing http request: {}", httpRequest.getRequestLine());
+		} catch (InvalidFieldException e) {
+			LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
+			exchange.sendResponse(new Response(Coap2CoapTranslator.STATUS_FIELD_MALFORMED));
+			return;
+		} catch (TranslationException e) {
+			LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
+			exchange.sendResponse(new Response(Coap2CoapTranslator.STATUS_TRANSLATION_ERROR));
+			return;
+		}
+
+		if (accept) {
+			exchange.sendAccept();
+		}
+
+		asyncClient.execute(httpHost, httpRequest, new BasicHttpContext(), new FutureCallback<HttpResponse>() {
+
+			@Override
+			public void completed(HttpResponse result) {
+				try {
+					long timestamp = ClockUtil.nanoRealtime();
+					LOGGER.debug("Incoming http response: {}", result.getStatusLine());
+					// the entity of the response, if non repeatable, could be
+					// consumed only one time, so do not debug it!
+					// System.out.println(EntityUtils.toString(httpResponse.getEntity()));
+
+					// translate the received http response in a coap response
+					Response coapResponse = translator.getCoapResponse(result, incomingCoapRequest);
+					coapResponse.setNanoTimestamp(timestamp);
+
+					exchange.sendResponse(coapResponse);
+				} catch (InvalidFieldException e) {
+					LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
+					exchange.sendResponse(new Response(Coap2CoapTranslator.STATUS_FIELD_MALFORMED));
+				} catch (TranslationException e) {
+					LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
+					exchange.sendResponse(new Response(Coap2CoapTranslator.STATUS_TRANSLATION_ERROR));
+				} catch (Throwable e) {
+					LOGGER.debug("Error during the http/coap translation: {}", e.getMessage(), e);
+					exchange.sendResponse(new Response(Coap2CoapTranslator.STATUS_FIELD_MALFORMED));
+				}
+				LOGGER.debug("Incoming http response: {} processed!", result.getStatusLine());
+			}
+
+			@Override
+			public void failed(Exception ex) {
+				LOGGER.debug("Failed to get the http response: {}", ex.getMessage());
+				exchange.sendResponse(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
+			}
+
+			@Override
+			public void cancelled() {
+				LOGGER.debug("Request canceled");
+				exchange.sendResponse(new Response(ResponseCode.SERVICE_UNAVAILABLE));
+			}
+		});
+
+	}
+
+}

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyCoapClientResource.java
@@ -18,194 +18,132 @@
  ******************************************************************************/
 package org.eclipse.californium.proxy.resources;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.eclipse.californium.compat.CompletableFuture;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
-import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.EndpointManager;
 import org.eclipse.californium.core.network.Exchange;
-import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.proxy.CoapTranslator;
-import org.eclipse.californium.proxy.EndpointPool;
+import org.eclipse.californium.proxy.EndPointManagerPool;
 import org.eclipse.californium.proxy.TranslationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * Resource that forwards a coap request with the proxy-uri option set to the
  * desired coap server.
+ * 
+ * @deprecated use {@link Proxy2CoapClientResource} instead.
  */
+@Deprecated
 public class ProxyCoapClientResource extends ForwardingResource {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(ProxyCoapClientResource.class);
 
-	private boolean destroyPool;
-	/**
-	 * Maps scheme to endpoint pool.
-	 */
-	private Map<String, EndpointPool> mapSchemeToPool = new HashMap<>();
-
 	public ProxyCoapClientResource() {
-		this("coapClient", new EndpointPool());
-		destroyPool = true;
-	}
-
+		this("coapClient");
+	} 
+	
 	public ProxyCoapClientResource(String name) {
-		this(name, new EndpointPool());
-		destroyPool = true;
-	}
-
-	/**
-	 * Create proxy resource.
-	 * 
-	 * @param name name of the resource
-	 * @param pools list of endpoint pool for outgoing requests
-	 */
-	public ProxyCoapClientResource(String name, EndpointPool... pools) {
 		// set the resource hidden
 		super(name, true);
 		getAttributes().setTitle("Forward the requests to a CoAP server.");
-		for (EndpointPool pool : pools) {
-			this.mapSchemeToPool.put(pool.getScheme(), pool);
-		}
-	}
-
-	public void destroy() {
-		if (destroyPool) {
-			for (EndpointPool pool : mapSchemeToPool.values()) {
-				pool.destroy();
-			}
-		}
 	}
 
 	@Override
-	public void handleRequest(final Exchange exchange) {
-		Request incomingRequest = exchange.getRequest();
-		LOGGER.debug("ProxyCoapClientResource forwards {}", incomingRequest);
+	public CompletableFuture<Response> forwardRequest(Request incomingRequest) {
+		final CompletableFuture<Response> future = new CompletableFuture<>();
+
+		LOGGER.info("ProxyCoapClientResource forwards {}", incomingRequest);
 
 		// check the invariant: the request must have the proxy-uri set
 		if (!incomingRequest.getOptions().hasProxyUri()) {
-			LOGGER.debug("Proxy-uri option not set.");
-			exchange.sendResponse(new Response(ResponseCode.BAD_OPTION));
-			return;
+			LOGGER.warn("Proxy-uri option not set.");
+			future.complete(new Response(ResponseCode.BAD_OPTION));
+			return future;
 		}
 
 		// remove the fake uri-path
 		// FIXME: HACK // TODO: why? still necessary in new Cf?
 		incomingRequest.getOptions().clearUriPath();
 
-		EndpointPool pool = null;
-		Endpoint endpoint = null;
+		final EndpointManager endpointManager = EndPointManagerPool.getManager();
 
+		// create a new request to forward to the requested coap server
+		Request outgoingRequest = null;
 		try {
 			// create the new request from the original
-			Request outgoingRequest = CoapTranslator.getRequest(incomingRequest);
-			pool = mapSchemeToPool.get(outgoingRequest.getScheme());
-			endpoint = pool.getEndpoint();
+			outgoingRequest = CoapTranslator.getRequest(incomingRequest);
 
-			// prepare to process the outcome
-			outgoingRequest.addMessageObserver(new ProxyMessageObserver(pool, exchange, endpoint));
+			// receive the response
+			outgoingRequest.addMessageObserver(new MessageObserverAdapter() {
+
+				@Override
+				public void onResponse(Response incomingResponse) {
+					LOGGER.debug("ProxyCoapClientResource received {}", incomingResponse);
+					future.complete(CoapTranslator.getResponse(incomingResponse));
+					EndPointManagerPool.putClient(endpointManager);
+				}
+
+				@Override
+				public void onReject() {
+					LOGGER.warn("Request rejected");
+					future.complete(new Response(ResponseCode.SERVICE_UNAVAILABLE));
+					EndPointManagerPool.putClient(endpointManager);
+				}
+
+				@Override
+				public void onTimeout() {
+					LOGGER.warn("Request timed out.");
+					future.complete(new Response(ResponseCode.GATEWAY_TIMEOUT));
+					EndPointManagerPool.putClient(endpointManager);
+				}
+
+				@Override
+				public void onCancel() {
+					LOGGER.warn("Request canceled");
+					future.complete(new Response(ResponseCode.SERVICE_UNAVAILABLE));
+					EndPointManagerPool.putClient(endpointManager);
+				}
+
+				@Override
+				public void onSendError(Throwable e) {
+					future.complete(new Response(ResponseCode.SERVICE_UNAVAILABLE));
+					LOGGER.warn("Send error", e);
+					EndPointManagerPool.putClient(endpointManager);
+				}
+
+				@Override
+				public void onContextEstablished(EndpointContext endpointContext) {
+				}
+			});
 
 			// execute the request
-			if (outgoingRequest.getDestinationContext() == null) {
-				exchange.sendResponse(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
-				pool.release(endpoint);
+			LOGGER.debug("Sending proxied CoAP request.");
+
+			if (outgoingRequest.getDestination() == null) {
 				throw new NullPointerException("Destination is null");
 			}
-			LOGGER.debug("Sending proxied CoAP request to {}", outgoingRequest.getDestinationContext());
-			endpoint.sendRequest(outgoingRequest);
+			if (outgoingRequest.getDestinationPort() == 0) {
+				throw new NullPointerException("Destination port is 0");
+			}
+
+			endpointManager.getDefaultEndpoint().sendRequest(outgoingRequest);
 		} catch (TranslationException e) {
-			LOGGER.debug("Proxy-uri option malformed: {}", e.getMessage());
-			exchange.sendResponse(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
+			LOGGER.warn("Proxy-uri option malformed: {}", e.getMessage());
+			future.complete(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
+			return future;
 		} catch (Exception e) {
 			LOGGER.warn("Failed to execute request: {}", e.getMessage());
-			exchange.sendResponse(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
-			if (pool != null) {
-				pool.release(endpoint);
-			}
+			future.complete(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
+			return future;
 		}
-	}
 
-	@Deprecated
-	@Override
-	public CompletableFuture<Response> forwardRequest(final Request incomingRequest) {
-		final CompletableFuture<Response> future = new CompletableFuture<>();
-		Exchange exchange = new Exchange(incomingRequest, Origin.REMOTE, null) {
-
-			@Override
-			public void sendAccept() {
-				// has no meaning for HTTP: do nothing
-			}
-
-			@Override
-			public void sendReject() {
-				future.complete(new Response(ResponseCode.SERVICE_UNAVAILABLE));
-			}
-
-			@Override
-			public void sendResponse(Response response) {
-				future.complete(response);
-			}
-		};
-		handleRequest(exchange);
 		return future;
-	}
-
-	private static class ProxyMessageObserver extends MessageObserverAdapter {
-
-		private final EndpointPool pool;
-		private final Exchange incomingExchange;
-		private final Endpoint outgoingEndpoint;
-
-		private ProxyMessageObserver(EndpointPool pool, Exchange incomingExchange, Endpoint outgoingEndpoint) {
-			this.pool = pool;
-			this.incomingExchange = incomingExchange;
-			this.outgoingEndpoint = outgoingEndpoint;
-		}
-
-		@Override
-		public void onResponse(Response incomingResponse) {
-			LOGGER.debug("ProxyCoapClientResource received {}", incomingResponse);
-			incomingExchange.sendResponse(CoapTranslator.getResponse(incomingResponse));
-			pool.release(outgoingEndpoint);
-		}
-
-		@Override
-		public void onReject() {
-			fail(ResponseCode.SERVICE_UNAVAILABLE);
-			LOGGER.debug("Request rejected");
-		}
-
-		@Override
-		public void onTimeout() {
-			fail(ResponseCode.GATEWAY_TIMEOUT);
-			LOGGER.debug("Request timed out.");
-		}
-
-		@Override
-		public void onCancel() {
-			fail(ResponseCode.SERVICE_UNAVAILABLE);
-			LOGGER.debug("Request canceled");
-		}
-
-		@Override
-		public void onSendError(Throwable e) {
-			fail(ResponseCode.SERVICE_UNAVAILABLE);
-			LOGGER.warn("Send error", e);
-		}
-
-		@Override
-		public void onContextEstablished(EndpointContext endpointContext) {
-		}
-
-		private void fail(ResponseCode response) {
-			incomingExchange.sendResponse(new Response(response));
-			pool.release(outgoingEndpoint);
-		}
 	}
 }

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyHttpClientResource.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyHttpClientResource.java
@@ -34,13 +34,14 @@ import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.elements.util.ClockUtil;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
-import org.eclipse.californium.core.network.Exchange;
-import org.eclipse.californium.core.network.Exchange.Origin;
 import org.eclipse.californium.proxy.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
+/**
+ * @deprecated use {@link Proxy2HttpClientResource} instead.
+ */
+@Deprecated
 public class ProxyHttpClientResource extends ForwardingResource {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(ProxyHttpClientResource.class);
@@ -67,14 +68,15 @@ public class ProxyHttpClientResource extends ForwardingResource {
 	}
 
 	@Override
-	public void handleRequest(final Exchange exchange) {
-		final Request incomingCoapRequest = exchange.getRequest();
-
+	public CompletableFuture<Response> forwardRequest(Request request) {
+		final CompletableFuture<Response> future = new CompletableFuture<>();
+		final Request incomingCoapRequest = request;
+		
 		// check the invariant: the request must have the proxy-uri set
 		if (!incomingCoapRequest.getOptions().hasProxyUri()) {
-			LOGGER.debug("Proxy-uri option not set.");
-			exchange.sendResponse(new Response(ResponseCode.BAD_OPTION));
-			return;
+			LOGGER.warn("Proxy-uri option not set.");
+			future.complete(new Response(ResponseCode.BAD_OPTION));
+			return future;
 		}
 
 		// remove the fake uri-path // TODO: why? still necessary in new Cf?
@@ -87,13 +89,13 @@ public class ProxyHttpClientResource extends ForwardingResource {
 					incomingCoapRequest.getOptions().getProxyUri(), "UTF-8");
 			proxyUri = new URI(proxyUriString);
 		} catch (UnsupportedEncodingException e) {
-			LOGGER.debug("Proxy-uri option malformed: {}", e.getMessage());
-			exchange.sendResponse(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
-			return;
+			LOGGER.warn("Proxy-uri option malformed: {}", e.getMessage());
+			future.complete(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
+			return future;
 		} catch (URISyntaxException e) {
-			LOGGER.debug("Proxy-uri option malformed: {}", e.getMessage());
-			exchange.sendResponse(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
-			return;
+			LOGGER.warn("Proxy-uri option malformed: {}", e.getMessage());
+			future.complete(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
+			return future;
 		}
 
 		// get the requested host, if the port is not specified, the constructor
@@ -106,13 +108,13 @@ public class ProxyHttpClientResource extends ForwardingResource {
 			httpRequest = new HttpTranslator().getHttpRequest(incomingCoapRequest);
 			LOGGER.debug("Outgoing http request: {}", httpRequest.getRequestLine());
 		} catch (InvalidFieldException e) {
-			LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
-			exchange.sendResponse(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
-			return;
+			LOGGER.warn("Problems during the http/coap translation: {}", e.getMessage());
+			future.complete(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
+			return future;
 		} catch (TranslationException e) {
-			LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
-			exchange.sendResponse(new Response(CoapTranslator.STATUS_TRANSLATION_ERROR));
-			return;
+			LOGGER.warn("Problems during the http/coap translation: {}", e.getMessage());
+			future.complete(new Response(CoapTranslator.STATUS_TRANSLATION_ERROR));
+			return future;
 		}
 
 		asyncClient.execute(httpHost, httpRequest, new BasicHttpContext(), new FutureCallback<HttpResponse>() {
@@ -129,53 +131,29 @@ public class ProxyHttpClientResource extends ForwardingResource {
 					Response coapResponse = new HttpTranslator().getCoapResponse(result, incomingCoapRequest);
 					coapResponse.setNanoTimestamp(timestamp);
 
-					exchange.sendResponse(coapResponse);
+					future.complete(coapResponse);
 				} catch (InvalidFieldException e) {
-					LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
-					exchange.sendResponse(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
+					LOGGER.warn("Problems during the http/coap translation: {}", e.getMessage());
+					future.complete(new Response(CoapTranslator.STATUS_FIELD_MALFORMED));
 				} catch (TranslationException e) {
-					LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
-					exchange.sendResponse(new Response(CoapTranslator.STATUS_TRANSLATION_ERROR));
+					LOGGER.warn("Problems during the http/coap translation: {}", e.getMessage());
+					future.complete(new Response(CoapTranslator.STATUS_TRANSLATION_ERROR));
 				}
 			}
 
 			@Override
 			public void failed(Exception ex) {
-				LOGGER.debug("Failed to get the http response: {}", ex.getMessage());
-				exchange.sendResponse(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
+				LOGGER.warn("Failed to get the http response: {}", ex.getMessage());
+				future.complete(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
 			}
 
 			@Override
 			public void cancelled() {
-				LOGGER.debug("Request canceled");
-				exchange.sendResponse(new Response(ResponseCode.SERVICE_UNAVAILABLE));
+				LOGGER.warn("Request canceled");
+				future.complete(new Response(ResponseCode.SERVICE_UNAVAILABLE));
 			}
 		});
 
-	}
-
-	@Deprecated
-	@Override
-	public CompletableFuture<Response> forwardRequest(final Request incomingRequest) {
-		final CompletableFuture<Response> future = new CompletableFuture<>();
-		Exchange exchange = new Exchange(incomingRequest, Origin.REMOTE, null) {
-
-			@Override
-			public void sendAccept() {
-				// has no meaning for HTTP: do nothing
-			}
-
-			@Override
-			public void sendReject() {
-				future.complete(new Response(ResponseCode.SERVICE_UNAVAILABLE));
-			}
-
-			@Override
-			public void sendResponse(Response response) {
-				future.complete(response);
-			}
-		};
-		handleRequest(exchange);
 		return future;
 	}
 }

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyMessageDeliverer.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/resources/ProxyMessageDeliverer.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+
+package org.eclipse.californium.proxy.resources;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.server.ServerMessageDeliverer;
+import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.californium.elements.util.NetworkInterfacesUtil;
+import org.eclipse.californium.proxy.CoapUriTranslator;
+import org.eclipse.californium.proxy.TranslationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProxyMessageDeliverer extends ServerMessageDeliverer {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ProxyMessageDeliverer.class);
+
+	private final CoapUriTranslator translater;
+	private final Map<String, Resource> scheme2resource;
+	private final Set<InetSocketAddress> exposedServices;
+	private final Set<InetAddress> exposedHosts;
+	private final Set<Integer> exposedPorts;
+
+	public ProxyMessageDeliverer(Resource root, CoapUriTranslator translater, Map<String, Resource> scheme2resource,
+			InetSocketAddress... exposed) {
+		super(root);
+		this.translater = translater;
+		this.scheme2resource = scheme2resource;
+		this.exposedServices = new HashSet<>();
+		this.exposedPorts = new HashSet<>();
+		this.exposedHosts = new HashSet<>();
+		if (exposed == null || exposed.length == 0) {
+			LOGGER.warn("No exposed interfaces are provided!");
+		} else {
+			Collection<InetAddress> all = NetworkInterfacesUtil.getNetworkInterfaces();
+			for (InetSocketAddress inetAddress : exposed) {
+				LOGGER.info("address {}", inetAddress);
+				this.exposedPorts.add(inetAddress.getPort());
+				InetAddress address = inetAddress.getAddress();
+				if (address.isAnyLocalAddress()) {
+					for (InetAddress eAddress : all) {
+						this.exposedServices.add(new InetSocketAddress(eAddress, inetAddress.getPort()));
+						this.exposedHosts.add(eAddress);
+					}
+				} else {
+					this.exposedServices.add(inetAddress);
+					this.exposedHosts.add(address);
+				}
+			}
+			for (Integer port : exposedPorts) {
+				LOGGER.info("Exposed port {}", port);
+			}
+			for (InetAddress address : exposedHosts) {
+				LOGGER.info("Exposed host {}", address);
+			}
+			for (InetSocketAddress inetAddress : exposedServices) {
+				LOGGER.info("Exposed service {}", inetAddress);
+			}
+		}
+	}
+
+	@Override
+	protected Resource findResource(Exchange exchange) {
+		Resource resource = super.findResource(exchange);
+		Request request = exchange.getRequest();
+		boolean proxyOption = request.getOptions().hasProxyUri() || request.getOptions().hasProxyScheme();
+		if (resource == getRootResource() && proxyOption) {
+			resource = null;
+		}
+		if (resource == null) {
+			try {
+				String scheme = translater.getDestinationScheme(request);
+				if (scheme != null) {
+					scheme = scheme.toLowerCase();
+					resource = scheme2resource.get(scheme);
+					if (resource != null && !proxyOption && CoAP.isSupportedScheme(scheme)) {
+						// check, if proxy is destination.
+						Integer port = request.getOptions().getUriPort();
+						String host = request.getOptions().getUriHost();
+						if (host == null) {
+							if (port == null || exposedPorts.contains(port)) {
+								// proxy is destination
+								resource = null;
+							}
+						} else {
+							if (port == null) {
+								try {
+									InetAddress address = InetAddress.getByName(host);
+									if (exposedHosts.contains(address)) {
+										// proxy is destination
+										resource = null;
+									}
+								} catch (UnknownHostException e) {
+									// destination not reachable
+									resource = null;
+								}
+							} else {
+								InetSocketAddress destination = new InetSocketAddress(host, port);
+								if (destination.isUnresolved() || exposedServices.contains(destination)) {
+									// destination not reachable
+									// or proxy is destination
+									resource = null;
+								}
+							}
+						}
+					}
+				}
+			} catch (TranslationException e) {
+				LOGGER.debug("Bad proxy request", e);
+			}
+		}
+		if (resource != null && request.getDestinationContext() == null) {
+			if (exchange.getEndpoint() != null) {
+				// set local receiving addess as destination
+				request.setDestinationContext(new AddressEndpointContext(exchange.getEndpoint().getAddress()));
+			}
+		}
+		return resource;
+	}
+}


### PR DESCRIPTION
Supports option proxy-uri, proxy-scheme, and coap-uri.
Move proxy-message-deliverer to top-level class in library module.
Deprecate static CoapTranslator in order to replace it with a modifiable
Coap2CoapTranslator. Restore old proxy-resources for backwards
compatibility and deprecate them.
Introduce the new proxy2 resources with cleaned up execution and new
functionality.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>