### PR TITLE
Fix accept-response race-condition.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -350,7 +350,8 @@ public class Exchange {
 	/**
 	 * Accept this exchange and therefore the request. Only if the request's
 	 * type was a <code>CON</code> and the request has not been acknowledged
-	 * yet, it sends an ACK to the client.
+	 * yet, it sends an ACK to the client and prepares to send the response as
+	 * separate response.
 	 * 
 	 * @param context endpoint context to send ack
 	 * 
@@ -359,8 +360,7 @@ public class Exchange {
 	public void sendAccept(EndpointContext context) {
 		assert (origin == Origin.REMOTE);
 		Request current = currentRequest;
-		if (current.getType() == Type.CON && current.hasMID() && !current.isAcknowledged()) {
-			current.setAcknowledged(true);
+		if (current.getType() == Type.CON && current.hasMID() && current.acknowledge()) {
 			EmptyMessage ack = EmptyMessage.newACK(current, context);
 			endpoint.sendEmptyMessage(this, ack);
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
@@ -123,19 +123,13 @@ public class ReliabilityLayer extends AbstractLayer {
 		Type respType = response.getType();
 		if (respType == null) {
 			Type reqType = exchange.getCurrentRequest().getType();
-			if (reqType == Type.CON) {
-				if (exchange.getCurrentRequest().isAcknowledged()) {
-					// send separate response
-					response.setType(Type.CON);
-				} else {
-					exchange.getCurrentRequest().setAcknowledged(true);
-					// send piggy-backed response
-					response.setType(Type.ACK);
-					response.setMID(exchange.getCurrentRequest().getMID());
-				}
+			if (exchange.getCurrentRequest().acknowledge()) {
+				// send piggy-backed response
+				response.setType(Type.ACK);
+				response.setMID(exchange.getCurrentRequest().getMID());
 			} else {
-				// send NON response
-				response.setType(Type.NON);
+				// send separate CON or NON response depending on the request's type
+				response.setType(reqType);
 			}
 
 			LOGGER.trace("{} switched response message type from {} to {} (request was {})", exchange, respType,


### PR DESCRIPTION
Add Message.acknowledge() with atomic state change. Use that atomic
acknowledge() in ReliabilityLayer.sendResponse and Exchange.sendAccept.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>