### PR TITLE
Fix reregistration

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
@@ -34,6 +34,7 @@ import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.californium.elements.util.StringUtil;
 
 
 /**
@@ -59,7 +60,7 @@ public class ObserveRelation {
 	private Response recentControlNotification;
 	private Response nextControlNotification;
 	
-	private String key = null;
+	private final String key;
 
 	/*
 	 * This value is false at first and must be set to true by the resource if
@@ -93,8 +94,8 @@ public class ObserveRelation {
 		NetworkConfig config = exchange.getEndpoint().getConfig();
 		checkIntervalTime = config.getLong(NetworkConfig.Keys.NOTIFICATION_CHECK_INTERVAL_TIME);
 		checkIntervalCount = config.getInt(NetworkConfig.Keys.NOTIFICATION_CHECK_INTERVAL_COUNT);
-		
-		this.key = getSource().toString() + "#" + exchange.getRequest().getTokenString();
+
+		this.key = StringUtil.toString(getSource()) + "#" + exchange.getRequest().getTokenString();
 	}
 	
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelationContainer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelationContainer.java
@@ -35,17 +35,17 @@ import java.util.concurrent.ConcurrentHashMap;
  * endpoint could establish more than one observe relation to the same resource.
  */
 public class ObserveRelationContainer implements Iterable<ObserveRelation> {
-	
+
 	/** The set of observe relations */
 	private final ConcurrentHashMap<String, ObserveRelation> observeRelations;
-	
+
 	/**
 	 * Constructs a container for observe relations.
 	 */
 	public ObserveRelationContainer() {
 		this.observeRelations = new ConcurrentHashMap<String, ObserveRelation>();
 	}
-	
+
 	/**
 	 * Adds the specified observe relation.
 	 *
@@ -54,16 +54,27 @@ public class ObserveRelationContainer implements Iterable<ObserveRelation> {
 	 *         false, if the provided relation was added.
 	 */
 	public boolean add(ObserveRelation relation) {
+		return addAndGetPrevious(relation) != null;
+	}
+
+	/**
+	 * Adds the specified observe relation.
+	 *
+	 * @param relation the observe relation
+	 * @return canceled previous relation, or {@code null}, if not previous
+	 *         relation was available.
+	 * @since 2.1
+	 */
+	public ObserveRelation addAndGetPrevious(ObserveRelation relation) {
 		if (relation == null)
 			throw new NullPointerException();
 		ObserveRelation previous = observeRelations.put(relation.getKey(), relation);
 		if (null != previous) {
 			previous.cancel();
-			return true;
 		}
-		return false;
+		return previous;
 	}
-	
+
 	/**
 	 * Removes the specified observe relation.
 	 *
@@ -75,7 +86,7 @@ public class ObserveRelationContainer implements Iterable<ObserveRelation> {
 			throw new NullPointerException();
 		return observeRelations.remove(relation.getKey(), relation);
 	}
-	
+
 	/**
 	 * Gets the number of observe relations in this container.
 	 *
@@ -92,5 +103,5 @@ public class ObserveRelationContainer implements Iterable<ObserveRelation> {
 	public Iterator<ObserveRelation> iterator() {
 		return observeRelations.values().iterator();
 	}
-	
+
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/ResourceObserverAdapter.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/ResourceObserverAdapter.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.core.server.resources;
+
+import org.eclipse.californium.core.observe.ObserveRelation;
+
+/**
+ * An abstract adapter class for reacting to a resources's lifecylce events.
+ * <p>
+ * The methods in this class are empty.
+ * <p>
+ * Subclasses should override the methods for the events of interest.
+ * <p>
+ * An instance of the concrete resource observer can then be registered with a
+ * resource using the resource's {@link Resource#addObserver(ResourceObserver)}.
+ * @since 2.1
+ */
+public abstract class ResourceObserverAdapter implements ResourceObserver {
+
+	@Override
+	public void changedName(String old) {
+	}
+
+	@Override
+	public void changedPath(String old) {
+	}
+
+	@Override
+	public void addedChild(Resource child) {
+	}
+
+	@Override
+	public void removedChild(Resource child) {
+	}
+
+	@Override
+	public void addedObserveRelation(ObserveRelation relation) {
+	}
+
+	@Override
+	public void removedObserveRelation(ObserveRelation relation) {
+	}
+
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ObserveProActiveCancelTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ObserveProActiveCancelTest.java
@@ -1,0 +1,241 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.core.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.californium.TestTools;
+import org.eclipse.californium.category.Medium;
+import org.eclipse.californium.core.CoapClient;
+import org.eclipse.californium.core.CoapObserveRelation;
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.CoapResponse;
+import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.EndpointManager;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.interceptors.MessageInterceptor;
+import org.eclipse.californium.core.network.interceptors.MessageTracer;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.elements.rule.TestNameLoggerRule;
+import org.eclipse.californium.elements.util.ExecutorsUtil;
+import org.eclipse.californium.elements.util.TestThreadFactory;
+import org.eclipse.californium.rule.CoapNetworkRule;
+import org.eclipse.californium.rule.CoapThreadsRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Medium.class)
+public class ObserveProActiveCancelTest {
+
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT,
+			CoapNetworkRule.Mode.NATIVE);
+
+	private static final int LOOPS = 100;
+	static final String TARGET_X = "resX";
+	static final String RESPONSE = "hi";
+
+	@Rule
+	public CoapThreadsRule cleanup = new CoapThreadsRule();
+
+	@Rule
+	public TestNameLoggerRule name = new TestNameLoggerRule();
+
+	private CoapEndpoint serverEndpoint;
+	private MyResource resourceX;
+	private ExecutorService executor;
+
+	private String uriX;
+
+	@Before
+	public void startupServer() {
+		cleanup.add(createServer());
+		executor = ExecutorsUtil.newFixedThreadPool(1, new TestThreadFactory("Core-Test-"));
+	}
+
+	@After
+	public void shutdown() {
+		Endpoint endpoint = EndpointManager.getEndpointManager().getDefaultEndpoint();
+		for (MessageInterceptor interceptor : endpoint.getInterceptors()) {
+			endpoint.removeInterceptor(interceptor);
+		}
+		for (MessageInterceptor interceptor : serverEndpoint.getInterceptors()) {
+			endpoint.removeInterceptor(interceptor);
+		}
+		ExecutorsUtil.shutdownExecutorGracefully(100, executor);
+	}
+
+	@Test
+	public void testObserveClient() throws Exception {
+
+		CoapClient client = new CoapClient(uriX);
+		cleanup.add(client);
+		for (int index = 0; index < LOOPS; ++index) {
+			ObserveCountingCoapHandler handler = new ObserveCountingCoapHandler();
+			CoapObserveRelation rel = client.observeAndWait(handler);
+
+			// onLoad is called asynchronous to returning the response
+			// therefore wait for one onLoad
+			assertTrue(handler.waitOnLoadCalls(1, 1000, TimeUnit.MILLISECONDS));
+
+			assertFalse("Response not received", rel.isCanceled());
+			assertNotNull("Response not received", rel.getCurrent());
+			assertEquals(RESPONSE, rel.getCurrent().getResponseText());
+
+			assertTrue("reregister denied", rel.reregister());
+			assertTrue("reregister failed", handler.waitOnLoadCalls(2, 1000, TimeUnit.MILLISECONDS));
+			assertTrue("reregister denied", rel.reregister());
+			rel.proactiveCancel();
+			assertTrue("observation not canceled", handler.waitOnNotify(false, 1000, TimeUnit.MILLISECONDS));
+		}
+	}
+
+	@Test
+	public void testObserveClientAsynchronous() throws Exception {
+
+		CoapClient client = new CoapClient(uriX);
+		cleanup.add(client);
+		for (int index = 0; index < LOOPS; ++index) {
+			ObserveCountingCoapHandler handler = new ObserveCountingCoapHandler();
+			final CoapObserveRelation rel = client.observeAndWait(handler);
+			final AtomicInteger reregisterCounter = new AtomicInteger();
+			Runnable reregisterJob = new Runnable() {
+
+				@Override
+				public void run() {
+					try {
+						if (rel.reregister()) {
+							reregisterCounter.incrementAndGet();
+						}
+					} catch (IllegalStateException ex) {
+					}
+				}
+			};
+			// onLoad is called asynchronous to returning the response
+			// therefore wait for one onLoad
+			assertTrue(handler.waitOnLoadCalls(1, 1000, TimeUnit.MILLISECONDS));
+
+			assertFalse("Response not received", rel.isCanceled());
+			assertNotNull("Response not received", rel.getCurrent());
+			assertEquals(RESPONSE, rel.getCurrent().getResponseText());
+
+			executor.execute(reregisterJob);
+			boolean ok = handler.waitOnLoadCalls(2, 1000, TimeUnit.MILLISECONDS);
+			assertTrue("reregister failed, " + reregisterCounter.get(), ok);
+			executor.execute(reregisterJob);
+			rel.proactiveCancel();
+			assertTrue("observation not canceled", handler.waitOnNotify(false, 1000, TimeUnit.MILLISECONDS));
+		}
+	}
+
+	private CoapServer createServer() {
+		// retransmit constantly all 200 milliseconds
+		NetworkConfig config = network.createTestConfig().setInt(NetworkConfig.Keys.ACK_TIMEOUT, 200)
+				.setFloat(NetworkConfig.Keys.ACK_RANDOM_FACTOR, 1f).setFloat(NetworkConfig.Keys.ACK_TIMEOUT_SCALE, 1f);
+
+		MessageTracer tracer = new MessageTracer();
+
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
+		builder.setInetSocketAddress(TestTools.LOCALHOST_EPHEMERAL);
+		builder.setNetworkConfig(config);
+
+		serverEndpoint = builder.build();
+		serverEndpoint.addInterceptor(tracer);
+
+		CoapServer server = new CoapServer(config);
+		server.addEndpoint(serverEndpoint);
+		resourceX = new MyResource(TARGET_X);
+		server.add(resourceX);
+		server.start();
+
+		uriX = TestTools.getUri(serverEndpoint, TARGET_X);
+
+		// setup the client endpoint using the special observation store
+		builder = new CoapEndpoint.Builder();
+		builder.setInetSocketAddress(TestTools.LOCALHOST_EPHEMERAL);
+		builder.setNetworkConfig(config);
+		CoapEndpoint coapEndpoint = builder.build();
+		coapEndpoint.addInterceptor(tracer);
+		EndpointManager.getEndpointManager().setDefaultEndpoint(coapEndpoint);
+
+		return server;
+	}
+
+	private static class MyResource extends CoapResource {
+
+		private volatile Type type = Type.CON;
+		private volatile String currentResponse;
+
+		public MyResource(String name) {
+			super(name);
+			currentResponse = RESPONSE;
+			setObservable(true);
+		}
+
+		@Override
+		public void handleGET(CoapExchange exchange) {
+			Response response = new Response(ResponseCode.CONTENT);
+			response.setPayload(currentResponse);
+			response.setType(type);
+			exchange.respond(response);
+		}
+
+	}
+
+	private static class ObserveCountingCoapHandler extends CountingCoapHandler {
+
+		private volatile boolean notify;
+
+		protected void assertLoad(CoapResponse response) {
+			notify = response.getOptions().hasObserve();
+			notify();
+		}
+
+		private synchronized boolean waitOnNotify(boolean notify, final long timeout, final TimeUnit unit)
+				throws InterruptedException {
+			if (0 < timeout) {
+				long end = System.nanoTime() + unit.toNanos(timeout);
+
+				while (this.notify != notify) {
+					long left = TimeUnit.NANOSECONDS.toMillis(end - System.nanoTime());
+					if (0 < left) {
+						wait(left);
+					} else {
+						break;
+					}
+				}
+			}
+			return this.notify == notify;
+		}
+
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
@@ -844,7 +844,7 @@ public class BlockwiseServerSideTest {
 		System.out.println("Establish observe relation to " + RESOURCE_PATH);
 
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).go();
-		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 128).size2(respPayload.length()).observe(0).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 128).size2(respPayload.length()).storeObserve("O1").block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
 
 		Token tok1 = generateNextToken();
 		client.sendRequest(CON, GET, tok1, ++mid).path(RESOURCE_PATH).block2(1, false, 128).go();
@@ -858,7 +858,7 @@ public class BlockwiseServerSideTest {
 		respPayload = generateRandomPayload(280);
 		testResource.changed();
 
-		client.expectResponse().type(CON, NON).storeType("T").code(CONTENT).token(tok).storeMID("A").size2(respPayload.length()).observe(1).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		client.expectResponse().type(CON, NON).storeType("T").code(CONTENT).token(tok).storeMID("A").size2(respPayload.length()).checkObs("O1", "O2").block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
 		if (client.get("T") == CON)
 			client.sendEmpty(ACK).loadMID("A").go();
 
@@ -874,7 +874,7 @@ public class BlockwiseServerSideTest {
 		respPayload = generateRandomPayload(290);
 		testResource.changed();
 
-		client.expectResponse().type(CON, NON).storeType("T").code(CONTENT).token(tok).storeMID("A").size2(respPayload.length()).observe(2).block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
+		client.expectResponse().type(CON, NON).storeType("T").code(CONTENT).token(tok).storeMID("A").size2(respPayload.length()).checkObs("O2", "O3").block2(0, true, 128).payload(respPayload.substring(0, 128)).go();
 		if (client.get("T") == CON)
 			client.sendEmpty(ACK).loadMID("A").go();
 
@@ -896,7 +896,7 @@ public class BlockwiseServerSideTest {
 		System.out.println("Establish observe relation to " + RESOURCE_PATH);
 
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).observe(0).block2(0, false, 64).go();
-		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 64).observe(0).size2(respPayload.length()).block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
+		client.expectResponse(ACK, CONTENT, tok, mid).block2(0, true, 64).storeObserve("O1").size2(respPayload.length()).block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
 
 		client.sendRequest(CON, GET, tok, ++mid).path(RESOURCE_PATH).block2(1, false, 64).go();
 		client.expectResponse(ACK, CONTENT, tok, mid).block2(1, true, 64).noOption(OBSERVE).payload(respPayload.substring(64, 128)).go();
@@ -909,7 +909,7 @@ public class BlockwiseServerSideTest {
 		respPayload = generateRandomPayload(140);
 		testResource.changed(); // First notification
 
-		client.expectResponse().type(CON, NON).storeType("T").code(CONTENT).token(tok).storeMID("A").observe(1).size2(respPayload.length()).block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
+		client.expectResponse().type(CON, NON).storeType("T").code(CONTENT).token(tok).storeMID("A").checkObs("O1", "O2").size2(respPayload.length()).block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
 		if (client.get("T") == CON)
 			client.sendEmpty(ACK).loadMID("A").go();
 
@@ -925,7 +925,7 @@ public class BlockwiseServerSideTest {
 		respPayload = generateRandomPayload(145);
 		testResource.changed(); // Second notification
 
-		client.expectResponse().type(CON, NON).storeType("T").code(CONTENT).token(tok).storeMID("A").observe(2).size2(respPayload.length()).block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
+		client.expectResponse().type(CON, NON).storeType("T").code(CONTENT).token(tok).storeMID("A").checkObs("O2", "O3").size2(respPayload.length()).block2(0, true, 64).payload(respPayload.substring(0, 64)).go();
 		if (client.get("T") == CON)
 			client.sendEmpty(ACK).loadMID("A").go();
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
@@ -643,6 +643,21 @@ public class LockstepEndpoint {
 			return this;
 		}
 
+		public MessageExpectation hasObserve() {
+			expectations.add(new Expectation<Message>() {
+
+				public void check(Message message) {
+					assertTrue("No observe option:", message.getOptions().hasObserve());
+					print("Has observe option");
+				}
+
+				public String toString() {
+					return "Expected observe option";
+				}
+			});
+			return this;
+		}
+
 		public MessageExpectation hasEtag(final byte[] etag) {
 
 			expectations.add(new Expectation<Message>() {
@@ -1048,6 +1063,12 @@ public class LockstepEndpoint {
 		}
 
 		@Override
+		public ResponseExpectation hasObserve() {
+			super.hasObserve();
+			return this;
+		}
+
+		@Override
 		public ResponseExpectation hasEtag(final byte[] etag) {
 			super.hasEtag(etag);
 			return this;
@@ -1159,7 +1180,19 @@ public class LockstepEndpoint {
 			return this;
 		}
 
+		/**
+		 * Check, if received observe is newer than the previous stored one.
+		 * 
+		 * @param key key of previous stored one
+		 * @return expectation for
+		 * @deprecated use {@link #newerObserve(String)}
+		 */
+		@Deprecated
 		public ResponseExpectation largerObserve(final String key) {
+			return newerObserve(key);
+		}
+
+		public ResponseExpectation newerObserve(final String key) {
 			expectations.add(new Expectation<Response>() {
 
 				public void check(Response response) {
@@ -1178,7 +1211,7 @@ public class LockstepEndpoint {
 		}
 
 		public ResponseExpectation checkObs(String former, String next) {
-			largerObserve(former);
+			newerObserve(former);
 			storeObserve(next);
 			return this;
 		}

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
@@ -63,8 +63,7 @@ import org.eclipse.californium.core.network.config.NetworkConfigDefaultHandler;
 import org.eclipse.californium.core.network.interceptors.HealthStatisticLogger;
 import org.eclipse.californium.core.network.interceptors.MessageTracer;
 import org.eclipse.californium.core.observe.ObserveRelation;
-import org.eclipse.californium.core.server.resources.Resource;
-import org.eclipse.californium.core.server.resources.ResourceObserver;
+import org.eclipse.californium.core.server.resources.ResourceObserverAdapter;
 import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.util.ClockUtil;
 import org.eclipse.californium.elements.util.DaemonThreadFactory;
@@ -250,23 +249,7 @@ public class BenchmarkClient {
 	/**
 	 * 
 	 */
-	private static abstract class ResourceObserverAdapter implements ResourceObserver {
-
-		@Override
-		public void changedName(String old) {
-		}
-
-		@Override
-		public void changedPath(String old) {
-		}
-
-		@Override
-		public void addedChild(Resource child) {
-		}
-
-		@Override
-		public void removedChild(Resource child) {
-		}
+	private static abstract class MyResourceObserverAdapter extends ResourceObserverAdapter {
 
 		@Override
 		public void addedObserveRelation(ObserveRelation relation) {
@@ -287,7 +270,7 @@ public class BenchmarkClient {
 
 	};
 
-	private class FeedObserver extends ResourceObserverAdapter {
+	private class FeedObserver extends MyResourceObserverAdapter {
 
 		@Override
 		public void addedObserveRelation(ObserveRelation relation) {


### PR DESCRIPTION
Next try :-).

Implement the request-pending monitor using a `MessageObserver` instead of the order-filtered `onResponse`. Reset the notification-orderer before sending the reregistration-request (resolving a rare race condition). Update the observe option value of the reregistration-response, otherwise that may be filtered out by the notification-orderer.
Add separate unit test for proactive cancel.

Signed-off-by: Achim Kraus <achim.kraus@bosch-si.com>