### PR TITLE
Fix requests extra options

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/OptionSet.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/OptionSet.java
@@ -78,10 +78,17 @@ public final class OptionSet {
 	private Integer      size1;
 	private Integer      size2;
 	private Integer      observe;
-	private byte[]		 oscore;
+	private byte[]       oscore;
 
 	// Arbitrary options
 	private List<Option> others;
+
+	/**
+	 * {@code true} if URI-path or URI-query are set independent from
+	 * {@link Request#setURI}. Preserve them from being cleand up, if the URI
+	 * doesn't contain them.
+	 */
+	private boolean      explicitUriOptions;
 
 	// TODO: When receiving, uri_host/port should be those from the sender 
 	/**
@@ -454,7 +461,7 @@ public final class OptionSet {
 	public OptionSet setUriPort(int port) {
 		if (port < 0 || (1<<16)-1 < port)
 			throw new IllegalArgumentException("URI port option must be between 0 and "+((1<<16)-1)+" (2 bytes) inclusive but was "+port);
-		uri_port = port;
+		this.uri_port = port;
 		return this;
 	}
 
@@ -644,6 +651,7 @@ public final class OptionSet {
 	public OptionSet addUriPath(String segment) {
 		checkOptionValue(segment, 0, 255, "Uri-Path");
 		getUriPath().add(segment);
+		this.explicitUriOptions = true;
 		return this;
 	}
 
@@ -819,6 +827,7 @@ public final class OptionSet {
 	public OptionSet addUriQuery(String argument) {
 		checkOptionValue(argument, 0, 255, "Uri-Query");
 		getUriQuery().add(argument);
+		this.explicitUriOptions = true;
 		return this;
 	}
 
@@ -1455,6 +1464,14 @@ public final class OptionSet {
 
 		Collections.sort(options);
 		return options;
+	}
+
+	boolean hasExplicitUriOptions() {
+		return explicitUriOptions;
+	}
+
+	void resetExplicitUriOptions() {
+		explicitUriOptions = false;
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -408,6 +408,15 @@ public class Request extends Message {
 	 * strict proxy/CoAP URI exclusion for backwards compatibility, set the
 	 * options directly in the optons-set using {@link #getOptions()}.
 	 * </p>
+	 * Note: if uri-path of uri-query option was set explicitly before, they are
+	 * not cleaned up, if the URI doesn't contain that part. e.g.
+	 * {@code request.getOptions().setUriQuery("param=2")} and
+	 * {@code request.setURI("coap://host/path")} results in
+	 * {@code "coap://host/path?param=2"}. But
+	 * {@code request.getOptions().setUriQuery("param=2")} and
+	 * {@code request.setURI("coap://host/path?mark")} results in
+	 * {@code "coap://host/path?mark"}. That will be removed in the next major
+	 * version! Don't set uri-path or uri-query options before the URI!
 	 * 
 	 * Provides a fluent API to chain setters.
 	 * 
@@ -450,6 +459,15 @@ public class Request extends Message {
 	 * strict proxy/CoAP URI exclusion for backwards compatibility, set the
 	 * options directly in the optons-set using {@link #getOptions()}.
 	 * </p>
+	 * Note: if uri-path of uri-query option was set explicitly before, they are
+	 * not cleaned up, if the URI doesn't contain that part. e.g.
+	 * {@code request.getOptions().setUriQuery("param=2")} and
+	 * {@code request.setURI("coap://host/path")} results in
+	 * {@code "coap://host/path?param=2"}. But
+	 * {@code request.getOptions().setUriQuery("param=2")} and
+	 * {@code request.setURI("coap://host/path?mark")} results in
+	 * {@code "coap://host/path?mark"}. That will be removed in the next major
+	 * version! Don't set uri-path or uri-query options before the URI!
 	 * 
 	 * Provides a fluent API to chain setters.
 	 * 
@@ -504,6 +522,15 @@ public class Request extends Message {
 	 * strict proxy/CoAP URI exclusion for backwards compatibility, set the
 	 * options directly in the optons-set using {@link #getOptions()}.
 	 * </p>
+	 * Note: if uri-path of uri-query option was set explicitly before, they are
+	 * not cleaned up, if the URI doesn't contain that part. e.g.
+	 * {@code request.getOptions().setUriQuery("param=2")} and
+	 * {@code request.setURI("coap://host/path")} results in
+	 * {@code "coap://host/path?param=2"}. But
+	 * {@code request.getOptions().setUriQuery("param=2")} and
+	 * {@code request.setURI("coap://host/path?mark")} results in
+	 * {@code "coap://host/path?mark"}. That will be removed in the next major
+	 * version! Don't set uri-path or uri-query options before the URI!
 	 * 
 	 * Provides a fluent API to chain setters.
 	 * 
@@ -579,6 +606,7 @@ public class Request extends Message {
 			throw new NullPointerException("destination address must not be null!");
 		}
 		OptionSet options = getOptions();
+		boolean explicitUriOption = options.hasExplicitUriOptions();
 		String host = uri.getHost();
 
 		if (host != null) {
@@ -628,15 +656,18 @@ public class Request extends Message {
 		String path = uri.getPath();
 		if (path != null && path.length() > 1) {
 			options.setUriPath(path);
-		} else {
+		} else if (!explicitUriOption) {
 			options.clearUriPath();
 		}
 		// set Uri-Query options
 		String query = uri.getQuery();
 		if (query != null) {
 			options.setUriQuery(query);
-		} else {
+		} else if (!explicitUriOption) {
 			options.clearUriQuery();
+		}
+		if (!explicitUriOption) {
+			options.resetExplicitUriOptions();
 		}
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/coap/RequestTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/coap/RequestTest.java
@@ -241,6 +241,26 @@ public class RequestTest {
 		assertThat(req.getDestinationContext().getPeerAddress().getPort(), is(CoAP.DEFAULT_COAP_SECURE_PORT));
 	}
 
+	@Test
+	public void testSetURITwice() throws UnknownHostException {
+
+		Request req = Request.newGet();
+
+		req.setURI("coap://192.168.0.1/test?param");
+		assertThat(req.getOptions().getUriPathString(), is("test"));
+		assertThat(req.getOptions().getUriQueryString(), is("param"));
+
+		req.setURI("coap://192.168.0.1/test2");
+		assertThat(req.getOptions().getUriPathString(), is("test2"));
+		assertThat(req.getOptions().getURIQueryCount(), is(0));
+
+		// only for 2.x.y, in 3.x.y the uri-query option must be set after the URI  
+		req.getOptions().addUriQuery("param2");
+		req.setURI("coap://192.168.0.1/test2");
+		assertThat(req.getOptions().getUriPathString(), is("test2"));
+		assertThat(req.getOptions().getUriQueryString(), is("param2"));
+	}
+
 	@Test(expected = IllegalStateException.class)
 	public void testSetOptionsFailsIfDestinationIsNotSet() {
 		Request.newGet().setOptions(URI.create("coap://iot.eclipse.org"));

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL02.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL02.java
@@ -38,10 +38,8 @@ public class CL02 extends TestClientAbstract {
 
 		// create the request
 		Request request = new Request(Code.GET, Type.CON);
-		// set query
-		request.getOptions().addUriQuery(EXPECTED_RT);
 		// set the parameters and execute the request
-		executeRequest(request, serverURI, RESOURCE_URI);
+		executeRequest(request, serverURI, RESOURCE_URI + "?" + EXPECTED_RT);
 	}
 
 	protected boolean checkResponse(Request request, Response response) {

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL03.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL03.java
@@ -38,10 +38,8 @@ public class CL03 extends TestClientAbstract {
 
 		// create the request
 		Request request = new Request(Code.GET, Type.CON);
-		// set query
-		request.getOptions().addUriQuery(EXPECTED_RT);
 		// set the parameters and execute the request
-		executeRequest(request, serverURI, RESOURCE_URI);
+		executeRequest(request, serverURI, RESOURCE_URI + "?" + EXPECTED_RT);
 	}
 
 	protected boolean checkResponse(Request request, Response response) {

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL04.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL04.java
@@ -38,10 +38,8 @@ public class CL04 extends TestClientAbstract {
 
 		// create the request
 		Request request = new Request(Code.GET, Type.CON);
-		// set query
-		request.getOptions().addUriQuery(EXPECTED_RT);
 		// set the parameters and execute the request
-		executeRequest(request, serverURI, RESOURCE_URI);
+		executeRequest(request, serverURI, RESOURCE_URI + "?" + EXPECTED_RT);
 	}
 
 	protected boolean checkResponse(Request request, Response response) {

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL05.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL05.java
@@ -39,10 +39,8 @@ public class CL05 extends TestClientAbstract {
 
 		// create the request
 		Request request = new Request(Code.GET, Type.CON);
-		// set query
-		request.getOptions().addUriQuery(EXPECTED_IF);
 		// set the parameters and execute the request
-		executeRequest(request, serverURI, RESOURCE_URI);
+		executeRequest(request, serverURI, RESOURCE_URI + "?" + EXPECTED_IF);
 	}
 
 	protected boolean checkResponse(Request request, Response response) {

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL06.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL06.java
@@ -39,10 +39,8 @@ public class CL06 extends TestClientAbstract {
 
 		// create the request
 		Request request = new Request(Code.GET, Type.CON);
-		// set query
-		request.getOptions().addUriQuery(EXPECTED_SZ);
 		// set the parameters and execute the request
-		executeRequest(request, serverURI, RESOURCE_URI);
+		executeRequest(request, serverURI, RESOURCE_URI + "?" + EXPECTED_SZ);
 	}
 
 	protected boolean checkResponse(Request request, Response response) {

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL07.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL07.java
@@ -39,10 +39,8 @@ public class CL07 extends TestClientAbstract {
 
 		// create the request
 		Request request = new Request(Code.GET, Type.CON);
-		// set query
-		request.getOptions().addUriQuery(EXPECTED_HREF);
 		// set the parameters and execute the request
-		executeRequest(request, serverURI, RESOURCE_URI);
+		executeRequest(request, serverURI, RESOURCE_URI + "?" + EXPECTED_HREF);
 	}
 
 	protected boolean checkResponse(Request request, Response response) {

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL08.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL08.java
@@ -39,10 +39,8 @@ public class CL08 extends TestClientAbstract {
 
 		// create the request
 		Request request = new Request(Code.GET, Type.CON);
-		// set query
-		request.getOptions().addUriQuery(EXPECTED_HREF);
 		// set the parameters and execute the request
-		executeRequest(request, serverURI, RESOURCE_URI);
+		executeRequest(request, serverURI, RESOURCE_URI + "?" + EXPECTED_HREF);
 	}
 
 	protected boolean checkResponse(Request request, Response response) {

--- a/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL09.java
+++ b/demo-apps/cf-plugtest-checker/src/main/java/org/eclipse/californium/plugtests/tests/CL09.java
@@ -44,8 +44,8 @@ public class CL09 extends TestClientAbstract {
 
 		// create the request
 		Request request = new Request(Code.GET, Type.CON);
-		request.getOptions().addUriQuery(URI_QUERY);
-		executeRequest(request, serverURI, RESOURCE_URI);
+//		request.getOptions().addUriQuery(URI_QUERY);
+		executeRequest(request, serverURI, RESOURCE_URI + "?" + URI_QUERY);
 	}
 
 	@Override


### PR DESCRIPTION
Ensure backwards compatibility for request setting uri-path or uri-query
before URI.

Plugtest failed after cleanup Request. This enable to set the uri-query
before the URI again. Will be changed for 3.0.0, which requires then to
set the URI before additional options.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>
