### PR TITLE
Enhance memory consumption

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentity.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentity.java
@@ -73,8 +73,8 @@ public final class PreSharedKeyIdentity extends AbstractExtensiblePrincipal<PreS
 			throw new NullPointerException("Identity must not be null");
 		} else {
 			scopedIdentity = sni;
-			StringBuilder b = new StringBuilder();
 			if (sni) {
+				StringBuilder b = new StringBuilder();
 				if (virtualHost == null) {
 					this.virtualHost = null;
 				} else if (StringUtil.isValidHostName(virtualHost)) {
@@ -84,16 +84,16 @@ public final class PreSharedKeyIdentity extends AbstractExtensiblePrincipal<PreS
 					throw new IllegalArgumentException("virtual host is not a valid hostname");
 				}
 				b.append(":");
+				b.append(identity);
+				this.name = b.toString();
 			} else {
 				if (virtualHost != null) {
 					throw new IllegalArgumentException("virtual host is not supported, if sni is disabled");
 				}
 				this.virtualHost = null;
+				this.name = identity;
 			}
 			this.identity = identity;
-
-			b.append(identity);
-			this.name = b.toString();
 		}
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -416,10 +416,12 @@ public class DTLSConnector implements Connector, RecordLayer {
 					if (health != null) {
 						health.endHandshake(true);
 					}
+					final Connection connection = handshaker.getConnection();
 					timer.schedule(new Runnable() {
+
 						@Override
 						public void run() {
-							handshaker.getConnection().startByClientHello(null);
+							connection.startByClientHello(null);
 						}
 					}, CLIENT_HELLO_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 				}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -48,8 +48,6 @@ package org.eclipse.californium.scandium.dtls;
 
 import java.net.InetSocketAddress;
 import java.security.Principal;
-import java.util.HashMap;
-import java.util.Map;
 
 import javax.crypto.SecretKey;
 import javax.security.auth.DestroyFailedException;
@@ -164,7 +162,8 @@ public final class DTLSSession implements Destroyable {
 	/**
 	 * The next record sequence number per epoch.
 	 */
-	private Map<Integer, Long> sequenceNumbers = new HashMap<>();
+	// We only need 2 values as we do not support DTLS re-negotiation.
+	private long[] sequenceNumbers = new long[2];
 
 	/**
 	 * Indicates the type of certificate to send to the peer in a CERTIFICATE message.
@@ -276,7 +275,7 @@ public final class DTLSSession implements Destroyable {
 			this.creationTime = creationTime;
 			this.handshakeTimeTag = Long.toString(System.currentTimeMillis());
 			this.peer = peerAddress;
-			this.sequenceNumbers.put(0, initialSequenceNo);
+			this.sequenceNumbers[0]= initialSequenceNo;
 		}
 	}
 
@@ -568,7 +567,7 @@ public final class DTLSSession implements Destroyable {
 		this.writeEpoch++;
 		// Sequence numbers are maintained separately for each epoch, with each
 		// sequence_number initially being 0 for each epoch.
-		this.sequenceNumbers.put(writeEpoch, 0L);
+		this.sequenceNumbers[writeEpoch] =  0L;
 	}
 
 	/**
@@ -594,9 +593,9 @@ public final class DTLSSession implements Destroyable {
 	 *     epoch has been reached (2^48 - 1)
 	 */
 	public long getSequenceNumber(int epoch) {
-		long sequenceNumber = this.sequenceNumbers.get(epoch);
+		long sequenceNumber = this.sequenceNumbers[epoch];
 		if (sequenceNumber < MAX_SEQUENCE_NO) {
-			this.sequenceNumbers.put(epoch, sequenceNumber + 1);
+			this.sequenceNumbers[epoch] =  sequenceNumber + 1;
 			return sequenceNumber;
 		} else {
 			// maximum sequence number has been reached

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DTLSSessionTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DTLSSessionTest.java
@@ -75,24 +75,6 @@ public class DTLSSessionTest {
 		assertAnyFragmentFitsIntoUnfragmentedDatagram(mtu);
 	}
 
-	@Test
-	public void testMaxFragmentLengthIsAdjustedToCipherSuite() {
-		// given a handshake over an ethernet connection (MTU 1500 bytes)
-		int mtu = 1500;
-		session.setMaxTransmissionUnit(mtu);
-		int initialMaxFragmentLength = session.getMaxFragmentLength();
-
-		// when negotiating a cipher suite introducing ciphertext expansion
-		CipherSuite cipherSuite = CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256;
-		DTLSConnectionState newWriteState = newConnectionState(cipherSuite);
-		session.setWriteState(newWriteState);
-
-		// then the maxFragmentLength is adjusted so that any fragment using
-		// current write state fits into a single unfragmented UDP datagram
-		assertAnyFragmentFitsIntoUnfragmentedDatagram(mtu);
-		assertTrue(session.getMaxFragmentLength() < initialMaxFragmentLength);
-	}
-
 	private void assertAnyFragmentFitsIntoUnfragmentedDatagram(int mtu) {
 		int datagramSize = session.getMaxFragmentLength()
 				+ session.getWriteState().getMaxCiphertextExpansion()


### PR DESCRIPTION
After reading #1238, I looked at some memory dump and find ways to reduce a bit memory consumption at scandium side.
I measured value with visualVM. I did 10000 handshake on ExampleDTLSServer.java, then I perform a GC.

**Do not keep unnecessary reference on handshaker : e26ecd3**
This allow the JVM to garbage collect the `Handshaker` just after the handshake is complete instead of waiting the 60s. (after the 60s there is no more benefits)
(before : 77MB, after : 43MB, gain 34MB for 10000 connections)
I don't see any drawback here.

**Do not store the whole ClientHello message : 1450641**
This allow the JVM to garbage collect the `ClientHello`  with the handshaker and only keep necessary value. (after the 60s there is no more benefits)
(before : 43MB, after : 33MB : gain 10MB for 10000 connections)
Maybe a little drawback is that after the 60s we use some more byte to store the seqNumber but I think this is worthy.

**Use only 1 string object for identity and name if possible : d86d474**
This is a very little optimization without any drawback.
(before : 33MB, after : 32MB : gain 1MB for 10000 connections)

**Use array instead of HashMap to store sequence numbers : 6385e37**
Looking at heap dump I see that seq numbers uses a HashMap with an internal cache array with a length of 15. As we do not allow renegotiation I think that we can replace it by a simple array[2].
(before: 32MB, after : 28 MB : gain 4MB for 10000 connections)
If instead of using a simple array we use an hashmap iniatialised to 2. (and so with an array of 4 internally) the gain is ~1MB for 10000 connections)

We could gain ~1MB more if `SessionID.text` attribute was removed but this means it must be regenerate each time we send a message. (see DTLSSession.getConnectionWriteContext()`)