### PR TITLE
OSCORE: Added case when context re-generation is initiated by the server

### DIFF
--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
@@ -50,7 +50,7 @@ public class ContextRederivation {
 	 *
 	 */
 	public static enum PHASE {
-		INACTIVE, CLIENT_INITIATE, SERVER_PHASE_1, SERVER_PHASE_2, SERVER_PHASE_3, CLIENT_PHASE_1, CLIENT_PHASE_2, CLIENT_PHASE_3;
+		INACTIVE, CLIENT_INITIATE, SERVER_INITIATE, SERVER_PHASE_1, SERVER_PHASE_2, SERVER_PHASE_3, CLIENT_PHASE_1, CLIENT_PHASE_2, CLIENT_PHASE_3;
 	}
 
 	/**
@@ -97,6 +97,12 @@ public class ContextRederivation {
 		// Retrieve the context for the target URI
 		OSCoreCtx ctx = db.getContext(uri);
 
+		// Check that context re-derivation is enabled for this context
+		if (ctx.getContextRederivationEnabled() == false) {
+			LOGGER.error("Context re-derivation is not enabled for this context.");
+			throw new IllegalStateException("Context re-derivation is not enabled for this context.");
+		}
+
 		printStateLogging(ctx);
 
 		// Generate a random Context ID (ID1)
@@ -120,6 +126,12 @@ public class ContextRederivation {
 	 */
 	static OSCoreCtx incomingResponse(OSCoreCtxDB db, OSCoreCtx ctx, byte[] contextID) throws OSException {
 
+		// Check if context re-derivation is enabled for this context
+		if (ctx.getContextRederivationEnabled() == false) {
+			LOGGER.debug("Context re-derivation not considered due to it being disabled for this context");
+			return ctx;
+		}
+
 		// Handle client phase 3 operations
 		if (ctx.getContextRederivationPhase() == PHASE.CLIENT_PHASE_3) {
 
@@ -133,6 +145,39 @@ public class ContextRederivation {
 			printStateLogging(ctx);
 
 			// Handle client phase 1 operations
+
+			// The Context ID in the incoming response is identified as R2
+			byte[] contextR2 = contextID;
+
+			// The Context ID of the original request in this exchange is ID1
+			byte[] contextID1 = ctx.getIdContext();
+
+			// Create Context ID to generate the new context with (R2 || ID1)
+			byte[] verifyContextID = Bytes.concatenate(contextR2, contextID1);
+
+			// Generate a new context with the concatenated Context ID
+			OSCoreCtx newCtx = rederiveWithContextID(ctx, verifyContextID);
+
+			// Add the new context to the context DB (replacing the old)
+			newCtx.setContextRederivationPhase(PHASE.CLIENT_PHASE_2);
+			db.addContext(SCHEME + ctx.getUri(), newCtx);
+			return newCtx;
+		} else if (ctx.getContextRederivationPhase() == PHASE.INACTIVE) {
+
+			printStateLogging(ctx);
+
+			// It may be that it was the server that lost the mutable parts of
+			// the context. In this case, if context re-derivation is explicitly
+			// enabled on the client, it should check if the response is in fact
+			// part of a context re-derivation procedure initiated by the
+			// server.
+
+			// For this to be a valid response #1 from the server it must have a
+			// contextID set and not match the one used in the client's context
+			// (ID1 is different from R2)
+			if (contextID == null || Arrays.equals(ctx.getIdContext(), contextID) == true) {
+				return ctx;
+			}
 
 			// The Context ID in the incoming response is identified as R2
 			byte[] contextR2 = contextID;
@@ -212,6 +257,12 @@ public class ContextRederivation {
 	 */
 	static OSCoreCtx incomingRequest(OSCoreCtxDB db, OSCoreCtx ctx, byte[] contextID) throws OSException {
 
+		 // Check if context re-derivation is enabled for this context
+		 if (ctx.getContextRederivationEnabled() == false) {
+			LOGGER.debug("Context re-derivation not initiated due to it being disabled for this context");
+			return ctx;
+		 }
+
 		// Handle server phase 2 operations
 		if (ctx.getContextRederivationPhase() == PHASE.SERVER_PHASE_2) {
 
@@ -260,6 +311,27 @@ public class ContextRederivation {
 			if (contextID1 == null || Arrays.equals(contextID1, ctx.getIdContext())) {
 				return ctx;
 			}
+
+			// Generate a new context with the received Context ID
+			OSCoreCtx newCtx = rederiveWithContextID(ctx, contextID1);
+
+			// Set next phase of the re-derivation procedure
+			newCtx.setContextRederivationPhase(PHASE.SERVER_PHASE_1);
+
+			// Add the new context to the context DB (replacing the old)
+			db.addContext(newCtx);
+			return newCtx;
+		} else if (ctx.getContextRederivationPhase() == PHASE.SERVER_INITIATE) {
+
+			printStateLogging(ctx);
+
+			// Handle initiation of re-derivation procedure
+			// In this case it is the server that initiates this procedure since
+			// it lost the mutable parts of the context
+
+			// The Context ID to use as ID1 is the same as the one used in the
+			// old context. The client may not include this in the request.
+			byte[] contextID1 = ctx.getIdContext();
 
 			// Generate a new context with the received Context ID
 			OSCoreCtx newCtx = rederiveWithContextID(ctx, contextID1);
@@ -359,6 +431,7 @@ public class ContextRederivation {
 		OSCoreCtx newCtx = new OSCoreCtx(ctx.getMasterSecret(), true, ctx.getAlg(), ctx.getSenderId(),
 				ctx.getRecipientId(), ctx.getKdf(), ctx.getRecipientReplaySize(), ctx.getSalt(), contextID);
 		newCtx.setContextRederivationKey(ctx.getContextRederivationKey());
+		newCtx.setContextRederivationEnabled(ctx.getContextRederivationEnabled());
 		return newCtx;
 	}
 
@@ -396,6 +469,9 @@ public class ContextRederivation {
 			break;
 		case CLIENT_INITIATE:
 			supplemental = "client will initiate context re-derivation";
+			break;
+		case SERVER_INITIATE:
+			supplemental = "server will initiate context re-derivation";
 			break;
 		case CLIENT_PHASE_1:
 			supplemental = "client has sent the first request in the procedure and is receving the response";

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtx.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtx.java
@@ -105,6 +105,14 @@ public class OSCoreCtx {
 	private boolean responsesIncludePartialIV;
 	
 	/**
+	 * Indicates if this client/server shall support the context re-derivation
+	 * procedure.
+	 * 
+	 * See https://tools.ietf.org/html/rfc8613#appendix-B.2
+	 */
+	private boolean contextRederivationEnabled;
+	
+	/**
 	 * URI this Context is associated with if any.
 	 *
 	 * That is what URI it is associated and stored under in the HashMapCtxDB.
@@ -233,10 +241,11 @@ public class OSCoreCtx {
 			this.context_id = null;
 		}
 
-		//Set default values for these two flags
+		// Set default values for these flags
 		//They can be set by the application using their setters
 		includeContextId = false;
 		responsesIncludePartialIV = false;
+		contextRederivationEnabled = false;
 
 		//Set string versions of sender ID, recipient ID and Context ID
 		contextIdString = toHex(this.context_id);
@@ -520,6 +529,26 @@ public class OSCoreCtx {
 	 */
 	public void setResponsesIncludePartialIV(boolean responsesIncludePartialIV) {
 		this.responsesIncludePartialIV = responsesIncludePartialIV;
+	}
+
+	/**
+	 * Get the flag controlling whether or not this context supports the context
+	 * re-derivation procedure.
+	 * 
+	 * @return the contextRederivationEnabled
+	 */
+	public boolean getContextRederivationEnabled() {
+		return contextRederivationEnabled;
+	}
+
+	/**
+	 * Set the flag controlling whether or not this context supports the context
+	 * re-derivation procedure.
+	 * 
+	 * @param contextRederivationEnabled the contextRederivationEnabled to set
+	 */
+	public void setContextRederivationEnabled(boolean contextRederivationEnabled) {
+		this.contextRederivationEnabled = contextRederivationEnabled;
 	}
 
 	/**

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
@@ -60,6 +60,11 @@ import org.eclipse.californium.cose.CoseException;
  * about the mutable parts of a context (e.g. sequence number) but retains
  * information about static parts (e.g. master secret)
  * 
+ * This class tests both when the server initiates the context re-derivation
+ * procedure and when it is the server that initiates it. Note that even when
+ * the server initiates it, it is triggered by an incoming request from the
+ * client.
+ * 
  */
 public class ContextRederivationTest {
 	@ClassRule
@@ -83,6 +88,7 @@ public class ContextRederivationTest {
 			(byte) 0x78, (byte) 0x63, (byte) 0x40 };
 	private final static byte[] sid = new byte[0];
 	private final static byte[] rid = new byte[] { 0x01 };
+	private final static byte[] context_id = { 0x74, 0x65, 0x73, 0x74, 0x74, 0x65, 0x73, 0x74 };
 
 	private static int SEGMENT_LENGTH = ContextRederivation.SEGMENT_LENGTH;
 
@@ -107,22 +113,37 @@ public class ContextRederivationTest {
 	}
 
 	/**
-	 * Test context re-derivation followed by a normal message exchange.
+	 * Test context re-derivation followed by a normal message exchange. This
+	 * test simulates a client losing the mutable parts of the OSCORE context,
+	 * and then explicitly initiating the context re-derivation procedure.
+	 * 
+	 * Note that the asserts in this test check things regarding request #2 and
+	 * response #2 as request #1 and response #1 are taken care of in the OSCORE
+	 * library code (so the application does not need to worry about them).
 	 * 
 	 * @throws OSException
 	 * @throws ConnectorException
 	 * @throws IOException
 	 * @throws CoseException
+	 * @throws InterruptedException
 	 */
 	@Test
-	public void rederivationTest() throws OSException, ConnectorException, IOException, CoseException {
+	public void testClientInitiatedRederivation()
+			throws OSException, ConnectorException, IOException, CoseException, InterruptedException {
 		
+		// Create a server that will not initiate the context re-derivation
+		// procedure. (But perform the procedure if the client initiates.)
+		createServer(false);
+
 		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, null);
 		String serverUri = serverEndpoint.getUri().toASCIIString();
-		dbClient.addContext(serverUri, ctx);
 
-		// Set the context to be in the initiate phase
+		// Enable context re-derivation functionality (in general)
+		ctx.setContextRederivationEnabled(true);
+		// Explicitly initiate the context re-derivation procedure
 		ctx.setContextRederivationPhase(PHASE.CLIENT_INITIATE);
+
+		dbClient.addContext(serverUri, ctx);
 
 		CoapClient c = new CoapClient(serverUri + hello1);
 		Request r = new Request(Code.GET);
@@ -137,10 +158,10 @@ public class ContextRederivationTest {
 		assertEquals(ContextRederivation.PHASE.INACTIVE, currCtx.getContextRederivationPhase()); // Phase
 		assertFalse(currCtx.getIncludeContextId()); // Do not include Context ID
 
-		// Length of Context ID in context
+		// Length of Context ID in context (R2 || R3)
 		int contextIdLen = currCtx.getIdContext().length;
 		assertEquals(3 * SEGMENT_LENGTH, contextIdLen);
-		// Check length of Context ID in the request
+		// Check length of Context ID in the request (R2 || R3)
 		assertEquals(3 * SEGMENT_LENGTH, requestTestObserver.requestIdContext.length);
 
 		// Check R2 value derived by server using its key with received one
@@ -175,6 +196,117 @@ public class ContextRederivationTest {
 	}
 
 	/**
+	 * Test context re-derivation followed by a normal message exchange. This
+	 * test simulates a server losing the mutable parts of the OSCORE context.
+	 * When a request from the client arrives this will initiate the context
+	 * re-derivation procedure. Note that the client does not explicitly
+	 * initiate the procedure before the request as it still has the context
+	 * information. It does not know the server has lost this information.
+	 * 
+	 * Note that the asserts in this test check things regarding request #1 &
+	 * response #1 and also response #2 as request #1. This is because in this
+	 * case the client does not initially know that a context re-derivation
+	 * procedure will take place. So the application code ends up explicitly
+	 * sending both request #1 and request #2.
+	 * 
+	 * @throws OSException
+	 * @throws ConnectorException
+	 * @throws IOException
+	 * @throws CoseException
+	 * @throws InterruptedException
+	 */
+	@Test
+	public void testServerInitiatedRederivation()
+			throws OSException, ConnectorException, IOException, CoseException, InterruptedException {
+
+		// Create a server that will initiate the context re-derivation (on
+		// reception of a request)
+		createServer(true);
+
+		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, context_id);
+		// Enable context re-derivation functionality (for client)
+		ctx.setContextRederivationEnabled(true);
+		String serverUri = serverEndpoint.getUri().toASCIIString();
+		dbClient.addContext(serverUri, ctx);
+
+		// Create first request (for request #1 and response #1 exchange)
+		CoapClient c = new CoapClient(serverUri + hello1);
+		Request r = new Request(Code.GET);
+		r.getOptions().setOscore(Bytes.EMPTY);
+		RequestTestObserver requestTestObserver = new RequestTestObserver();
+		r.addMessageObserver(requestTestObserver);
+		CoapResponse resp = c.advanced(r);
+
+		System.out.println((Utils.prettyPrint(resp)));
+
+		OSCoreCtx currCtx = dbClient.getContext(serverUri);
+		assertEquals(ContextRederivation.PHASE.CLIENT_PHASE_2, currCtx.getContextRederivationPhase()); // Phase
+		assertFalse(currCtx.getIncludeContextId()); // Do not include Context ID
+
+		// Length of Context ID in context (R2 || ID1)
+		int contextIdLen = currCtx.getIdContext().length;
+		assertEquals(3 * SEGMENT_LENGTH, contextIdLen);
+		// Check length of Context ID in the request (ID1)
+		assertEquals(1 * SEGMENT_LENGTH, requestTestObserver.requestIdContext.length);
+
+		// Check R2 value derived by server using its key with received one
+		// The R2 value is composed of S2 || HMAC(K_HMAC, S2).
+		OSCoreCtx serverCtx = dbServer.getContext(sid);
+		byte[] srvContextRederivationKey = serverCtx.getContextRederivationKey();
+		byte[] contextS2 = Arrays.copyOfRange(currCtx.getIdContext(), 0, SEGMENT_LENGTH);
+		byte[] hmacOutput = OSCoreCtx.deriveKey(srvContextRederivationKey, srvContextRederivationKey, SEGMENT_LENGTH,
+				"SHA256", contextS2);
+		byte[] messageHmacValue = Arrays.copyOfRange(currCtx.getIdContext(), SEGMENT_LENGTH, SEGMENT_LENGTH * 2);
+
+		// The OSCORE option in the response should include the correct R2 value
+		byte[] contextR2 = Bytes.concatenate(contextS2, hmacOutput);
+		byte[] oscoreOption = resp.getOptions().getOscore();
+		byte[] oscoreOptionR2 = Arrays.copyOfRange(oscoreOption, oscoreOption.length - 2 * SEGMENT_LENGTH,
+				oscoreOption.length);
+		assertArrayEquals(contextR2, oscoreOptionR2);
+		assertArrayEquals(hmacOutput, messageHmacValue);
+
+		assertEquals(ResponseCode.CONTENT, resp.getCode());
+		assertEquals(SERVER_RESPONSE, resp.getResponseText());
+
+		// 2nd request (for request #2 and response #2 exchange)
+		r = new Request(Code.GET);
+		r.getOptions().setOscore(Bytes.EMPTY);
+		requestTestObserver = new RequestTestObserver();
+		r.addMessageObserver(requestTestObserver);
+		resp = c.advanced(r);
+		System.out.println((Utils.prettyPrint(resp)));
+
+		currCtx = dbClient.getContext(serverUri);
+		assertEquals(ContextRederivation.PHASE.INACTIVE, currCtx.getContextRederivationPhase()); // Phase
+		assertFalse(currCtx.getIncludeContextId()); // Do not include Context ID
+
+		// Length of Context ID in context (R2 || R3)
+		contextIdLen = currCtx.getIdContext().length;
+		assertEquals(3 * SEGMENT_LENGTH, contextIdLen);
+		// Check length of Context ID in the request (R2 || R3)
+		assertEquals(3 * SEGMENT_LENGTH, requestTestObserver.requestIdContext.length);
+
+		// Check R2 value derived by server using its key with received one
+		// The R2 value is composed of S2 || HMAC(K_HMAC, S2).
+		serverCtx = dbServer.getContext(sid);
+		srvContextRederivationKey = serverCtx.getContextRederivationKey();
+		contextS2 = Arrays.copyOfRange(currCtx.getIdContext(), 0, SEGMENT_LENGTH);
+		hmacOutput = OSCoreCtx.deriveKey(srvContextRederivationKey, srvContextRederivationKey, SEGMENT_LENGTH, "SHA256",
+				contextS2);
+		messageHmacValue = Arrays.copyOfRange(currCtx.getIdContext(), SEGMENT_LENGTH, SEGMENT_LENGTH * 2);
+		assertArrayEquals(hmacOutput, messageHmacValue);
+
+		// Empty OSCORE option in response
+		assertArrayEquals(Bytes.EMPTY, resp.getOptions().getOscore());
+
+		assertEquals(ResponseCode.CONTENT, resp.getCode());
+		assertEquals(SERVER_RESPONSE, resp.getResponseText());
+
+		c.shutdown();
+	}
+
+	/**
 	 * Message observer that will save the ID Context used in the outgoing
 	 * request from the client for comparison.
 	 *
@@ -192,21 +324,39 @@ public class ContextRederivationTest {
 
 	/**
 	 * Creates server with resources for test
+	 * 
+	 * @param initiateRederivation if the server will initiate the context
+	 *            re-derivation procedure
+	 * 
 	 * @throws InterruptedException if resource update task fails
-	 * @throws OSException 
+	 * @throws OSException
 	 */
-	@Before
-	public void createServer() throws InterruptedException, OSException {
+	public void createServer(boolean initiateRederivation) throws InterruptedException, OSException {
 		//Do not create server if it is already running
 		if(server != null) {
 			return;
 		}
-		
+
+		byte[] contextId = null;
+		if (initiateRederivation) {
+			contextId = context_id;
+		}
+
 		//Set up OSCORE context information for response (server)
 		byte[] sid = new byte[] { 0x01 };
 		byte[] rid = new byte[0];
-		OSCoreCtx ctx = new OSCoreCtx(master_secret, false, alg, sid, rid, kdf, 32, master_salt, null);
+		OSCoreCtx ctx = new OSCoreCtx(master_secret, false, alg, sid, rid, kdf, 32, master_salt, contextId);
 		String clientUri = "coap://" + TestTools.LOCALHOST_EPHEMERAL.getAddress().getHostAddress();
+
+		// Enable context re-derivation functionality in general
+		ctx.setContextRederivationEnabled(true);
+
+		// If the server is to initiate the context re-derivation procedure, set
+		// accordingly in the context
+		if (initiateRederivation) {
+			ctx.setContextRederivationPhase(PHASE.SERVER_INITIATE);
+		}
+
 		dbServer.addContext(clientUri, ctx);
 
 		//Create server


### PR DESCRIPTION
This pull request adds the case for the context re-generation functionality where it is the server that loses the mutable parts of the OSCORE context and thus takes initiative to start the context re-derivation procedure.

That is the client will not explicitly send Request 1 as described in the context re-derivation procedure below. Rather the client will sends a normal request and since it is the server that has lost the mutable parts of the context it is the server that will then continue with the re-derivation procedure.
https://tools.ietf.org/html/rfc8613#appendix-B.2
