### PR TITLE
Adapt javadoc of CertificateVerifier.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/CertificateVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/CertificateVerifier.java
@@ -42,7 +42,11 @@ public interface CertificateVerifier {
 	 * Return an array of certificate authority certificates which are trusted
 	 * for authenticating peers.
 	 * 
-	 * @return the trusted CA certificates (possibly <code>null</code>)
+	 * The javadoc of previous versions (2.1.0 and before) permits to use
+	 * {@code null}. This causes a failure, please adapt to use an empty array.
+	 * 
+	 * @return a non-null (possibly empty) array of acceptable CA issuer
+	 *         certificates.
 	 */
 	X509Certificate[] getAcceptedIssuers();
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticCertificateVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticCertificateVerifier.java
@@ -50,10 +50,13 @@ public class StaticCertificateVerifier implements AdvancedCertificateVerifier {
 	/**
 	 * Create instance of static certificate verifier.
 	 * 
-	 * @param rootCertificates array with trusted root certificates.
-	 *            {@code null} trust none, empty trust all.
+	 * @param rootCertificates array with trusted root certificates, empty array
+	 *            to trust all.
 	 */
 	public StaticCertificateVerifier(X509Certificate[] rootCertificates) {
+		if (rootCertificates == null) {
+			throw new NullPointerException("root certificates must not be null!");
+		}
 		this.rootCertificates = rootCertificates;
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
@@ -126,7 +126,6 @@ public class HandshakerTest {
 		rpkStore = new InMemoryRpkTrustStore(Collections.singleton(new RawPublicKeyIdentity(serverPublicKey)));
 		DtlsConnectorConfig.Builder builder = new Builder();
 		builder.setClientOnly();
-		builder.setCertificateVerifier(new StaticCertificateVerifier(null));
 		builder.setRpkTrustStore(rpkStore);
 
 		handshakerWithoutAnchors = new TestHandshaker(session, recordLayer, builder.build());


### PR DESCRIPTION
Suppport only "empty array" for issuers.
null is considered to be valid return value.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>