### PR TITLE
Add unix health logger based on netstat.

### DIFF
--- a/cf-unix-health/pom.xml
+++ b/cf-unix-health/pom.xml
@@ -1,0 +1,95 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.californium</groupId>
+		<artifactId>parent</artifactId>
+		<version>2.2.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>cf-unix-health</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>Cf-Unix-Health</name>
+	<description>Californium (Cf) Unix Health</description>
+
+	<properties>
+		<assembly.mainClass>org.eclipse.californium.examples.SecureServer</assembly.mainClass>
+		<skipTests>true</skipTests>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>element-connector</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
+
+	</dependencies>
+
+	<profiles>
+		<profile>
+			<!-- maven compile would try to resolve test dependencies, 
+				even if tests are skipped. Therefore include this 
+				test dependency only, if tests are enabled -->
+			<id>tests</id>
+			<activation>
+				<property>
+					<name>maven.test.skip</name>
+					<value>!true</value>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>californium-core</artifactId>
+					<classifier>tests</classifier>
+					<scope>test</scope>
+					<type>test-jar</type>
+				</dependency>
+				<dependency>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>element-connector</artifactId>
+					<type>test-jar</type>
+					<classifier>tests</classifier>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Export-Package>
+							org.eclipse.californium.unixhealth
+						</Export-Package>
+						<Bundle-SymbolicName>${project.groupId}.unixhealth</Bundle-SymbolicName>
+					</instructions>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>enhanced-jar-with-licenses</descriptorRef>
+					</descriptorRefs>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/cf-unix-health/src/main/java/org/eclipse/californium/unixhealth/NetStatLogger.java
+++ b/cf-unix-health/src/main/java/org/eclipse/californium/unixhealth/NetStatLogger.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.unixhealth;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.eclipse.californium.elements.util.CounterStatisticManager;
+import org.eclipse.californium.elements.util.SimpleCounterStatistic;
+import org.eclipse.californium.elements.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Netstat logger.
+ * 
+ * Dumps network statistic informations from OS. Currently only supports unix
+ * and UDP.
+ * 
+ * @since 2.2
+ */
+public class NetStatLogger extends CounterStatisticManager {
+
+	/** the logger. */
+	private static final Logger LOGGER = LoggerFactory.getLogger(NetStatLogger.class);
+
+	/**
+	 * File to read the OS network statistic.
+	 */
+	private static final File SNMP = new File("/proc/net/snmp");
+	// Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors
+	// InCsumErrors IgnoredMulti
+	private final SimpleCounterStatistic sent = new SimpleCounterStatistic("OutDatagrams", align);
+	private final SimpleCounterStatistic received = new SimpleCounterStatistic("InDatagrams", align);
+	private final SimpleCounterStatistic sendBufferErrors = new SimpleCounterStatistic("SndbufErrors", align);
+	private final SimpleCounterStatistic receiveBufferErrors = new SimpleCounterStatistic("RcvbufErrors", align);
+	private final SimpleCounterStatistic inErrors = new SimpleCounterStatistic("InErrors", align);
+	private final SimpleCounterStatistic inChecksumErrors = new SimpleCounterStatistic("InCsumErrors", align);
+	private final SimpleCounterStatistic noPorts = new SimpleCounterStatistic("NoPorts", align);
+
+	/**
+	 * Start values to adjust logged values.
+	 */
+	private final long[] START = new long[10];
+
+	/**
+	 * Create passive netstat logger.
+	 * 
+	 * {@link #dump()} is intended to be called externally.
+	 * 
+	 * @param tag logging tag
+	 */
+	public NetStatLogger(String tag) {
+		super(tag);
+		init();
+	}
+
+	/**
+	 * Create active netstat logger.
+	 * 
+	 * {@link #dump()} is called repeated with configurable interval.
+	 * 
+	 * @param tag logging tag
+	 * @param interval interval in seconds. {@code 0} to disable active logging.
+	 * @param executor executor executor to schedule active logging.
+	 * @throws NullPointerException if executor is {@code null}
+	 */
+	public NetStatLogger(String tag, int interval, ScheduledExecutorService executor) {
+		super(tag, interval, executor);
+		init();
+	}
+
+	private void init() {
+		add(sent);
+		add(received);
+		add(sendBufferErrors);
+		add(receiveBufferErrors);
+		add(inErrors);
+		add(inChecksumErrors);
+		add(noPorts);
+		read(true);
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return LOGGER.isDebugEnabled() && SNMP.canRead();
+	}
+
+	@Override
+	public void dump() {
+		try {
+			read(false);
+			if (sent.isUsed() || received.isUsed()) {
+				String eol = StringUtil.lineSeparator();
+				String head = "   " + tag;
+				StringBuilder log = new StringBuilder();
+				log.append(tag).append("network statistic:").append(eol);
+				log.append(head).append(sent).append(eol);
+				log.append(head).append(received).append(eol);
+				log.append(head).append(sendBufferErrors).append(eol);
+				log.append(head).append(receiveBufferErrors).append(eol);
+				log.append(head).append(inErrors).append(eol);
+				log.append(head).append(inChecksumErrors).append(eol);
+				log.append(head).append(noPorts);
+				LOGGER.debug("{}", log);
+			}
+		} catch (Throwable e) {
+			LOGGER.error("{}", tag, e);
+		}
+	}
+
+	private void read(boolean start) {
+
+		try (BufferedReader reader = new BufferedReader(new FileReader(SNMP))) {
+			String head = null;
+			String values = null;
+			String line;
+			while ((line = reader.readLine()) != null) {
+				if (line.startsWith("Udp: ")) {
+					head = line;
+					values = reader.readLine();
+					break;
+				}
+			}
+			if (head != null) {
+				String[] headFields = head.split(" ");
+				String[] valueFields = values.split(" ");
+				for (int index = 1; index < headFields.length; ++index) {
+					SimpleCounterStatistic statistic = get(headFields[index]);
+					if (statistic != null) {
+						try {
+							long current = Long.parseLong(valueFields[index]);
+							if (start) {
+								START[index] = current;
+							} else {
+								current -= START[index];
+								long previous = statistic.getCounter();
+								statistic.increment((int) (current - previous));
+							}
+						} catch (NumberFormatException ex) {
+						}
+					}
+				}
+			}
+		} catch (FileNotFoundException e) {
+			LOGGER.warn("{} missing!", SNMP.getAbsolutePath(), e);
+		} catch (IOException e) {
+			LOGGER.warn("{} error!", SNMP.getAbsolutePath(), e);
+		}
+	}
+}

--- a/cf-unix-health/src/main/resources/logback.xml
+++ b/cf-unix-health/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder 
+			by default -->
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} %level [%logger{0}]: %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<!-- Strictly speaking, the level attribute is not necessary since -->
+	<!-- the level of the root level is set to DEBUG by default. -->
+	<root level="INFO">
+		<appender-ref ref="STDOUT" />
+	</root>
+
+</configuration>

--- a/cf-unix-health/src/test/resources/logback-test.xml
+++ b/cf-unix-health/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder 
+			by default -->
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} %level [%logger{0}]: %msg \(%class{25}.%method:%line\)%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="INFO">
+		<appender-ref ref="STDOUT" />
+	</root>
+
+</configuration>

--- a/demo-apps/cf-extplugtest-client/pom.xml
+++ b/demo-apps/cf-extplugtest-client/pom.xml
@@ -26,6 +26,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>cf-unix-health</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 		</dependency>

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
@@ -75,6 +75,7 @@ import org.eclipse.californium.plugtests.ClientInitializer;
 import org.eclipse.californium.plugtests.ClientInitializer.Arguments;
 import org.eclipse.californium.scandium.dtls.cipher.RandomManager;
 import org.eclipse.californium.scandium.dtls.cipher.ThreadLocalKeyPairGenerator;
+import org.eclipse.californium.unixhealth.NetStatLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -724,6 +725,7 @@ public class BenchmarkClient {
 		final AtomicBoolean errors = new AtomicBoolean();
 		final NetworkConfig config = effectiveConfig;
 		final HealthStatisticLogger health = new HealthStatisticLogger(uri.getScheme(), !CoAP.isTcpScheme(uri.getScheme()));
+		final NetStatLogger netstat = new NetStatLogger("udp");
 		final int min = intervalMin;
 		final int max = intervalMin;
 		for (int index = 0; index < clients; ++index) {
@@ -963,7 +965,7 @@ public class BenchmarkClient {
 					(overallSentRequests * 100L) / overallRequests);
 		}
 		health.dump();
-
+		netstat.dump();
 		if (1 < clients) {
 			synchronized (statistic) {
 				Arrays.sort(statistic);

--- a/demo-apps/cf-extplugtest-client/src/main/resources/logback.xml
+++ b/demo-apps/cf-extplugtest-client/src/main/resources/logback.xml
@@ -45,6 +45,10 @@
 		<appender-ref ref="STDOUT_SIMPLE" />
 	</logger>
 
+	<logger name="org.eclipse.californium.unixhealth.NetStatLogger" level="DEBUG" additivity="false">
+		<appender-ref ref="STDOUT_SIMPLE" />
+	</logger>
+
 	<logger name="org.eclipse.californium.plugtests.ClientInitializer" level="INFO" additivity="false" >
 		<appender-ref ref="STDOUT_SIMPLE" />
 	</logger>

--- a/demo-apps/cf-extplugtest-server/pom.xml
+++ b/demo-apps/cf-extplugtest-server/pom.xml
@@ -27,6 +27,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>cf-unix-health</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 		</dependency>

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
@@ -53,6 +53,7 @@ import org.eclipse.californium.extplugtests.resources.ReverseObserve;
 import org.eclipse.californium.extplugtests.resources.ReverseRequest;
 import org.eclipse.californium.plugtests.AbstractTestServer;
 import org.eclipse.californium.plugtests.PlugtestServer;
+import org.eclipse.californium.unixhealth.NetStatLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -197,6 +198,7 @@ public class ExtendedTestServer extends AbstractTestServer {
 			if (noBenchmark) {
 				System.out.println(ExtendedTestServer.class.getSimpleName() + " without benchmark started ...");
 			} else {
+				NetStatLogger netstat = new NetStatLogger("udp");
 				Runtime runtime = Runtime.getRuntime();
 				long max = runtime.maxMemory();
 				StringBuilder builder = new StringBuilder(ExtendedTestServer.class.getSimpleName());
@@ -231,6 +233,7 @@ public class ExtendedTestServer extends AbstractTestServer {
 					if (lastGcCount < gcCount) {
 						printManagamentStatistic();
 						lastGcCount = gcCount;
+						netstat.dump();
 					}
 				}
 			}

--- a/demo-apps/cf-extplugtest-server/src/main/resources/logback.xml
+++ b/demo-apps/cf-extplugtest-server/src/main/resources/logback.xml
@@ -77,6 +77,9 @@
 	<logger name="org.eclipse.californium.core.network.interceptors.HealthStatisticLogger" level="DEBUG" additivity="false">
 		<appender-ref ref="STDOUT" />
 	</logger>
+	<logger name="org.eclipse.californium.unixhealth.NetStatLogger" level="DEBUG" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
 	<logger name="org.eclipse.californium.scandium.DTLSConnector.health" level="DEBUG" additivity="false">
 		<appender-ref ref="STDOUT" />
 	</logger>

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,7 @@
 		<module>demo-certs</module>
 		<module>cf-oscore</module>
 		<module>cf-pubsub</module>
+		<module>cf-unix-health</module>
 	</modules>
 
 	<build>


### PR DESCRIPTION
Read /proc/net/snmp to access udp diagnose statistics from OS.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>