### PR TITLE
Fix ExchangeCompleteException

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -186,7 +186,7 @@ public final class UdpMatcher extends BaseMatcher {
 
 		if (message.getType() == Type.RST && exchange != null) {
 			// We have rejected the request or response
-			exchange.setComplete();
+			exchange.executeComplete();
 		}
 	}
 


### PR DESCRIPTION
Fix `ExchangeCompleteException` rejecting a notify for a canceled observe-request.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>