### PR TITLE
New proxy2

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -831,27 +831,14 @@ public class CoapEndpoint implements Endpoint, MessagePostProcessInterceptors {
 
 	@Override
 	public URI getUri() {
-		URI uri = null;
 		try {
-			InetSocketAddress socketAddress = getAddress();
-			String host = socketAddress.getAddress().getHostAddress();
-			try {
-				uri = new URI(scheme, null, host, socketAddress.getPort(), null, null, null);
-			} catch (URISyntaxException e) {
-				try {
-					// workaround for openjdk bug JDK-8199396.
-					// some characters are not supported for the ipv6 scope.
-					host = host.replaceAll("[-._~]", "");
-					uri = new URI(scheme, null, host, socketAddress.getPort(), null, null, null);
-				} catch (URISyntaxException e2) {
-					// warn with the original violation
-					LOGGER.warn("{}URI", tag, e);
-				}
-			}
-		} catch (IllegalArgumentException e) {
+			InetSocketAddress address = getAddress();
+			String hostname = StringUtil.getUriHostname(address.getAddress());
+			return new URI(scheme, null, hostname, address.getPort(), null, null, null);
+		} catch (URISyntaxException e) {
 			LOGGER.warn("{}URI", tag, e);
 		}
-		return uri;
+		return null;
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/ServerMessageDeliverer.java
@@ -89,8 +89,7 @@ public class ServerMessageDeliverer implements MessageDeliverer {
 		}
 		boolean processed = preDeliverRequest(exchange);
 		if (!processed) {
-			Request request = exchange.getRequest();
-			final Resource resource = findResource(request);
+			final Resource resource = findResource(exchange);
 			if (resource != null) {
 				checkForObserveOption(exchange, resource);
 
@@ -108,6 +107,7 @@ public class ServerMessageDeliverer implements MessageDeliverer {
 				}
 			} else {
 				if (LOGGER.isInfoEnabled()) {
+					Request request = exchange.getRequest();
 					LOGGER.info("did not find resource /{} requested by {}", request.getOptions().getUriPathString(),
 							request.getSourceContext().getPeerAddress());
 				}
@@ -188,11 +188,13 @@ public class ServerMessageDeliverer implements MessageDeliverer {
 	 * may accept requests to subresources, e.g., to allow addresses with
 	 * wildcards like <code>coap://example.com:5683/devices/*</code>
 	 * 
-	 * @param request request including the path of resource names
+	 * @param exchange The exchange containing the inbound request including the
+	 *            path of resource names
 	 * @return the resource or {@code null}, if not found
+	 * @since 2.1
 	 */
-	protected Resource findResource(Request request) {
-		return findResource(request.getOptions().getUriPath());
+	protected Resource findResource(Exchange exchange) {
+		return findResource(exchange.getRequest().getOptions().getUriPath());
 	}
 
 	/**

--- a/californium-proxy2/.gitignore
+++ b/californium-proxy2/.gitignore
@@ -1,0 +1,2 @@
+/Proxy.properties
+/ProxyMapping.properties

--- a/californium-proxy2/pom.xml
+++ b/californium-proxy2/pom.xml
@@ -1,0 +1,170 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<modelVersion>4.0.0</modelVersion>
+	
+	<parent>
+		<groupId>org.eclipse.californium</groupId>
+		<artifactId>parent</artifactId>
+		<version>2.1.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>californium-proxy2</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>Californium (Cf) Proxy2</name>
+	<description>Cross-proxy2 module</description>
+
+	<properties>
+		<httpasyncclient.version>4.1.4</httpasyncclient.version>
+		<httpasyncclient.version.spec>
+			version="[${versionmask;==;${httpasyncclient.version}},${versionmask;+;${httpasyncclient.version}})"
+		</httpasyncclient.version.spec>
+		<httpclient.version>4.5.11</httpclient.version>
+		<httpclient.version.spec>version="[${versionmask;==;${httpclient.version}},${versionmask;+;${httpclient.version}})"</httpclient.version.spec>
+		<!-- use same version for httpcore and httpcore-nio -->
+		<httpcore.version>4.4.13</httpcore.version>
+		<httpcore.version.spec>version="[${versionmask;==;${httpcore.version}},${versionmask;+;${httpcore.version}})"</httpcore.version.spec>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>californium-legal</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>californium-core</artifactId>
+		</dependency>		
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>15.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpasyncclient</artifactId>
+			<version>${httpasyncclient.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore</artifactId>
+			<version>${httpcore.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore-nio</artifactId>
+			<version>${httpcore.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>${httpclient.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-codec</groupId>
+					<artifactId>commons-codec</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<!-- test dependencies -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.revapi</groupId>
+				<artifactId>revapi-maven-plugin</artifactId>
+				<configuration>
+					<analysisConfiguration combine.children="append">
+						<revapi.ignore>
+							<item>
+								<regex>true</regex>
+								<code>java\.class\.externalClassExposedInAPI</code>
+								<package>org\.apache\.http(\..*)*</package>
+								<justification>
+								</justification>
+							</item>
+							<item>
+								<regex>true</regex>
+								<code>java\.class\.externalClassExposedInAPI</code>
+								<package>org\.slf4j</package>
+								<justification>
+								</justification>
+							</item>
+							<item>
+								<regex>true</regex>
+								<code>java\.class\.externalClassExposedInAPI</code>
+								<package>com\.google\.common(\..*)*</package>
+								<justification>
+								</justification>
+							</item>
+						</revapi.ignore>
+					</analysisConfiguration>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Export-Package>
+							org.eclipse.californium.proxy2*
+						</Export-Package>
+						<Import-Package>
+							org.apache.http; ${httpcore.version.spec},
+							org.apache.http.client.*; ${httpclient.version.spec},
+							org.apache.http.concurrent; ${httpcore.version.spec},
+							org.apache.http.conn*; ${httpclient.version.spec},
+							org.apache.http.entity; ${httpcore.version.spec},
+							org.apache.http.impl; ${httpcore.version.spec},
+							org.apache.http.impl.client; ${httpclient.version.spec},
+							org.apache.http.impl.nio; ${httpcore.version.spec},
+							org.apache.http.impl.nio.client; ${httpasyncclient.version.spec},
+							org.apache.http.impl.nio.conn; ${httpasyncclient.version.spec},
+							org.apache.http.impl.nio.reactor; ${httpcore.version.spec},
+							org.apache.http.message; ${httpcore.version.spec},
+							org.apache.http.nio; ${httpcore.version.spec},
+							org.apache.http.nio.conn; ${httpasyncclient.version.spec},
+							org.apache.http.nio.protocol; ${httpcore.version.spec},
+							org.apache.http.nio.reactor; ${httpcore.version.spec},
+							org.apache.http.params; ${httpcore.version.spec},
+							org.apache.http.protocol; ${httpcore.version.spec},
+							org.apache.http.util; ${httpcore.version.spec},
+							*
+						</Import-Package>
+						<Bundle-SymbolicName>${project.groupId}.proxy2</Bundle-SymbolicName>
+					</instructions>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>enhanced-jar-with-licenses</descriptorRef>
+					</descriptorRefs>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/Coap2CoapTranslator.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/Coap2CoapTranslator.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - derived from org.eclipse.californium.proxy
+ ******************************************************************************/
+
+package org.eclipse.californium.proxy2;
+
+import java.net.URI;
+
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.OptionSet;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Static class that provides the translations between the messages from the
+ * internal CoAP nodes and external ones.
+ */
+public class Coap2CoapTranslator extends CoapUriTranslator {
+
+	/** The Constant LOG. */
+	private static final Logger LOGGER = LoggerFactory.getLogger(Coap2CoapTranslator.class);
+
+	/**
+	 * Starting from an external CoAP request, the method fills a new request
+	 * for the internal CaAP nodes. Translates the proxy-uri option in the uri
+	 * of the new request and simply copies the options and the payload from the
+	 * original request to the new one.
+	 * 
+	 * @param destination destination for outgoing request
+	 * @param incomingRequest the original incoming request
+	 * @return Request the created outgoing request
+	 * @throws TranslationException the translation exception
+	 */
+	public Request getRequest(URI destination, Request incomingRequest) throws TranslationException {
+		// check parameters
+		if (destination == null) {
+			throw new NullPointerException("destination == null");
+		}
+		if (incomingRequest == null) {
+			throw new NullPointerException("incomingRequest == null");
+		}
+
+		// get the code
+		Code code = incomingRequest.getCode();
+
+		// get message type
+		Type type = incomingRequest.getType();
+
+		// create the request
+		Request outgoingRequest = new Request(code);
+		outgoingRequest.setConfirmable(type == Type.CON);
+
+		// copy payload
+		byte[] payload = incomingRequest.getPayload();
+		outgoingRequest.setPayload(payload);
+
+		// copy every option from the original message
+		// do not copy the proxy-uri option because it is not necessary in
+		// the new message
+		// do not copy the token option because it is a local option and
+		// have to be assigned by the proper layer
+		// do not copy the block* option because it is a local option and
+		// have to be assigned by the proper layer
+		// do not copy the uri-* options because they are already filled in
+		// the new message
+		OptionSet options = new OptionSet(incomingRequest.getOptions());
+		options.removeProxyScheme();
+		options.removeProxyUri();
+		options.removeBlock1();
+		options.removeBlock2();
+		options.removeUriHost();
+		options.removeUriPort();
+		options.clearUriPath();
+		options.clearUriQuery();
+		outgoingRequest.setOptions(options);
+
+		// set the proxy-uri as the outgoing uri
+		outgoingRequest.setURI(destination);
+
+		LOGGER.debug("Incoming request translated correctly");
+		return outgoingRequest;
+	}
+
+	/**
+	 * Fills the new response with the response received from the internal CoAP
+	 * node. Simply copies the options and the payload from the forwarded
+	 * response to the new one.
+	 * 
+	 * @param incomingResponse the incoming response
+	 * @return the response to outgoing response
+	 */
+	public Response getResponse(Response incomingResponse) {
+		if (incomingResponse == null) {
+			throw new IllegalArgumentException("incomingResponse == null");
+		}
+
+		// get the status
+		ResponseCode status = incomingResponse.getCode();
+
+		// create the response
+		Response outgoingResponse = new Response(status);
+
+		// copy payload
+		byte[] payload = incomingResponse.getPayload();
+		outgoingResponse.setPayload(payload);
+
+		// copy the timestamp
+		long timestamp = incomingResponse.getNanoTimestamp();
+		outgoingResponse.setNanoTimestamp(timestamp);
+
+		// copy every option
+		outgoingResponse.setOptions(incomingResponse.getOptions());
+
+		LOGGER.debug("Incoming response translated correctly");
+		return outgoingResponse;
+	}
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/Coap2HttpTranslator.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/Coap2HttpTranslator.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - derived from org.eclipse.californium.proxy
+ ******************************************************************************/
+package org.eclipse.californium.proxy2;
+
+import java.net.URI;
+import java.util.List;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.HttpVersion;
+import org.apache.http.RequestLine;
+import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicHttpEntityEnclosingRequest;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.message.BasicRequestLine;
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.Option;
+import org.eclipse.californium.core.coap.OptionNumberRegistry;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class providing the translations (mappings) from the CoAP request
+ * representations to the HTTP request representations and back from HTTP
+ * response representations to CoAP response representations.
+ */
+public class Coap2HttpTranslator extends CoapUriTranslator {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(Coap2HttpTranslator.class);
+
+	protected final HttpTranslator httpTranslator;
+
+	public Coap2HttpTranslator(String mappingPropertiesFileName) {
+		httpTranslator = new HttpTranslator(mappingPropertiesFileName);
+	}
+
+	public Coap2HttpTranslator() {
+		httpTranslator = new HttpTranslator();
+	}
+
+	public HttpRequest getHttpRequest(URI uri, Request coapRequest) throws TranslationException {
+		if (coapRequest == null) {
+			throw new IllegalArgumentException("coapRequest == null");
+		}
+
+		String coapMethod = httpTranslator.getHttpMethod(coapRequest.getCode());
+
+		// create the requestLine
+		RequestLine requestLine = new BasicRequestLine(coapMethod, uri.toASCIIString(), HttpVersion.HTTP_1_1);
+
+		// get the http entity
+		HttpEntity httpEntity = httpTranslator.getHttpEntity(coapRequest);
+
+		// create the http request
+		HttpRequest httpRequest;
+		if (httpEntity == null) {
+			httpRequest = new BasicHttpRequest(requestLine);
+		} else {
+			httpRequest = new BasicHttpEntityEnclosingRequest(requestLine);
+			((HttpEntityEnclosingRequest) httpRequest).setEntity(httpEntity);
+
+			// get the content-type from the entity and set the header
+			ContentType contentType = ContentType.get(httpEntity);
+			httpRequest.setHeader("content-type", contentType.toString());
+		}
+
+		// set the headers
+		Header[] headers = httpTranslator.getHttpHeaders(coapRequest.getOptions().asSortedList());
+		for (Header header : headers) {
+			httpRequest.addHeader(header);
+		}
+
+		return httpRequest;
+	}
+
+	/**
+	 * Gets the CoAP response from an incoming HTTP response. No null value is
+	 * returned. The response is created from a the mapping of the HTTP response
+	 * code retrieved from the properties file. If the code is 204, which has
+	 * multiple meaning, the mapping is handled looking on the request method
+	 * that has originated the response. The options are set thorugh the HTTP
+	 * headers and the option max-age, if not indicated, is set to the default
+	 * value (60 seconds). if the response has an enclosing entity, it is mapped
+	 * to a CoAP payload and the content-type of the CoAP message is set
+	 * properly.
+	 * 
+	 * @param httpResponse the http response
+	 * @param coapRequest
+	 * 
+	 * 
+	 * @return the coap response * @throws TranslationException the translation
+	 *         exception
+	 */
+	public Response getCoapResponse(HttpResponse httpResponse, Request coapRequest) throws TranslationException {
+		if (httpResponse == null) {
+			throw new IllegalArgumentException("httpResponse == null");
+		}
+		if (coapRequest == null) {
+			throw new IllegalArgumentException("coapRequest == null");
+		}
+
+		// get/set the response code
+		int httpCode = httpResponse.getStatusLine().getStatusCode();
+		Code coapMethod = coapRequest.getCode();
+
+		if (httpCode == HttpStatus.SC_NO_CONTENT) {
+			// special mapping for http 2.04 using the coap request code
+			// RFC 7252 5.9.1.2 and 5.9.1.4
+			httpCode += 10000 * coapMethod.value;
+		}
+		// get the translation from the property file
+		ResponseCode coapCode = httpTranslator.getCoapResponseCode(httpCode);
+
+		// create the coap reaponse
+		Response coapResponse = new Response(coapCode);
+
+		// translate the http headers in coap options
+		List<Option> coapOptions = httpTranslator.getCoapOptions(httpResponse.getAllHeaders());
+
+		for (Option option : coapOptions) {
+			coapResponse.getOptions().addOption(option);
+		}
+
+		// the response should indicate a max-age value (RFC 7252, Section
+		// 10.1.1)
+		if (!coapResponse.getOptions().hasMaxAge()) {
+			// The Max-Age Option for responses to POST, PUT or DELETE requests
+			// should always be set to 0 (draft-castellani-core-http-mapping).
+			if (coapMethod == Code.GET) {
+				coapResponse.getOptions().setMaxAge(OptionNumberRegistry.Defaults.MAX_AGE);
+			} else {
+				coapResponse.getOptions().setMaxAge(0);
+			}
+		}
+
+		// get the entity
+		HttpEntity httpEntity = httpResponse.getEntity();
+		if (httpEntity != null) {
+			// translate the http entity in coap payload
+			byte[] payload = httpTranslator.getCoapPayload(httpEntity);
+			if (payload != null && payload.length > 0) {
+				coapResponse.setPayload(payload);
+
+				// set the content-type
+				int coapContentType = httpTranslator.getCoapMediaType(httpResponse);
+				coapResponse.getOptions().setContentFormat(coapContentType);
+			}
+		}
+
+		return coapResponse;
+	}
+
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/EndpointPool.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/EndpointPool.java
@@ -1,0 +1,219 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.proxy2;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.eclipse.californium.core.coap.MessageObserver;
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A pool of Endpoints.
+ */
+public class EndpointPool {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(EndpointPool.class);
+
+	/**
+	 * Size of pool.
+	 */
+	private final int size;
+	/**
+	 * Network configuration for new endpoints.
+	 */
+	protected final NetworkConfig config;
+	/**
+	 * Scheme of endpoints.
+	 */
+	private final String scheme;
+	/**
+	 * Pool of endpoints.
+	 */
+	private final Queue<Endpoint> pool;
+	/**
+	 * Main executor for endpoints.
+	 * 
+	 * @see Endpoint#setExecutors(ScheduledExecutorService,
+	 *      ScheduledExecutorService)
+	 */
+	protected final ScheduledExecutorService mainExecutor;
+	/**
+	 * Secondary executor for endpoints.
+	 * 
+	 * @see Endpoint#setExecutors(ScheduledExecutorService,
+	 *      ScheduledExecutorService)
+	 */
+	protected final ScheduledExecutorService secondaryExecutor;
+
+	/**
+	 * Create endpoint pool with specific network configuration and executors.
+	 * 
+	 * @param size size of pool
+	 * @param init initial size of pool
+	 * @param config network configuration to create endpoints.
+	 * @param mainExecutor main executor for endpoints
+	 * @param secondaryExecutor secondary executor for endpoints
+	 */
+	public EndpointPool(int size, int init, NetworkConfig config, ScheduledExecutorService mainExecutor,
+			ScheduledExecutorService secondaryExecutor) {
+		this.size = size;
+		this.pool = new ArrayDeque<>(size);
+		this.config = config;
+		this.mainExecutor = mainExecutor;
+		this.secondaryExecutor = secondaryExecutor;
+		if (init > size) {
+			init = size;
+		}
+		this.scheme = init(init);
+	}
+
+	/**
+	 * Initialize pool with endpoints.
+	 * 
+	 * @param init number of initial endpoints.
+	 * @return scheme of endpoints
+	 */
+	private String init(int init) {
+		String scheme = null;
+		try {
+			Endpoint endpoint = createEndpoint();
+			scheme = endpoint.getUri().getScheme();
+			pool.add(endpoint);
+			for (int i = 1; i < init; i++) {
+				pool.add(createEndpoint());
+			}
+		} catch (IOException ex) {
+			LOGGER.warn("endpoint pool could not be filled!", ex);
+		}
+		return scheme;
+	}
+
+	/**
+	 * Returns scheme of endpoint.
+	 * 
+	 * @return scheme of endpoint
+	 */
+	public String getScheme() {
+		return scheme;
+	}
+
+	/**
+	 * @return An Endpoint that is not in use.
+	 * @throws IOException
+	 */
+	public Endpoint getEndpoint() throws IOException {
+		synchronized (pool) {
+			if (pool.size() > 0) {
+				return pool.remove();
+			}
+		}
+
+		LOGGER.warn("Out of endpoints, creating more");
+
+		return createEndpoint();
+	}
+
+	public void sendRequest(Request outgoingRequest, MessageObserver callback) throws IOException {
+		Endpoint outgoingEndpoint = getEndpoint();
+		outgoingRequest.addMessageObserver(new PoolMessageObserver(outgoingEndpoint));
+		outgoingRequest.addMessageObserver(callback);
+		outgoingEndpoint.sendRequest(outgoingRequest);
+	}
+
+	/**
+	 * Create new endpoint.
+	 * 
+	 * Maybe overriden to create endpoints using other schemes and protocols.
+	 * 
+	 * @return new created endpoint.
+	 * @throws IOException
+	 */
+	protected Endpoint createEndpoint() throws IOException {
+		Endpoint endpoint = new CoapEndpoint.Builder().setNetworkConfig(config).build();
+		endpoint.setExecutors(mainExecutor, secondaryExecutor);
+		try {
+			endpoint.start();
+			return endpoint;
+		} catch (IOException e) {
+			endpoint.destroy();
+			throw e;
+		}
+	}
+
+	/**
+	 * Release a Endpoint so that other requests can use it.
+	 * 
+	 * @param endpoint Endpoint to free. {@code null} will return without
+	 *            releasing it.
+	 */
+	public void release(final Endpoint endpoint) {
+		if (endpoint == null) {
+			return;
+		}
+		synchronized (pool) {
+			if (pool.size() < size) {
+				pool.add(endpoint);
+				return;
+			}
+		}
+		endpoint.destroy();
+	}
+
+	/**
+	 * Destroy endpoints in pool.
+	 */
+	public void destroy() {
+		synchronized (pool) {
+			for (Endpoint endpoint : pool) {
+				endpoint.destroy();
+			}
+		}
+	}
+
+	private class PoolMessageObserver extends MessageObserverAdapter {
+
+		private final Endpoint outgoingEndpoint;
+
+		private PoolMessageObserver(Endpoint outgoingEndpoint) {
+			this.outgoingEndpoint = outgoingEndpoint;
+		}
+
+		@Override
+		public void onResponse(Response incomingResponse) {
+			release(outgoingEndpoint);
+		}
+
+		@Override
+		public void onCancel() {
+			release(outgoingEndpoint);
+		}
+
+		@Override
+		protected void failed() {
+			release(outgoingEndpoint);
+		}
+	}
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/Http2CoapTranslator.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/Http2CoapTranslator.java
@@ -1,0 +1,327 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - derived from org.eclipse.californium.proxy
+ ******************************************************************************/
+package org.eclipse.californium.proxy2;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.NameValuePair;
+import org.apache.http.StatusLine;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.EnglishReasonPhraseCatalog;
+import org.apache.http.message.BasicStatusLine;
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.Option;
+import org.eclipse.californium.core.coap.OptionNumberRegistry;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.elements.util.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class providing the translations (mappings) from the HTTP request
+ * representations to the CoAP request representations and back from CoAP
+ * response representations to HTTP response representations.
+ */
+public class Http2CoapTranslator {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(Http2CoapTranslator.class);
+
+	protected final HttpTranslator httpTranslator;
+
+	public Http2CoapTranslator(String mappingPropertiesFileName) {
+		httpTranslator = new HttpTranslator(mappingPropertiesFileName);
+	}
+
+	public Http2CoapTranslator() {
+		httpTranslator = new HttpTranslator();
+	}
+
+	/**
+	 * Gets the coap request. Creates the CoAP request from the HTTP method and
+	 * mapping it through the properties file. The uri is translated using
+	 * regular expressions, the uri format expected is either the embedded
+	 * mapping (http://proxyname.domain:80/proxy/coap://coapserver:5683/resource
+	 * converted in coap://coapserver:5683/resource) or the standard uri to
+	 * indicate a local request not to be forwarded. The method uses a decoder
+	 * to translate the application/x-www-form-urlencoded format of the uri. The
+	 * CoAP options are set translating the headers. If the HTTP message has an
+	 * enclosing entity, it is converted to create the payload of the CoAP
+	 * message; finally the content-type is set accordingly to the header and to
+	 * the entity type.
+	 * 
+	 * @param httpRequest the http request
+	 * @param httpResource the http resource, if present in the uri, indicates
+	 *            the need of forwarding for the current request
+	 * @param proxyingEnabled {@code true} to forward the request using the
+	 *            sub-path as URI, {@code false} to access a local coap
+	 *            resource.
+	 * @return the coap request
+	 * @throws TranslationException the translation exception
+	 */
+	public Request getCoapRequest(HttpRequest httpRequest, String httpResource, boolean proxyingEnabled)
+			throws TranslationException {
+		if (httpRequest == null) {
+			throw new NullPointerException("httpRequest == null");
+		}
+		if (httpResource == null) {
+			throw new NullPointerException("httpResource == null");
+		}
+
+		// get the http method
+		String httpMethod = httpRequest.getRequestLine().getMethod().toLowerCase();
+
+		// get the coap method
+		Code code = httpTranslator.getCoapCode(httpMethod);
+
+		// create the request -- since HTTP is reliable use CON
+		Request coapRequest = new Request(code, Type.CON);
+
+		// get the uri
+		URI uri = null;
+		String uriString = httpRequest.getRequestLine().getUri();
+		LOGGER.debug("URI <= '{}'", uriString);
+
+		// decode the uri to translate the application/x-www-form-urlencoded
+		// format
+		try {
+			uri = new URI(uriString);
+		} catch (URISyntaxException e) {
+			LOGGER.debug("Malformed uri", e);
+			throw new TranslationException("Malformed uri: " + e.getMessage());
+		} catch (IllegalArgumentException e) {
+			LOGGER.debug("Malformed uri", e);
+			throw new TranslationException("Malformed uri: " + e.getMessage());
+		} catch (Throwable e) {
+			LOGGER.warn("Malformed uri", e);
+			throw new InvalidFieldException("Malformed uri: " + e.getMessage());
+		}
+
+		// if the uri contains the proxy resource name, the request should be
+		// forwarded and it is needed to get the real requested coap server's
+		// uri
+		// e.g.:
+		// /proxy/coap://vslab-dhcp-17.inf.ethz.ch:5684/helloWorld
+		// proxy resource: /proxy
+		// coap server: coap://vslab-dhcp-17.inf.ethz.ch:5684
+		// coap resource: helloWorld
+		String path = uri.getPath();
+		LOGGER.debug("URI path => '{}'", path);
+		if (path.startsWith("/" + httpResource + "/")) {
+			path = path.substring(httpResource.length() + 2);
+			String target = path;
+			if (uri.getQuery() != null) {
+				target = path + "?" + uri.getQuery();
+			}
+			try {
+				uri = new URI(target);
+				if (proxyingEnabled) {
+					// forwarding proxy
+					// if the uri hasn't the indication of the scheme, add it
+					if (uri.getScheme() == null) {
+						throw new InvalidFieldException(
+								"Malformed uri: destination scheme missing! Use http://<proxy-host>/" + httpResource
+										+ "/coap://<destination-host>/<path>");
+					}
+					// "coap://host" may have been normalized to "coap:/host"
+					int index = uri.getScheme().length() + 2;
+					if (target.charAt(index) != '/') {
+						// add it
+						target = target.substring(0, index) + "/" + target.substring(index);
+					}
+					// the uri will be set as a proxy-uri option
+					LOGGER.debug("URI destination => '{}'", target);
+					coapRequest.getOptions().setProxyUri(target);
+				} else {
+					if (uri.getScheme() != null) {
+						throw new InvalidFieldException(
+								"Malformed uri: local destination doesn't support scheme! Use http://<proxy-host>/"
+										+ httpResource + "/<path>");
+					}
+					// the uri will be set as a coap-uri
+					target = "coap://localhost/" + target;
+					LOGGER.debug("URI local => '{}'", target);
+					coapRequest.setURI(target);
+				}
+			} catch (URISyntaxException e) {
+				LOGGER.warn("Malformed destination uri", e);
+				throw new InvalidFieldException("Malformed destination uri: " + target + "!");
+			}
+		} else if (proxyingEnabled && path.equals("/" + httpResource)) {
+			String target = null;
+			if (uri.getQuery() != null) {
+				List<NameValuePair> query = URLEncodedUtils.parse(uri.getQuery(), StandardCharsets.UTF_8);
+				for (NameValuePair arg : query) {
+					if (arg.getName().equalsIgnoreCase("target_uri")) {
+						target = arg.getValue();
+						break;
+					}
+				}
+			}
+			if (target == null) {
+				throw new InvalidFieldException("Malformed uri: target_uri is missing! Use http://<proxy-host>/"
+						+ httpResource + "?target_uri=coap://<destination-host>/<path>");
+			}
+			try {
+				uri = new URI(target);
+				// forwarding proxy
+				// if the uri hasn't the indication of the scheme, add it
+				if (uri.getScheme() == null) {
+					throw new InvalidFieldException(
+							"Malformed uri: destination scheme missing! Use http://<proxy-host>/" + httpResource
+									+ "?target_uri=coap://<destination-host>/<path>");
+				}
+				// the uri will be set as a proxy-uri option
+				LOGGER.debug("URI destination => '{}'", target);
+				coapRequest.getOptions().setProxyUri(target);
+			} catch (URISyntaxException e) {
+				LOGGER.warn("Malformed destination uri", e);
+				throw new InvalidFieldException("Malformed destination uri: " + target + "!");
+			}
+		} else if (proxyingEnabled && uri.getScheme() != null) {
+			// http-server configured as http-proxy
+			int index = path.lastIndexOf('/');
+			if (0 < index) {
+				String scheme = path.substring(index + 1);
+				if (scheme.matches("\\w+:$")) {
+					scheme = scheme.substring(0, scheme.length() - 1);
+					path = path.substring(0, index);
+					try {
+						URI destination = new URI(scheme, null, uri.getHost(), uri.getPort(), path, uri.getQuery(),
+								null);
+						coapRequest.getOptions().setProxyUri(destination.toASCIIString());
+					} catch (URISyntaxException e) {
+						LOGGER.debug("Malformed proxy uri", e);
+						throw new TranslationException("Malformed proxy uri: '" + uriString + "' " + e.getMessage());
+					}
+				} else {
+					throw new TranslationException(
+							"Malformed proxy uri: target scheme missing! Use http://<destination-host>/<path>/<target-scheme>:");
+				}
+			} else {
+				throw new TranslationException(
+						"Malformed proxy uri: target scheme missing! Use http://<destination-host>/<path>/<target-scheme>:");
+			}
+		} else {
+			throw new IllegalArgumentException("URI '" + uriString + "' doesn't match handler '" + httpResource + "'!");
+		}
+
+		// translate the http headers in coap options
+		List<Option> coapOptions = httpTranslator.getCoapOptions(httpRequest.getAllHeaders());
+		for (Option option : coapOptions) {
+			coapRequest.getOptions().addOption(option);
+		}
+
+		// set the payload if the http entity is present
+		if (httpRequest instanceof HttpEntityEnclosingRequest) {
+			HttpEntity httpEntity = ((HttpEntityEnclosingRequest) httpRequest).getEntity();
+
+			// translate the http entity in coap payload
+			byte[] payload = httpTranslator.getCoapPayload(httpEntity);
+			coapRequest.setPayload(payload);
+
+			// set the content-type
+			int coapContentType = httpTranslator.getCoapMediaType(httpRequest);
+			coapRequest.getOptions().setContentFormat(coapContentType);
+		}
+
+		return coapRequest;
+	}
+
+	/**
+	 * Sets the parameters of the incoming http response from a CoAP response.
+	 * The status code is mapped through the properties file and is set through
+	 * the StatusLine. The options are translated to the corresponding headers
+	 * and the max-age (in the header cache-control) is set to the default value
+	 * (60 seconds) if not already present. If the request method was not HEAD
+	 * and the coap response has a payload, the entity and the content-type are
+	 * set in the http response.
+	 * 
+	 * @param httpRequest http-request
+	 * @param coapResponse the coap-response
+	 * @param httpResponse http-response to be filled with the coap-response
+	 * @throws TranslationException the translation exception
+	 */
+	public void getHttpResponse(HttpRequest httpRequest, Response coapResponse, HttpResponse httpResponse)
+			throws TranslationException {
+		if (httpRequest == null) {
+			throw new IllegalArgumentException("httpRequest == null");
+		}
+		if (coapResponse == null) {
+			throw new IllegalArgumentException("coapResponse == null");
+		}
+		if (httpResponse == null) {
+			throw new IllegalArgumentException("httpResponse == null");
+		}
+
+		// get/set the response code
+		ResponseCode coapCode = coapResponse.getCode();
+		int httpCode = httpTranslator.getHttpCode(coapResponse.getCode());
+
+		// create the http response and set the status line
+		String reason = EnglishReasonPhraseCatalog.INSTANCE.getReason(httpCode, Locale.ENGLISH);
+		StatusLine statusLine = new BasicStatusLine(HttpVersion.HTTP_1_1, httpCode, reason);
+		httpResponse.setStatusLine(statusLine);
+
+		// set the headers
+		Header[] headers = httpTranslator.getHttpHeaders(coapResponse.getOptions().asSortedList());
+		httpResponse.setHeaders(headers);
+
+		// set max-age if not already set
+		if (!httpResponse.containsHeader("cache-control")) {
+			httpResponse.setHeader("cache-control", "max-age=" + OptionNumberRegistry.Defaults.MAX_AGE);
+		}
+
+		// get the http entity if the request was not HEAD
+		if (!httpRequest.getRequestLine().getMethod().equalsIgnoreCase("head")) {
+
+			// if the content-type is not set in the coap response and if the
+			// response contains an error, then the content-type should set to
+			// text-plain
+			if (coapResponse.getOptions().getContentFormat() == MediaTypeRegistry.UNDEFINED
+					&& (ResponseCode.isClientError(coapCode) || ResponseCode.isServerError(coapCode))) {
+				LOGGER.info("Set contenttype to TEXT_PLAIN");
+				coapResponse.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
+				if (coapResponse.getPayloadSize() == 0) {
+					coapResponse.setPayload(httpCode + ": " + reason);
+				}
+			}
+
+			HttpEntity httpEntity = httpTranslator.getHttpEntity(coapResponse);
+			if (httpEntity != null) {
+				httpResponse.setEntity(httpEntity);
+
+				// get the content-type from the entity and set the header
+				ContentType contentType = ContentType.get(httpEntity);
+				httpResponse.setHeader("content-type", contentType.toString());
+			}
+		}
+	}
+
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/HttpClientFactory.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/HttpClientFactory.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2017 NTNU Gjøvik and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *    Martin Storø Nyfløtt (NTNU Gjøvik) - performance improvements to HTTP cross-proxy
+ ******************************************************************************/
+package org.eclipse.californium.proxy2;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.protocol.RequestAcceptEncoding;
+import org.apache.http.client.protocol.ResponseContentEncoding;
+import org.apache.http.impl.client.DefaultConnectionKeepAliveStrategy;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
+import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
+import org.apache.http.nio.reactor.ConnectingIOReactor;
+import org.apache.http.nio.reactor.IOReactorException;
+import org.apache.http.protocol.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provide http clients using pooled connection management.
+ */
+public class HttpClientFactory {
+	private static final int KEEP_ALIVE = 5000;
+	private static final Logger LOGGER = LoggerFactory.getLogger(HttpClientFactory.class);
+
+	private HttpClientFactory() {
+	}
+
+	public static CloseableHttpAsyncClient createClient() {
+		try {
+			final CloseableHttpAsyncClient client = HttpAsyncClientBuilder.create()
+					.disableCookieManagement()
+					.setDefaultRequestConfig(createCustomRequestConfig())
+					.setConnectionManager(createPoolingConnManager())
+					.addInterceptorFirst(new RequestAcceptEncoding())
+					.addInterceptorFirst(new RequestConnControl())
+					// .addInterceptorFirst(new RequestContent())
+					.addInterceptorFirst(new RequestDate())
+					.addInterceptorFirst(new RequestExpectContinue(true))
+					.addInterceptorFirst(new RequestTargetHost())
+					.addInterceptorFirst(new RequestUserAgent())
+					.addInterceptorFirst(new ResponseContentEncoding())
+					.setKeepAliveStrategy(new DefaultConnectionKeepAliveStrategy() {
+						@Override
+						public long getKeepAliveDuration(HttpResponse response, HttpContext context) {
+							long keepAlive = super.getKeepAliveDuration(response, context);
+							if (keepAlive == -1) {
+								// Keep connections alive if a keep-alive value
+								// has not be explicitly set by the server
+								keepAlive = KEEP_ALIVE;
+							}
+							return keepAlive;
+						}
+
+					})
+					.build();
+			client.start();
+			return client;
+		} catch (IOReactorException e) {
+			LOGGER.error("create http-client failed!", e);
+			return null;
+		}
+	}
+
+	private static RequestConfig createCustomRequestConfig() {
+		return RequestConfig.custom()
+				.setConnectionRequestTimeout(5000)
+				.setConnectTimeout(1000)
+				.setSocketTimeout(500).build();
+	}
+
+	private static PoolingNHttpClientConnectionManager createPoolingConnManager() throws IOReactorException {
+		ConnectingIOReactor ioReactor = new DefaultConnectingIOReactor();
+
+		PoolingNHttpClientConnectionManager cm = new PoolingNHttpClientConnectionManager(ioReactor);
+		cm.setMaxTotal(50);
+		cm.setDefaultMaxPerRoute(50);
+
+		return cm;
+	}
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/HttpServer.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/HttpServer.java
@@ -1,0 +1,205 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.proxy2;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpResponseInterceptor;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.protocol.RequestAcceptEncoding;
+import org.apache.http.client.protocol.ResponseContentEncoding;
+import org.apache.http.config.ConnectionConfig;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.DefaultConnectionReuseStrategy;
+import org.apache.http.impl.DefaultHttpResponseFactory;
+import org.apache.http.impl.nio.DefaultHttpServerIODispatch;
+import org.apache.http.impl.nio.DefaultNHttpServerConnection;
+import org.apache.http.impl.nio.DefaultNHttpServerConnectionFactory;
+import org.apache.http.impl.nio.reactor.DefaultListeningIOReactor;
+import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.apache.http.nio.NHttpConnectionFactory;
+import org.apache.http.nio.protocol.BasicAsyncRequestHandler;
+import org.apache.http.nio.protocol.HttpAsyncService;
+import org.apache.http.nio.protocol.UriHttpAsyncRequestHandlerMapper;
+import org.apache.http.nio.reactor.IOEventDispatch;
+import org.apache.http.nio.reactor.ListeningIOReactor;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpProcessor;
+import org.apache.http.protocol.HttpRequestHandler;
+import org.apache.http.protocol.ImmutableHttpProcessor;
+import org.apache.http.protocol.ResponseConnControl;
+import org.apache.http.protocol.ResponseContent;
+import org.apache.http.protocol.ResponseDate;
+import org.apache.http.protocol.ResponseServer;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.elements.util.DaemonThreadFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Create simple http server.
+ */
+public class HttpServer {
+
+	/**
+	 * The default thread group for Californium threads.
+	 */
+	public static final ThreadGroup HTTP_THREAD_GROUP = new ThreadGroup("Http"); //$NON-NLS-1$
+
+	static {
+		// reset daemon, may be set by parent group!
+		HTTP_THREAD_GROUP.setDaemon(false);
+	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(HttpServer.class);
+
+	private final UriHttpAsyncRequestHandlerMapper registry;
+	private final IOEventDispatch ioEventDispatch;
+	private final IOReactorConfig ioReactorConfig;
+	private final int httpPort;
+	private ThreadFactory threadFactory = new DaemonThreadFactory("Http#", HTTP_THREAD_GROUP);
+	private ListeningIOReactor ioReactor;
+
+	/**
+	 * Create http server.
+	 * 
+	 * @param config network configuration
+	 * @param httpPort port ot be used.
+	 */
+	public HttpServer(NetworkConfig config, int httpPort) {
+		this.httpPort = httpPort;
+		// Create HTTP protocol processing chain
+		// Use standard server-side protocol interceptors
+		HttpRequestInterceptor[] requestInterceptors = new HttpRequestInterceptor[] { new RequestAcceptEncoding() };
+		HttpResponseInterceptor[] responseInterceptors = new HttpResponseInterceptor[] { new ResponseContentEncoding(),
+				new ResponseDate(), new ResponseServer(), new ResponseContent(), new ResponseConnControl() };
+		HttpProcessor httpProcessor = new ImmutableHttpProcessor(requestInterceptors, responseInterceptors);
+
+		// Create request handler registry
+		registry = new UriHttpAsyncRequestHandlerMapper();
+
+		// Create server-side HTTP protocol handler
+		HttpAsyncService protocolHandler = new HttpAsyncService(httpProcessor, new DefaultConnectionReuseStrategy(),
+				new DefaultHttpResponseFactory(), registry, null);
+
+		// Create HTTP connection factory
+		NHttpConnectionFactory<DefaultNHttpServerConnection> connFactory = new DefaultNHttpServerConnectionFactory(
+				ConnectionConfig.DEFAULT);
+
+		// Create server-side I/O event dispatch
+		ioEventDispatch = new DefaultHttpServerIODispatch<HttpAsyncService>(protocolHandler, connFactory);
+
+		// configuring IOReactor
+		int socketTimeout = config.getInt(NetworkConfig.Keys.HTTP_SERVER_SOCKET_TIMEOUT);
+		int socketBufferSize = config.getInt(NetworkConfig.Keys.HTTP_SERVER_SOCKET_BUFFER_SIZE);
+		ioReactorConfig = IOReactorConfig.custom().setRcvBufSize(socketBufferSize).setSoTimeout(socketTimeout)
+				.setTcpNoDelay(true).setSoLinger(0).build();
+	}
+
+	UriHttpAsyncRequestHandlerMapper getRequestHandlerMapper() {
+		return registry;
+	}
+
+	/**
+	 * Start http server.
+	 * 
+	 * @throws IOException in case if a non-recoverable I/O error.
+	 */
+	public void start() throws IOException {
+		ioReactor = new DefaultListeningIOReactor(ioReactorConfig, threadFactory);
+		// Listen of the given port
+		ioReactor.listen(new InetSocketAddress(httpPort));
+		// create the listener thread
+		Thread listener = new Thread("Http-Listener") {
+
+			@Override
+			public void run() {
+				// Starts the reactor and initiates the dispatch of I/O
+				// event notifications to the given IOEventDispatch.
+				try {
+					ioReactor.execute(ioEventDispatch);
+				} catch (IOException e) {
+					LOGGER.error("I/O Exception in HttpServer", e);
+				}
+			}
+		};
+		listener.setDaemon(false);
+		listener.start();
+		LOGGER.info("HttpServer listening on port {} started.", httpPort);
+	}
+
+	/**
+	 * Start http server.
+	 */
+	public void stop() {
+		try {
+			ioReactor.shutdown(1000);
+			System.out.println("shutdown ...");
+		} catch (IOException e) {
+			LOGGER.error("shutdown failed!", e);
+		}
+		LOGGER.info("HttpServer on port {} stopped.", httpPort);
+	}
+
+	/**
+	 * Set simple resource.
+	 * 
+	 * Apply {@link String#format(String, Object...)} to the message using the
+	 * {@code httpPort} and {@code requestCounter} as parameter.
+	 * 
+	 * @param resource resource path
+	 * @param message message template for response
+	 * @param requestCounter counter for requests.
+	 */
+	public void setSimpleResource(String resource, String message, AtomicLong requestCounter) {
+		registry.register(resource,
+				new BasicAsyncRequestHandler(new RequestCounterHandler(message, httpPort, requestCounter)));
+	}
+
+	/**
+	 * The Class BaseRequestHandler handles simples requests that do not need
+	 * the proxying.
+	 */
+	private static class RequestCounterHandler implements HttpRequestHandler {
+
+		private final String message;
+		private final int httpPort;
+		private final AtomicLong requestCounter;
+
+		private RequestCounterHandler(String message, int httpPort, AtomicLong requestCounter) {
+			this.message = message;
+			this.httpPort = httpPort;
+			this.requestCounter = requestCounter == null ? new AtomicLong() : requestCounter;
+		}
+
+		@Override
+		public void handle(HttpRequest httpRequest, HttpResponse httpResponse, HttpContext httpContext)
+				throws HttpException, IOException {
+			long counter = requestCounter.incrementAndGet();
+			String payload = String.format(message, httpPort, counter);
+			httpResponse.setStatusCode(HttpStatus.SC_OK);
+			httpResponse.setEntity(new StringEntity(payload));
+			LOGGER.debug("{} request handled!", counter);
+		}
+	}
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/HttpStack.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/HttpStack.java
@@ -1,0 +1,344 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - derived from org.eclipse.californium.proxy
+ ******************************************************************************/
+
+package org.eclipse.californium.proxy2;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
+import java.util.Locale;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpException;
+import org.apache.http.HttpInetConnection;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.EnglishReasonPhraseCatalog;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.nio.protocol.BasicAsyncRequestConsumer;
+import org.apache.http.nio.protocol.HttpAsyncExchange;
+import org.apache.http.nio.protocol.HttpAsyncRequestConsumer;
+import org.apache.http.nio.protocol.HttpAsyncRequestHandler;
+import org.apache.http.nio.protocol.UriHttpAsyncRequestHandlerMapper;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.Exchange.Origin;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.server.MessageDeliverer;
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.californium.elements.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class encapsulating the logic of a http server. The class create a receiver
+ * thread that it is always blocked on the listen primitive. For each connection
+ * this thread creates a new thread that handles the client/server dialog.
+ * 
+ * <a href="https://tools.ietf.org/html/rfc8075">RFC8075 - HTTP2CoAP</a>
+ */
+public class HttpStack {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(HttpStack.class);
+
+	private static final String SERVER_NAME = "Californium Http Proxy";
+
+	/**
+	 * Resource associated with the proxying behavior. If a client requests
+	 * resource indicated by
+	 * http://proxy-address/PROXY_RESOURCE_NAME/coap-server, the proxying
+	 * handler will forward the request desired coap server.
+	 */
+	private static final String PROXY_RESOURCE_NAME = "proxy";
+
+	/**
+	 * The resource associated with the local resources behavior. If a client
+	 * requests resource indicated by
+	 * http://proxy-address/LOCAL_RESOURCE_NAME/coap-resource, the proxying
+	 * handler will forward the request to the local resource requested.
+	 */
+	public static final String LOCAL_RESOURCE_NAME = "local";
+
+	private final HttpServer server;
+
+	private Http2CoapTranslator translator;
+	private MessageDeliverer requestDeliverer;
+
+	/**
+	 * Instantiates a new http stack on the requested port. It creates an http
+	 * listener thread on the port and the handlers as provided.
+	 * 
+	 * @param config configuration with HTTP_SERVER_SOCKET_TIMEOUT and
+	 *            HTTP_SERVER_SOCKET_BUFFER_SIZE.
+	 * @param httpPort the http port
+	 * @throws IOException Signals that an I/O exception has occurred.
+	 */
+	public HttpStack(NetworkConfig config, int httpPort) throws IOException {
+		server = new HttpServer(config, httpPort);
+		// register the default handler for root URIs
+		// wrapping a common request handler with an async request handler
+		server.setSimpleResource("*", SERVER_NAME + " on port " + httpPort + ".", null);
+	}
+
+	/**
+	 * Set http translator for incoming http requests and outgoing http
+	 * responses.
+	 * 
+	 * set in {@link HttpStack} on {@link #start()}.
+	 * 
+	 * @param translator http translator
+	 */
+	void setHttpTranslator(Http2CoapTranslator translator) {
+		this.translator = translator;
+	}
+
+	/**
+	 * Register "local" request handler.
+	 *
+	 * Handles requests for
+	 * "http:/<proxy-host>:<proxy-port>/local/<local-coap-path>".
+	 * 
+	 */
+	void registerLocalRequestHandler() {
+		UriHttpAsyncRequestHandlerMapper registry = server.getRequestHandlerMapper();
+		// register the handler for local coap resources
+		registry.register("/" + LOCAL_RESOURCE_NAME + "/*", new ProxyAsyncRequestHandler(LOCAL_RESOURCE_NAME, false));
+	}
+
+	/**
+	 * Register "porxy" request handlers.
+	 *
+	 * Handles proxy requests for
+	 * "http:/<proxy-host>:<proxy-port>/proxy/<destination-uri>".
+	 */
+	void registerProxyRequestHandler() {
+		UriHttpAsyncRequestHandlerMapper registry = server.getRequestHandlerMapper();
+		// register the handler for proxy coap resources
+		ProxyAsyncRequestHandler handler = new ProxyAsyncRequestHandler(PROXY_RESOURCE_NAME, true);
+		registry.register("/" + PROXY_RESOURCE_NAME + "/*", handler);
+		registry.register("/" + PROXY_RESOURCE_NAME, handler);
+		registry.register("http*", handler);
+	}
+
+	/**
+	 * Register http-proxy request handlers.
+	 * 
+	 * Enables to catch calls, if this http server is configures as http-proxy
+	 * for the client. In that case, the http-request contains the URI
+	 * (including destination host).
+	 * 
+	 * Handles proxy requests for
+	 * "http:/<destination>:<port>/<destination-uri>/<destination-scheme>:".
+	 */
+	void registerHttpProxyRequestHandler() {
+		UriHttpAsyncRequestHandlerMapper registry = server.getRequestHandlerMapper();
+		// register the handler for proxy coap resources
+		registry.register("http*", new ProxyAsyncRequestHandler(PROXY_RESOURCE_NAME, true));
+	}
+
+	/**
+	 * Start http server.
+	 * 
+	 * @throws IOException in case if a non-recoverable I/O error.
+	 */
+	public void start() throws IOException {
+		server.start();
+	}
+
+	/**
+	 * Stop http server.
+	 */
+	public void stop() {
+		server.stop();
+	}
+
+	/**
+	 * Set message deliverer for http request.
+	 * 
+	 * @param requestDeliverer message deliverer for http request
+	 */
+	public void setRequestDeliverer(MessageDeliverer requestDeliverer) {
+		this.requestDeliverer = requestDeliverer;
+	}
+
+	/**
+	 * Class associated with the http service to translate the http requests in
+	 * coap requests and to produce the http responses. Even if the class
+	 * accepts a string indicating the name of the proxy resource, it is still
+	 * thread-safe because the local resource is set in the constructor and then
+	 * only read by the methods.
+	 */
+	private class ProxyAsyncRequestHandler implements HttpAsyncRequestHandler<HttpRequest> {
+
+		private final String resourceName;
+		private final boolean proxyingEnabled;
+
+		/**
+		 * Instantiates a new proxy request handler.
+		 * 
+		 * @param resourceName the http resource name
+		 * @param proxyingEnabled
+		 */
+		public ProxyAsyncRequestHandler(String resourceName, boolean proxyingEnabled) {
+			this.resourceName = resourceName;
+			this.proxyingEnabled = proxyingEnabled;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * 
+		 * @see
+		 * org.apache.http.nio.protocol.HttpAsyncRequestHandler#handle(java.
+		 * lang.Object, org.apache.http.nio.protocol.HttpAsyncExchange,
+		 * org.apache.http.protocol.HttpContext)
+		 */
+		@Override
+		public void handle(HttpRequest httpRequest, final HttpAsyncExchange httpExchange, HttpContext httpContext)
+				throws HttpException, IOException {
+
+			HttpInetConnection connection = (HttpInetConnection) httpContext
+					.getAttribute(HttpCoreContext.HTTP_CONNECTION);
+			InetSocketAddress endpoint = new InetSocketAddress(connection.getLocalAddress(), connection.getLocalPort());
+			InetSocketAddress source = new InetSocketAddress(connection.getRemoteAddress(), connection.getRemotePort());
+
+			LOGGER.debug("handler {}, proxy {}", resourceName, proxyingEnabled);
+			LOGGER.debug("Incoming http request: on {} from {}{}   {}", endpoint, source, StringUtil.lineSeparator(),
+					httpRequest.getRequestLine());
+
+			try {
+				// translate the request in a valid coap request
+				final Request coapRequest = translator.getCoapRequest(httpRequest, resourceName, proxyingEnabled);
+				// if (Bench_Help.DO_LOG)
+				LOGGER.info("Received HTTP request and translate to {}", coapRequest);
+				coapRequest.setSourceContext(new AddressEndpointContext(source));
+				coapRequest.setDestinationContext(new AddressEndpointContext(endpoint));
+				// handle the requset
+				Exchange exchange = new Exchange(coapRequest, Origin.REMOTE, null) {
+
+					@Override
+					public void sendAccept() {
+						// has no meaning for HTTP: do nothing
+					}
+
+					@Override
+					public void sendReject() {
+						sendSimpleHttpResponse(httpExchange, HttpTranslator.STATUS_NOT_FOUND, null);
+					}
+
+					@Override
+					public void sendResponse(Response response) {
+						coapRequest.setResponse(response);
+						sendHttpResponse(httpExchange, response);
+						LOGGER.debug("HTTP returned {}", response);
+					}
+				};
+				requestDeliverer.deliverRequest(exchange);
+			} catch (InvalidMethodException e) {
+				LOGGER.warn("Method not implemented", e);
+				sendSimpleHttpResponse(httpExchange, HttpTranslator.STATUS_WRONG_METHOD, e.getMessage());
+			} catch (InvalidFieldException e) {
+				LOGGER.warn("Request malformed", e);
+				sendSimpleHttpResponse(httpExchange, HttpTranslator.STATUS_URI_MALFORMED, e.getMessage());
+			} catch (TranslationException e) {
+				LOGGER.warn("Failed to translate the http request in a valid coap request", e);
+				sendSimpleHttpResponse(httpExchange, HttpTranslator.STATUS_TRANSLATION_ERROR, e.getMessage());
+			} catch (Throwable e) {
+				LOGGER.error("Unexpected error", e);
+				sendSimpleHttpResponse(httpExchange, HttpTranslator.STATUS_INTERNAL_SERVER_ERROR, e.getMessage());
+			}
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * 
+		 * @see
+		 * org.apache.http.nio.protocol.HttpAsyncRequestHandler#processRequest
+		 * (org.apache.http.HttpRequest, org.apache.http.protocol.HttpContext)
+		 */
+		@Override
+		public HttpAsyncRequestConsumer<HttpRequest> processRequest(HttpRequest httpRequest, HttpContext httpContext)
+				throws HttpException, IOException {
+			// Buffer request content in memory for simplicity
+			return new BasicAsyncRequestConsumer();
+		}
+	}
+
+	/**
+	 * Sedn http response.
+	 * 
+	 * @param httpExchange http exchange
+	 * @param coapResponse coap response
+	 */
+	private void sendHttpResponse(HttpAsyncExchange httpExchange, Response coapResponse) {
+		LOGGER.debug("Incoming response: {}", coapResponse);
+
+		// get the sample http response
+		HttpResponse httpResponse = httpExchange.getResponse();
+
+		try {
+			// translate the coap response in an http response
+			translator.getHttpResponse(httpExchange.getRequest(), coapResponse, httpResponse);
+
+			LOGGER.debug("Outgoing http response: {}", httpResponse.getStatusLine());
+			// send the response
+			httpExchange.submitResponse();
+		} catch (TranslationException e) {
+			LOGGER.warn("Failed to translate coap response to http response: {}", e.getMessage());
+			sendSimpleHttpResponse(httpExchange, HttpTranslator.STATUS_TRANSLATION_ERROR, null);
+		} catch (Throwable e) {
+			LOGGER.warn("Failed to translate coap response to http response: {}", e.getMessage(), e);
+			sendSimpleHttpResponse(httpExchange, HttpTranslator.STATUS_TRANSLATION_ERROR, null);
+		}
+	}
+
+	/**
+	 * Send simple http response.
+	 *
+	 * @param httpExchange the http exchange
+	 * @param httpCode the http code
+	 * @param message additional message, maybe {@code null}
+	 */
+	private static void sendSimpleHttpResponse(HttpAsyncExchange httpExchange, int httpCode, String message) {
+		// get the empty response from the exchange
+		HttpResponse httpResponse = httpExchange.getResponse();
+
+		// create and set the status line
+		String reason = EnglishReasonPhraseCatalog.INSTANCE.getReason(httpCode, Locale.ENGLISH);
+		StatusLine statusLine = new BasicStatusLine(HttpVersion.HTTP_1_1, httpCode, reason);
+		httpResponse.setStatusLine(statusLine);
+
+		try {
+			StringBuilder payload = new StringBuilder();
+			payload.append(httpCode).append(": ").append(reason);
+			if (message != null) {
+				payload.append("\r\n\r\n").append(message);
+			}
+			HttpEntity entity = new StringEntity(payload.toString());
+			httpResponse.setEntity(entity);
+		} catch (UnsupportedEncodingException e) {
+		}
+
+		// send the error response
+		httpExchange.submitResponse();
+	}
+
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/HttpTranslator.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/HttpTranslator.java
@@ -1,0 +1,589 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - derived from org.eclipse.californium.proxy
+ ******************************************************************************/
+package org.eclipse.californium.proxy2;
+
+import static org.eclipse.californium.elements.util.StandardCharsets.ISO_8859_1;
+import static org.eclipse.californium.elements.util.StandardCharsets.UTF_8;
+import static org.eclipse.californium.proxy2.MappingProperties.*;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.UnmappableCharacterException;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpMessage;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.AbstractHttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.coap.Option;
+import org.eclipse.californium.core.coap.OptionNumberRegistry;
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.OptionNumberRegistry.optionFormats;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class providing the translations (mappings) from the HTTP message artefacts
+ * to the CoAP message artefacts and vice versa.
+ */
+public class HttpTranslator {
+
+	/**
+	 * Property file containing the mappings between coap messages and http
+	 * messages.
+	 */
+	private static final MappingProperties DEFAULT_HTTP_TRANSLATION_PROPERTIES = new MappingProperties(
+			"Proxy2.properties");
+	private MappingProperties translationMapping;
+
+	// Error constants
+	public static final int STATUS_TIMEOUT = HttpStatus.SC_GATEWAY_TIMEOUT;
+	public static final int STATUS_NOT_FOUND = HttpStatus.SC_BAD_GATEWAY;
+	public static final int STATUS_TRANSLATION_ERROR = HttpStatus.SC_BAD_GATEWAY;
+	public static final int STATUS_URI_MALFORMED = HttpStatus.SC_BAD_REQUEST;
+	public static final int STATUS_WRONG_METHOD = HttpStatus.SC_NOT_IMPLEMENTED;
+	public static final int STATUS_INTERNAL_SERVER_ERROR = HttpStatus.SC_INTERNAL_SERVER_ERROR;
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(HttpTranslator.class);
+
+	public HttpTranslator(String mappingPropertiesFileName) {
+		translationMapping = new MappingProperties(mappingPropertiesFileName);
+	}
+
+	public HttpTranslator() {
+		translationMapping = DEFAULT_HTTP_TRANSLATION_PROPERTIES;
+	}
+
+	public ResponseCode getCoapResponseCode(int code) throws TranslationException {
+		ResponseCode responseCode = translationMapping.getCoapResponseCode(code);
+
+		if (responseCode == null) {
+			LOGGER.warn("coap response code missing for {}", code);
+			throw new TranslationException("coap response-code missing!");
+		}
+		return responseCode;
+	}
+
+	public Code getCoapCode(String httpMethod) throws InvalidMethodException {
+		return translationMapping.getCoapCode(httpMethod);
+	}
+
+	/**
+	 * Gets the coap media type associated to the http entity. Firstly, it looks
+	 * for a valid mapping in the property file. If this step fails, then it
+	 * tries to explicitly map/parse the declared mime/type by the http entity.
+	 * If even this step fails, it sets application/octet-stream as
+	 * content-type.
+	 * 
+	 * @param httpMessage
+	 * 
+	 * 
+	 * @return the coap media code associated to the http message entity. * @see
+	 *         HttpHeader, ContentType, MediaTypeRegistry
+	 */
+	public int getCoapMediaType(HttpMessage httpMessage) {
+		if (httpMessage == null) {
+			throw new IllegalArgumentException("httpMessage == null");
+		}
+
+		// get the entity
+		HttpEntity httpEntity = null;
+		if (httpMessage instanceof HttpResponse) {
+			httpEntity = ((HttpResponse) httpMessage).getEntity();
+		} else if (httpMessage instanceof HttpEntityEnclosingRequest) {
+			httpEntity = ((HttpEntityEnclosingRequest) httpMessage).getEntity();
+		}
+
+		// check that the entity is actually present in the http message
+		if (httpEntity == null) {
+			throw new IllegalArgumentException("The http message does not contain any httpEntity.");
+		}
+
+		// set the content-type with a default value
+		int coapContentType = MediaTypeRegistry.UNDEFINED;
+
+		// get the content-type from the entity
+		ContentType contentType = ContentType.get(httpEntity);
+		if (contentType == null) {
+			// if the content-type is not set, search in the headers
+			Header contentTypeHeader = httpMessage.getFirstHeader("content-type");
+			if (contentTypeHeader != null) {
+				String contentTypeString = contentTypeHeader.getValue();
+				contentType = ContentType.parse(contentTypeString);
+			}
+		}
+
+		// check if there is an associated content-type with the current http
+		// message
+		if (contentType != null) {
+			// get the value of the content-type
+			String httpContentTypeString = contentType.getMimeType();
+			// delete the last part (if any)
+			httpContentTypeString = httpContentTypeString.split(";")[0];
+
+			// retrieve the mapping from the property file
+			String coapContentTypeString = translationMapping
+					.getProperty(KEY_HTTP_CONTENT_TYPE + httpContentTypeString);
+
+			if (coapContentTypeString != null) {
+				coapContentType = Integer.parseInt(coapContentTypeString);
+			} else {
+				// try to parse the media type if the property file has given to
+				// mapping
+				coapContentType = MediaTypeRegistry.parse(httpContentTypeString);
+			}
+		}
+
+		// if not recognized, the content-type should be
+		// application/octet-stream (draft-castellani-core-http-mapping 6.2)
+		if (coapContentType == MediaTypeRegistry.UNDEFINED) {
+			coapContentType = MediaTypeRegistry.APPLICATION_OCTET_STREAM;
+		}
+
+		return coapContentType;
+	}
+
+	/**
+	 * Gets the coap options starting from an array of http headers. The
+	 * content-type is not handled by this method. The method iterates over an
+	 * array of headers and for each of them tries to find a mapping in the
+	 * properties file, if the mapping does not exists it skips the header
+	 * ignoring it. The method handles separately certain headers which are
+	 * translated to options (such as accept or cache-control) whose content
+	 * should be semantically checked or requires ad-hoc translation. Otherwise,
+	 * the headers content is translated with the appropriate format required by
+	 * the mapped option.
+	 * 
+	 * @param headers
+	 * 
+	 */
+	public List<Option> getCoapOptions(Header[] headers) {
+		if (headers == null) {
+			throw new IllegalArgumentException("httpMessage == null");
+		}
+
+		List<Option> optionList = new LinkedList<Option>();
+
+		// iterate over the headers
+		for (Header header : headers) {
+			try {
+				String headerName = header.getName().toLowerCase();
+
+				// FIXME: CoAP does no longer support multiple accept-options.
+				// If an HTTP request contains multiple accepts, this method
+				// fails. Therefore, we currently skip accepts at the moment.
+				if (headerName.startsWith("accept"))
+					continue;
+
+				// get the mapping from the property file
+				String optionCodeString = translationMapping.getProperty(KEY_HTTP_HEADER + headerName);
+
+				// ignore the header if not found in the properties file
+				if (optionCodeString == null || optionCodeString.isEmpty()) {
+					continue;
+				}
+
+				// get the option number
+				int optionNumber = OptionNumberRegistry.RESERVED_0;
+				try {
+					optionNumber = Integer.parseInt(optionCodeString.trim());
+				} catch (Exception e) {
+					LOGGER.warn("Problems in the parsing", e);
+					// ignore the option if not recognized
+					continue;
+				}
+
+				// ignore the content-type because it will be handled within the
+				// payload
+				if (optionNumber == OptionNumberRegistry.CONTENT_FORMAT) {
+					continue;
+				}
+
+				// get the value of the current header
+				String headerValue = header.getValue().trim();
+
+				// if the option is accept, it needs to translate the
+				// values
+				if (optionNumber == OptionNumberRegistry.ACCEPT) {
+					// remove the part where the client express the weight of
+					// each
+					// choice
+					headerValue = headerValue.trim().split(";")[0].trim();
+
+					// iterate for each content-type indicated
+					for (String headerFragment : headerValue.split(",")) {
+						// translate the content-type
+						Integer[] coapContentTypes = { MediaTypeRegistry.UNDEFINED };
+						if (headerFragment.contains("*")) {
+							coapContentTypes = MediaTypeRegistry.parseWildcard(headerFragment);
+						} else {
+							coapContentTypes[0] = MediaTypeRegistry.parse(headerFragment);
+						}
+
+						// if is present a conversion for the content-type, then
+						// add
+						// a new option
+						for (int coapContentType : coapContentTypes) {
+							if (coapContentType != MediaTypeRegistry.UNDEFINED) {
+								// create the option
+								Option option = new Option(optionNumber, coapContentType);
+								optionList.add(option);
+							}
+						}
+					}
+				} else if (optionNumber == OptionNumberRegistry.MAX_AGE) {
+					int maxAge = 0;
+					if (!headerValue.contains("no-cache")) {
+						headerValue = headerValue.split(",")[0];
+						if (headerValue != null) {
+							int index = headerValue.indexOf('=');
+							try {
+								maxAge = Integer.parseInt(headerValue.substring(index + 1).trim());
+							} catch (NumberFormatException e) {
+								LOGGER.warn("Cannot convert cache control in max-age option", e);
+								continue;
+							}
+						}
+					}
+					// create the option
+					Option option = new Option(optionNumber, maxAge);
+					// option.setValue(headerValue.getBytes(Charset.forName("ISO-8859-1")));
+					optionList.add(option);
+				} else {
+					// create the option
+					Option option = new Option(optionNumber);
+					switch (OptionNumberRegistry.getFormatByNr(optionNumber)) {
+					case INTEGER:
+						option.setIntegerValue(Integer.parseInt(headerValue));
+						break;
+					case OPAQUE:
+						option.setValue(headerValue.getBytes(ISO_8859_1));
+						break;
+					case STRING:
+					default:
+						option.setStringValue(headerValue);
+						break;
+					}
+					// option.setValue(headerValue.getBytes(Charset.forName("ISO-8859-1")));
+					optionList.add(option);
+				}
+			} catch (RuntimeException e) {
+				// Martin: I have added this try-catch block. The problem is
+				// that HTTP support multiple Accepts while CoAP does not. A
+				// headder line might look like this:
+				// Accept:
+				// text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+				// This cannot be parsed into a single CoAP Option and yields a
+				// NumberFormatException
+				LOGGER.warn("Could not parse header line {}", header);
+			}
+		} // while (headerIterator.hasNext())
+
+		return optionList;
+	}
+
+	/**
+	 * Method to map the http entity of a http message in a coherent payload for
+	 * the coap message. The method simply gets the bytes from the entity and,
+	 * if needed changes the charset of the obtained bytes to UTF-8.
+	 * 
+	 * @param httpEntity the http entity
+	 * 
+	 * @return byte[]
+	 * @throws TranslationException the translation exception
+	 */
+	public byte[] getCoapPayload(HttpEntity httpEntity) throws TranslationException {
+		if (httpEntity == null) {
+			throw new IllegalArgumentException("httpEntity == null");
+		}
+
+		byte[] payload = null;
+		try {
+			// get the bytes from the entity
+			payload = EntityUtils.toByteArray(httpEntity);
+			if (payload != null && payload.length > 0) {
+
+				// the only supported charset in CoAP is UTF-8
+				Charset coapCharset = UTF_8;
+
+				// get the charset for the http entity
+				ContentType httpContentType = ContentType.getOrDefault(httpEntity);
+				Charset httpCharset = httpContentType.getCharset();
+
+				// check if the charset is the one allowed by coap
+				if (httpCharset != null && !httpCharset.equals(coapCharset)) {
+					// translate the payload to the utf-8 charset
+					payload = changeCharset(payload, httpCharset, coapCharset);
+				}
+			}
+		} catch (IOException e) {
+			LOGGER.warn("Cannot get the content of the http entity: " + e.getMessage());
+			throw new TranslationException("Cannot get the content of the http entity", e);
+		} finally {
+			try {
+				// ensure all content has been consumed, so that the
+				// underlying connection could be re-used
+				EntityUtils.consume(httpEntity);
+			} catch (IOException e) {
+
+			}
+		}
+
+		return payload;
+	}
+
+	public int getHttpCode(ResponseCode coapCode) throws TranslationException {
+		Integer httpCode = translationMapping.getHttpCode(coapCode);
+
+		if (httpCode == null) {
+			LOGGER.warn("httpCode not defined for {}", coapCode);
+			throw new TranslationException("no httpCode for " + coapCode);
+		}
+
+		return httpCode;
+	}
+
+	public String getHttpMethod(Code coapCode) throws TranslationException {
+		return translationMapping.getHttpMethod(coapCode);
+	}
+
+	/**
+	 * Generates an HTTP entity starting from a CoAP request. If the coap
+	 * message has no payload, it returns a null http entity. It takes the
+	 * payload from the CoAP message and encapsulates it in an entity. If the
+	 * content-type is recognized, and a mapping is present in the properties
+	 * file, it is translated to the correspondent in HTTP, otherwise it is set
+	 * to application/octet-stream. If the content-type has a charset, namely it
+	 * is printable, the payload is encapsulated in a StringEntity, if not it a
+	 * ByteArrayEntity is used.
+	 * 
+	 * 
+	 * @param coapMessage the coap message
+	 * 
+	 * 
+	 * @return null if the request has no payload * @throws TranslationException
+	 *         the translation exception
+	 */
+	public HttpEntity getHttpEntity(Message coapMessage) throws TranslationException {
+		if (coapMessage == null) {
+			throw new IllegalArgumentException("coapMessage == null");
+		}
+
+		// the result
+		HttpEntity httpEntity = null;
+
+		// check if coap request has a payload
+		byte[] payload = coapMessage.getPayload();
+		if (payload != null && payload.length != 0) {
+
+			ContentType contentType = null;
+
+			// if the content type is not set, translate with octect-stream
+			if (!coapMessage.getOptions().hasContentFormat()) {
+				contentType = ContentType.APPLICATION_OCTET_STREAM;
+			} else {
+				int coapContentType = coapMessage.getOptions().getContentFormat();
+				// search for the media type inside the property file
+				String coapContentTypeString = translationMapping.getProperty(KEY_COAP_MEDIA + coapContentType);
+
+				// if the content-type has not been found in the property file,
+				// try to get its string value (expressed in mime type)
+				if (coapContentTypeString == null || coapContentTypeString.isEmpty()) {
+					coapContentTypeString = MediaTypeRegistry.toString(coapContentType);
+
+					// if the coap content-type is printable, it is needed to
+					// set the default charset (i.e., UTF-8)
+					if (MediaTypeRegistry.isPrintable(coapContentType)) {
+						coapContentTypeString += "; charset=UTF-8";
+					}
+				}
+
+				// parse the content type
+				try {
+					contentType = ContentType.parse(coapContentTypeString);
+				} catch (UnsupportedCharsetException e) {
+					LOGGER.debug("Cannot convert string to ContentType", e);
+					contentType = ContentType.APPLICATION_OCTET_STREAM;
+				}
+			}
+
+			// get the charset
+			Charset charset = contentType.getCharset();
+
+			// if there is a charset, means that the content is not binary
+			if (charset != null) {
+
+				// according to the class ContentType the default content-type
+				// with UTF-8 charset is application/json. If the content-type
+				// parsed is different and is not iso encoded, a translation is
+				// needed
+				Charset isoCharset = ISO_8859_1;
+				if (!charset.equals(isoCharset)
+						&& !contentType.getMimeType().equals(ContentType.APPLICATION_JSON.getMimeType())) {
+					byte[] newPayload = changeCharset(payload, charset, isoCharset);
+
+					// since ISO-8859-1 is a subset of UTF-8, it is needed to
+					// check if the mapping could be accomplished, only if the
+					// operation is successful the payload and the charset
+					// should
+					// be changed
+					if (newPayload != null) {
+						payload = newPayload;
+						// if the charset is changed, also the entire
+						// content-type must change
+						contentType = ContentType.create(contentType.getMimeType(), isoCharset);
+					}
+				}
+
+				// create the content
+				String payloadString = new String(payload, contentType.getCharset());
+
+				// create the entity
+				httpEntity = new StringEntity(payloadString, contentType);
+			} else {
+				// create the entity
+				httpEntity = new ByteArrayEntity(payload);
+			}
+
+			// set the content-type
+			((AbstractHttpEntity) httpEntity).setContentType(contentType.toString());
+		}
+
+		return httpEntity;
+	}
+
+	/**
+	 * Gets the http headers from a list of CoAP options. The method iterates
+	 * over the list looking for a translation of each option in the properties
+	 * file, this process ignores the proxy-uri and the content-type because
+	 * they are managed differently. If a mapping is present, the content of the
+	 * option is mapped to a string accordingly to its original format and set
+	 * as the content of the header.
+	 * 
+	 * 
+	 * @param optionList the coap message
+	 * 
+	 * @return Header[]
+	 */
+	public Header[] getHttpHeaders(List<Option> optionList) {
+		if (optionList == null) {
+			throw new IllegalArgumentException("coapMessage == null");
+		}
+
+		List<Header> headers = new LinkedList<Header>();
+
+		// iterate over each option
+		for (Option option : optionList) {
+			// skip content-type because it should be translated while handling
+			// the payload; skip proxy-uri because it has to be translated in a
+			// different way
+			int optionNumber = option.getNumber();
+			if (optionNumber != OptionNumberRegistry.CONTENT_FORMAT && optionNumber != OptionNumberRegistry.PROXY_URI) {
+				// get the mapping from the property file
+				String headerName = translationMapping.getProperty(KEY_COAP_OPTION + optionNumber);
+
+				// set the header
+				if (headerName != null && !headerName.isEmpty()) {
+					// format the value
+					String stringOptionValue = null;
+					if (OptionNumberRegistry.getFormatByNr(optionNumber) == optionFormats.STRING) {
+						stringOptionValue = option.getStringValue();
+					} else if (OptionNumberRegistry.getFormatByNr(optionNumber) == optionFormats.INTEGER) {
+						stringOptionValue = Integer.toString(option.getIntegerValue());
+					} else if (OptionNumberRegistry.getFormatByNr(optionNumber) == optionFormats.OPAQUE) {
+						stringOptionValue = new String(option.getValue());
+					} else {
+						// if the option is not formattable, skip it
+						continue;
+					}
+
+					// custom handling for max-age
+					// format: cache-control: max-age=60
+					if (optionNumber == OptionNumberRegistry.MAX_AGE) {
+						stringOptionValue = "max-age=" + stringOptionValue;
+					}
+
+					Header header = new BasicHeader(headerName, stringOptionValue);
+					headers.add(header);
+				}
+			}
+		}
+
+		return headers.toArray(new Header[0]);
+	}
+
+	public Properties getHttpTranslationProperties() {
+		return translationMapping;
+	}
+
+	/**
+	 * Change charset.
+	 * 
+	 * @param payload the payload
+	 * @param fromCharset the from charset
+	 * @param toCharset the to charset
+	 * 
+	 * 
+	 * @return the byte[] * @throws TranslationException the translation
+	 *         exception
+	 */
+	public byte[] changeCharset(byte[] payload, Charset fromCharset, Charset toCharset) throws TranslationException {
+		try {
+			// decode with the source charset
+			CharsetDecoder decoder = fromCharset.newDecoder();
+			CharBuffer charBuffer = decoder.decode(ByteBuffer.wrap(payload));
+			decoder.flush(charBuffer);
+
+			// encode to the destination charset
+			CharsetEncoder encoder = toCharset.newEncoder();
+			ByteBuffer byteBuffer = encoder.encode(charBuffer);
+			encoder.flush(byteBuffer);
+			payload = byteBuffer.array();
+		} catch (UnmappableCharacterException e) {
+			// thrown when an input character (or byte) sequence is valid but
+			// cannot be mapped to an output byte (or character) sequence.
+			// If the character sequence starting at the input buffer's current
+			// position cannot be mapped to an equivalent byte sequence and the
+			// current unmappable-character
+			LOGGER.debug("Charset translation: cannot mapped to an output char byte", e);
+			return null;
+		} catch (CharacterCodingException e) {
+			LOGGER.warn("Problem in the decoding/encoding charset", e);
+			throw new TranslationException("Problem in the decoding/encoding charset", e);
+		}
+
+		return payload;
+	}
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/InvalidFieldException.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/InvalidFieldException.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Matthias Kovatsch - creator and main architect
+ *    Martin Lanter - architect and re-implementation
+ *    Francesco Corazza - HTTP cross-proxy
+ ******************************************************************************/
+package org.eclipse.californium.proxy2;
+
+import java.io.IOException;
+
+
+/**
+ * The Class InvalidFieldException.
+ */
+public class InvalidFieldException extends TranslationException {
+	private static final long serialVersionUID = 1L;
+
+	public InvalidFieldException() {
+		super();
+	}
+
+	public InvalidFieldException(String message) {
+		super(message);
+	}
+
+	public InvalidFieldException(String string, IOException e) {
+		super(string, e);
+	}
+
+	public InvalidFieldException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public InvalidFieldException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/InvalidMethodException.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/InvalidMethodException.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Matthias Kovatsch - creator and main architect
+ *    Martin Lanter - architect and re-implementation
+ *    Francesco Corazza - HTTP cross-proxy
+ ******************************************************************************/
+package org.eclipse.californium.proxy2;
+
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+
+/**
+ * The Class InvalidMethodException.
+ */
+public class InvalidMethodException extends TranslationException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final ResponseCode error;
+
+	public InvalidMethodException() {
+		this(ResponseCode.BAD_GATEWAY);
+	}
+
+	public InvalidMethodException(ResponseCode error) {
+		super();
+		this.error = error;
+	}
+
+	public ResponseCode getError() {
+		return error;
+	}
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/MappingProperties.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/MappingProperties.java
@@ -1,0 +1,341 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - derived from org.eclipse.californium.proxy
+ ******************************************************************************/
+package org.eclipse.californium.proxy2;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.OptionNumberRegistry;
+
+/**
+ * This class maps different protocol constants for the Cf cross-proxy.
+ */
+public class MappingProperties extends Properties {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MappingProperties.class);
+
+	/**
+	 * auto-generated to eliminate warning
+	 */
+	private static final long serialVersionUID = 4126898261482584755L;
+
+	/** The header for Californium property files. */
+	private static final String HEADER = "Californium Cross-Proxy2 mapping properties file";
+
+	private static final String KEY_COAP_METHOD = "coap.request.code.";
+	private static final String KEY_COAP_CODE = "coap.response.code.";
+	public static final String KEY_COAP_OPTION = "coap.message.option.";
+	public static final String KEY_COAP_MEDIA = "coap.message.media.";
+	private static final String KEY_HTTP_CODE = "http.response.code.";
+	private static final String KEY_HTTP_METHOD = "http.request.method.";
+	public static final String KEY_HTTP_HEADER = "http.message.header.";
+	public static final String KEY_HTTP_CONTENT_TYPE = "http.message.content-type.";
+
+	// Constructors ////////////////////////////////////////////////////////////
+
+	private final Map<ResponseCode, Integer> httpCodes = new HashMap<>();
+	private final Map<Integer, ResponseCode> coapCodes = new HashMap<>();
+	private final Map<String, Object> httpMethods = new HashMap<>();
+	private final Map<Code, String> coapMethods = new HashMap<>();
+
+	public MappingProperties(String fileName) {
+		init();
+		initUserDefined(fileName);
+		for (String key : stringPropertyNames()) {
+			if (key.startsWith(KEY_COAP_CODE)) {
+				initResponseCode(key);
+			} else if (key.startsWith(KEY_HTTP_CODE)) {
+				initHttpCode(key);
+			} else if (key.startsWith(KEY_HTTP_METHOD)) {
+				initHttpMethod(key);
+			} else if (key.startsWith(KEY_COAP_METHOD)) {
+				initCoapMethod(key);
+			}
+		}
+	}
+
+	private void initResponseCode(String key) {
+		int httpCode = getInt(key);
+		ResponseCode code = ResponseCode.valueOfText(key.substring(KEY_COAP_CODE.length()));
+		if (code != null) {
+			httpCodes.put(code, httpCode);
+		}
+	}
+
+	private void initHttpCode(String key) {
+		String tag = getStr(key);
+		ResponseCode code = ResponseCode.valueOfText(tag);
+		Integer httpCode = Integer.valueOf(key.substring(KEY_HTTP_CODE.length()), 10);
+		if (httpCode != null && code != null) {
+			coapCodes.put(httpCode, code);
+		}
+	}
+
+	private void initHttpMethod(String key) {
+		String mapKey = key.substring(KEY_HTTP_METHOD.length());
+		String tag = getStr(key);
+		Object code = Code.valueOfText(tag);
+		if (code == null) {
+			code = ResponseCode.valueOfText(tag);
+		}
+		if (code != null) {
+			httpMethods.put(mapKey, code);
+		}
+	}
+
+	private void initCoapMethod(String key) {
+		String httpMethod = getStr(key);
+		String tag = key.substring(KEY_COAP_METHOD.length());
+		Code code = Code.valueOfText(tag);
+		if (code != null && httpMethod != null) {
+			coapMethods.put(code, httpMethod);
+		}
+	}
+
+	public Code getCoapCode(String httpMethod) throws InvalidMethodException {
+		Object code = httpMethods.get(httpMethod);
+		if (code instanceof Code) {
+			return (Code) code;
+		} else if (code instanceof ResponseCode) {
+			throw new InvalidMethodException((ResponseCode) code);
+		}
+		throw new InvalidMethodException(ResponseCode.BAD_GATEWAY);
+	}
+
+	public String getHttpMethod(Code code) {
+		return coapMethods.get(code);
+	}
+
+	public Integer getHttpCode(ResponseCode code) {
+		return httpCodes.get(code);
+	}
+
+	public ResponseCode getCoapResponseCode(Integer code) {
+		return coapCodes.get(code);
+	}
+
+	public int getInt(String key) {
+		String value = getProperty(key);
+		if (value != null) {
+			try {
+				return Integer.parseInt(value.trim());
+			} catch (NumberFormatException e) {
+				LOG.error(String.format("Invalid integer property: %s=%s", key, value));
+			}
+		} else {
+			LOG.error(String.format("Undefined integer property: %s", key));
+		}
+		return 0;
+	}
+
+	public String getStr(String key) {
+		String value = getProperty(key);
+		if (value == null) {
+			LOG.error(String.format("Undefined string property: %s", key));
+		}
+		return value;
+	}
+
+	public boolean getBool(String key) {
+		String value = getProperty(key);
+		if (value != null) {
+			try {
+				return Boolean.parseBoolean(value);
+			} catch (NumberFormatException e) {
+				LOG.error(String.format("Invalid boolean property: %s=%s", key, value));
+			}
+		} else {
+			LOG.error(String.format("Undefined boolean property: %s", key));
+		}
+		return false;
+	}
+
+	public void load(String fileName) throws IOException {
+		InputStream in = new FileInputStream(fileName);
+		load(in);
+	}
+
+	public void set(String key, int value) {
+		setProperty(key, String.valueOf(value));
+	}
+
+	public void set(String key, String value) {
+		setProperty(key, value);
+	}
+
+	public void set(String key, boolean value) {
+		setProperty(key, String.valueOf(value));
+	}
+
+	public void store(String fileName) throws IOException {
+		OutputStream out = new FileOutputStream(fileName);
+		store(out, HEADER);
+	}
+
+	private void init() {
+
+		/* HTTP Methods */
+		set(KEY_HTTP_METHOD + "options", "5.01");
+		set(KEY_HTTP_METHOD + "trace", "5.01");
+		set(KEY_HTTP_METHOD + "connect", "5.01");
+		set(KEY_HTTP_METHOD + "head", "0.01");
+		set(KEY_HTTP_METHOD + "get", "0.01");
+		set(KEY_HTTP_METHOD + "post", "0.02");
+		set(KEY_HTTP_METHOD + "put", "0.03");
+		set(KEY_HTTP_METHOD + "delete", "0.04");
+
+		/* HTTP response codes */
+		set(KEY_HTTP_CODE + "100", "5.02");
+		set(KEY_HTTP_CODE + "101", "5.02");
+		set(KEY_HTTP_CODE + "102", "5.02");
+
+		set(KEY_HTTP_CODE + "200", "2.05");
+		set(KEY_HTTP_CODE + "201", "2.01");
+		set(KEY_HTTP_CODE + "202", "2.05");
+		set(KEY_HTTP_CODE + "203", "2.05");
+		set(KEY_HTTP_CODE + "20204", "2.04"); // 2.04 for POST 0.02 * 10000
+		set(KEY_HTTP_CODE + "30204", "2.04"); // 2.04 for PUT  0.03 * 10000
+		set(KEY_HTTP_CODE + "40204", "2.02"); // 2.02 for DELETE 0.04 * 10000
+		set(KEY_HTTP_CODE + "205", "2.05");
+		set(KEY_HTTP_CODE + "206", "2.05");
+		set(KEY_HTTP_CODE + "207", "2.05");
+
+		set(KEY_HTTP_CODE + "300", "5.02");
+		set(KEY_HTTP_CODE + "301", "5.02");
+		set(KEY_HTTP_CODE + "302", "5.02");
+		set(KEY_HTTP_CODE + "303", "5.02");
+		set(KEY_HTTP_CODE + "304", "2.03");
+		set(KEY_HTTP_CODE + "305", "5.02");
+		set(KEY_HTTP_CODE + "307", "5.02");
+
+		set(KEY_HTTP_CODE + "400", "4.00");
+		set(KEY_HTTP_CODE + "401", "4.01");
+		set(KEY_HTTP_CODE + "402", "4.00");
+		set(KEY_HTTP_CODE + "403", "4.03");
+		set(KEY_HTTP_CODE + "404", "4.04");
+		set(KEY_HTTP_CODE + "405", "4.05");
+		set(KEY_HTTP_CODE + "406", "4.06");
+		set(KEY_HTTP_CODE + "407", "4.00");
+		set(KEY_HTTP_CODE + "408", "4.00");
+		set(KEY_HTTP_CODE + "409", "4.00");
+		set(KEY_HTTP_CODE + "410", "4.00");
+		set(KEY_HTTP_CODE + "411", "4.00");
+		set(KEY_HTTP_CODE + "412", "4.12");
+		set(KEY_HTTP_CODE + "413", "4.13");
+		set(KEY_HTTP_CODE + "414", "4.00");
+		set(KEY_HTTP_CODE + "415", "4.15");
+		set(KEY_HTTP_CODE + "416", "4.00");
+		set(KEY_HTTP_CODE + "417", "4.00");
+		set(KEY_HTTP_CODE + "418", "4.00");
+		set(KEY_HTTP_CODE + "419", "4.00");
+		set(KEY_HTTP_CODE + "420", "4.00");
+		set(KEY_HTTP_CODE + "422", "4.00");
+		set(KEY_HTTP_CODE + "423", "4.00");
+		set(KEY_HTTP_CODE + "424", "4.00");
+
+		set(KEY_HTTP_CODE + "500", "5.00");
+		set(KEY_HTTP_CODE + "501", "5.01");
+		set(KEY_HTTP_CODE + "502", "5.02");
+		set(KEY_HTTP_CODE + "503", "5.03");
+		set(KEY_HTTP_CODE + "504", "5.04");
+		set(KEY_HTTP_CODE + "505", "5.02");
+		set(KEY_HTTP_CODE + "507", "5.00");
+
+		/* CoAP Request Codes / Methods */
+		set(KEY_COAP_METHOD + "0.01", "GET");
+		set(KEY_COAP_METHOD + "0.02", "POST");
+		set(KEY_COAP_METHOD + "0.03", "PUT");
+		set(KEY_COAP_METHOD + "0.04", "DELETE");
+
+		/* CoAP Response Codes */
+		set(KEY_COAP_CODE + "2.01", 201);
+		set(KEY_COAP_CODE + "2.02", 204); // RFC 7252, 5.9.1.2
+		set(KEY_COAP_CODE + "2.03", 304); // RFC 7252, 5.9.1.3
+		set(KEY_COAP_CODE + "2.04", 204);
+		set(KEY_COAP_CODE + "2.05", 200); // RFC 7252, 5.9.1.5
+		set(KEY_COAP_CODE + "4.00", 400);
+		set(KEY_COAP_CODE + "4.01", 401);
+		set(KEY_COAP_CODE + "4.02", 400);
+		set(KEY_COAP_CODE + "4.03", 403);
+		set(KEY_COAP_CODE + "4.04", 404);
+		set(KEY_COAP_CODE + "4.05", 405);
+		set(KEY_COAP_CODE + "4.06", 406);
+		set(KEY_COAP_CODE + "4.12", 412);
+		set(KEY_COAP_CODE + "4.13", 413);
+		set(KEY_COAP_CODE + "4.15", 415);
+		set(KEY_COAP_CODE + "5.00", 500);
+		set(KEY_COAP_CODE + "5.01", 501);
+		set(KEY_COAP_CODE + "5.02", 502);
+		set(KEY_COAP_CODE + "5.03", 503);
+		set(KEY_COAP_CODE + "5.04", 504);
+		set(KEY_COAP_CODE + "5.05", 502);
+
+		/* HTTP header options */
+		set("http.message.header.content-type", OptionNumberRegistry.CONTENT_FORMAT);
+		set("http.message.header.accept", OptionNumberRegistry.ACCEPT);
+		set("http.message.header.if-match", OptionNumberRegistry.IF_MATCH);
+		set("http.message.header.if-none-match", OptionNumberRegistry.IF_NONE_MATCH);
+		set("http.message.header.etag", OptionNumberRegistry.ETAG);
+		set("http.message.header.cache-control", OptionNumberRegistry.MAX_AGE);
+
+		/* CoAP header options */
+		set("coap.message.option." + OptionNumberRegistry.CONTENT_FORMAT, "Content-Type");
+		set("coap.message.option." + OptionNumberRegistry.MAX_AGE, "Cache-Control");
+		set("coap.message.option." + OptionNumberRegistry.ETAG, "Etag");
+		set("coap.message.option." + OptionNumberRegistry.LOCATION_PATH, "Location");
+		set("coap.message.option." + OptionNumberRegistry.LOCATION_QUERY, "Location");
+		set("coap.message.option." + OptionNumberRegistry.ACCEPT, "Accept");
+		set("coap.message.option." + OptionNumberRegistry.IF_MATCH, "If-Match");
+		set("coap.message.option." + OptionNumberRegistry.IF_NONE_MATCH, "If-None-Match");
+
+		/* Media types */
+		set("http.message.content-type.text/plain", MediaTypeRegistry.TEXT_PLAIN);
+		set("http.message.content-type.application/link-format", MediaTypeRegistry.APPLICATION_LINK_FORMAT);
+		set("http.message.content-type.application/xml", MediaTypeRegistry.APPLICATION_XML);
+		set("http.message.content-type.application/json", MediaTypeRegistry.APPLICATION_JSON);
+
+		set("coap.message.media." + MediaTypeRegistry.TEXT_PLAIN, "text/plain; charset=utf-8");
+		set("coap.message.media." + MediaTypeRegistry.APPLICATION_LINK_FORMAT, "application/link-format");
+		set("coap.message.media." + MediaTypeRegistry.APPLICATION_XML, "application/xml");
+		set("coap.message.media." + MediaTypeRegistry.APPLICATION_JSON, "application/json; charset=UTF-8");
+
+	}
+
+	private void initUserDefined(String fileName) {
+		try {
+			load(fileName);
+		} catch (IOException e) {
+			// file does not exist:
+			// write default properties
+			try {
+				store(fileName);
+			} catch (IOException e1) {
+				LOG.warn(String.format("Failed to create configuration file: %s", e1.getMessage()));
+			}
+		}
+	}
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/ProxyHttpServer.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/ProxyHttpServer.java
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - derived from org.eclipse.californium.proxy
+ ******************************************************************************/
+
+package org.eclipse.californium.proxy2;
+
+import java.io.IOException;
+
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.server.MessageDeliverer;
+import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.californium.proxy2.resources.ProxyCacheResource;
+import org.eclipse.californium.proxy2.resources.StatsResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The class represent the container of the resources and the layers used by the
+ * proxy. A URI of an HTTP request might look like this:
+ * http://localhost:8080/proxy/coap://localhost:5683/example
+ */
+public class ProxyHttpServer {
+
+	private final static Logger LOGGER = LoggerFactory.getLogger(ProxyHttpServer.class);
+
+	private final ProxyCacheResource cacheResource = new ProxyCacheResource(true);
+	private final StatsResource statsResource = new StatsResource(cacheResource);
+
+	private MessageDeliverer proxyCoapDeliverer;
+	private MessageDeliverer localCoapDeliverer;
+	private Http2CoapTranslator translator;
+	private boolean handlerRegistered;
+	private HttpStack httpStack;
+
+	/**
+	 * Instantiates a new proxy endpoint.
+	 * 
+	 * @param config network configuration
+	 * @param httpPort the http port
+	 * @throws IOException the socket exception
+	 */
+	public ProxyHttpServer(NetworkConfig config, int httpPort) throws IOException {
+		this(new HttpStack(config, httpPort));
+	}
+
+	private ProxyHttpServer(HttpStack stack) {
+		this.httpStack = stack;
+		this.httpStack.setRequestDeliverer(new MessageDeliverer() {
+
+			@Override
+			public void deliverRequest(Exchange exchange) {
+				ProxyHttpServer.this.handleRequest(exchange);
+			}
+
+			@Override
+			public void deliverResponse(Exchange exchange, Response response) {
+			}
+		});
+	}
+
+	/**
+	 * Start http server.
+	 * 
+	 * @throws IOException in case if a non-recoverable I/O error.
+	 */
+	public void start() throws IOException {
+		if (!handlerRegistered) {
+			if (proxyCoapDeliverer != null) {
+				httpStack.registerProxyRequestHandler();
+				httpStack.registerHttpProxyRequestHandler();
+			}
+			if (localCoapDeliverer != null) {
+				httpStack.registerLocalRequestHandler();
+			}
+			if (translator == null) {
+				translator = new Http2CoapTranslator();
+			}
+			httpStack.setHttpTranslator(translator);
+			handlerRegistered = true;
+		}
+		httpStack.start();
+	}
+
+	/**
+	 * Stop http server.
+	 */
+	public void stop() {
+		httpStack.stop();
+	}
+
+	public void handleRequest(final Exchange exchange) {
+		final Request request = exchange.getRequest();
+
+		LOGGER.info("ProxyEndpoint handles request {}", request);
+
+		Response response = null;
+		// ignore the request if it is reset or acknowledge
+		// check if the proxy-uri is defined
+		if (request.getOptions().hasProxyUri()) {
+			// get the response from the cache
+			response = cacheResource.getResponse(request);
+
+			LOGGER.debug("Cache returned {}", response);
+
+			// update statistics
+			statsResource.updateStatistics(request, response != null);
+		}
+
+		// check if the response is present in the cache
+		if (response != null) {
+			// link the retrieved response with the request to set the
+			// parameters request-specific (i.e., token, id, etc)
+			exchange.sendResponse(response);
+			return;
+		} else {
+
+			request.addMessageObserver(new MessageObserverAdapter() {
+				@Override
+				public void onResponse(final Response response) {
+					responseProduced(request, response);
+				}
+			});
+
+			if (request.getOptions().hasProxyUri()) {
+				// handle the request as usual
+				if (proxyCoapDeliverer != null) {
+					proxyCoapDeliverer.deliverRequest(exchange);
+				} else {
+					exchange.sendResponse(new Response(ResponseCode.PROXY_NOT_SUPPORTED));
+				}
+			} else {
+				if (localCoapDeliverer != null) {
+					localCoapDeliverer.deliverRequest(exchange);
+				} else {
+					exchange.sendResponse(new Response(ResponseCode.PROXY_NOT_SUPPORTED));
+				}
+			}
+
+			/*
+			 * Martin: Originally, the request was delivered to the
+			 * ProxyCoAP2Coap which was at the path proxy/coapClient or to
+			 * proxy/httpClient This approach replaces this implicit fuzzy
+			 * connection with an explicit and dynamically changeable one.
+			 */
+		}
+	}
+
+	public Resource getStatistics() {
+		return statsResource;
+	}
+
+	/**
+	 * Set http translator for incoming http requests and outgoing http responses.
+	 * 
+	 * set in {@link HttpStack} on {@link #start()}.
+	 * 
+	 * @param translator http translator
+	 */
+	public void setHttpTranslator(Http2CoapTranslator translator) {
+		this.translator = translator;
+	}
+
+	/**
+	 * Set deliverer for forward proxy.
+	 * 
+	 * Register {@link HttpStack#registerProxyRequestHandler()} and
+	 * {@link HttpStack#registerHttpProxyRequestHandler()} on {@link #start()}.
+	 * 
+	 * @param deliverer mesage deliverer for proxy-requests
+	 */
+	public void setProxyCoapDeliverer(MessageDeliverer deliverer) {
+		this.proxyCoapDeliverer = deliverer;
+	}
+
+	/**
+	 * Set deliverer for local coap resources.
+	 * 
+	 * Register {@link HttpStack#registerLocalRequestHandler()} on
+	 * {@link #start()}.
+	 * 
+	 * @param deliverer mesage deliverer for local coap resources
+	 */
+	public void setLocalCoapDeliverer(MessageDeliverer deliverer) {
+		this.localCoapDeliverer = deliverer;
+	}
+
+	protected void responseProduced(Request request, Response response) {
+		// check if the proxy-uri is defined
+		if (request.getOptions().hasProxyUri()) {
+			LOGGER.info("Cache response {}", request.getOptions().getProxyUri());
+			// insert the response in the cache
+			cacheResource.cacheResponse(request, response);
+		} else {
+			LOGGER.info("Do not cache response");
+		}
+	}
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/TranslationException.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/TranslationException.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Matthias Kovatsch - creator and main architect
+ *    Martin Lanter - architect and re-implementation
+ *    Francesco Corazza - HTTP cross-proxy
+ ******************************************************************************/
+package org.eclipse.californium.proxy2;
+
+import java.io.IOException;
+
+
+/**
+ * The Class TranslationException.
+ */
+public class TranslationException extends Exception {
+	private static final long serialVersionUID = 1L;
+
+	public TranslationException() {
+		super();
+	}
+
+	public TranslationException(String message) {
+		super(message);
+	}
+
+	public TranslationException(String string, IOException e) {
+		super(string, e);
+	}
+
+	public TranslationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public TranslationException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/CacheResource.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/CacheResource.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Matthias Kovatsch - creator and main architect
+ *    Martin Lanter - architect and re-implementation
+ *    Francesco Corazza - HTTP cross-proxy
+ ******************************************************************************/
+package org.eclipse.californium.proxy2.resources;
+
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+
+import com.google.common.cache.CacheStats;
+
+
+public interface CacheResource {
+
+	/**
+	 * 
+	 */
+	public void cacheResponse(Request request, Response response);
+
+	public CacheStats getCacheStats();
+
+	/**
+	 * Gets cached response.
+	 * 
+	 * @param request
+	 *            the request
+	 * @return the cached response or null in case it is not present
+	 */
+	public Response getResponse(Request request);
+
+	public void invalidateRequest(Request request);
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/ProxyCacheResource.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/ProxyCacheResource.java
@@ -1,0 +1,518 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2017 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Matthias Kovatsch - creator and main architect
+ *    Martin Lanter - architect and re-implementation
+ *    Francesco Corazza - HTTP cross-proxy
+ *    Bosch Software Innovations GmbH - migrate to SLF4J
+ ******************************************************************************/
+package org.eclipse.californium.proxy2.resources;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.OptionNumberRegistry;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.elements.util.ClockUtil;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.CacheStats;
+import com.google.common.cache.LoadingCache;
+import com.google.common.primitives.Ints;
+
+
+/**
+ * Resource to handle the caching in the proxy.
+ */
+public class ProxyCacheResource extends CoapResource implements CacheResource {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ProxyCacheResource.class);
+
+	/**
+	 * The time after which an entry is removed. Since it is not possible to set
+	 * the expiration for the single instances, this constant represent the
+	 * upper bound for the cache. The real lifetime will be handled explicitly
+	 * with the max-age option.
+	 */
+	private static final int CACHE_RESPONSE_MAX_AGE = 
+			NetworkConfig.getStandard().getInt(NetworkConfig.Keys.HTTP_CACHE_RESPONSE_MAX_AGE);
+
+	/**
+	 * Maximum size for the cache.
+	 */
+	private static final long CACHE_SIZE = 
+			NetworkConfig.getStandard().getInt(NetworkConfig.Keys.HTTP_CACHE_SIZE);
+
+	/**
+	 * The cache. http://code.google.com/p/guava-libraries/wiki/CachesExplained
+	 */
+	private final LoadingCache<CacheKey, Response> responseCache;
+
+	private boolean enabled = false;
+
+	/**
+	 * Instantiates a new proxy cache resource.
+	 */
+	public ProxyCacheResource() {
+		this(false);
+	}
+	
+	/**
+	 * Instantiates a new proxy cache resource.
+	 */
+	public ProxyCacheResource(boolean enabled) {
+		super("cache");
+		this.enabled = enabled;
+
+		// builds a new cache that:
+		// - has a limited size of CACHE_SIZE entries
+		// - removes entries after CACHE_RESPONSE_MAX_AGE seconds from the last
+		// write
+		// - record statistics
+		responseCache = CacheBuilder.newBuilder().maximumSize(CACHE_SIZE).recordStats().expireAfterWrite(CACHE_RESPONSE_MAX_AGE, TimeUnit.SECONDS).build(new CacheLoader<CacheKey, Response>() {
+			@Override
+			public Response load(CacheKey request) throws NullPointerException {
+				// retrieve the response from the incoming request, no
+				// exceptions are thrown
+				Response cachedResponse = request.getResponse();
+
+				// check for null and raise an exception that clients must
+				// handle
+				if (cachedResponse == null) {
+					throw new NullPointerException();
+				}
+
+				return cachedResponse;
+			}
+		});
+	}
+
+	/**
+	 * Puts in cache an entry or, if already present, refreshes it. The method
+	 * first checks the response code, only the 2.xx codes are cached by coap.
+	 * In case of 2.01, 2.02, and 2.04 response codes it invalidates the
+	 * possibly present response. In case of 2.03 it updates the freshness of
+	 * the response with the max-age option provided. In case of 2.05 it creates
+	 * the key and caches the response if the max-age option is higher than
+	 * zero.
+	 */
+	@Override
+	public void cacheResponse(Request request, Response response) {
+		// enable or disable the caching (debug purposes)
+		if (!enabled) {
+			return;
+		}
+
+		// only the response with success codes should be cached
+		ResponseCode code = response.getCode();
+		if (ResponseCode.isSuccess(code)) {
+			// get the request
+//			Request request = response.getRequest();
+			CacheKey cacheKey = null;
+			try {
+				cacheKey = CacheKey.fromContentTypeOption(request);
+			} catch (URISyntaxException e) {
+				LOGGER.warn("Cannot create the cache key: {}", e.getMessage());
+			}
+
+			if (code == ResponseCode.CREATED || code == ResponseCode.DELETED || code == ResponseCode.CHANGED) {
+				// the stored response should be invalidated if the response has
+				// codes: 2.01, 2.02, 2.04.
+				invalidateRequest(cacheKey);
+			} else if (code == ResponseCode.VALID) {
+				// increase the max-age value according to the new response
+//				Option maxAgeOption = response.getFirstOption(OptionNumberRegistry.MAX_AGE);
+				Long maxAgeOption = response.getOptions().getMaxAge();
+				if (maxAgeOption != null) {
+					// get the cached response
+					Response cachedResponse = responseCache.getUnchecked(cacheKey);
+
+					// calculate the new parameters
+					long newCurrentTime = response.getNanoTimestamp();
+					long newMaxAge = maxAgeOption.longValue();
+
+					// set the new parameters
+					cachedResponse.getOptions().setMaxAge(newMaxAge);
+					cachedResponse.setNanoTimestamp(newCurrentTime);
+
+					LOGGER.debug("Updated cached response");
+				} else {
+					LOGGER.warn("No max-age option set in response: {}", response);
+				}
+			} else if (code == ResponseCode.CONTENT) {
+				// set max-age if not set
+//				Option maxAgeOption = response.getFirstOption(OptionNumberRegistry.MAX_AGE);
+				Long maxAgeOption = response.getOptions().getMaxAge();
+				if (maxAgeOption == null) {
+					response.getOptions().setMaxAge(OptionNumberRegistry.Defaults.MAX_AGE);
+				}
+
+				if (maxAgeOption > 0) {
+					// cache the request
+					try {
+						// Caches loaded by a CacheLoader will call
+						// CacheLoader.load(K) to load new values into the cache
+						// when used the get method.
+						Response responseInserted = responseCache.get(cacheKey);
+						if (responseInserted != null) {
+//							if (Bench_Help.DO_LOG) 
+								LOGGER.debug("Cached response");
+						} else {
+							LOGGER.warn("Failed to insert the response in the cache");
+						}
+					} catch (ExecutionException e) {
+						// swallow
+						LOGGER.warn("Exception while inserting the response in the cache", e);
+					}
+				} else {
+					// if the max-age option is set to 0, then the response
+					// should be invalidated
+					invalidateRequest(request);
+				}
+			} else {
+				// this code should not be reached
+				LOGGER.error("Code not recognized: {}", code);
+			}
+		}
+	}
+
+	@Override
+	public CacheStats getCacheStats() {
+		return responseCache.stats();
+	}
+
+	/**
+	 * Retrieves the response in the cache that matches the request passed, null
+	 * otherwise. The method creates the key for the cache starting from the
+	 * request and checks if the cache contains it. If present, the method
+	 * updates the max-age of the linked response to consider the time passed in
+	 * the cache (according to the freshness model) and returns it. On the
+	 * contrary, if the response has passed its expiration time, it is
+	 * invalidated and the method returns null.
+	 */
+	@Override
+	public Response getResponse(Request request) {
+		if (!enabled) {
+			return null;
+		}
+
+		// search the desired representation
+		Response response = null;
+		CacheKey cacheKey = null;
+
+		for (CacheKey acceptKey : CacheKey.fromAcceptOptions(request)) {
+			response = responseCache.getIfPresent(acceptKey);
+			cacheKey = acceptKey;
+
+			if (response != null) {
+				break;
+			}
+		}
+
+		// if the response is not null, manage the cached response
+		if (response != null) {
+			LOGGER.debug("Cache hit");
+
+			// check if the response is expired
+			long currentTime = ClockUtil.nanoRealtime();
+			long nanosLeft = getRemainingLifetime(response, currentTime);
+			if (nanosLeft > 0) {
+				// if the response can be used, then update its max-age to
+				// consider the aging of the response while in the cache
+				response.getOptions().setMaxAge(nanosLeft);
+				// set the current time as the response timestamp
+				response.setNanoTimestamp(currentTime);
+			} else {
+				LOGGER.debug("Expired response");
+
+				// try to validate the response
+				response = validate(cacheKey);
+				if (response != null) {
+					LOGGER.debug("Validation successful");
+				} else {
+					invalidateRequest(cacheKey);
+				}
+			}
+		}
+
+		return response;
+	}
+	
+	@Override
+	public void invalidateRequest(Request request) {
+		invalidateRequest(CacheKey.fromAcceptOptions(request));
+		LOGGER.debug("Invalidated request");
+	}
+
+	@Override
+	public void handleDELETE(CoapExchange exchange) {
+		responseCache.invalidateAll();
+		exchange.respond(ResponseCode.DELETED);
+	}
+
+	@Override
+	public void handleGET(CoapExchange exchange) {
+		StringBuilder builder = new StringBuilder();
+		builder.append("Available commands:\n - GET: show cached values\n - DELETE: empty the cache\n - POST: enable/disable caching\n");
+
+		// get cache values
+		builder.append("\nCached values:\n");
+		for (CacheKey cachedRequest : responseCache.asMap().keySet()) {
+			Response response = responseCache.asMap().get(cachedRequest);
+
+			builder.append(cachedRequest.getProxyUri()).append(" (").append(
+					MediaTypeRegistry.toString(cachedRequest.getMediaType())).append(") > ").append(getRemainingLifetime(response)).append(" seconds | (").append(cachedRequest.getMediaType()).append(")\n");
+		}
+
+		exchange.respond(ResponseCode.CONTENT, builder.toString());
+	}
+
+	@Override
+	public void handlePOST(CoapExchange exchange) {
+		enabled = !enabled;
+		String content = enabled ? "Enabled" : "Disabled";
+		exchange.respond(ResponseCode.CHANGED, content);
+	}
+
+	private long getRemainingLifetime(Response response) {
+		return getRemainingLifetime(response, ClockUtil.nanoRealtime());
+	}
+
+	/**
+	 * Method that checks if the lifetime allowed for the response if expired.
+	 * The result is calculated with the initial timestamp (when the response
+	 * has been received) and the max-age option compared against the current
+	 * timestamp. If the max-age option is not specified, it will be assumed the
+	 * default (60 seconds).
+	 * 
+	 * @param response
+	 *            the response
+	 * @param currentTime
+	 * @return true, if is expired
+	 */
+	private long getRemainingLifetime(Response response, long currentTime) {
+		// get the timestamp
+		long arriveTime = response.getNanoTimestamp();
+		
+		Long maxAgeOption = response.getOptions().getMaxAge();
+		long oldMaxAge = OptionNumberRegistry.Defaults.MAX_AGE;
+		if (maxAgeOption != null) {
+			oldMaxAge = maxAgeOption.longValue();
+		}
+
+		// calculate the time that the response has spent in the cache
+		double secondsInCache = TimeUnit.NANOSECONDS.toSeconds(currentTime - arriveTime);
+		int cacheTime = Ints.checkedCast(Math.round(secondsInCache));
+		return oldMaxAge - cacheTime;
+	}
+
+	private void invalidateRequest(CacheKey cacheKey) {
+		responseCache.invalidate(cacheKey);
+	}
+
+	private void invalidateRequest(List<CacheKey> cacheKeys) {
+		responseCache.invalidateAll(cacheKeys);
+	}
+
+	private Response validate(CacheKey cachedRequest) {
+		// TODO
+		return null;
+	}
+
+	/**
+	 * Nested class that normalizes the variable fields of the coap requests to
+	 * be used as a key for the cache. The class tries to handle also the
+	 * different requests that must refer to the same response (e.g., requests
+	 * that with or without the accept options produce the same response).
+	 */
+	private static final class CacheKey {
+		private final String proxyUri;
+		private final int mediaType;
+		private Response response;
+		private final byte[] payload;
+
+		/**
+		 * Creates a list of keys for the cache from a request with multiple
+		 * accept options set. Method needed to search for content-type
+		 * wildcards in the cache (text/* means: text/plain, text/html,
+		 * text/xml, text/csv, etc.). If the accept option is not set, it simply
+		 * gives back the keys for every representation.
+		 * 
+		 * @param request
+		 * @return the list of cache keys
+		 */
+		private static List<CacheKey> fromAcceptOptions(Request request) {
+			if (request == null) {
+				throw new IllegalArgumentException("request == null");
+			}
+
+			List<CacheKey> cacheKeys = new LinkedList<ProxyCacheResource.CacheKey>();
+			String proxyUri = request.getOptions().getProxyUri();
+			try {
+				// TODO why not UTF-8?
+				proxyUri = URLEncoder.encode(proxyUri, "ISO-8859-1");
+			} catch (UnsupportedEncodingException e) {
+				LOGGER.error("ISO-8859-1 encoding not supported: {}", e.getMessage());
+			}
+			byte[] payload = request.getPayload();
+
+			// Implementation in new Cf (Only one accept option allowed)
+			int accept = request.getOptions().getAccept();
+			if (accept < 0) {
+				// if the accept options are not set, simply set all media types
+				// FIXME not efficient
+				for (Integer acceptType : MediaTypeRegistry.getAllMediaTypes()) {
+					cacheKeys.add(new CacheKey(proxyUri, acceptType, payload));
+				}
+			} else {
+				cacheKeys.add(new CacheKey(proxyUri, accept, payload));
+			}
+
+			return cacheKeys;
+		}
+
+		/**
+		 * Create a key for the cache starting from a request and the
+		 * content-type of the corresponding response.
+		 * 
+		 * @param request
+		 * @return
+		 * @throws URISyntaxException
+		 */
+		private static CacheKey fromContentTypeOption(Request request) throws URISyntaxException {
+			if (request == null) {
+				throw new IllegalArgumentException("request == null");
+			}
+
+			Response response = request.getResponse();
+			if (response == null) {
+				return fromAcceptOptions(request).get(0);
+			}
+
+			String proxyUri = request.getOptions().getProxyUri();
+			int mediaType = response.getOptions().getContentFormat();
+			if (mediaType < 0) {
+				// content-format option not set, use default
+				mediaType = MediaTypeRegistry.TEXT_PLAIN;
+			}
+			byte[] payload = request.getPayload();
+
+			// create the new cacheKey
+			CacheKey cacheKey = new CacheKey(proxyUri, mediaType, payload);
+			cacheKey.setResponse(response);
+
+			return cacheKey;
+		}
+
+		public CacheKey(String proxyUri, int mediaType, byte[] payload) {
+			this.proxyUri = proxyUri;
+			this.mediaType = mediaType;
+			this.payload = payload;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.lang.Object#equals(java.lang.Object)
+		 */
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+			CacheKey other = (CacheKey) obj;
+			if (mediaType != other.mediaType) {
+				return false;
+			}
+			if (!Arrays.equals(payload, other.payload)) {
+				return false;
+			}
+			if (proxyUri == null) {
+				if (other.proxyUri != null) {
+					return false;
+				}
+			} else if (!proxyUri.equals(other.proxyUri)) {
+				return false;
+			}
+			return true;
+		}
+
+		/**
+		 * @return the mediaType
+		 */
+		public int getMediaType() {
+			return mediaType;
+		}
+
+		/**
+		 * @return the proxyUri
+		 */
+		public String getProxyUri() {
+			return proxyUri;
+		}
+
+		/**
+		 * @return the response
+		 */
+		public Response getResponse() {
+			return response;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.lang.Object#hashCode()
+		 */
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + mediaType;
+			result = prime * result + Arrays.hashCode(payload);
+			result = prime * result + (proxyUri == null ? 0 : proxyUri.hashCode());
+			return result;
+		}
+
+		private void setResponse(Response response) {
+			this.response = response;
+
+		}
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/ProxyCoapClientResource.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/ProxyCoapClientResource.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - derived from org.eclipse.californium.proxy
+ ******************************************************************************/
+
+package org.eclipse.californium.proxy2.resources;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MessageObserverAdapter;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.proxy2.Coap2CoapTranslator;
+import org.eclipse.californium.proxy2.EndpointPool;
+import org.eclipse.californium.proxy2.TranslationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resource that forwards a coap request with the proxy-uri option set to the
+ * desired coap server.
+ */
+public class ProxyCoapClientResource extends ProxyCoapResource {
+
+	static final Logger LOGGER = LoggerFactory.getLogger(ProxyCoapClientResource.class);
+
+	/**
+	 * Maps scheme to endpoint pool.
+	 */
+	private Map<String, EndpointPool> mapSchemeToPool = new HashMap<>();
+	/**
+	 * Coap2Coap translator.
+	 */
+	private Coap2CoapTranslator translator;
+
+	/**
+	 * Create proxy resource.
+	 * 
+	 * @param name name of the resource
+	 * @param visible visibility of the resource
+	 * @param accept accept CON request befor forwarding the request
+	 * @param translator translater for coap2coap messages. {@code null} to sue
+	 *            default implementation {@link Coap2CoapTranslator}.
+	 * @param pools list of endpoint pools for outgoing requests
+	 */
+	public ProxyCoapClientResource(String name, boolean visible, boolean accept, Coap2CoapTranslator translator,
+			EndpointPool... pools) {
+		// set the resource hidden
+		super(name, visible, accept);
+		getAttributes().setTitle("Forward the requests to a CoAP server.");
+		this.translator = translator;
+		for (EndpointPool pool : pools) {
+			this.mapSchemeToPool.put(pool.getScheme(), pool);
+		}
+	}
+
+	@Override
+	public void handleRequest(final Exchange exchange) {
+		Request incomingRequest = exchange.getRequest();
+		LOGGER.debug("ProxyCoapClientResource forwards {}", incomingRequest);
+
+		try {
+			// create the new request from the original
+			InetSocketAddress exposedInterface = translator.getExposedInterface(incomingRequest);
+			URI destination = translator.getDestinationURI(incomingRequest, exposedInterface);
+			Request outgoingRequest = translator.getRequest(destination, incomingRequest);
+			// execute the request
+			if (outgoingRequest.getDestinationContext() == null) {
+				exchange.sendResponse(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
+				throw new NullPointerException("Destination is null");
+			}
+			LOGGER.debug("Sending proxied CoAP request to {}", outgoingRequest.getDestinationContext());
+			if (accept) {
+				exchange.sendAccept();
+			}
+			EndpointPool pool = mapSchemeToPool.get(outgoingRequest.getScheme());
+			pool.sendRequest(outgoingRequest, new ProxySendResponseMessageObserver(translator, exchange));
+		} catch (TranslationException e) {
+			LOGGER.debug("Proxy-uri option malformed: {}", e.getMessage());
+			exchange.sendResponse(new Response(Coap2CoapTranslator.STATUS_FIELD_MALFORMED));
+		} catch (Exception e) {
+			LOGGER.warn("Failed to execute request: {}", e.getMessage(), e);
+			exchange.sendResponse(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
+		}
+	}
+
+	@Override
+	public Set<String> getDestinationSchemes() {
+		return Collections.unmodifiableSet(mapSchemeToPool.keySet());
+	}
+
+	private static class ProxySendResponseMessageObserver extends MessageObserverAdapter {
+
+		private final Coap2CoapTranslator translator;
+		private final Exchange incomingExchange;
+
+		private ProxySendResponseMessageObserver(Coap2CoapTranslator translator, Exchange incomingExchange) {
+			this.translator = translator;
+			this.incomingExchange = incomingExchange;
+		}
+
+		@Override
+		public void onResponse(Response incomingResponse) {
+			ProxyCoapClientResource.LOGGER.debug("ProxyCoapClientResource received {}", incomingResponse);
+			incomingExchange.sendResponse(translator.getResponse(incomingResponse));
+		}
+
+		@Override
+		public void onReject() {
+			fail(ResponseCode.SERVICE_UNAVAILABLE);
+			ProxyCoapClientResource.LOGGER.debug("Request rejected");
+		}
+
+		@Override
+		public void onTimeout() {
+			fail(ResponseCode.GATEWAY_TIMEOUT);
+			ProxyCoapClientResource.LOGGER.debug("Request timed out.");
+		}
+
+		@Override
+		public void onCancel() {
+			fail(ResponseCode.SERVICE_UNAVAILABLE);
+			ProxyCoapClientResource.LOGGER.debug("Request canceled");
+		}
+
+		@Override
+		public void onSendError(Throwable e) {
+			fail(ResponseCode.SERVICE_UNAVAILABLE);
+			ProxyCoapClientResource.LOGGER.warn("Send error", e);
+		}
+
+		private void fail(ResponseCode response) {
+			incomingExchange.sendResponse(new Response(response));
+		}
+	}	
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/ProxyCoapResource.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/ProxyCoapResource.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+
+package org.eclipse.californium.proxy2.resources;
+
+import java.util.Set;
+
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.network.Exchange;
+
+/**
+ * Resource that forwards a coap request.
+ */
+public abstract class ProxyCoapResource extends CoapResource {
+
+	/**
+	 * Accept CON request before forwarding it.
+	 */
+	protected final boolean accept;
+
+	/**
+	 * Create proxy resource.
+	 * 
+	 * @param name name of the resource
+	 * @param visable visibility of the resource
+	 * @param accept accept CON request befor forwarding the request
+	 */
+	public ProxyCoapResource(String name, boolean visable, boolean accept) {
+		// set the resource hidden
+		super(name, visable);
+		this.accept = accept;
+	}
+
+	/**
+	 * Set of supported destination schemes.
+	 * 
+	 * @return set of supported destination schemes.
+	 */
+	public abstract Set<String> getDestinationSchemes();
+
+	@Override
+	public abstract void handleRequest(final Exchange exchange);
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/ProxyHttpClientResource.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/ProxyHttpClientResource.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - derived from org.eclipse.californium.proxy
+ ******************************************************************************/
+
+package org.eclipse.californium.proxy2.resources;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.protocol.BasicHttpContext;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.elements.util.ClockUtil;
+import org.eclipse.californium.proxy2.Coap2CoapTranslator;
+import org.eclipse.californium.proxy2.Coap2HttpTranslator;
+import org.eclipse.californium.proxy2.HttpClientFactory;
+import org.eclipse.californium.proxy2.InvalidFieldException;
+import org.eclipse.californium.proxy2.TranslationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProxyHttpClientResource extends ProxyCoapResource {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ProxyHttpClientResource.class);
+
+	private final Coap2HttpTranslator translator;
+
+	private final Set<String> schemes = new HashSet<String>();
+
+	/**
+	 * DefaultHttpClient is thread safe. It is recommended that the same
+	 * instance of this class is reused for multiple request executions.
+	 */
+	private static final CloseableHttpAsyncClient asyncClient = HttpClientFactory.createClient();
+
+	public ProxyHttpClientResource(String name, boolean visible, boolean accept, Coap2HttpTranslator translator, String... schemes) {
+		// set the resource hidden
+		super(name, visible, accept);
+		getAttributes().setTitle("Forward the requests to a HTTP client.");
+		this.translator = translator;
+		if (schemes == null || schemes.length == 0) {
+			this.schemes.add("http");
+		} else {
+			for (String scheme : schemes) {
+				this.schemes.add(scheme);
+			}
+		}
+	}
+
+	@Override
+	public void handleRequest(final Exchange exchange) {
+		final Request incomingCoapRequest = exchange.getRequest();
+
+		URI uri;
+		try {
+			InetSocketAddress exposedInterface = translator.getExposedInterface(incomingCoapRequest);
+			uri = translator.getDestinationURI(incomingCoapRequest, exposedInterface);
+		} catch (TranslationException ex) {
+			LOGGER.debug("URI error.", ex);
+			exchange.sendResponse(new Response(Coap2CoapTranslator.STATUS_FIELD_MALFORMED));
+			return;
+		}
+
+		// get the requested host, if the port is not specified, the constructor
+		// sets it to -1
+		HttpHost httpHost = new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());
+
+		HttpRequest httpRequest = null;
+		try {
+			// get the mapping to http for the incoming coap request
+			httpRequest = translator.getHttpRequest(uri, incomingCoapRequest);
+			LOGGER.debug("Outgoing http request: {}", httpRequest.getRequestLine());
+		} catch (InvalidFieldException e) {
+			LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
+			exchange.sendResponse(new Response(Coap2CoapTranslator.STATUS_FIELD_MALFORMED));
+			return;
+		} catch (TranslationException e) {
+			LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
+			exchange.sendResponse(new Response(Coap2CoapTranslator.STATUS_TRANSLATION_ERROR));
+			return;
+		}
+
+		if (accept) {
+			exchange.sendAccept();
+		}
+
+		asyncClient.execute(httpHost, httpRequest, new BasicHttpContext(), new FutureCallback<HttpResponse>() {
+
+			@Override
+			public void completed(HttpResponse result) {
+				try {
+					long timestamp = ClockUtil.nanoRealtime();
+					LOGGER.debug("Incoming http response: {}", result.getStatusLine());
+					// the entity of the response, if non repeatable, could be
+					// consumed only one time, so do not debug it!
+					// System.out.println(EntityUtils.toString(httpResponse.getEntity()));
+
+					// translate the received http response in a coap response
+					Response coapResponse = translator.getCoapResponse(result, incomingCoapRequest);
+					coapResponse.setNanoTimestamp(timestamp);
+
+					exchange.sendResponse(coapResponse);
+				} catch (InvalidFieldException e) {
+					LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
+					exchange.sendResponse(new Response(Coap2CoapTranslator.STATUS_FIELD_MALFORMED));
+				} catch (TranslationException e) {
+					LOGGER.debug("Problems during the http/coap translation: {}", e.getMessage());
+					exchange.sendResponse(new Response(Coap2CoapTranslator.STATUS_TRANSLATION_ERROR));
+				} catch (Throwable e) {
+					LOGGER.debug("Error during the http/coap translation: {}", e.getMessage(), e);
+					exchange.sendResponse(new Response(Coap2CoapTranslator.STATUS_FIELD_MALFORMED));
+				}
+				LOGGER.debug("Incoming http response: {} processed!", result.getStatusLine());
+			}
+
+			@Override
+			public void failed(Exception ex) {
+				LOGGER.debug("Failed to get the http response: {}", ex.getMessage());
+				exchange.sendResponse(new Response(ResponseCode.INTERNAL_SERVER_ERROR));
+			}
+
+			@Override
+			public void cancelled() {
+				LOGGER.debug("Request canceled");
+				exchange.sendResponse(new Response(ResponseCode.SERVICE_UNAVAILABLE));
+			}
+		});
+
+	}
+
+	@Override
+	public Set<String> getDestinationSchemes() {
+		return Collections.unmodifiableSet(schemes);
+	}
+
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/ProxyMessageDeliverer.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/ProxyMessageDeliverer.java
@@ -1,0 +1,227 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+
+package org.eclipse.californium.proxy2.resources;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.OptionSet;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.server.ServerMessageDeliverer;
+import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.californium.elements.util.NetworkInterfacesUtil;
+import org.eclipse.californium.proxy2.CoapUriTranslator;
+import org.eclipse.californium.proxy2.TranslationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Proxy message deliverer
+ * 
+ * Delivers message either to proxy resources registered for the destination
+ * scheme, or, to local resources using the requests path.
+ */
+public class ProxyMessageDeliverer extends ServerMessageDeliverer {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ProxyMessageDeliverer.class);
+
+	/**
+	 * Translator to determine destination scheme.
+	 * 
+	 * @see CoapUriTranslator#getDestinationScheme(Request)
+	 */
+	private final CoapUriTranslator translater;
+	/**
+	 * Map schemes to proxy resources.
+	 */
+	private final Map<String, Resource> scheme2resource;
+	/**
+	 * Set of exposed services. Using containers, this may be different from the
+	 * local interfaces.
+	 */
+	private final Set<InetSocketAddress> exposedServices;
+	/**
+	 * Set of exposed addresses. Using containers, this may be different from
+	 * the local interfaces.
+	 */
+	private final Set<InetAddress> exposedHosts;
+	/**
+	 * Set of exposed ports. Using containers, this may be different from the
+	 * local ports.
+	 */
+	private final Set<Integer> exposedPorts;
+	/**
+	 * Create message deliverer with proxy support.
+	 * 
+	 * @param root root resource of coap-proxy-server
+	 * @param translater translator for coap-request-uri's
+	 */
+	public ProxyMessageDeliverer(Resource root, CoapUriTranslator translater) {
+		super(root);
+		this.translater = translater;
+		this.scheme2resource = new HashMap<String, Resource>();
+		this.exposedServices = new HashSet<>();
+		this.exposedPorts = new HashSet<>();
+		this.exposedHosts = new HashSet<>();
+	}
+
+	/**
+	 * Add exposed service address to suppress recursive requests.
+	 * 
+	 * @param exposed list of exposed interface addresses to suppress recursive
+	 *            proxy request. The exposed interfaces may differ from the
+	 *            localone, if containers are used. Maybe {@code null} or empty,
+	 *            if recursion suppression is not required.
+	 */
+	public ProxyMessageDeliverer addExposedServiceAddresses(InetSocketAddress... exposed) {
+		if (exposed == null) {
+			throw new NullPointerException("exposed interfaces must not be null!");
+		}
+		if (exposed.length == 0) {
+			throw new IllegalArgumentException("exposed interfaces must not be empty!");
+		}
+		Collection<InetAddress> all = NetworkInterfacesUtil.getNetworkInterfaces();
+		for (InetSocketAddress inetAddress : exposed) {
+			LOGGER.info("address {}", inetAddress);
+			this.exposedPorts.add(inetAddress.getPort());
+			InetAddress address = inetAddress.getAddress();
+			if (address.isAnyLocalAddress()) {
+				for (InetAddress eAddress : all) {
+					this.exposedServices.add(new InetSocketAddress(eAddress, inetAddress.getPort()));
+					this.exposedHosts.add(eAddress);
+				}
+			} else {
+				this.exposedServices.add(inetAddress);
+				this.exposedHosts.add(address);
+			}
+		}
+		for (Integer port : exposedPorts) {
+			LOGGER.info("Exposed port {}", port);
+		}
+		for (InetAddress address : exposedHosts) {
+			LOGGER.info("Exposed host {}", address);
+		}
+		for (InetSocketAddress inetAddress : exposedServices) {
+			LOGGER.info("Exposed service {}", inetAddress);
+		}
+		return this;
+	}
+
+	/**
+	 * 
+	 * @param proxies list of proxy resources.
+	 */
+	public ProxyMessageDeliverer addProxyCoapResources(ProxyCoapResource... proxies) {
+		if (proxies == null) {
+			throw new NullPointerException("proxies must not be null!");
+		}
+		if (proxies.length == 0) {
+			throw new IllegalArgumentException("proxies must not be empty!");
+		}
+		for (ProxyCoapResource proxy : proxies) {
+			Set<String> schemes = proxy.getDestinationSchemes();
+			for (String scheme : schemes) {
+				if (scheme2resource.put(scheme, proxy) != null) {
+					LOGGER.warn("ambig proxy resource for scheme {}!", scheme);
+				}
+			}
+		}
+		return this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * Route proxy requests to registered proxy resources. Suppress forwarding
+	 * of proxy request to own exposed interfaces reducing recursion.
+	 */
+	@Override
+	protected Resource findResource(Exchange exchange) {
+		Resource resource = null;
+		Request request = exchange.getRequest();
+		OptionSet options = request.getOptions();
+		boolean proxyOption = options.hasProxyUri() || options.hasProxyScheme();
+		boolean hostOption = options.hasUriHost() || options.hasUriPort();
+
+		if (proxyOption || hostOption) {
+			try {
+				String scheme = translater.getDestinationScheme(request);
+				if (scheme != null) {
+					scheme = scheme.toLowerCase();
+					resource = scheme2resource.get(scheme);
+					if (!proxyOption && CoAP.isSupportedScheme(scheme) && !exposedServices.isEmpty()) {
+						if (resource != null) {
+							// check, if proxy is destination.
+							Integer port = options.getUriPort();
+							String host = options.getUriHost();
+							if (host == null) {
+								if (exposedPorts.contains(port)) {
+									// proxy is destination
+									resource = null;
+								}
+							} else {
+								if (port == null) {
+									try {
+										InetAddress address = InetAddress.getByName(host);
+										if (exposedHosts.contains(address)) {
+											// proxy is destination
+											resource = null;
+										}
+									} catch (UnknownHostException e) {
+										// destination not reachable
+										resource = null;
+									}
+								} else {
+									InetSocketAddress destination = new InetSocketAddress(host, port);
+									if (destination.isUnresolved() || exposedServices.contains(destination)) {
+										// destination not reachable
+										// or proxy is destination
+										resource = null;
+									}
+								}
+							}
+						}
+						if (resource == null) {
+							// proxy is destionation, try to find local resource
+							resource = super.findResource(exchange);
+						}
+					}
+			}
+			} catch (TranslationException e) {
+				LOGGER.debug("Bad proxy request", e);
+			}
+		} else {
+			resource = super.findResource(exchange);
+		}
+		if (resource != null && request.getDestinationContext() == null) {
+			if (exchange.getEndpoint() != null) {
+				// set local receiving addess as destination
+				request.setDestinationContext(new AddressEndpointContext(exchange.getEndpoint().getAddress()));
+			}
+		}
+		return resource;
+	}
+}

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/StatsResource.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/StatsResource.java
@@ -1,0 +1,298 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2017 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Matthias Kovatsch - creator and main architect
+ *    Martin Lanter - architect and re-implementation
+ *    Francesco Corazza - HTTP cross-proxy
+ *    Bosch Software Innovations GmbH - migrate to SLF4J
+ ******************************************************************************/
+package org.eclipse.californium.proxy2.resources;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.elements.util.ClockUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.cache.CacheStats;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+
+
+/**
+ * Resource that encapsulate the proxy statistics.
+ */
+public class StatsResource extends CoapResource {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(StatsResource.class);
+
+	private final Table<String, String, StatHelper> statsTable = HashBasedTable.create();
+
+	private static String CACHE_LOG_NAME = "_cache_log.log";
+
+	/**
+	 * Instantiates a new stats resource.
+	 * 
+	 * @param cacheResource
+	 */
+	public StatsResource(CacheResource cacheResource) {
+		super("stats");
+		getAttributes().setTitle("Keeps track of the requests served by the proxy.");
+
+		// add the sub-resource to show stats
+		add(new CacheStatResource("cache", cacheResource));
+		add(new ProxyStatResource("proxy"));
+	}
+
+	public void updateStatistics(Request request, boolean cachedResponse) {
+		URI proxyUri = null;
+		try {
+			proxyUri = new URI(request.getOptions().getProxyUri());
+		} catch (URISyntaxException e) {
+			LOGGER.warn("Proxy-uri malformed: {}", request.getOptions().getProxyUri());
+		}
+
+		if (proxyUri == null) {
+			// throw new IllegalArgumentException("proxyUri == null");
+			return;
+		}
+
+		// manage the address requester
+		String addressString = proxyUri.getHost();
+		if (addressString != null) {
+			// manage the resource requested
+			String resourceString = proxyUri.getPath();
+			if (resourceString != null) {
+				// check if there is already an entry for the row/column
+				// association
+				StatHelper statHelper = statsTable.get(addressString, resourceString);
+				if (statHelper == null) {
+					// create a new stat if it not present
+					statHelper = new StatHelper();
+
+					// add the new element to the table
+					statsTable.put(addressString, resourceString, statHelper);
+				}
+
+				// increment the count of the requests
+				statHelper.increment(cachedResponse);
+			}
+		}
+	}
+
+	/**
+	 * Builds a pretty print from the statistics gathered.
+	 * 
+	 * @return the statistics as string
+	 */
+	private String getStatString() {
+		StringBuilder builder = new StringBuilder();
+
+		builder.append(String.format("Served %d addresses and %d resources\n", statsTable.rowKeySet().size(), statsTable.cellSet().size()));
+		builder.append("＿\n");
+		// iterate over every row (addresses)
+		for (String address : statsTable.rowKeySet()) {
+			builder.append(String.format("|- %s\n", address));
+			builder.append("|\t ＿\n");
+			// iterate over every column for a specific address
+			for (String resource : statsTable.row(address).keySet()) {
+				builder.append(String.format("|\t |- %s: \n", resource));
+
+				// get the statistics
+				StatHelper statHelper = statsTable.get(address, resource);
+				builder.append(String.format("|\t |------ total requests: %d\n", statHelper.getTotalCount()));
+				builder.append(String.format("|\t |------ total cached replies: %d\n", statHelper.getCachedCount()));
+				// builder.append(String.format("|\t |------ last period (%d sec) requests: %d\n",
+				// PERIOD_SECONDS, statHelper.getLastPeriodCount()));
+				// builder.append(String.format("|\t |------ last period (%d sec) avg delay (nanosec): %d\n",
+				// PERIOD_SECONDS, statHelper.getLastPeriodAvgDelay()));
+				builder.append("|\t |\n");
+			}
+			builder.append("|\t ￣\n");
+			builder.append("|\n");
+		}
+		builder.append("￣\n");
+
+		return builder.length() == 0 ? "The proxy has not received any request, yet." : builder.toString();
+	}
+
+	private static final class CacheStatResource extends CoapResource {
+		private CacheStats relativeCacheStats;
+		private final CacheResource cacheResource;
+
+		private static final long DEFAULT_LOGGING_DELAY = 5;
+		ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+		/**
+		 * Instantiates a new debug resource.
+		 * 
+		 * @param resourceIdentifier
+		 *            the resource identifier
+		 * @param cacheResource
+		 */
+		public CacheStatResource(String resourceIdentifier, CacheResource cacheResource) {
+			super(resourceIdentifier);
+
+			this.cacheResource = cacheResource;
+			relativeCacheStats = cacheResource.getCacheStats();
+		}
+
+		/**
+		 * Method to get the stats about the cache.
+		 * 
+		 * @return
+		 */
+		public String getStats() {
+			StringBuilder stringBuilder = new StringBuilder();
+			CacheStats cacheStats = cacheResource.getCacheStats().minus(relativeCacheStats);
+
+			stringBuilder.append(String.format("Total successful loaded values: %d %n", cacheStats.loadSuccessCount()));
+			stringBuilder.append(String.format("Total requests: %d %n", cacheStats.requestCount()));
+			stringBuilder.append(String.format("Hits ratio: %d/%d - %.3f %n", cacheStats.hitCount(), cacheStats.missCount(), cacheStats.hitRate()));
+			stringBuilder.append(String.format("Average time spent loading new values (nanoseconds): %.3f %n", cacheStats.averageLoadPenalty()));
+			stringBuilder.append(String.format("Number of cache evictions: %d %n", cacheStats.evictionCount()));
+
+			return stringBuilder.toString();
+		}
+
+		@Override
+		public void handleDELETE(CoapExchange exchange) {
+			// reset the cache
+			relativeCacheStats = cacheResource.getCacheStats().minus(relativeCacheStats);
+			exchange.respond(ResponseCode.DELETED);
+		}
+
+		@Override
+		public void handleGET(CoapExchange exchange) {
+			String payload = "Available commands:\n - GET: show statistics\n - POST write stats to file\n - DELETE: reset statistics\n\n";
+			payload += getStats();
+			Response response = new Response(ResponseCode.CONTENT);
+			response.setPayload(payload);
+			response.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
+			exchange.respond(response);
+		}
+
+		@Override
+		public void handlePOST(CoapExchange exchange) {
+			// TODO include stopping the writing => make something for the whole
+			// proxy
+			// executor.shutdown();
+			// request.respond(CodeRegistry.RESP_DELETED, "Stopped",
+			// MediaTypeRegistry.TEXT_PLAIN);
+
+			// starting to log the stats on a new file
+
+			// create the new file
+			String logName = ClockUtil.nanoRealtime() + CACHE_LOG_NAME;
+			final File cacheLog = new File(logName);
+			try {
+				cacheLog.createNewFile();
+
+				// write the header
+				com.google.common.io.Files.write("hits%, avg. load, #evictions \n", cacheLog, Charset.defaultCharset());
+			} catch (IOException e) {
+			}
+
+			executor.scheduleWithFixedDelay(new Runnable() {
+
+				@Override
+				public void run() {
+					CacheStats cacheStats = cacheResource.getCacheStats().minus(relativeCacheStats);
+
+					String csvStats = String.format("%.3f, %.3f, %d %n", cacheStats.hitRate(), cacheStats.averageLoadPenalty(), cacheStats.evictionCount());
+					try {
+						com.google.common.io.Files.append(csvStats, cacheLog, Charset.defaultCharset());
+					} catch (IOException e) {
+					}
+				}
+			}, 0, DEFAULT_LOGGING_DELAY, TimeUnit.SECONDS);
+
+			Response response = new Response(ResponseCode.CREATED);
+			response.setPayload("Creted log: " + logName);
+			response.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
+			exchange.respond(response);
+		}
+	}
+
+	private final class ProxyStatResource extends CoapResource {
+
+		public ProxyStatResource(String resourceIdentifier) {
+			super(resourceIdentifier);
+		}
+
+		@Override
+		public void handleDELETE(CoapExchange exchange) {
+			// reset all the statistics
+			statsTable.clear();
+			exchange.respond(ResponseCode.DELETED);
+		}
+
+		@Override
+		public void handleGET(CoapExchange exchange) {
+			String payload = "Available commands:\n - GET: show statistics\n - POST write stats to file\n - DELETE: reset statistics\n\n";
+			payload += getStatString();
+			Response response = new Response(ResponseCode.CONTENT);
+			response.setPayload(payload);
+			response.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
+			exchange.respond(response);
+		}
+
+	}
+
+	/**
+	 * The Class StatisticsHelper.
+	 */
+	private static class StatHelper {
+		private int totalCount = 0;
+		private int cachedCount = 0;
+
+		public int getCachedCount() {
+			return cachedCount;
+		}
+		
+		/**
+		 * @return the totalCount
+		 */
+		public int getTotalCount() {
+			return totalCount;
+		}
+
+		public void increment(boolean cachedResponse) {
+			// add the total request counter
+			totalCount++;
+			if (cachedResponse) {
+				cachedCount++;
+			}
+
+			// add the new request's timestamp to the list
+			// long currentTimestamp = System.nanoTime();
+			// lastPeriodTimestamps.add(currentTimestamp);
+
+			// clean the list by the old entries
+			// cleanTimestamps(currentTimestamp);
+		}
+	}
+}

--- a/californium-proxy2/src/test/java/org/eclipse/californium/proxy2/CoapTranslatorTest.java
+++ b/californium-proxy2/src/test/java/org/eclipse/californium/proxy2/CoapTranslatorTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch Software Innovations - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.proxy2;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.junit.Test;
+
+/**
+ * This tests checks the functionality of the CoapTranslator.
+ */
+public class CoapTranslatorTest {
+
+	@Test
+	public void testTranslateDeprecatedRequest() throws TranslationException {
+		Coap2CoapTranslator translator = new Coap2CoapTranslator();
+
+		Request request = Request.newGet();
+		request.setURI("coap://localhost:5685/coap2coap");
+		request.getOptions().setProxyUri("coap://localhost:5683/targetResource");
+		request.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
+
+		URI uri = translator.getDestinationURI(request, null);
+		Request translatedRequest = translator.getRequest(uri, request);
+
+		assertThat(translatedRequest.getOptions().getContentFormat(), is(MediaTypeRegistry.TEXT_PLAIN));
+		assertThat(translatedRequest.getCode(), is(Code.GET));
+		assertThat(translatedRequest.getOptions().getUriHost(), is("localhost"));
+		assertThat(translatedRequest.getOptions().getUriPort(), is(nullValue()));
+		assertThat(translatedRequest.getOptions().getUriPathString(), is("targetResource"));
+		assertThat(translatedRequest.getOptions().hasObserve(), is(request.getOptions().hasObserve()));
+	}
+
+	@Test
+	public void testTranslateRequest() throws TranslationException {
+		Coap2CoapTranslator translator = new Coap2CoapTranslator();
+
+		Request request = Request.newGet();
+		request.setDestinationContext(new AddressEndpointContext(new InetSocketAddress("localhost", 5684)));
+		request.setURI("coap://localhost:5686/targetResource");
+		request.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
+
+		URI uri = translator.getDestinationURI(request, null);
+		Request translatedRequest = translator.getRequest(uri, request);
+
+		assertThat(translatedRequest.getOptions().getContentFormat(), is(MediaTypeRegistry.TEXT_PLAIN));
+		assertThat(translatedRequest.getCode(), is(Code.GET));
+		assertThat(translatedRequest.getOptions().getUriHost(), is("localhost"));
+		assertThat(translatedRequest.getOptions().getUriPort(), is(nullValue()));
+		assertThat(translatedRequest.getOptions().getUriPathString(), is("targetResource"));
+		assertThat(translatedRequest.getOptions().hasObserve(), is(request.getOptions().hasObserve()));
+	}
+}

--- a/californium-proxy2/src/test/java/org/eclipse/californium/proxy2/HttpTranslatorTest.java
+++ b/californium-proxy2/src/test/java/org/eclipse/californium/proxy2/HttpTranslatorTest.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Paul LeMarquand - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.proxy2;
+
+import static org.hamcrest.core.StringContains.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestFactory;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.DefaultHttpRequestFactory;
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.CoAP.Code;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.elements.util.StandardCharsets;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class HttpTranslatorTest {
+	/**
+	 * No exception expected by default
+	 */
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testPutHttpEntity() throws Exception {
+		Request req = new Request(Code.PUT);
+		req.setPayload("payload");
+		req.getOptions().setContentFormat(MediaTypeRegistry.TEXT_PLAIN);
+
+		validateCharset(req, StandardCharsets.ISO_8859_1);
+	}
+
+	@Test
+	public void testPutHttpEntityWithJSON() throws Exception {
+		Request req = new Request(Code.PUT);
+		req.setPayload("{}");
+		req.getOptions().setContentFormat(MediaTypeRegistry.APPLICATION_JSON);
+
+		// Charset should be modified to be ISO_8859_1 unless the contentFormat
+		// is APPLICATION_JSON, in which case it should stay UTF-8
+		validateCharset(req, StandardCharsets.UTF_8);
+	}
+
+//	public Request getCoapRequest(HttpRequest httpRequest, String httpResource, boolean proxyingEnabled) throws TranslationException {
+
+	@Test
+	public void testHttp2CoapLocalUri() throws Exception {
+		HttpRequestFactory factory = new DefaultHttpRequestFactory();
+		HttpRequest request = factory.newHttpRequest("GET", "/local/l-target?para1=1&para2=t");
+
+		Request coapRequest = new Http2CoapTranslator().getCoapRequest(request, "local", false);
+		assertThat(coapRequest.getCode(), is(CoAP.Code.GET));
+		assertThat(coapRequest.getURI(), is("coap://localhost/l-target?para1=1&para2=t"));
+	}
+
+	@Test
+	public void testHttp2CoapLocalMalformedUri() throws Exception {
+		exception.expect(TranslationException.class);
+		exception.expectMessage(containsString("scheme"));
+		HttpRequestFactory factory = new DefaultHttpRequestFactory();
+		HttpRequest request = factory.newHttpRequest("GET", "/local/coap://destination/target?para1=1&para2=t");
+
+		new Http2CoapTranslator().getCoapRequest(request, "local", false);
+	}
+
+	@Test
+	public void testHttp2CoapProxyUri() throws Exception {
+		HttpRequestFactory factory = new DefaultHttpRequestFactory();
+		HttpRequest request = factory.newHttpRequest("PUT", "/proxy/coap://destination:5683/target?para1=1&para2=t");
+		addEntity(request, "put");
+
+		Request coapRequest = new Http2CoapTranslator().getCoapRequest(request, "proxy", true);
+		assertThat(coapRequest.getCode(), is(CoAP.Code.PUT));
+		assertThat(coapRequest.getOptions().getProxyUri(), is("coap://destination:5683/target?para1=1&para2=t"));
+		assertThat(coapRequest.getPayloadString(), is("put"));
+	}
+
+	@Test
+	public void testHttp2CoapProxyMalformedUri() throws Exception {
+		exception.expect(TranslationException.class);
+		exception.expectMessage(containsString("scheme"));
+		HttpRequestFactory factory = new DefaultHttpRequestFactory();
+		HttpRequest request = factory.newHttpRequest("PUT", "/proxy/coap//destination:5683/target?para1=1&para2=t");
+		addEntity(request, "put");
+
+		new Http2CoapTranslator().getCoapRequest(request, "proxy", true);
+	}
+
+	@Test
+	public void testHttp2CoapHttpProxyUri() throws Exception {
+		HttpRequestFactory factory = new DefaultHttpRequestFactory();
+		HttpRequest request = factory.newHttpRequest("POST", "http://destination:5683/target/coap:?para1=1&para2=t");
+		addEntity(request, "post");
+
+		Request coapRequest = new Http2CoapTranslator().getCoapRequest(request, "proxy", true);
+		assertThat(coapRequest.getCode(), is(CoAP.Code.POST));
+		assertThat(coapRequest.getOptions().getProxyUri(), is("coap://destination:5683/target?para1=1&para2=t"));
+		assertThat(coapRequest.getPayloadString(), is("post"));
+	}
+
+	@Test
+	public void testHttp2CoapHttpProxyMalformedUri() throws Exception {
+		exception.expect(TranslationException.class);
+		exception.expectMessage(containsString("scheme"));
+		HttpRequestFactory factory = new DefaultHttpRequestFactory();
+		HttpRequest request = factory.newHttpRequest("POST", "http://destination:5683/target?para1=1&para2=t");
+		addEntity(request, "post");
+
+		new Http2CoapTranslator().getCoapRequest(request, "proxy", true);
+	}
+
+	private void validateCharset(Message request, Charset charset) throws TranslationException {
+		HttpEntity httpEntity = new HttpTranslator().getHttpEntity(request);
+		Charset httpEntityCharset = ContentType.parse(httpEntity.getContentType().getValue()).getCharset();
+
+		assertThat(httpEntityCharset, equalTo(charset));
+	}
+
+	private void addEntity(HttpRequest request, String message) throws UnsupportedEncodingException {
+		if (request instanceof HttpEntityEnclosingRequest) {
+			HttpEntity entity = new StringEntity(message);
+			((HttpEntityEnclosingRequest)request).setEntity(entity);
+		}
+	}
+}

--- a/californium-proxy2/src/test/resources/logback-test.xml
+++ b/californium-proxy2/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder 
+			by default -->
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} %level [%logger{0}]: %msg \(%class{25}.%method:%line\)%n</pattern>
+		</encoder>
+	</appender>
+
+	<!-- Strictly speaking, the level attribute is not necessary since -->
+	<!-- the level of the root level is set to DEBUG by default. -->
+	<root level="WARN">
+		<appender-ref ref="STDOUT" />
+	</root>
+
+</configuration>

--- a/demo-apps/cf-proxy/src/main/java/org/eclipse/californium/examples/ExampleCrossProxy.java
+++ b/demo-apps/cf-proxy/src/main/java/org/eclipse/californium/examples/ExampleCrossProxy.java
@@ -16,141 +16,71 @@
 package org.eclipse.californium.examples;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapServer;
-import org.eclipse.californium.core.coap.CoAP;
-import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.network.config.NetworkConfig;
-import org.eclipse.californium.core.server.MessageDeliverer;
-import org.eclipse.californium.core.server.ServerMessageDeliverer;
 import org.eclipse.californium.core.server.resources.CoapExchange;
-import org.eclipse.californium.core.server.resources.Resource;
-import org.eclipse.californium.elements.util.DaemonThreadFactory;
-import org.eclipse.californium.elements.util.ExecutorsUtil;
-import org.eclipse.californium.proxy.EndpointPool;
+
+import org.eclipse.californium.proxy.DirectProxyCoapResolver;
 import org.eclipse.californium.proxy.ProxyHttpServer;
+import org.eclipse.californium.proxy.resources.ForwardingResource;
 import org.eclipse.californium.proxy.resources.ProxyCoapClientResource;
 import org.eclipse.californium.proxy.resources.ProxyHttpClientResource;
 
 /**
- * Http2CoAP: Insert in browser: 
- * URI: http://localhost:8080/proxy/coap://localhost:PORT/target
+ * Http2CoAP: Insert in browser:
+ *     URI: http://localhost:8080/proxy/coap://localhost:PORT/target
  * 
- * Http2LocalCoAPResource: Insert in browser: 
- * URI: http://localhost:8080/local/target
- * 
- * Http2CoAP: configure browser to use the proxy "localhost:8080". 
- * Insert in browser: ("localhost" requests are not send to a proxy,
- * so use the hostname or none-local-ip-address)
- * URI: http://<hostname>:5683/target/coap:
- * 
- * CoAP2CoAP: Insert in Copper: 
- * URI: coap://localhost:PORT/coap2coap 
- * Proxy: coap://localhost:PORT/targetA
+ * CoAP2CoAP: Insert in Copper:
+ *     URI: coap://localhost:PORT/coap2coap
+ *     Proxy: coap://localhost:PORT/targetA
  *
- * CoAP2Http: Insert in Copper: 
- * URI: coap://localhost:PORT/coap2http
- * Proxy: http://lantersoft.ch/robots.txt
+ * CoAP2Http: Insert in Copper:
+ *     URI: coap://localhost:PORT/coap2http
+ *     Proxy: http://lantersoft.ch/robots.txt
  */
 public class ExampleCrossProxy {
-
+	
 	private static final int PORT = NetworkConfig.getStandard().getInt(NetworkConfig.Keys.COAP_PORT);
 
-	private static final String COAP2COAP = "coap2coap";
-	private static final String COAP2HTTP = "coap2http";
-
 	private CoapServer targetServerA;
-	private ProxyHttpServer httpServer;
-
+	
 	public ExampleCrossProxy() throws IOException {
-		NetworkConfig config = NetworkConfig.getStandard();
-		int threads = config.getInt(NetworkConfig.Keys.PROTOCOL_STAGE_THREAD_COUNT);
-		ScheduledExecutorService mainExecutor = ExecutorsUtil.newScheduledThreadPool(threads,
-				new DaemonThreadFactory("Proxy#"));
-		ScheduledExecutorService secondaryExecutor = ExecutorsUtil.newDefaultSecondaryScheduler("ProxyTimer#");
-		NetworkConfig outgoingConfig = new NetworkConfig(config);
-		outgoingConfig.setInt(NetworkConfig.Keys.NETWORK_STAGE_RECEIVER_THREAD_COUNT, 1);
-		outgoingConfig.setInt(NetworkConfig.Keys.NETWORK_STAGE_SENDER_THREAD_COUNT, 1);
-		EndpointPool pool = new EndpointPool(1000, 250, outgoingConfig, mainExecutor, secondaryExecutor);
-		CoapResource coap2coap = new ProxyCoapClientResource(COAP2COAP, pool);
-		CoapResource coap2http = new ProxyHttpClientResource(COAP2HTTP);
-
+		ForwardingResource coap2coap = new ProxyCoapClientResource("coap2coap");
+		ForwardingResource coap2http = new ProxyHttpClientResource("coap2http");
+		
 		// Create CoAP Server on PORT with proxy resources form CoAP to CoAP and HTTP
-		targetServerA = new CoapServer(config, PORT);
-		targetServerA.setExecutors(mainExecutor, secondaryExecutor, false);
+		targetServerA = new CoapServer(PORT);
 		targetServerA.add(coap2coap);
 		targetServerA.add(coap2http);
 		targetServerA.add(new TargetResource("target"));
-		MessageDeliverer local = targetServerA.getMessageDeliverer();
-		MessageDeliverer proxy = new ProxyMessageDeliverer(targetServerA.getRoot());
-		targetServerA.setMessageDeliverer(proxy);
 		targetServerA.start();
-
-		httpServer = new ProxyHttpServer(config, 8080);
-		httpServer.setLocalCoapDeliverer(local);
-		httpServer.setProxyCoapDeliverer(proxy);
-		httpServer.start();
-
-		System.out.println(
-				"CoAP resource \"target\" available over HTTP at: http://localhost:8080/proxy/coap://localhost:PORT/target");
-		System.out.println(
-				"CoAP resource \"target\" available over HTTP at: http://localhost:8080/local/target");
+		
+		ProxyHttpServer httpServer = new ProxyHttpServer(8080);
+		httpServer.setProxyCoapResolver(new DirectProxyCoapResolver(coap2coap));
+		
+		System.out.println("CoAP resource \"target\" available over HTTP at: http://localhost:8080/proxy/coap://localhost:PORT/target");
 	}
-
-	public void stop() {
-		httpServer.stop();
-		targetServerA.destroy();
-	}
-
-	private static class ProxyMessageDeliverer extends ServerMessageDeliverer {
-
-		private ProxyMessageDeliverer(Resource root) {
-			super(root);
-		}
-
-		@Override
-		protected Resource findResource(Request request) {
-			if (request.getOptions().hasProxyUri()) {
-				try {
-					URI uri = new URI(request.getOptions().getProxyUri());
-					String scheme = uri.getScheme();
-					scheme = scheme.toLowerCase();
-					if (scheme.equals("http") || scheme.equals("https")) {
-						return getRootResource().getChild(COAP2HTTP);
-					} else if (CoAP.isSupportedScheme(scheme)) {
-						return getRootResource().getChild(COAP2COAP);
-					}
-				} catch (URISyntaxException e) {
-				}
-			}
-			return super.findResource(request);
-		}
-	}
-
+	
 	/**
 	 * A simple resource that responds to GET requests with a small response
 	 * containing the resource's name.
 	 */
 	private static class TargetResource extends CoapResource {
-
-		private final AtomicInteger counter = new AtomicInteger();
-
+		
+		private int counter = 0;
+		
 		public TargetResource(String name) {
 			super(name);
 		}
-
+		
 		@Override
 		public void handleGET(CoapExchange exchange) {
-			int count = counter.incrementAndGet();
-			exchange.respond("Response " + count + " from resource " + getName());
+			exchange.respond("Response "+(++counter)+" from resource " + getName());
 		}
 	}
-
+	
 	public static void main(String[] args) throws Exception {
 		new ExampleCrossProxy();
 	}

--- a/demo-apps/cf-proxy2/pom.xml
+++ b/demo-apps/cf-proxy2/pom.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.californium</groupId>
+		<artifactId>demo-apps</artifactId>
+		<version>2.1.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>cf-proxy2</artifactId>
+	<packaging>jar</packaging>
+
+	<name>Cf-ExampleCrossProxy2</name>
+	<description>Californium (Cf) HTTP cross-proxy2 for testing californium-proxy2 module</description>
+
+	<properties>
+		<assembly.mainClass>org.eclipse.californium.examples.ExampleCrossProxy</assembly.mainClass>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>californium-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>californium-proxy2</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<!-- inherit configuration from parent POM -->
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/CrossExampleProxy2.java
+++ b/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/CrossExampleProxy2.java
@@ -1,0 +1,371 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - derived from org.eclipse.californium.examples.ExampleCrossProxy
+ ******************************************************************************/
+package org.eclipse.californium.examples;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.lang.management.ThreadMXBean;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Date;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
+import org.eclipse.californium.core.network.config.NetworkConfigDefaultHandler;
+import org.eclipse.californium.core.server.MessageDeliverer;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.elements.util.DaemonThreadFactory;
+import org.eclipse.californium.elements.util.ExecutorsUtil;
+import org.eclipse.californium.proxy2.Coap2CoapTranslator;
+import org.eclipse.californium.proxy2.Coap2HttpTranslator;
+import org.eclipse.californium.proxy2.EndpointPool;
+import org.eclipse.californium.proxy2.Http2CoapTranslator;
+import org.eclipse.californium.proxy2.ProxyHttpServer;
+import org.eclipse.californium.proxy2.TranslationException;
+import org.eclipse.californium.proxy2.resources.ProxyCoapClientResource;
+import org.eclipse.californium.proxy2.resources.ProxyCoapResource;
+import org.eclipse.californium.proxy2.resources.ProxyHttpClientResource;
+import org.eclipse.californium.proxy2.resources.ProxyMessageDeliverer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Demonstrates the examples for cross proxy functionality of CoAP.
+ * 
+ * Http2CoAP: Insert in browser: URI:
+ * http://localhost:8080/proxy/coap://localhost:PORT/target
+ * 
+ * Http2LocalCoAPResource: Insert in browser: URI:
+ * http://localhost:8080/local/target
+ * 
+ * Http2CoAP: configure browser to use the proxy "localhost:8080". Insert in
+ * browser: ("localhost" requests are not send to a proxy, so use the hostname
+ * or none-local-ip-address) URI: http://<hostname>:5683/target/coap:
+ * 
+ * CoAP2CoAP: Insert in Copper: URI: coap://localhost:PORT/coap2coap Proxy:
+ * coap://localhost:PORT/targetA
+ *
+ * CoAP2Http: Insert in Copper: URI: coap://localhost:PORT/coap2http Proxy:
+ * http://lantersoft.ch/robots.txt
+ */
+public class CrossExampleProxy2 {
+
+	private static final Logger STATISTIC_LOGGER = LoggerFactory.getLogger("org.eclipse.californium.proxy.statistics");
+
+	/**
+	 * File name for network configuration.
+	 */
+	private static final File CONFIG_FILE = new File("Californium.properties");
+	/**
+	 * Header for network configuration.
+	 */
+	private static final String CONFIG_HEADER = "Californium CoAP Properties file for Example Proxy";
+	/**
+	 * Default maximum resource size.
+	 */
+	private static final int DEFAULT_MAX_RESOURCE_SIZE = 8192;
+	/**
+	 * Default block size.
+	 */
+	private static final int DEFAULT_BLOCK_SIZE = 1024;
+
+	/**
+	 * Special network configuration defaults handler.
+	 */
+	private static final NetworkConfigDefaultHandler DEFAULTS = new NetworkConfigDefaultHandler() {
+
+		@Override
+		public void applyDefaults(NetworkConfig config) {
+			config.setInt(Keys.MAX_ACTIVE_PEERS, 20000);
+			config.setInt(Keys.MAX_RESOURCE_BODY_SIZE, DEFAULT_MAX_RESOURCE_SIZE);
+			config.setInt(Keys.MAX_MESSAGE_SIZE, DEFAULT_BLOCK_SIZE);
+			config.setInt(Keys.PREFERRED_BLOCK_SIZE, DEFAULT_BLOCK_SIZE);
+			config.setInt(Keys.EXCHANGE_LIFETIME, 24700); // 24.7s instead of
+															// 247s
+			config.setInt(Keys.MAX_PEER_INACTIVITY_PERIOD, 60 * 60 * 24); // 24h
+			config.setInt(Keys.TCP_CONNECTION_IDLE_TIMEOUT, 60 * 60 * 12); // 12h
+			config.setInt(Keys.TCP_CONNECT_TIMEOUT, 30 * 1000); // 20s
+			config.setInt(Keys.TLS_HANDSHAKE_TIMEOUT, 30 * 1000); // 20s
+			config.setInt(Keys.UDP_CONNECTOR_RECEIVE_BUFFER, 8192);
+			config.setInt(Keys.UDP_CONNECTOR_SEND_BUFFER, 8192);
+			config.setInt(Keys.HEALTH_STATUS_INTERVAL, 60);
+		}
+
+	};
+
+	private static final String COAP2COAP = "coap2coap";
+	private static final String COAP2HTTP = "coap2http";
+
+	private static String start;
+
+	private CoapServer coapProxyServer;
+	private EndpointPool pool;
+	private ProxyHttpServer httpServer;
+	private int coapPort;
+	private int httpPort;
+
+	public CrossExampleProxy2(NetworkConfig config) throws IOException {
+		coapPort = config.getInt(Keys.COAP_PORT);
+		httpPort = config.getInt(Keys.HTTP_PORT);
+		int threads = config.getInt(NetworkConfig.Keys.PROTOCOL_STAGE_THREAD_COUNT);
+		ScheduledExecutorService mainExecutor = ExecutorsUtil.newScheduledThreadPool(threads,
+				new DaemonThreadFactory("Proxy#"));
+		ScheduledExecutorService secondaryExecutor = ExecutorsUtil.newDefaultSecondaryScheduler("ProxyTimer#");
+		Coap2CoapTranslator translater = new Coap2CoapTranslator();
+		NetworkConfig outgoingConfig = new NetworkConfig(config);
+		outgoingConfig.setInt(NetworkConfig.Keys.NETWORK_STAGE_RECEIVER_THREAD_COUNT, 1);
+		outgoingConfig.setInt(NetworkConfig.Keys.NETWORK_STAGE_SENDER_THREAD_COUNT, 1);
+		pool = new EndpointPool(1000, 250, outgoingConfig, mainExecutor, secondaryExecutor);
+		ProxyCoapResource coap2coap = new ProxyCoapClientResource(COAP2COAP, false, true, translater, pool);
+		ProxyCoapResource coap2http = new ProxyHttpClientResource(COAP2HTTP, false, true, new Coap2HttpTranslator());
+
+		// Forwards requests Coap to Coap or Coap to Http server
+		coapProxyServer = new CoapServer(config, coapPort);
+		MessageDeliverer local = coapProxyServer.getMessageDeliverer();
+		ProxyMessageDeliverer proxyMessageDeliverer = new ProxyMessageDeliverer(coapProxyServer.getRoot(), translater);
+		proxyMessageDeliverer.addProxyCoapResources(coap2coap, coap2http);
+		proxyMessageDeliverer.addExposedServiceAddresses(new InetSocketAddress(coapPort));
+		coapProxyServer.setMessageDeliverer(proxyMessageDeliverer);
+		coapProxyServer.setExecutors(mainExecutor, secondaryExecutor, false);
+		coapProxyServer.add(coap2http);
+		coapProxyServer.add(coap2coap);
+		coapProxyServer.add(new SimpleCoapResource("target",
+				"Hi! I am the local coap server on port " + coapPort + ". Request %d."));
+
+		CoapResource targets = new CoapResource("targets");
+		coapProxyServer.add(targets);
+
+		// HTTP Proxy which forwards http request to coap server and forwards
+		// translated coap response back to http client
+		httpServer = new ProxyHttpServer(config, 8080);
+		httpServer.setHttpTranslator(new Http2CoapTranslator());
+		httpServer.setLocalCoapDeliverer(local);
+		httpServer.setProxyCoapDeliverer(proxyMessageDeliverer);
+		httpServer.start();
+		System.out.println("** HTTP Local at: http://localhost:" + httpPort + "/local/");
+		System.out.println("** HTTP Proxy at: http://localhost:" + httpPort + "/proxy/");
+
+		coapProxyServer.add(httpServer.getStatistics());
+		coapProxyServer.start();
+		System.out.println("** CoAP Proxy at: coap://localhost:" + coapPort + "/coap2http");
+		System.out.println("** CoAP Proxy at: coap://localhost:" + coapPort + "/coap2coap");
+	}
+
+	public static void main(String args[]) throws IOException {
+		NetworkConfig proxyConfig = NetworkConfig.createWithFile(CONFIG_FILE, CONFIG_HEADER, DEFAULTS);
+		CrossExampleProxy2 proxy = new CrossExampleProxy2(proxyConfig);
+		NetworkConfig config = ExampleCoapServer.init();
+		for (int index = 0; index < args.length; ++index) {
+			Integer port = parse(args[index], "coap", ExampleCoapServer.DEFAULT_COAP_PORT, config,
+					NetworkConfig.Keys.COAP_PORT);
+			if (port != null) {
+				new ExampleCoapServer(config, port);
+
+				// reverse proxy: add a proxy resource with a translator returning a fixed destination URI
+				final URI uri = URI.create("coap://localhost:" + port + "/coap-target");
+				proxy.coapProxyServer.getRoot().getChild("targets")
+						.add(new ProxyCoapClientResource("destination1", true, true, new Coap2CoapTranslator() {
+
+							@Override
+							public URI getDestinationURI(Request incomingRequest, InetSocketAddress exposed)
+									throws TranslationException {
+								return uri;
+							}
+						}, proxy.pool));
+
+				System.out.println("CoAP Proxy at: coap://localhost:" + proxy.coapPort
+						+ "/coap2coap and demo-server at coap://localhost:" + port + ExampleCoapServer.RESOURCE);
+				System.out.println("HTTP Proxy at: http://localhost:" + proxy.httpPort + "/proxy/coap://localhost:"
+						+ port + ExampleCoapServer.RESOURCE);
+			} else {
+				port = parse(args[index], "http", ExampleHttpServer.DEFAULT_PORT, null, null);
+				if (port != null) {
+					new ExampleHttpServer(config, port);
+					// reverse proxy: add a proxy resource with a translator returning a fixed destination URI
+					final URI uri = URI.create("http://localhost:" + port + "/http-target");
+					proxy.coapProxyServer.getRoot().getChild("targets")
+							.add(new ProxyHttpClientResource("destination2", true, true, new Coap2HttpTranslator() {
+
+								@Override
+								public URI getDestinationURI(Request incomingRequest, InetSocketAddress exposed)
+										throws TranslationException {
+									return uri;
+								}
+							}));
+
+					System.out.println("CoAP Proxy at: coap://localhost:" + proxy.coapPort
+							+ "/coap2http and demo server at http://localhost:" + port + ExampleHttpServer.RESOURCE);
+				}
+			}
+		}
+		startManagamentStatistic();
+		Runtime runtime = Runtime.getRuntime();
+		long max = runtime.maxMemory();
+		System.out.println(
+				CrossExampleProxy2.class.getSimpleName() + " started (" + max / (1024 * 1024) + "MB heap) ...");
+		long lastGcCount = 0;
+		for (;;) {
+			try {
+				Thread.sleep(15000);
+			} catch (InterruptedException e) {
+				break;
+			}
+			long used = runtime.totalMemory() - runtime.freeMemory();
+			int fill = (int) ((used * 100L) / max);
+			if (fill > 80) {
+				System.out.println("Maxium heap size: " + max / (1024 * 1024) + "M " + fill + "% used.");
+				System.out.println("Heap may exceed! Enlarge the maxium heap size.");
+				System.out.println("Or consider to reduce the value of " + Keys.EXCHANGE_LIFETIME);
+				System.out.println("in \"" + CONFIG_FILE + "\" or set");
+				System.out.println(Keys.DEDUPLICATOR + " to " + Keys.NO_DEDUPLICATOR + " there.");
+				break;
+			}
+			long gcCount = 0;
+			for (GarbageCollectorMXBean gcMXBean : ManagementFactory.getGarbageCollectorMXBeans()) {
+				long count = gcMXBean.getCollectionCount();
+				if (0 < count) {
+					gcCount += count;
+				}
+			}
+			if (lastGcCount < gcCount) {
+				printManagamentStatistic();
+				lastGcCount = gcCount;
+			}
+		}
+
+	}
+
+	private static Integer parse(String arg, String prefix, int defaultValue, NetworkConfig config, String key) {
+		Integer result = null;
+		if (arg.startsWith(prefix)) {
+			arg = arg.substring(prefix.length());
+			if (arg.isEmpty()) {
+				if (config == null || key == null) {
+					result = defaultValue;
+				} else {
+					result = config.getInt(key, defaultValue);
+				}
+			} else if (arg.startsWith("=")) {
+				arg = arg.substring(1);
+				result = Integer.decode(arg);
+			}
+		}
+		return result;
+	}
+
+	private static class SimpleCoapResource extends CoapResource {
+
+		private final String value;
+
+		private final AtomicInteger counter = new AtomicInteger();
+
+		public SimpleCoapResource(String name, String value) {
+			// set the resource hidden
+			super(name);
+			getAttributes().setTitle("Simple local coap resource.");
+			this.value = value;
+		}
+
+		public void handleGET(CoapExchange exchange) {
+			exchange.setMaxAge(0);
+			exchange.respond(ResponseCode.CONTENT, String.format(value, counter.incrementAndGet()),
+					MediaTypeRegistry.TEXT_PLAIN);
+		}
+	}
+
+	private static void startManagamentStatistic() {
+		ThreadMXBean mxBean = ManagementFactory.getThreadMXBean();
+		if (mxBean.isThreadCpuTimeSupported() && !mxBean.isThreadCpuTimeEnabled()) {
+			mxBean.setThreadCpuTimeEnabled(true);
+		}
+		RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
+		start = new Date(runtimeMXBean.getStartTime()).toString();
+	}
+
+	private static void printManagamentStatistic() {
+		OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();
+		int processors = osMxBean.getAvailableProcessors();
+		RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
+		Logger logger = STATISTIC_LOGGER;
+		logger.info("{} processors, started {}, up {}", processors, start, formatTime(runtimeMXBean.getUptime()));
+		ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
+		if (threadMxBean.isThreadCpuTimeSupported() && threadMxBean.isThreadCpuTimeEnabled()) {
+			long alltime = 0;
+			long[] ids = threadMxBean.getAllThreadIds();
+			for (long id : ids) {
+				long time = threadMxBean.getThreadCpuTime(id);
+				if (0 < time) {
+					alltime += time;
+				}
+			}
+			long pTime = alltime / processors;
+			logger.info("cpu-time: {} ms (per-processor: {} ms)", TimeUnit.NANOSECONDS.toMillis(alltime),
+					TimeUnit.NANOSECONDS.toMillis(pTime));
+		}
+		long gcCount = 0;
+		long gcTime = 0;
+		for (GarbageCollectorMXBean gcMxBean : ManagementFactory.getGarbageCollectorMXBeans()) {
+			long count = gcMxBean.getCollectionCount();
+			if (0 < count) {
+				gcCount += count;
+			}
+			long time = gcMxBean.getCollectionTime();
+			if (0 < time) {
+				gcTime += time;
+			}
+		}
+		logger.info("gc: {} ms, {} calls", gcTime, gcCount);
+		double loadAverage = osMxBean.getSystemLoadAverage();
+		if (!(loadAverage < 0.0d)) {
+			logger.info("average load: {}", String.format("%.2f", loadAverage));
+		}
+	}
+
+	private static String formatTime(long millis) {
+		long time = millis;
+		if (time < 10000) {
+			return time + " [ms]";
+		}
+		time /= 100; // 1/10s
+		if (time < 10000) {
+			return (time / 10) + "." + (time % 10) + " [s]";
+		}
+		time /= 10;
+		long seconds = time % 60;
+		time /= 60;
+		long minutes = time % 60;
+		time /= 60;
+		long hours = time % 24;
+		time /= 24; // days
+		if (time > 0) {
+			return String.format("%d:%02d:%02d:%02d [d:hh:mm:ss]", time, hours, minutes, seconds);
+		} else {
+			return String.format("%d:%02d:%02d [h:mm:ss]", hours, minutes, seconds);
+		}
+	}
+}

--- a/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/ExampleCoapServer.java
+++ b/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/ExampleCoapServer.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.examples;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.config.NetworkConfigDefaultHandler;
+import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+
+/**
+ * Example CoAP server for proxy demonstration.
+ * 
+ * {@link coap://localhost:5683/coap-target}
+ */
+public class ExampleCoapServer {
+	/**
+	 * File name for network configuration.
+	 */
+	private static final File CONFIG_FILE = new File("CaliforniumDemo.properties");
+	/**
+	 * Header for network configuration.
+	 */
+	private static final String CONFIG_HEADER = "Californium CoAP Properties file for Proxy Demo-Server";
+
+	public static final String RESOURCE = "/coap-target";
+
+	public static final int DEFAULT_COAP_PORT = 5685;
+
+	/**
+	 * Special network configuration defaults handler.
+	 */
+	private static final NetworkConfigDefaultHandler DEFAULTS = new NetworkConfigDefaultHandler() {
+
+		@Override
+		public void applyDefaults(NetworkConfig config) {
+			config.setInt(Keys.COAP_PORT, DEFAULT_COAP_PORT);
+		}
+	};
+
+	private CoapServer coapServer;
+
+	public ExampleCoapServer(NetworkConfig config, final int port) throws IOException {
+		String path = RESOURCE;
+		if (path.startsWith("/")) {
+			path = path.substring(1);
+		}
+		// Create CoAP Server on PORT with a target resource
+		coapServer = new CoapServer(config, port);
+		coapServer.add(new CoapResource(path) {
+
+			private final AtomicInteger counter = new AtomicInteger();
+
+			@Override
+			public void handleGET(CoapExchange exchange) {
+				exchange.setMaxAge(0);
+				exchange.respond(ResponseCode.CONTENT,
+						"Hi! I am the coap server on port " + port + ". Request " + counter.incrementAndGet() + ".",
+						MediaTypeRegistry.TEXT_PLAIN);
+			}
+
+		});
+		coapServer.start();
+		System.out.println("Started CoAP server on port " + port);
+		System.out.println("Request: coap://localhost:" + port + RESOURCE);
+	}
+
+	public static NetworkConfig init() {
+		return NetworkConfig.createWithFile(CONFIG_FILE, CONFIG_HEADER, DEFAULTS);
+	}
+
+	public static void main(String arg[]) throws IOException {
+		NetworkConfig config = init();
+		int port;
+		if (arg.length > 0) {
+			port = Integer.parseInt(arg[0]);
+		} else {
+			port = config.getInt(NetworkConfig.Keys.COAP_PORT);
+		}
+		new ExampleCoapServer(config, port);
+	}
+}

--- a/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/ExampleHttpServer.java
+++ b/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/ExampleHttpServer.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+
+package org.eclipse.californium.examples;
+
+import java.io.IOException;
+
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.proxy2.HttpServer;
+
+/**
+ * Example HTTP server for proxy demonstration.
+ * 
+ * {@link http://localhost:8000/http-target}
+ */
+public class ExampleHttpServer {
+
+	public static final int DEFAULT_PORT = 8000;
+	public static final String RESOURCE = "/http-target";
+
+	public ExampleHttpServer(NetworkConfig config, final int httpPort) throws IOException {
+		HttpServer server = new HttpServer(config, httpPort);
+		server.setSimpleResource(RESOURCE, "Hi! I am the Http Server on port %d. Request %d.", null);
+		server.start();
+	}
+
+	public static void main(String arg[]) throws IOException {
+		// NetworkConfig HTTP_PORT is used for proxy
+		NetworkConfig config = NetworkConfig.getStandard();
+		int port = DEFAULT_PORT;
+		if (arg.length > 0) {
+			port = Integer.parseInt(arg[0]);
+		}
+		new ExampleHttpServer(config, port);
+	}
+}

--- a/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/ExampleProxy2CoapClient.java
+++ b/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/ExampleProxy2CoapClient.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+
+package org.eclipse.californium.examples;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+import org.eclipse.californium.core.CoapClient;
+import org.eclipse.californium.core.CoapResponse;
+import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.californium.elements.exception.ConnectorException;
+import org.eclipse.californium.proxy2.resources.ProxyHttpClientResource;
+
+/**
+ * Class ExampleProxyCoapClient. <br/>
+ * Example CoAP client which sends a request to Proxy Coap server with a
+ * {@link ProxyHttpClientResource} to get the response from HttpServer. <br/>
+ * 
+ * For testing Coap2Http:<br/>
+ * Destination: localhost:5683 (proxy's address)<br/>
+ * Coap Uri: {@code coap://localhost:8000/http-target}<br/>
+ * Proxy Scheme: {@code http}.
+ * 
+ * or <br/>
+ * 
+ * Destination: localhost:5683 (proxy's address)<br/>
+ * Proxy Uri: {@code http://user@localhost:8000/http-target}.<br/>
+ * 
+ * For testing Coap2coap: <br/>
+ * Destination: localhost:5683 (proxy's address)<br/>
+ * Coap Uri: {@code coap://localhost:5685/coap-target}.<br/>
+ * 
+ * Deprecated modes:<br/>
+ * Uri: {@code coap://localhost:8000/coap2http}. <br/>
+ * Proxy Uri: {@code http://localhost:8000/http-target}.<br/>
+ * 
+ * For testing Coap2coap: <br/>
+ * Uri: {@code coap://localhost:5683/coap2coap}. <br/>
+ * Proxy Uri: {@code coap://localhost:5685/coap-target}.<br/>
+ * 
+ */
+public class ExampleProxy2CoapClient {
+
+	private static final int PROXY_PORT = 5683;
+
+	private static void request(CoapClient client, Request request) {
+		try {
+			CoapResponse response = client.advanced(request);
+			if (response != null) {
+				int format = response.getOptions().getContentFormat();
+				if (format != MediaTypeRegistry.TEXT_PLAIN && format != MediaTypeRegistry.UNDEFINED) {
+					System.out.print(MediaTypeRegistry.toString(format));
+				}
+				String text = response.getResponseText();
+				if (text.isEmpty()) {
+					System.out.println(response.getCode() + "/" + response.getCode().name());
+				} else {
+					System.out.println(response.getCode() + "/" + response.getCode().name() + " --- "
+							+ response.getResponseText());
+				}
+			}
+		} catch (ConnectorException | IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public static void main(String[] args) {
+
+		CoapClient client = new CoapClient();
+		// deprecated proxy request - use CoAP and Proxy URI together
+		Request request = Request.newGet();
+		request.setURI("coap://localhost:" + PROXY_PORT + "/coap2http");
+		// set proxy URI in option set to bypass the CoAP/proxy URI exclusion
+		request.getOptions().setProxyUri("http://localhost:8000/http-target");
+		request(client, request);
+
+		// deprecated proxy request - use CoAP and Proxy URI together
+		request = Request.newGet();
+		request.setURI("coap://localhost:" + PROXY_PORT + "/coap2coap");
+		// set proxy URI in option set to bypass the CoAP/proxy URI exclusion
+		request.getOptions().setProxyUri("coap://localhost:5685/coap-target");
+		request(client, request);
+
+		AddressEndpointContext proxy = new AddressEndpointContext(new InetSocketAddress("localhost", PROXY_PORT));
+		// RFC7252 proxy request - use CoAP-URI, proxy scheme, and destination to proxy
+		request = Request.newGet();
+		request.setDestinationContext(proxy);
+		request.setURI("coap://localhost:8000/http-target");
+		request.setProxyScheme("http");
+		request(client, request);
+
+		// RFC7252 proxy request - use CoAP-URI, and destination to proxy
+		request = Request.newGet();
+		request.setDestinationContext(proxy);
+		request.setURI("coap://localhost:5685/coap-target");
+		request(client, request);
+
+		// RFC7252 proxy request - use Proxy-URI, and destination to proxy
+		request = Request.newGet();
+		request.setDestinationContext(proxy);
+		request.setProxyUri("http://user@localhost:8000/http-target");
+		request.setType(Type.NON);
+		request(client, request);
+
+		// RFC7252 proxy request - use CoAP-URI, and destination to proxy
+		request = Request.newGet();
+		request.setDestinationContext(proxy);
+		request.setURI("coap://localhost:5683/coap-target");
+		request(client, request);
+
+		// RFC7252 reverse proxy request
+		request = Request.newGet();
+		request.setURI("coap://localhost:5683/targets/destination1");
+		request(client, request);
+
+		request = Request.newGet();
+		request.setURI("coap://localhost:5683/targets/destination2");
+		request(client, request);
+
+		client.shutdown();
+	}
+}

--- a/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/ExampleProxy2HttpClient.java
+++ b/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/ExampleProxy2HttpClient.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+
+package org.eclipse.californium.examples;
+
+import java.io.IOException;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.eclipse.californium.proxy2.ProxyHttpServer;
+
+/**
+ * Class ExampleProxyHttpClient.<br/>
+ * 
+ * Example proxy Http client which sends a request via {@link ProxyHttpServer}
+ * to a coap-server.<br/>
+ * 
+ * Http2Coap Uri:<br/>
+ * <a href=
+ * "http://localhost:8080/proxy/coap://localhost:5685/coap-target">http://localhost:8080/proxy/coap://localhost:5685/coap-target</a>.
+ */
+public class ExampleProxy2HttpClient {
+
+	private static void request(HttpClient client, String uri) {
+		try {
+			HttpGet request = new HttpGet(uri);
+			HttpResponse response = client.execute(request);
+			System.out.println(EntityUtils.toString(response.getEntity()));
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public static void main(String[] args) {
+		HttpClient client = HttpClientBuilder.create().build();
+		request(client, "http://localhost:8080/proxy/coap://localhost:5685/coap-target");
+		// keep the "coap://" after normalize the URI requires to use %2f%2f instead of //
+		request(client, "http://localhost:8080/proxy/coap:%2f%2flocalhost:5685/coap-target");
+		request(client, "http://localhost:8080/proxy?target_uri=coap://localhost:5685/coap-target");
+
+		// not really intended, http2http
+		request(client, "http://localhost:8080/proxy/http:%2f%2flocalhost:8000/http-target");
+
+		// request to local (in same process) coap-server
+		request(client, "http://localhost:8080/local/target");
+
+		// http-request via proxy
+		HttpHost proxy = new HttpHost("localhost", 8080, "http");
+		client = HttpClientBuilder.create().setProxy(proxy).build();
+		request(client, "http://localhost:5685/coap-target/coap:");
+	}
+}

--- a/demo-apps/cf-proxy2/src/main/resources/logback.xml
+++ b/demo-apps/cf-proxy2/src/main/resources/logback.xml
@@ -1,0 +1,21 @@
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder 
+			by default -->
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} %level [%logger{0}]: %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="org.eclipse.californium.proxy" level="INFO" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+
+	<!-- Strictly speaking, the level attribute is not necessary since -->
+	<!-- the level of the root level is set to DEBUG by default. -->
+	<root level="WARN">
+		<appender-ref ref="STDOUT" />
+	</root>
+
+</configuration>

--- a/demo-apps/pom.xml
+++ b/demo-apps/pom.xml
@@ -29,6 +29,7 @@
 		<module>cf-plugtest-client</module>
 		<module>cf-plugtest-server</module>
 		<module>cf-proxy</module>
+		<module>cf-proxy2</module>
 		<module>cf-secure</module>
 		<module>cf-simplefile-server</module>
 		<module>cf-unix-setup</module>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,11 @@
 			</dependency>
 			<dependency>
 				<groupId>${project.groupId}</groupId>
+				<artifactId>californium-proxy2</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>${project.groupId}</groupId>
 				<artifactId>cf-nat</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -258,6 +263,7 @@
 		<module>californium-core</module>
 		<module>californium-integration-tests</module>
 		<module>californium-proxy</module>
+		<module>californium-proxy2</module>
 		<module>californium-osgi</module>
 		<module>demo-apps</module>
 		<module>demo-certs</module>


### PR DESCRIPTION
Add new modules with a new proxy implementation.
Supports reading URI not only from the proxy-URI option, it also supports the other RFC 7252 variants with proxy-scheme, URI-host, URI-port, URI-path, and URI-query option.
Introduce flexible translators, e.g. to inject a "fixed destination" to support reverse-proxy implementations. Split http-translator in coap2http, http2coap and a common http-translater, which uses the configurable mapping properties to map http an coap values. 
Update used apache-http libraries.
Add example clients, more elaborated example cross poxy, including a simple examples http-server and coap-server. 

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>