### PR TITLE
Fix reregistration leak.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.eclipse.californium.core.coap.InternalMessageObserver;
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.MessageObserver;
 import org.eclipse.californium.core.coap.Request;
@@ -158,9 +159,14 @@ public class CoapObserveRelation {
 			refresh.setOptions(request.getOptions());
 
 			// use same message observers
-			for (MessageObserver mo : request.getMessageObservers()) {
-				request.removeMessageObserver(mo);
-				refresh.addMessageObserver(mo);
+			for (MessageObserver observer : request.getMessageObservers()) {
+				if (observer instanceof InternalMessageObserver) {
+					if (((InternalMessageObserver) observer).isInternal()) {
+						continue;
+					}
+				}
+				request.removeMessageObserver(observer);
+				refresh.addMessageObserver(observer);
 			}
 
 			this.request = refresh;

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/InternalMessageObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/InternalMessageObserver.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.core.coap;
+
+import org.eclipse.californium.elements.util.PublicAPIExtension;
+
+/**
+ * Additional interface for {@link MessageObserver}, to prevent a message
+ * observer from being moved for reregistration.
+ */
+@PublicAPIExtension(type = MessageObserver.class)
+public interface InternalMessageObserver {
+
+	/**
+	 * Check, if observer is internal and is not intended to be cloned.
+	 * 
+	 * @return {@code true}, internal, {@code false}, maybe cloned.
+	 */
+	boolean isInternal();
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/InternalMessageObserverAdapter.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/InternalMessageObserverAdapter.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.core.coap;
+
+/**
+ * InternalMessageObserverAdapter to prevent a message observer from being moved
+ * for reregistration.
+ */
+public abstract class InternalMessageObserverAdapter extends MessageObserverAdapter implements InternalMessageObserver {
+
+	@Override
+	public boolean isInternal() {
+		return true;
+	}
+
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/BaseMatcher.java
@@ -70,8 +70,8 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.eclipse.californium.core.coap.InternalMessageObserverAdapter;
 import org.eclipse.californium.core.coap.CoAP;
-import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.Token;
@@ -294,7 +294,7 @@ public abstract class BaseMatcher implements Matcher {
 	 * Message observer removing observations. May be shared by multiple (block)
 	 * request and will call {@link ObservationStore#remove(Token)} only once.
 	 */
-	private class ObservationObserverAdapter extends MessageObserverAdapter {
+	private class ObservationObserverAdapter extends InternalMessageObserverAdapter {
 
 		/**
 		 * Flag to suppress multiple observation store remove calls.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -92,10 +92,10 @@ import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.CoAPMessageFormatException;
 import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.InternalMessageObserverAdapter;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.MessageFormatException;
 import org.eclipse.californium.core.coap.MessageObserver;
-import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.Token;
@@ -455,7 +455,7 @@ public class CoapEndpoint implements Endpoint, MessagePostProcessInterceptors {
 		}
 		if (enableHealth) {
 			this.health = health;
-			this.requestTransmission = new MessageObserverAdapter() {
+			this.requestTransmission = new InternalMessageObserverAdapter() {
 
 				@Override
 				public void  onSendError(Throwable error) {
@@ -468,7 +468,7 @@ public class CoapEndpoint implements Endpoint, MessagePostProcessInterceptors {
 				}
 			};
 
-			this.responseTransmission = new MessageObserverAdapter() {
+			this.responseTransmission = new InternalMessageObserverAdapter() {
 				@Override
 				public void  onSendError(Throwable error) {
 					CoapEndpoint.this.health.sendError();
@@ -479,7 +479,7 @@ public class CoapEndpoint implements Endpoint, MessagePostProcessInterceptors {
 					CoapEndpoint.this.health.sentResponse(retransmission);
 				}
 			};
-			this.rejectTransmission = new MessageObserverAdapter() {
+			this.rejectTransmission = new InternalMessageObserverAdapter() {
 				@Override
 				public void  onSendError(Throwable error) {
 					CoapEndpoint.this.health.sendError();

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CleanupMessageObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CleanupMessageObserver.java
@@ -19,10 +19,11 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
-import org.eclipse.californium.core.coap.MessageObserverAdapter;
+import org.eclipse.californium.core.coap.InternalMessageObserverAdapter;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.elements.util.NoPublicAPI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,8 @@ import org.slf4j.LoggerFactory;
  * Cleanup exchange when user cancelled outgoing requests or messages which
  * failed to be send.
  */
-public class CleanupMessageObserver extends MessageObserverAdapter {
+@NoPublicAPI
+public class CleanupMessageObserver extends InternalMessageObserverAdapter {
 
 	protected static final Logger LOGGER = LoggerFactory.getLogger(CleanupMessageObserver.class);
 
@@ -38,6 +40,11 @@ public class CleanupMessageObserver extends MessageObserverAdapter {
 
 	protected CleanupMessageObserver(final Exchange exchange) {
 		this.exchange = exchange;
+	}
+
+	@Override
+	public boolean isInternal() {
+		return true;
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/MulticastCleanupMessageObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/MulticastCleanupMessageObserver.java
@@ -21,12 +21,14 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.elements.util.NoPublicAPI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Cleanup multicast exchange by time to enable request for multiple responses.
  */
+@NoPublicAPI
 public class MulticastCleanupMessageObserver extends CleanupMessageObserver {
 
 	static final Logger LOGGER = LoggerFactory.getLogger(MulticastCleanupMessageObserver.class);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
@@ -45,8 +45,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.EmptyMessage;
+import org.eclipse.californium.core.coap.InternalMessageObserverAdapter;
 import org.eclipse.californium.core.coap.Message;
-import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange;
@@ -175,7 +175,7 @@ public class ReliabilityLayer extends AbstractLayer {
 		exchange.setRetransmissionHandle(null); // cancel before reschedule
 		updateRetransmissionTimeout(exchange, task.getReliabilityLayerParameters());
 
-		task.message.addMessageObserver(new MessageObserverAdapter() {
+		task.message.addMessageObserver(new InternalMessageObserverAdapter() {
 
 			@Override
 			public void onSent(boolean retransmission) {


### PR DESCRIPTION
Prevent the cleanup- and observation-message-observer from being
transferred to the reregistration.
(Deprecated healthchecks must also be excluded from being transferred.)

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>