### PR TITLE
Cleanup ecdhe

### DIFF
--- a/demo-apps/cf-secure/src/test/java/org/eclipse/californium/interoperability/test/ScandiumUtil.java
+++ b/demo-apps/cf-secure/src/test/java/org/eclipse/californium/interoperability/test/ScandiumUtil.java
@@ -126,28 +126,29 @@ public class ScandiumUtil {
 	 *                     provided bind address
 	 */
 	public void start(InetSocketAddress bind, String trust, CipherSuite... cipherSuites) throws IOException {
-		start(bind, true, trust, cipherSuites);
+		start(bind, null, trust, cipherSuites);
 	}
 
 	/**
 	 * Start connector.
 	 * 
 	 * @param bind         address to bind connector to
-	 * @param truncate     {@code true} truncate client certificate path, {@code false}, otherwise.
+	 * @param dtlsBuilder  preconfigured dtls builder. Maybe {@link null}.
 	 * @param trust        alias of trusted certificate, or {@code null} to trust
 	 *                     all received certificates.
 	 * @param cipherSuites cipher suites to support.
 	 * @throws IOException if an error occurred starting the connector on the
 	 *                     provided bind address
 	 */
-	public void start(InetSocketAddress bind, boolean truncate, String trust, CipherSuite... cipherSuites) throws IOException {
+	public void start(InetSocketAddress bind, DtlsConnectorConfig.Builder dtlsBuilder, String trust, CipherSuite... cipherSuites) throws IOException {
 		List<CipherSuite> suites = Arrays.asList(cipherSuites);
-		DtlsConnectorConfig.Builder dtlsBuilder = new DtlsConnectorConfig.Builder();
+		if (dtlsBuilder == null) {
+			dtlsBuilder = new DtlsConnectorConfig.Builder();
+		}
 		dtlsBuilder.setAddress(bind);
 		dtlsBuilder.setRecommendedCipherSuitesOnly(false);
 		dtlsBuilder.setConnectionThreadCount(2);
 		dtlsBuilder.setReceiverThreadCount(2);
-		dtlsBuilder.setUseTruncatedCertificatePathForClientsCertificateMessage(truncate);
 		if (CipherSuite.containsPskBasedCipherSuite(suites)) {
 			dtlsBuilder.setPskStore(
 					new StaticPskStore(CredentialsUtil.OPEN_PSK_IDENTITY, CredentialsUtil.OPEN_PSK_SECRET));

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/Asn1DerDecoder.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/Asn1DerDecoder.java
@@ -60,6 +60,13 @@ public class Asn1DerDecoder {
 	 */
 	public static final String ECv2 = "EC.v2";
 	/**
+	 * ECPoint uncompressed.
+	 * <a href="https://tools.ietf.org/html/rfc5480#section-2.2">RFC 5480, Section 2.2</a>
+	 * 
+	 * @since 2.3
+	 */
+	public static final int EC_PUBLIC_KEY_UNCOMPRESSED = 4;
+	/**
 	 * Maximum supported default length for ASN.1.
 	 */
 	private static final int MAX_DEFAULT_LENGTH = 0x10000;
@@ -493,7 +500,7 @@ public class Asn1DerDecoder {
 		// PUBLIC KEY, compression, 4 := uncompressed
 		int compress = reader.read(Byte.SIZE);
 		int left = reader.bitsLeft() / Byte.SIZE;
-		if (compress == 4 && left % 2 == 0) {
+		if (compress == EC_PUBLIC_KEY_UNCOMPRESSED && left % 2 == 0) {
 			left /= 2;
 			if (left == keySize) {
 				BigInteger x = new BigInteger(1, reader.readBytes(left));

--- a/scandium-core/api-changes.json
+++ b/scandium-core/api-changes.json
@@ -50,5 +50,102 @@
 				}
 			]
 		}
+	},
+	"2.3.0": {
+		"revapi": {
+			"ignore": [
+				{
+					"code": "java.method.removed",
+					"old": "method void org.eclipse.californium.scandium.dtls.ECDHClientKeyExchange::<init>(java.security.PublicKey, java.net.InetSocketAddress)",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method int org.eclipse.californium.scandium.dtls.ECDHServerKeyExchange::getCurveId()",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method int org.eclipse.californium.scandium.dtls.EcdhPskServerKeyExchange::getCurveId()",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method java.security.interfaces.ECPublicKey org.eclipse.californium.scandium.dtls.ECDHServerKeyExchange::getPublicKey()",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method java.security.interfaces.ECPublicKey org.eclipse.californium.scandium.dtls.EcdhPskServerKeyExchange::getPublicKey()",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method void org.eclipse.californium.scandium.dtls.SupportedEllipticCurvesExtension::<init>(org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedGroup[])",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method java.util.List<java.lang.Integer> org.eclipse.californium.scandium.dtls.SupportedEllipticCurvesExtension::getSupportedGroupIds()",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method void org.eclipse.californium.scandium.dtls.EcdhPskClientKeyExchange::<init>(org.eclipse.californium.scandium.dtls.PskPublicInformation, java.security.PublicKey, java.net.InetSocketAddress)",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method void org.eclipse.californium.scandium.dtls.ECDHServerKeyExchange::<init>(org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm, org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography, java.security.PrivateKey, org.eclipse.californium.scandium.dtls.Random, org.eclipse.californium.scandium.dtls.Random, int, java.net.InetSocketAddress) throws java.security.GeneralSecurityException",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method org.eclipse.californium.scandium.dtls.HandshakeMessage org.eclipse.californium.scandium.dtls.ECDHServerKeyExchange::fromReader(org.eclipse.californium.elements.util.DatagramReader, java.net.InetSocketAddress) throws org.eclipse.californium.scandium.dtls.HandshakeException",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method void org.eclipse.californium.scandium.dtls.ECDHServerKeyExchange::verifySignature(java.security.PublicKey, org.eclipse.californium.scandium.dtls.Random, org.eclipse.californium.scandium.dtls.Random) throws org.eclipse.californium.scandium.dtls.HandshakeException",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},
+				{
+					"code": "java.field.removed",
+					"old": "field org.eclipse.californium.scandium.dtls.Handshaker.ecdhe",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},
+				{
+					"code": "java.field.visibilityReduced",
+					"old": "field org.eclipse.californium.scandium.dtls.Handshaker.ecdhe @ org.eclipse.californium.scandium.dtls.ServerHandshaker",
+					"new": "field org.eclipse.californium.scandium.dtls.ServerHandshaker.ecdhe",
+					"justification": "not part of the public API - change requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},
+				{
+					"code": "java.field.removedWithConstant",
+					"old": "field org.eclipse.californium.scandium.dtls.EcdhPskClientKeyExchange.LENGTH_BITS",
+					"justification": "not part of the public API - change requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method void org.eclipse.californium.scandium.dtls.SupportedPointFormatsExtension::addECPointFormat(org.eclipse.californium.scandium.dtls.SupportedPointFormatsExtension.ECPointFormat)",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				}
+			]
+		}
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchange.java
@@ -20,361 +20,135 @@
 package org.eclipse.californium.scandium.dtls;
 
 import java.net.InetSocketAddress;
-import java.security.GeneralSecurityException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
 import java.security.Signature;
 import java.security.SignatureException;
-import java.security.interfaces.ECPublicKey;
-import java.security.spec.ECParameterSpec;
 import java.util.Arrays;
 
-import org.eclipse.californium.elements.util.Asn1DerDecoder;
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.NoPublicAPI;
 import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
-import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
-import org.eclipse.californium.scandium.dtls.cipher.ThreadLocalSignature;
-import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedGroup;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
 
 /**
- * The server's ephemeral ECDH with ECDSA signatures.
+/**
+ * The server's ephemeral ECDH.
  * 
  * See <a href="http://tools.ietf.org/html/rfc4492#section-5.4">
  * RFC 4492, section 5.4 Server Key Exchange</a> for details regarding
  * the message format.
+ * 
+ * According <a href= "https://tools.ietf.org/html/rfc8422#section-5.1.1">RFC
+ * 8422, 5.1.1. Supported Elliptic Curves Extension</a> only "named curves" are
+ * valid, the "prime" and "char2" curve descriptions are deprecated. Also only
+ * "UNCOMPRESSED" as point format is valid, the other formats have been
+ * deprecated.
  */
-public final class ECDHServerKeyExchange extends ServerKeyExchange {
-
-	private static final String MSG_UNKNOWN_CURVE_TYPE = "Unknown curve type [{}]";
-	private static final Logger LOGGER = LoggerFactory.getLogger(ECDHServerKeyExchange.class);
+@NoPublicAPI
+public abstract class ECDHServerKeyExchange extends ServerKeyExchange {
 
 	// DTLS-specific constants ////////////////////////////////////////
 
 	private static final int CURVE_TYPE_BITS = 8;
 	private static final int NAMED_CURVE_BITS = 16;
 	private static final int PUBLIC_LENGTH_BITS = 8;
-	private static final int HASH_ALGORITHM_BITS = 8;
-	private static final int SIGNATURE_ALGORITHM_BITS = 8;
-	private static final int SIGNATURE_LENGTH_BITS = 16;
 
 	/** The ECCurveType */
-	// parameters are conveyed verbosely; underlying finite field is a prime
-	// field
-	private static final int EXPLICIT_PRIME = 1;
-	// parameters are conveyed verbosely; underlying finite field is a
-	// characteristic-2 field
-	private static final int EXPLICIT_CHAR2 = 2;
 	// a named curve is used
 	private static final int NAMED_CURVE = 3;
 
 	// Members ////////////////////////////////////////////////////////
 
 	/** ephemeral keys */
-	private ECPublicKey publicKey = null;
+	private final SupportedGroup supportedGroup;
 
-	private byte[] pointEncoded = null;
-
-	private final int curveId;
-
-	private byte[] signatureEncoded = null;
-
-	/** The signature and hash algorithm which must be included into the digitally-signed struct. */
-	private final SignatureAndHashAlgorithm signatureAndHashAlgorithm;
-
-	// TODO right now only named curve is supported
-	private int curveType = NAMED_CURVE;
+	private final byte[] encodedPoint;
 
 	// Constructors //////////////////////////////////////////////////
 
 	/**
-	 * Called by server, generates ephemeral keys and signature.
-	 * 
-	 * @param signatureAndHashAlgorithm
-	 *            the algorithm to use
-	 * @param ecdhe
-	 *            the ECDHE helper class
-	 * @param serverPrivateKey
-	 *            the server's private key
-	 * @param clientRandom
-	 *            the client's random (used for signature)
-	 * @param serverRandom
-	 *            the server's random (used for signature)
-	 * @param namedCurveId
-	 *            the named curve's id which will be used for the ECDH
-	 * @param peerAddress the IP address and port of the peer this
-	 *            message has been received from or should be sent to
-	 * @throws GeneralSecurityException if generating the signature providing prove of
-	 *            possession of the private key fails, e.g. due to an unsupported
-	 *            signature or hash algorithm or an invalid key
-	 */
-	public ECDHServerKeyExchange(SignatureAndHashAlgorithm signatureAndHashAlgorithm, ECDHECryptography ecdhe,
-			PrivateKey serverPrivateKey, Random clientRandom, Random serverRandom, int namedCurveId,
-			InetSocketAddress peerAddress) throws GeneralSecurityException {
-
-		this(signatureAndHashAlgorithm, namedCurveId, peerAddress);
-		
-		publicKey = ecdhe.getPublicKey();
-		ECParameterSpec parameters = publicKey.getParams();
-
-		pointEncoded = ECDHECryptography.encodePoint(publicKey.getW(), parameters.getCurve());
-
-		// make signature
-		// See http://tools.ietf.org/html/rfc4492#section-2.2
-		// These parameters MUST be signed with ECDSA using the private key
-		// corresponding to the public key in the server's Certificate.
-		ThreadLocalSignature localSignature = signatureAndHashAlgorithm.getThreadLocalSignature();
-		Signature signature = localSignature.currentWithCause();
-		signature.initSign(serverPrivateKey);
-
-		updateSignature(signature, clientRandom, serverRandom);
-
-		signatureEncoded = signature.sign();
-	}
-
-	/**
 	 * Called when reconstructing the byte array.
 	 * 
-	 * @param signatureAndHashAlgorithm
-	 *            the algorithm to use
-	 * @param curveId
-	 *            the named curve index
-	 * @param pointEncoded
-	 *            the point on the curve (encoded)
-	 * @param signatureEncoded
-	 *            the signature (encoded)
+	 * @param supportedGroup
+	 *            supported group (named curve)
+	 * @param encodedPoint
+	 *            the encoded point on the curve (public key). 
 	 * @param peerAddress the IP address and port of the peer this
 	 *            message has been received from or should be sent to
-	 * @throws HandshakeException if the server's public key could not be re-constructed
-	 *            from the parameters contained in the message
 	 */
-	private ECDHServerKeyExchange(SignatureAndHashAlgorithm signatureAndHashAlgorithm, int curveId, byte[] pointEncoded,
-			byte[] signatureEncoded, InetSocketAddress peerAddress) throws HandshakeException {
-		this(signatureAndHashAlgorithm, curveId, peerAddress);
-		this.pointEncoded = Arrays.copyOf(pointEncoded, pointEncoded.length);
-		this.signatureEncoded = Arrays.copyOf(signatureEncoded, signatureEncoded.length);
-		// re-create public key from params
+	protected ECDHServerKeyExchange(SupportedGroup supportedGroup, byte[] encodedPoint, InetSocketAddress peerAddress) {
+		super(peerAddress);
+		if (encodedPoint == null) {
+			throw new NullPointerException("encoded point cannot be null!");
+		}
+		this.supportedGroup = supportedGroup;
+		this.encodedPoint = encodedPoint;
+	}
+
+	// Serialization //////////////////////////////////////////////////
+
+	protected int getNamedCurveLength() {
+		return 4 + encodedPoint.length;
+	}
+
+	protected void writeNamedCurve(DatagramWriter writer) {
+		// http://tools.ietf.org/html/rfc4492#section-5.4
+		writer.write(NAMED_CURVE, CURVE_TYPE_BITS);
+		writer.write(supportedGroup.getId(), NAMED_CURVE_BITS);
+		writer.write(encodedPoint.length, PUBLIC_LENGTH_BITS);
+		writer.writeBytes(encodedPoint);
+	}
+
+	protected static EcdhData readNamedCurve(final DatagramReader reader, final InetSocketAddress peerAddress) throws HandshakeException {
+		int curveType = reader.read(CURVE_TYPE_BITS);
+		if (curveType != NAMED_CURVE) {
+		throw new HandshakeException(
+				String.format(
+						"Curve type [%s] received in ServerKeyExchange message from peer [%s] is unsupported",
+						curveType, peerAddress),
+				new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, peerAddress));
+		}
+		int curveId = reader.read(NAMED_CURVE_BITS);
 		SupportedGroup group = SupportedGroup.fromId(curveId);
 		if (group == null || !group.isUsable()) {
 			throw new HandshakeException(
 				String.format("Server used unsupported elliptic curve (%d) for ECDH", curveId),
 				new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, peerAddress));
-		} else {
-			try {
-				ECParameterSpec params = group.getEcParams();
-				DatagramReader reader = new DatagramReader(pointEncoded, false);
-				publicKey = Asn1DerDecoder.readEcPublicKey(reader, params);
-			} catch (GeneralSecurityException e) {
-				LOGGER.debug("Cannot re-create server's public key from params", e);
-				throw new HandshakeException(
-					String.format("Cannot re-create server's public key from params: %s", e.getMessage()),
-					new AlertMessage(AlertLevel.FATAL, AlertDescription.INTERNAL_ERROR, peerAddress));
-			}
 		}
-	}
-
-	private ECDHServerKeyExchange(SignatureAndHashAlgorithm signatureAndHashAlgorithm, int namedCurveId, InetSocketAddress peerAddress) {
-		super(peerAddress);
-		this.signatureAndHashAlgorithm = signatureAndHashAlgorithm;
-		this.curveId = namedCurveId;
-	}
-
-	// Serialization //////////////////////////////////////////////////
-
-	// TODO this is called 4 times for Flight 4
-	@Override
-	public byte[] fragmentToByteArray() {
-		DatagramWriter writer = new DatagramWriter();
-
-		switch (curveType) {
-		// TODO add support for other curve types
-		case EXPLICIT_PRIME:
-		case EXPLICIT_CHAR2:
-			break;
-
-		case NAMED_CURVE:
-			writeNamedCurve(writer);
-			break;
-
-		default:
-			LOGGER.warn(MSG_UNKNOWN_CURVE_TYPE, curveType);
-			break;
-		}
-
-		return writer.toByteArray();
-	}
-
-	private void writeNamedCurve(DatagramWriter writer) {
-		// http://tools.ietf.org/html/rfc4492#section-5.4
-		writer.write(NAMED_CURVE, CURVE_TYPE_BITS);
-		writer.write(curveId, NAMED_CURVE_BITS);
-		writer.write(pointEncoded.length, PUBLIC_LENGTH_BITS);
-		writer.writeBytes(pointEncoded);
-
-		// signature
-		if (signatureEncoded != null) {
-			// according to http://tools.ietf.org/html/rfc5246#section-A.7 the
-			// signature algorithm must also be included
-			writer.write(signatureAndHashAlgorithm.getHash().getCode(), HASH_ALGORITHM_BITS);
-			writer.write(signatureAndHashAlgorithm.getSignature().getCode(), SIGNATURE_ALGORITHM_BITS);
-			
-			writer.write(signatureEncoded.length, SIGNATURE_LENGTH_BITS);
-			writer.writeBytes(signatureEncoded);
-		}
-	}
-
-	public static HandshakeMessage fromReader(DatagramReader reader, InetSocketAddress peerAddress) throws HandshakeException {
-		int curveType = reader.read(CURVE_TYPE_BITS);
-		switch (curveType) {
-		// TODO right now only named curve supported
-		case NAMED_CURVE:
-			return readNamedCurve(reader, peerAddress);
-		default:
-			throw new HandshakeException(
-					String.format(
-							"Curve type [%s] received in ServerKeyExchange message from peer [%s] is unsupported",
-							curveType, peerAddress),
-					new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, peerAddress));
-		}
-	}
-
-	private static ECDHServerKeyExchange readNamedCurve(final DatagramReader reader, final InetSocketAddress peerAddress) throws HandshakeException {
-		int curveId = reader.read(NAMED_CURVE_BITS);
 		int length = reader.read(PUBLIC_LENGTH_BITS);
-		byte[] pointEncoded = reader.readBytes(length);
+		byte[] encodedPoint = reader.readBytes(length);
+		return new EcdhData(group, encodedPoint);
+	}
 
-		// default is SHA256withECDSA
-		SignatureAndHashAlgorithm signAndHash = new SignatureAndHashAlgorithm(SignatureAndHashAlgorithm.HashAlgorithm.SHA256, SignatureAndHashAlgorithm.SignatureAlgorithm.ECDSA);
-
-		byte[] signatureEncoded = null;
-		if (reader.bytesAvailable()) {
-			int hashAlgorithm = reader.read(HASH_ALGORITHM_BITS);
-			int signatureAlgorithm = reader.read(SIGNATURE_ALGORITHM_BITS);
-			signAndHash = new SignatureAndHashAlgorithm(hashAlgorithm, signatureAlgorithm);
-			length = reader.read(SIGNATURE_LENGTH_BITS);
-			signatureEncoded = reader.readBytes(length);
-		}
-
-		return new ECDHServerKeyExchange(signAndHash, curveId, pointEncoded, signatureEncoded, peerAddress);
+	protected void updateSignatureForNamedCurve(Signature signature) throws SignatureException {
+		int curveId = getSupportedGroup().getId();
+		signature.update((byte) NAMED_CURVE);
+		signature.update((byte) (curveId >> 8));
+		signature.update((byte) curveId);
+		signature.update((byte) encodedPoint.length);
+		signature.update(encodedPoint);
 	}
 
 	// Methods ////////////////////////////////////////////////////////
 
-	@Override
-	public int getMessageLength() {
-		int length = 0;
-		switch (curveType) {
-		case EXPLICIT_PRIME:
-		case EXPLICIT_CHAR2:
-			break;
-		
-		case NAMED_CURVE:
-			// the signature length field uses 2 bytes, if a signature available
-			int signatureLength = (signatureEncoded == null) ? 0 : 2 + 2 + signatureEncoded.length;
-			length = 4 + pointEncoded.length + signatureLength;
-			break;
-
-		default:
-			LOGGER.warn(MSG_UNKNOWN_CURVE_TYPE, curveType);
-			break;
-		}
-		
-		return length;
+	/**
+	 * Get supported group for ECDH.
+	 * 
+	 * @return supported group
+	 */
+	public SupportedGroup getSupportedGroup() {
+		return supportedGroup;
 	}
 
 	/**
-	 * Called by the client after receiving the server's
-	 * {@link ServerKeyExchange} message. Verifies the contained signature.
+	 * Get encoded point
 	 * 
-	 * @param serverPublicKey
-	 *            the server's public key.
-	 * @param clientRandom
-	 *            the client's random (used in signature).
-	 * @param serverRandom
-	 *            the server's random (used in signature).
-	 * @throws HandshakeException
-	 *             if the signature could not be verified.
+	 * @return encoded point (public key).
 	 */
-	public void verifySignature(PublicKey serverPublicKey, Random clientRandom, Random serverRandom) throws HandshakeException {
-		if (signatureEncoded == null) {
-			// no signature available, nothing to verify
-			return;
-		}
-		boolean verified = false;
-		try {
-			ThreadLocalSignature localSignature = signatureAndHashAlgorithm.getThreadLocalSignature();
-			Signature signature = localSignature.currentWithCause();
-			signature.initVerify(serverPublicKey);
-
-			updateSignature(signature, clientRandom, serverRandom);
-
-			verified = signature.verify(signatureEncoded);
-
-		} catch (GeneralSecurityException e) {
-			LOGGER.error("Could not verify the server's signature.",e);
-		}
-		
-		if (!verified) {
-			String message = "The server's ECDHE key exchange message's signature could not be verified.";
-			AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, getPeer());
-			throw new HandshakeException(message, alert);
-		}
-	}
-
-	/**
-	 * Update the signature: SHA(ClientHello.random + ServerHello.random +
-	 * ServerKeyExchange.params). See <a
-	 * href="http://tools.ietf.org/html/rfc4492#section-5.4">RFC 4492, Section
-	 * 5.4. Server Key Exchange</a> for further details on the signature format.
-	 * 
-	 * @param signature
-	 *            the signature
-	 * @param clientRandom
-	 *            the client random
-	 * @param serverRandom
-	 *            the server random
-	 * @throws SignatureException
-	 *             the signature exception
-	 */
-	private void updateSignature(Signature signature, Random clientRandom, Random serverRandom) throws SignatureException {
-		signature.update(clientRandom.getBytes());
-		signature.update(serverRandom.getBytes());
-
-		switch (curveType) {
-		case EXPLICIT_PRIME:
-		case EXPLICIT_CHAR2:
-
-			break;
-
-		case NAMED_CURVE:
-			updateSignatureForNamedCurve(signature);
-			break;
-
-		default:
-			LOGGER.warn(MSG_UNKNOWN_CURVE_TYPE, curveType);
-			break;
-		}
-	}
-
-	private void updateSignatureForNamedCurve(Signature signature) throws SignatureException {
-		signature.update((byte) NAMED_CURVE);
-		signature.update((byte) (curveId >> 8));
-		signature.update((byte) curveId);
-		signature.update((byte) pointEncoded.length);
-		signature.update(pointEncoded);
-	}
-
-	public ECPublicKey getPublicKey() {
-		return publicKey;
-	}
-
-	public int getCurveId() {
-		return curveId;
+	public byte[] getEncodedPoint() {
+		return Arrays.copyOf(encodedPoint, encodedPoint.length);
 	}
 
 	@Override
@@ -382,10 +156,24 @@ public final class ECDHServerKeyExchange extends ServerKeyExchange {
 		StringBuilder sb = new StringBuilder();
 		sb.append(super.toString());
 		sb.append("\t\tDiffie-Hellman public key: ");
-		sb.append(getPublicKey().toString());
-		// bug in ECPublicKey.toString() gives object pointer
+		sb.append(supportedGroup.name()).append("-").append(StringUtil.byteArray2HexString(encodedPoint, StringUtil.NO_SEPARATOR, 10));
 		sb.append(StringUtil.lineSeparator());
 
 		return sb.toString();
+	}
+
+	/**
+	 * Utility class to keep results of reading the supported group and the
+	 * encoded point-
+	 */
+	protected static class EcdhData {
+
+		public final SupportedGroup supportedGroup;
+		public final byte[] encodedPoint;
+
+		EcdhData(SupportedGroup supportedGroup, byte[] encodedPoint) {
+			this.supportedGroup = supportedGroup;
+			this.encodedPoint = encodedPoint;
+		}
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhEcdsaServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhEcdsaServerKeyExchange.java
@@ -1,0 +1,257 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial creation
+ *                    derived from previous ECDHServerKeyExchange
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import java.net.InetSocketAddress;
+import java.security.GeneralSecurityException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
+
+import org.eclipse.californium.elements.util.DatagramReader;
+import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.NoPublicAPI;
+import org.eclipse.californium.elements.util.StringUtil;
+import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
+import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
+import org.eclipse.californium.scandium.dtls.cipher.ThreadLocalSignature;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The server's ephemeral ECDH with ECDSA signatures.
+ * 
+ * See <a href="http://tools.ietf.org/html/rfc4492#section-5.4">
+ * RFC 4492, section 5.4 Server Key Exchange</a> for details regarding
+ * the message format.
+ * 
+ * According <a href= "https://tools.ietf.org/html/rfc8422#section-5.1.1">RFC
+ * 8422, 5.1.1. Supported Elliptic Curves Extension</a> only "named curves" are
+ * valid, the "prime" and "char2" curve descriptions are deprecated. Also only
+ * "UNCOMPRESSED" as point format is valid, the other formats have been
+ * deprecated.
+ * 
+ * @since 2.3
+ */
+@NoPublicAPI
+public final class EcdhEcdsaServerKeyExchange extends ECDHServerKeyExchange {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(EcdhEcdsaServerKeyExchange.class);
+
+	// DTLS-specific constants ////////////////////////////////////////
+
+	private static final int HASH_ALGORITHM_BITS = 8;
+	private static final int SIGNATURE_ALGORITHM_BITS = 8;
+	private static final int SIGNATURE_LENGTH_BITS = 16;
+
+	// Members ////////////////////////////////////////////////////////
+
+	private byte[] signatureEncoded = null;
+
+	/** The signature and hash algorithm which must be included into the digitally-signed struct. */
+	private final SignatureAndHashAlgorithm signatureAndHashAlgorithm;
+
+	// Constructors //////////////////////////////////////////////////
+
+	/**
+	 * Called by server with generated ephemeral keys and generates signature.
+	 * 
+	 * @param signatureAndHashAlgorithm
+	 *            the algorithm to use
+	 * @param ecdhe
+	 *            the ECDHE helper class. Contains generated ephemeral keys.
+	 * @param serverPrivateKey
+	 *            the server's private key
+	 * @param clientRandom
+	 *            the client's random (used for signature)
+	 * @param serverRandom
+	 *            the server's random (used for signature)
+	 * @param peerAddress the IP address and port of the peer this
+	 *            message has been received from or should be sent to
+	 * @throws GeneralSecurityException if generating the signature providing prove of
+	 *            possession of the private key fails, e.g. due to an unsupported
+	 *            signature or hash algorithm or an invalid key
+	 * @throws HandshakeException 
+	 */
+	public EcdhEcdsaServerKeyExchange(SignatureAndHashAlgorithm signatureAndHashAlgorithm, XECDHECryptography ecdhe,
+			PrivateKey serverPrivateKey, Random clientRandom, Random serverRandom, InetSocketAddress peerAddress) throws GeneralSecurityException {
+
+		this(signatureAndHashAlgorithm, ecdhe.getSupportedGroup(), ecdhe.getEncodedPoint(), peerAddress);
+
+		// make signature
+		// See http://tools.ietf.org/html/rfc4492#section-2.2
+		// These parameters MUST be signed with ECDSA using the private key
+		// corresponding to the public key in the server's Certificate.
+		ThreadLocalSignature localSignature = signatureAndHashAlgorithm.getThreadLocalSignature();
+		Signature signature = localSignature.currentWithCause();
+		signature.initSign(serverPrivateKey);
+
+		updateSignature(signature, clientRandom, serverRandom);
+
+		signatureEncoded = signature.sign();
+	}
+
+	/**
+	 * Called when reconstructing from the byte array.
+	 * 
+	 * @param signatureAndHashAlgorithm
+	 *            the algorithm to use
+	 * @param supportedGroup
+	 *            the supported group (curve)
+	 * @param encodedPoint
+	 *            the encoded point of the other peeer (public key)
+	 * @param signatureEncoded
+	 *            the signature (encoded)
+	 * @param peerAddress the IP address and port of the peer this
+	 *            message has been received from or should be sent to
+	 * @throws HandshakeException if the server's public key could not be re-constructed
+	 *            from the parameters contained in the message
+	 */
+	private EcdhEcdsaServerKeyExchange(SignatureAndHashAlgorithm signatureAndHashAlgorithm, SupportedGroup supportedGroup, byte[] encodedPoint,
+			byte[] signatureEncoded, InetSocketAddress peerAddress) {
+		this(signatureAndHashAlgorithm, supportedGroup, encodedPoint, peerAddress);
+		this.signatureEncoded = signatureEncoded;
+	}
+
+	private EcdhEcdsaServerKeyExchange(SignatureAndHashAlgorithm signatureAndHashAlgorithm, SupportedGroup supportedGroup, byte[] encodedPoint, InetSocketAddress peerAddress) {
+		super(supportedGroup, encodedPoint, peerAddress);
+		if (signatureAndHashAlgorithm == null) {
+			throw new NullPointerException("signature and hash algorithm cannot be null");
+		}
+		this.signatureAndHashAlgorithm = signatureAndHashAlgorithm;
+	}
+
+	// Serialization //////////////////////////////////////////////////
+
+	@Override
+	public int getMessageLength() {
+		// the signature length field uses 2 bytes, if a signature available
+		int signatureLength = (signatureEncoded == null) ? 0 : 2 + 2 + signatureEncoded.length;
+		return getNamedCurveLength() + signatureLength;
+	}
+
+	@Override
+	public byte[] fragmentToByteArray() {
+		DatagramWriter writer = new DatagramWriter();
+		writeNamedCurve(writer);
+
+		// signature
+		if (signatureEncoded != null) {
+			// according to http://tools.ietf.org/html/rfc5246#section-A.7 the
+			// signature algorithm must also be included
+			writer.write(signatureAndHashAlgorithm.getHash().getCode(), HASH_ALGORITHM_BITS);
+			writer.write(signatureAndHashAlgorithm.getSignature().getCode(), SIGNATURE_ALGORITHM_BITS);
+			
+			writer.write(signatureEncoded.length, SIGNATURE_LENGTH_BITS);
+			writer.writeBytes(signatureEncoded);
+		}
+		return writer.toByteArray();
+	}
+
+	public static HandshakeMessage fromReader(DatagramReader reader, InetSocketAddress peerAddress) throws HandshakeException {
+		EcdhData ecdhData = readNamedCurve(reader, peerAddress);
+		// default is SHA256withECDSA
+		SignatureAndHashAlgorithm signAndHash = new SignatureAndHashAlgorithm(SignatureAndHashAlgorithm.HashAlgorithm.SHA256, SignatureAndHashAlgorithm.SignatureAlgorithm.ECDSA);
+
+		byte[] signatureEncoded = null;
+		if (reader.bytesAvailable()) {
+			int hashAlgorithm = reader.read(HASH_ALGORITHM_BITS);
+			int signatureAlgorithm = reader.read(SIGNATURE_ALGORITHM_BITS);
+			signAndHash = new SignatureAndHashAlgorithm(hashAlgorithm, signatureAlgorithm);
+			int length = reader.read(SIGNATURE_LENGTH_BITS);
+			signatureEncoded = reader.readBytes(length);
+		}
+		return new EcdhEcdsaServerKeyExchange(signAndHash, ecdhData.supportedGroup, ecdhData.encodedPoint, signatureEncoded, peerAddress);
+	}
+
+	// Methods ////////////////////////////////////////////////////////
+
+	/**
+	 * Called by the client after receiving the server's
+	 * {@link ServerKeyExchange} message. Verifies the contained signature.
+	 * 
+	 * @param serverPublicKey
+	 *            the server's public key.
+	 * @param clientRandom
+	 *            the client's random (used in signature).
+	 * @param serverRandom
+	 *            the server's random (used in signature).
+	 * @throws HandshakeException
+	 *             if the signature could not be verified.
+	 */
+	public void verifySignature(PublicKey serverPublicKey, Random clientRandom, Random serverRandom) throws HandshakeException {
+		if (signatureEncoded == null) {
+			// no signature available, nothing to verify
+			return;
+		}
+		boolean verified = false;
+		try {
+			ThreadLocalSignature localSignature = signatureAndHashAlgorithm.getThreadLocalSignature();
+			Signature signature = localSignature.currentWithCause();
+			signature.initVerify(serverPublicKey);
+
+			updateSignature(signature, clientRandom, serverRandom);
+
+			verified = signature.verify(signatureEncoded);
+
+		} catch (GeneralSecurityException e) {
+			LOGGER.error("Could not verify the server's signature.",e);
+		}
+
+		if (!verified) {
+			String message = "The server's ECDHE key exchange message's signature could not be verified.";
+			AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE, getPeer());
+			throw new HandshakeException(message, alert);
+		}
+	}
+
+	/**
+	 * Update the signature: SHA(ClientHello.random + ServerHello.random +
+	 * ServerKeyExchange.params). See <a
+	 * href="http://tools.ietf.org/html/rfc4492#section-5.4">RFC 4492, Section
+	 * 5.4. Server Key Exchange</a> for further details on the signature format.
+	 * 
+	 * @param signature
+	 *            the signature
+	 * @param clientRandom
+	 *            the client random
+	 * @param serverRandom
+	 *            the server random
+	 * @throws SignatureException
+	 *             the signature exception
+	 */
+	private void updateSignature(Signature signature, Random clientRandom, Random serverRandom) throws SignatureException {
+		signature.update(clientRandom.getBytes());
+		signature.update(serverRandom.getBytes());
+		updateSignatureForNamedCurve(signature);
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append(super.toString());
+		if (signatureEncoded != null)
+		sb.append("\t\tSignature: ");
+		sb.append(signatureAndHashAlgorithm.toString()).append("-").append(StringUtil.byteArray2HexString(signatureEncoded, StringUtil.NO_SEPARATOR, 10));
+		sb.append(StringUtil.lineSeparator());
+
+		return sb.toString();
+	}
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchange.java
@@ -16,88 +16,63 @@
 package org.eclipse.californium.scandium.dtls;
 
 import java.net.InetSocketAddress;
-import java.security.PublicKey;
-import java.security.interfaces.ECPublicKey;
-import java.security.spec.ECParameterSpec;
-import java.security.spec.ECPoint;
-import java.util.Arrays;
 
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.NoPublicAPI;
 import org.eclipse.californium.elements.util.StringUtil;
-import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
 
 /**
- * Generates client ephemeral ECDH keys for Dtls ECDH_PSK mode.
+ * {@link ClientKeyExchange} message for PSK-ECDH based key exchange methods.
+ * Contains the client's ephemeral public key as encoded point and the PSK
+ * idenity. See <a href="https://tools.ietf.org/html/rfc5489#section-2">RFC
+ * 5489</a> for details. It is assumed, that the client's ECDH public key is not
+ * in the client's certificate, so it must be provided here.
  * 
- * See <a href="https://tools.ietf.org/html/rfc5489#section-2">RFC 5489</a> for details.
+ * According <a href= "https://tools.ietf.org/html/rfc8422#section-5.1.1">RFC
+ * 8422, 5.1.1. Supported Elliptic Curves Extension</a> only "named curves" are
+ * valid, the "prime" and "char2" curve descriptions are deprecated. Also only
+ * "UNCOMPRESSED" as point format is valid, the other formats have been
+ * deprecated.
  */
-public final class EcdhPskClientKeyExchange extends ClientKeyExchange {
+@NoPublicAPI
+public final class EcdhPskClientKeyExchange extends ECDHClientKeyExchange {
 
-
-	protected static final int LENGTH_BITS = 8; // opaque point <1..2^8-1>
 	private static final int IDENTITY_LENGTH_BITS = 16; // opaque <0..2^16-1>;
 
 	/**
 	 *See <a href="https://tools.ietf.org/html/rfc5489#section-2">RFC 5489</a>.
 	 */
 	private final PskPublicInformation identity;
-	private final byte[] pointEncoded;
-	
+
 	/**
 	 * Creates a new key exchange message for an identity hint and a public key.
 	 * 
 	 * @param identity PSK identity as public information
-	 * @param clientPublicKey ephemeral public key of client
+	 * @param encodedPoint ephemeral public key as encoded point
 	 * @param peerAddress peer's address
-	 * @throws NullPointerException if either hint or clietPublicKey are {@code null}
+	 * @throws NullPointerException if either identity or clietPublicKey are {@code null}
 	 */
-	public EcdhPskClientKeyExchange(PskPublicInformation identity, PublicKey clientPublicKey, InetSocketAddress peerAddress) {
-		super(peerAddress);
+	public EcdhPskClientKeyExchange(PskPublicInformation identity, byte[] encodedPoint, InetSocketAddress peerAddress) {
+		super(encodedPoint, peerAddress);
 		if (identity == null) {
 			throw new NullPointerException("identity cannot be null");
 		}
-		if (clientPublicKey == null) {
-			throw new NullPointerException("ephemeral public key cannot be null");
-		}
 		this.identity = identity;
-		ECPublicKey publicKey = (ECPublicKey) clientPublicKey;
-		ECPoint point = publicKey.getW();
-		ECParameterSpec params = publicKey.getParams();
-			
-		this.pointEncoded = ECDHECryptography.encodePoint(point, params.getCurve());
-	}
-	
-	/**
-	 * Creates a new key exchange message for an identity hint and a public key.
-	 * 
-	 * @param identityEncoded opaque encoded PSK identity hint for server
-	 * @param pointEncoded ephemeral public key of client (encoded point)
-	 * @param peerAddress peer's address
-	 * @throws NullPointerException if either hintEncoded or pointEncoded are {@code null}
-	 */
-	public EcdhPskClientKeyExchange(byte[] identityEncoded, byte[] pointEncoded, InetSocketAddress peerAddress) {
-		super(peerAddress);
-		if (identityEncoded ==null) {
-			throw new NullPointerException("identity cannot be null");
-		}
-		if (pointEncoded == null) {
-			throw new NullPointerException("epehemeral public key cannot be null");
-		}
-		this.identity = PskPublicInformation.fromByteArray(identityEncoded);
-		this.pointEncoded = Arrays.copyOf(pointEncoded, pointEncoded.length);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * Write the identity and encoded point.
+	 */
 	@Override
-	public byte[] fragmentToByteArray() {
-		DatagramWriter writer = new DatagramWriter();
+	protected void writeFragment(DatagramWriter writer) {
 		writer.write(identity.length(), IDENTITY_LENGTH_BITS);
 		writer.writeBytes(identity.getBytes());
-		writer.write(pointEncoded.length, LENGTH_BITS);
-		writer.writeBytes(pointEncoded);
-		return writer.toByteArray();
+		super.writeFragment(writer);
 	}
-	
+
 	/**
 	 * Creates a new client key exchange instance from its byte representation.
 	 * 
@@ -111,39 +86,27 @@ public final class EcdhPskClientKeyExchange extends ClientKeyExchange {
 			throw new NullPointerException("peer address cannot be null");
 		}
 		int identityLength = reader.read(IDENTITY_LENGTH_BITS);
-		byte[] identityEncoded = reader.readBytes(identityLength);	
-		int length = reader.read(LENGTH_BITS);
-		byte[] pointEncoded = reader.readBytes(length);
-		return new EcdhPskClientKeyExchange(identityEncoded, pointEncoded, peerAddress);
+		byte[] identityEncoded = reader.readBytes(identityLength);
+		PskPublicInformation identity = PskPublicInformation.fromByteArray(identityEncoded);
+		byte[] pointEncoded = readEncodedPoint(reader);
+		return new EcdhPskClientKeyExchange(identity, pointEncoded, peerAddress);
 	}
-		
 
 	@Override
 	public int getMessageLength() {
-		return 3 + identity.length() + pointEncoded.length;
-	}
-
-	/**
-	 * This method returns the ephemeral public key (encoded point) from {@link ClientKeyExchange}.
-	 * 
-	 * @return encoded point in byte array
-	 */
-	public byte[] getEncodedPoint() {
-		return Arrays.copyOf(pointEncoded, pointEncoded.length);
+		return 2 + identity.length() + super.getMessageLength();
 	}
 
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append(super.toString());
 		sb.append("\t\t Encoded identity value: ");
 		sb.append(identity).append(StringUtil.lineSeparator());;
-		sb.append("\t\tEC Diffie-Hellman public value: ");		
-		sb.append(StringUtil.byteArray2Hex(pointEncoded));
+		sb.append(super.toString());
 		sb.append(StringUtil.lineSeparator());
 		return sb.toString();
-	}		
-	
+	}
+
 	/**
 	 * This method returns the PSK identity as public information.
 	 * 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeMessage.java
@@ -319,7 +319,7 @@ public abstract class HandshakeMessage extends AbstractMessage {
 			throws HandshakeException {
 		switch (keyExchange) {
 		case EC_DIFFIE_HELLMAN:
-			return ECDHServerKeyExchange.fromReader(reader, peerAddress);
+			return EcdhEcdsaServerKeyExchange.fromReader(reader, peerAddress);
 		case PSK:
 			return PSKServerKeyExchange.fromReader(reader, peerAddress);
 		case ECDHE_PSK:

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -96,7 +96,6 @@ import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
-import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
 import org.eclipse.californium.scandium.dtls.cipher.PseudoRandomFunction;
 import org.eclipse.californium.scandium.dtls.cipher.PseudoRandomFunction.Label;
 import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
@@ -126,9 +125,6 @@ public abstract class Handshaker implements Destroyable {
 	protected ProtocolVersion usedProtocol;
 	protected Random clientRandom;
 	protected Random serverRandom;
-
-	/** The helper class to execute the ECDHE key agreement and key generation. */
-	protected ECDHECryptography ecdhe;
 
 	/**
 	 * The master secret for this handshake.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
@@ -256,8 +256,8 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 	@Override
 	public void startHandshake() throws HandshakeException {
 		handshakeStarted();
-		ClientHello message = new ClientHello(new ProtocolVersion(), session,
-				supportedClientCertificateTypes, supportedServerCertificateTypes);
+		ClientHello message = new ClientHello(new ProtocolVersion(), session, supportedSignatureAlgorithms,
+				supportedClientCertificateTypes, supportedServerCertificateTypes, supportedGroups);
 
 		clientRandom = message.getRandom();
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/ECDHECryptography.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/ECDHECryptography.java
@@ -53,7 +53,9 @@ import javax.crypto.SecretKey;
 
 /**
  * A helper class to execute the ECDHE key agreement and key generation.
+ * @deprecated use {@link XECDHECryptography} instead
  */
+@Deprecated
 public final class ECDHECryptography {
 
 	// Logging ////////////////////////////////////////////////////////

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/ThreadLocalCrypto.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/ThreadLocalCrypto.java
@@ -88,6 +88,8 @@ public class ThreadLocalCrypto<CryptoFunction> {
 	 * @return thread local crypto function.
 	 * @throws GeneralSecurityException if crypto function is not supported by
 	 *             the java-vm.
+	 * 
+	 * @since 2.3
 	 */
 	public CryptoFunction currentWithCause() throws GeneralSecurityException {
 		if (exception != null) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/ThreadLocalKeyFactory.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/ThreadLocalKeyFactory.java
@@ -16,32 +16,32 @@
 package org.eclipse.californium.scandium.dtls.cipher;
 
 import java.security.GeneralSecurityException;
-import java.security.Signature;
+import java.security.KeyFactory;
 
 /**
- * Thread local Signature.
+ * Thread local KeyFactory.
  * 
  * Uses {@link ThreadLocal} to cache calls to
- * {@link Signature#getInstance(String)}.
+ * {@link KeyFactory#getInstance(String)}.
  * 
  * @since 2.3
  */
-public class ThreadLocalSignature extends ThreadLocalCrypto<Signature> {
+public class ThreadLocalKeyFactory extends ThreadLocalCrypto<KeyFactory> {
 
 	/**
-	 * {@inheritDoc} Create thread local Signature.
+	 * {@inheritDoc} Create thread local KeyFactory.
 	 * 
-	 * Try to instance the Signature for the provided algorithm.
+	 * Try to instance the KeyFactory for the provided algorithm.
 	 * 
 	 * @param algorithm algorithm. Passed to
-	 *            {@link Signature#getInstance(String)}.
+	 *            {@link KeyFactory#getInstance(String)}.
 	 */
-	public ThreadLocalSignature(final String algorithm) {
-		super(new Factory<Signature>() {
+	public ThreadLocalKeyFactory(final String algorithm) {
+		super(new Factory<KeyFactory>() {
 
 			@Override
-			public Signature getInstance() throws GeneralSecurityException {
-				return Signature.getInstance(algorithm);
+			public KeyFactory getInstance() throws GeneralSecurityException {
+				return KeyFactory.getInstance(algorithm);
 			}
 
 		});

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/XECDHECryptography.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/XECDHECryptography.java
@@ -1,0 +1,759 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial creation
+ *                    derived from ECDHECryptography
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls.cipher;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.EllipticCurve;
+import java.security.spec.KeySpec;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.californium.elements.util.Asn1DerDecoder;
+import org.eclipse.californium.elements.util.Bytes;
+import org.eclipse.californium.elements.util.StringUtil;
+import org.eclipse.californium.scandium.util.SecretUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.crypto.KeyAgreement;
+import javax.crypto.SecretKey;
+import javax.security.auth.Destroyable;
+
+/**
+ * A helper class to execute the XDH and ECDHE key agreement and key generation.
+ * Support X25519 and X448 with java 11. The API is simplified compared to the
+ * previous API of the deprecated {@link ECDHECryptography}.
+ * 
+ * A ECDHE key exchange starts with negotiating a curve. The possible curves are
+ * listed at <a href=
+ * "http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8">
+ * IANA Transport Layer Security (TLS) Parameters - TLS Supported Groups</a>.
+ * The {@link SupportedGroup} reflects that and offer the curve's
+ * {@link SupportedGroup#name()} (description in the IANA table) or
+ * {@link SupportedGroup#getId()} (value in the IANA table). You may refer
+ * directly a member, e.g. {@link SupportedGroup#X25519}, or get it by id
+ * {@link SupportedGroup#fromId(int)} or by the curve-name
+ * {@link SupportedGroup#valueOf(String)}.
+ * 
+ * Once you have a curve negotiated, you create a instance of
+ * {@link XECDHECryptography#XECDHECryptography(SupportedGroup)} providing this
+ * curve as parameter. This will also create the ephemeral key-pair for the key
+ * exchange. After each peer creates such a instance (and so different
+ * key-pairs), the "public key" is sent to the other peer. Though the curve is
+ * transfered by it's {@link SupportedGroup#getId()} (named curve), the public
+ * key itself is sent just by the {@link #getEncodedPoint()} and not the ASN.1
+ * encoding ({@link PublicKey#getEncoded()}). Each peer converts the received
+ * encoded point of the other peer into a {@link PublicKey} and applies that to
+ * {@link KeyAgreement#doPhase(java.security.Key, boolean)}. Outside of this
+ * class only the encoded point and the {@link SupportedGroup} is used to do the
+ * key exchange. Access to the {@link PrivateKey} nor {@link PublicKey} is
+ * required outside.
+ * 
+ * <pre>
+ * 
+ * SupportedGroup group = SupportedGroup.X25519;
+ * 
+ * // peer 1
+ * XECDHECryptography ecdhe1 = new XECDHECryptography(group);
+ * byte[] point1 = ecdhe1.getEncodedPoint();
+ * 
+ * // send group + encoded point to other peer
+ * 
+ * // peer 2, use received group 
+ * XECDHECryptography ecdhe2 = new XECDHECryptography(group);
+ * byte[] point2 = ecdhe2.getEncodedPoint();
+ * SecretKey secret2 = ecdhe2.generateSecret(point1);
+ * 
+ * // send own encoded point back to first peer
+ * 
+ * // peer 1
+ * SecretKey secret1 = ecdhe1.generateSecret(point2);
+ * 
+ * </pre>
+ * 
+ * results in same secrets {@code secret1} and {@secret2}.
+ * 
+ * @see https://tools.ietf.org/html/rfc7748
+ * @since 2.3
+ */
+public final class XECDHECryptography implements Destroyable {
+
+	// Logging ////////////////////////////////////////////////////////
+
+	protected static final Logger LOGGER = LoggerFactory.getLogger(XECDHECryptography.class);
+
+	// Static members /////////////////////////////////////////////////
+
+	/**
+	 * The algorithm for the elliptic curve key pair generation.
+	 * 
+	 * See also <a href=
+	 * "http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#KeyPairGenerator"
+	 * >KeyPairGenerator Algorithms</a>.
+	 */
+	private static final String EC_KEYPAIR_GENERATOR_ALGORITHM = "EC";
+
+	private static final ThreadLocalKeyPairGenerator EC_KEYPAIR_GENERATOR = new ThreadLocalKeyPairGenerator(EC_KEYPAIR_GENERATOR_ALGORITHM);
+
+	/**
+	 * X25519 and X448.
+	 */
+	private static final String XDH_KEYPAIR_GENERATOR_ALGORITHM = "XDH";
+
+	private static final ThreadLocalKeyPairGenerator XDH_KEYPAIR_GENERATOR = new ThreadLocalKeyPairGenerator(XDH_KEYPAIR_GENERATOR_ALGORITHM);
+
+	private static final String EC_KEY_FACTORY_ALGORITHM = "EC";
+
+	private static final ThreadLocalKeyFactory EC_KEY_FACTORY = new ThreadLocalKeyFactory(EC_KEY_FACTORY_ALGORITHM);
+
+	private static final String XDH_KEY_FACTORY_ALGORITHM = "XDH";
+
+	private static final ThreadLocalKeyFactory XDH_KEY_FACTORY = new ThreadLocalKeyFactory(XDH_KEY_FACTORY_ALGORITHM);
+
+	/**
+	 * Elliptic Curve Diffie-Hellman algorithm name. See also <a href=
+	 * "http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#KeyAgreement"
+	 * >KeyAgreement Algorithms</a>.
+	 */
+	private static final String ECDH_KEY_AGREEMENT_ALGORITHM = "ECDH";
+
+	private static final ThreadLocalKeyAgreement ECDH_KEY_AGREEMENT = new ThreadLocalKeyAgreement(ECDH_KEY_AGREEMENT_ALGORITHM);
+
+	/**
+	 * X25519 and X448.
+	 */
+	private static final String XDH_KEY_AGREEMENT_ALGORITHM = "XDH";
+
+	private static final ThreadLocalKeyAgreement XDH_KEY_AGREEMENT = new ThreadLocalKeyAgreement(XDH_KEY_AGREEMENT_ALGORITHM);
+
+	/**
+	 * Use java 11 XDH via reflection.
+	 */
+	private static final Class<?> XECPublicKeyClass;
+	private static final Method XECPublicKeyGetU;
+	private static final Method XECPublicKeyGetParams;
+	private static final Method NamedParameterSpecGetName;
+	private static final Constructor<?> XECPublicKeySpecInit;
+
+	static {
+		Class<?> cls =null;
+		Method getParams = null;
+		Method getU = null;
+		Method getName = null;
+		Constructor<?> init = null;
+		try {
+			cls = Class.forName("java.security.spec.XECPublicKeySpec");
+			init = cls.getConstructor(AlgorithmParameterSpec.class, BigInteger.class);
+			cls = Class.forName("java.security.spec.NamedParameterSpec");
+			getName = cls.getMethod("getName");
+			cls = Class.forName("java.security.interfaces.XECPublicKey");
+			getU = cls.getMethod("getU");
+			getParams = cls.getMethod("getParams");
+		} catch (Exception e) {
+			LOGGER.info("X25519/X448 not supported!");
+		}
+		XECPublicKeyClass = cls;
+		XECPublicKeyGetU = getU;
+		XECPublicKeyGetParams = getParams;
+		NamedParameterSpecGetName = getName;
+		XECPublicKeySpecInit = init;
+	}
+
+	/**
+	 * Map of {@link SupportedGroup#getId() to {@link SupportedGroup}.
+	 * 
+	 * @see {@link SupportedGroup#fromId(int)}.
+	 */
+	private static final Map<Integer, SupportedGroup> EC_CURVE_MAP_BY_ID = new HashMap<>();
+	/**
+	 * Map of {@link SupportedGroup#getId() to {@link SupportedGroup}.
+	 * 
+	 * @see {@link SupportedGroup#fromId(int)}.
+	 */
+	private static final Map<EllipticCurve, SupportedGroup> EC_CURVE_MAP_BY_CURVE = new HashMap<>();
+
+	// Members ////////////////////////////////////////////////////////
+
+	/**
+	 * Supported group (curve) of this key exchange.
+	 */
+	private final SupportedGroup supportedGroup;
+
+	/** The ephemeral private key. */
+	private PrivateKey privateKey;
+
+	/** The ephemeral public key. */
+	private PublicKey publicKey;
+
+	private byte[] encodedPoint;
+
+	// Constructors ///////////////////////////////////////////////////
+
+	/**
+	 * Creates an ephemeral ECDH key pair for a given supported group.
+	 * 
+	 * @param supportedGroup a curve as defined in the <a href=
+	 *            "http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8">
+	 *            IANA Supported Groups Registry</a>
+	 * @throws GeneralSecurityException if the key pair cannot be created from
+	 *             the given supported group, e.g. because the JRE's crypto
+	 *             provider doesn't support the group
+	 */
+	public XECDHECryptography(SupportedGroup supportedGroup) throws GeneralSecurityException {
+		KeyPair keyPair;
+		if (supportedGroup.getAlgorithmName().equals(EC_KEYPAIR_GENERATOR_ALGORITHM)) {
+			KeyPairGenerator keyPairGenerator = EC_KEYPAIR_GENERATOR.currentWithCause();
+			ECGenParameterSpec params = new ECGenParameterSpec(supportedGroup.name());
+			keyPairGenerator.initialize(params, RandomManager.currentSecureRandom());
+			keyPair = keyPairGenerator.generateKeyPair();
+		} else if (supportedGroup.getAlgorithmName().equals(XDH_KEYPAIR_GENERATOR_ALGORITHM)) {
+			KeyPairGenerator keyPairGenerator = XDH_KEYPAIR_GENERATOR.currentWithCause();
+			ECGenParameterSpec params = new ECGenParameterSpec(supportedGroup.name());
+			keyPairGenerator.initialize(params, RandomManager.currentSecureRandom());
+			keyPair = keyPairGenerator.generateKeyPair();
+		} else {
+			throw new GeneralSecurityException(supportedGroup.name() + " not supported by KeyPairGenerator!");
+		}
+		privateKey = keyPair.getPrivate();
+		publicKey = keyPair.getPublic();
+		this.supportedGroup = supportedGroup;
+		this.encodedPoint = encodedPoint(keyPair.getPublic());
+	}
+
+	/**
+	 * Get public key.
+	 * 
+	 * Unit-tests only!
+	 * 
+	 * @return public key
+	 */
+	PublicKey getPublicKey() {
+		return publicKey;
+	}
+
+	/**
+	 * Get the supported group (curve) of this key exchange.
+	 * @return supported group
+	 */
+	public SupportedGroup getSupportedGroup() {
+		return supportedGroup;
+	}
+
+	/**
+	 * Get public key as encoded point.
+	 * 
+	 * The key exchange contains the used curve by its
+	 * {@link SupportedGroup#getId()}, therefore the ASN.1
+	 * {@link PublicKey#getEncoded()} is not required.
+	 * 
+	 * @return encoded point to be sent to the other peer
+	 * @throws GeneralSecurityException if the public key could not be converted
+	 *             into a encoded point.
+	 */
+	public byte[] getEncodedPoint() {
+		return encodedPoint;
+	}
+
+	/**
+	 * Generate secret of key exchange.
+	 * 
+	 * @param encodedPoint the other peer's public key as encoded point
+	 * @return the premaster secret
+	 * @throws NullPointerException if encodedPoint is {@code null}.
+	 * @throws GeneralSecurityException if a crypt error occurred.
+	 */
+	public SecretKey generateSecret(byte[] encodedPoint) throws GeneralSecurityException {
+		if (encodedPoint == null) {
+			throw new NullPointerException("encoded point must not be null!");
+		}
+		PublicKey peerPublicKey;
+		int keySize = supportedGroup.getKeySizeInBytes();
+		// extract public key
+		if (supportedGroup.getAlgorithmName().equals(EC_KEYPAIR_GENERATOR_ALGORITHM)) {
+			int left = encodedPoint.length - 1;
+			if (encodedPoint[0] == Asn1DerDecoder.EC_PUBLIC_KEY_UNCOMPRESSED && left % 2 == 0 && left / 2 == keySize) {
+				left /= 2;
+				byte[] encoded = new byte[keySize];
+				System.arraycopy(encodedPoint, 1, encoded, 0, keySize);
+				BigInteger x = new BigInteger(1, encoded);
+				System.arraycopy(encodedPoint, 1 + keySize, encoded, 0, keySize);
+				BigInteger y = new BigInteger(1, encoded);
+				ECParameterSpec ecParams = ((ECPrivateKey)privateKey).getParams();
+				KeySpec publicKeySpec = new ECPublicKeySpec(new ECPoint(x, y), ecParams);
+				KeyFactory keyFactory = EC_KEY_FACTORY.currentWithCause();
+				peerPublicKey = keyFactory.generatePublic(publicKeySpec);
+			} else {
+				throw new GeneralSecurityException(
+						"DHE: failed to decoded point! " + supportedGroup.name());
+			}
+		} else {
+			BigInteger u = new BigInteger(1, revert(encodedPoint, keySize));
+			KeySpec spec = getXECPublicKeySpec(supportedGroup.name(), u);
+			KeyFactory keyFactory = XDH_KEY_FACTORY.currentWithCause();
+			peerPublicKey = keyFactory.generatePublic(spec);
+		}
+		check("IN: ", peerPublicKey, encodedPoint);
+		return generateSecret(peerPublicKey);
+	}
+
+	/**
+	 * Runs the specified key agreement algorithm (ECDH) to generate the
+	 * premaster secret.
+	 * 
+	 * @param peerPublicKey
+	 *            the other peer's ephemeral public key.
+	 * @return the premaster secret.
+	 * @throws GeneralSecurityException if a crypt error occurred.
+	 */
+	private SecretKey generateSecret(PublicKey peerPublicKey) throws GeneralSecurityException {
+		KeyAgreement keyAgreement = null;
+		if (supportedGroup.getAlgorithmName().equals(EC_KEYPAIR_GENERATOR_ALGORITHM)) {
+			keyAgreement = ECDH_KEY_AGREEMENT.currentWithCause();
+		} else if (supportedGroup.getAlgorithmName().equals(XDH_KEYPAIR_GENERATOR_ALGORITHM)) {
+			keyAgreement = XDH_KEY_AGREEMENT.currentWithCause();
+		}
+		keyAgreement.init(privateKey);
+		keyAgreement.doPhase(peerPublicKey, true);
+		byte[] secret = keyAgreement.generateSecret();
+		SecretKey secretKey = SecretUtil.create(secret, "TlsPremasterSecret");
+		Bytes.clear(secret);
+		return secretKey;
+	}
+
+	@Override
+	public void destroy() {
+		privateKey = null;
+	}
+
+	@Override
+	public boolean isDestroyed() {
+		return privateKey == null;
+	}
+
+	/**
+	 * Get public key as encoded point.
+	 * 
+	 * The key exchange contains the used curve by its
+	 * {@link SupportedGroup#getId()}, therefore the ASN.1
+	 * {@link PublicKey#getEncoded()} is not required.
+	 * 
+	 * @param publicKey public key
+	 * @return encoded point to be sent to the other peer
+	 * @throws GeneralSecurityException if the public key could not be converted
+	 *             into a encoded point.
+	 */
+	private byte[] encodedPoint(PublicKey publicKey) throws GeneralSecurityException {
+		byte[] result = null;
+		int keySizeInBytes = supportedGroup.getKeySizeInBytes();
+		try {
+			if (supportedGroup.getAlgorithmName().equals(EC_KEYPAIR_GENERATOR_ALGORITHM)) {
+				ECPublicKey ecPublicKey = (ECPublicKey) publicKey;
+				result = encodePoint(ecPublicKey.getW(), keySizeInBytes);
+			} else if (supportedGroup.getAlgorithmName().equals(XDH_KEYPAIR_GENERATOR_ALGORITHM)) {
+				BigInteger u = getXECPublicKeyU(publicKey);
+				result = revert(u.toByteArray(), keySizeInBytes);
+			}
+		} catch (RuntimeException ex) {
+			throw new GeneralSecurityException("DHE: failed to encoded point! " + supportedGroup.name(), ex);
+		}
+		if (result == null) {
+			throw new GeneralSecurityException("DHE: failed to encoded point! " + supportedGroup.name());
+		}
+		check("OUT: ", publicKey, result);
+		return result;
+	}
+
+	private void check(String tag, PublicKey publicKey, byte[] point) throws GeneralSecurityException {
+		if (LOGGER.isDebugEnabled()) {
+			byte[] asn1 = publicKey.getEncoded();
+			String s1 = StringUtil.byteArray2Hex(asn1);
+			String s2 = StringUtil.byteArray2Hex(point);
+			if (s2.length() < s1.length()) {
+				s2 = String.format("%" + s1.length() + "s", s2);
+			}
+			LOGGER.debug("{}ASN1 encoded '{}'", tag, s1);
+			LOGGER.debug("{}DHE  encoded '{}'", tag, s2);
+			for (int index = 0; index < point.length; ++index) {
+				if (point[point.length - index - 1] != asn1[asn1.length - index - 1]) {
+					throw new GeneralSecurityException(
+							"DHE: failed to encoded point! " + supportedGroup.name() + ", position: " + index);
+				}
+			}
+		}
+	}
+
+	// Serialization //////////////////////////////////////////////////
+
+	private BigInteger getXECPublicKeyU(PublicKey publicKey) throws GeneralSecurityException {
+		if (XECPublicKeyGetU == null) {
+			throw new GeneralSecurityException(supportedGroup.name() + " not supported by JRE!");
+		}
+		try {
+			return (BigInteger) XECPublicKeyGetU.invoke(publicKey);
+		} catch (Exception e) {
+			throw new GeneralSecurityException(supportedGroup.name() + " not supported by JRE!", e);
+		}
+	}
+
+	private KeySpec getXECPublicKeySpec(String name, BigInteger u) throws GeneralSecurityException {
+		if (XECPublicKeySpecInit == null) {
+			throw new GeneralSecurityException(supportedGroup.name() + " not supported by JRE!");
+		}
+		try {
+			ECGenParameterSpec parameterSpec = new ECGenParameterSpec(name);
+			return (KeySpec) XECPublicKeySpecInit.newInstance(parameterSpec, u);
+		} catch (Exception e) {
+			throw new GeneralSecurityException(supportedGroup.name() + " not supported by JRE!", e);
+		}
+	}
+
+	private static String getXECPublicKeyName(PublicKey publicKey) throws GeneralSecurityException {
+		if (XECPublicKeyGetParams == null || NamedParameterSpecGetName == null) {
+			throw new GeneralSecurityException("X25519/X448 not supported by JRE!");
+		}
+		try {
+			Object params = XECPublicKeyGetParams.invoke(publicKey);
+			return (String) NamedParameterSpecGetName.invoke(params);
+		} catch (Exception e) {
+			throw new GeneralSecurityException("X25519/X448 not supported by JRE!");
+		}
+	}
+
+	/**
+	 * Get offset for none zero data.
+	 * 
+	 * @param byteArray bytes to check for first none zero value
+	 * @return offset of first none zero value
+	 */
+	private static int noneZeroOffset(byte[] byteArray) {
+		int offset = 0;
+		while (offset < byteArray.length && byteArray[offset] == 0) {
+			++offset;
+		}
+		return offset;
+	}
+
+	/**
+	 * Revert provided bytes into a array of provided size.
+	 * 
+	 * Strip leading zeros of the provided array. Adjust size of resulting array
+	 * by append zeros.
+	 * 
+	 * @param byteArray array to revert
+	 * @param size size of reverse array
+	 * @return reverse array with appended padding zeros
+	 */
+	private static byte[] revert(byte[] byteArray, int size) {
+		int offset = noneZeroOffset(byteArray);
+		int length = byteArray.length - offset;
+		if (length > size) {
+			throw new IllegalArgumentException("big integer array exceeds size! " + length + " > " + size);
+		}
+		byte[] result = new byte[size];
+		for (int index = 0; index < length; ++index) {
+			result[length - 1 - index] = byteArray[index + offset];
+		}
+		return result;
+	}
+
+	/**
+	 * Encodes an EC point according to the X9.62 specification.
+	 * 
+	 * @param point
+	 *            the EC point to be encoded.
+	 * @param keySizeInBytes
+	 *            the keysize in bytes.
+	 * @return the encoded EC point.
+	 */
+	private static byte[] encodePoint(ECPoint point, int keySizeInBytes) {
+		// get field size in bytes (rounding up)
+
+		byte[] xb = point.getAffineX().toByteArray();
+		byte[] yb = point.getAffineY().toByteArray();
+		int xbOffset = noneZeroOffset(xb);
+		int xbLength = xb.length - xbOffset;
+		int ybOffset = noneZeroOffset(yb);
+		int ybLength = yb.length - ybOffset;
+
+		if ((xbLength > keySizeInBytes) || (ybLength > keySizeInBytes)) {
+			throw new IllegalArgumentException("ec point exceeds size! " + xbLength + "," + ybLength + " > " + keySizeInBytes);
+		}
+
+		// 1 byte (compression state) + twice field size
+		byte[] encoded = new byte[1 + (keySizeInBytes * 2)];
+		encoded[0] = Asn1DerDecoder.EC_PUBLIC_KEY_UNCOMPRESSED; // uncompressed
+		System.arraycopy(xb, xbOffset, encoded, keySizeInBytes + 1 - xbLength, xbLength);
+		System.arraycopy(yb, ybOffset, encoded, encoded.length - ybLength, ybLength);
+
+		return encoded;
+	}
+
+	/**
+	 * The <em>Supported Groups</em> as defined in the official
+	 * <a href="http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8">
+	 * IANA Transport Layer Security (TLS) Parameters</a>.
+	 * 
+	 * Also see <a href="http://tools.ietf.org/html/rfc4492#section-5.1.1">RFC 4492,
+	 * Section 5.1.1 Supported Elliptic Curves Extension</a>.
+	 */
+	public enum SupportedGroup {
+
+		sect163k1(1, false),
+		sect163r1(2, false),
+		sect163r2(3, false),
+		sect193r1(4, false),
+		sect193r2(5, false),
+		sect233k1(6, false),
+		sect233r1(7, false),
+		sect239k1(8, false),
+		sect283k1(9, false),
+		sect283r1(10, false),
+		sect409k1(11, false),
+		sect409r1(12, false),
+		sect571k1(13, false),
+		sect571r1(14, false),
+		secp160k1(15, false),
+		secp160r1(16, false),
+		secp160r2(17, false),
+		secp192k1(18, false),
+		secp192r1(19, false),
+		secp224k1(20, false),
+		secp224r1(21, false),
+		secp256k1(22, false),
+		secp256r1(23, true),
+		secp384r1(24, true),
+		secp521r1(25, false),
+		brainpoolP256r1(26, false),
+		brainpoolP384r1(27, false),
+		brainpoolP512r1(28, false),
+		ffdhe2048(256, false),
+		ffdhe3072(257, false),
+		ffdhe4096(258, false),
+		ffdhe6144(259, false),
+		ffdhe8192(260, false),
+		arbitrary_explicit_prime_curves(65281, false),
+		arbitrary_explicit_char2_curves(65282, false),
+
+		X25519(29, 32, XDH_KEYPAIR_GENERATOR_ALGORITHM, true),
+		X448(30, 56, XDH_KEYPAIR_GENERATOR_ALGORITHM, true);
+
+		private final int id;
+		private final String algorithmName;
+		private final int keySizeInBytes;
+		private final boolean usable;
+		private final boolean recommended;
+
+		/**
+		 * Create supported group.
+		 * 
+		 * @param code code according IANA
+		 * @param recommended {@code true}, for IANA recommeded curves,
+		 *            {@code false}, otherwise.
+		 */
+		private SupportedGroup(int code, boolean recommended) {
+			this.id = code;
+			this.algorithmName = EC_KEYPAIR_GENERATOR_ALGORITHM;
+			this.recommended = recommended;
+			EllipticCurve curve = null;
+			int keySize = 0;
+			try {
+				KeyPairGenerator keyPairGenerator = EC_KEYPAIR_GENERATOR.currentWithCause();
+				ECGenParameterSpec genParams = new ECGenParameterSpec(name());
+				keyPairGenerator.initialize(genParams);
+				ECPublicKey apub = (ECPublicKey) keyPairGenerator.generateKeyPair().getPublic();
+				curve= apub.getParams().getCurve();
+				keySize = (curve.getField().getFieldSize() + Byte.SIZE - 1) / Byte.SIZE;
+				EC_CURVE_MAP_BY_CURVE.put(curve, this);
+			} catch (GeneralSecurityException e) {
+				LOGGER.trace("Group [{}] is not supported by JRE! {}", name(), e.getMessage());
+			}
+			this.keySizeInBytes = keySize;
+			this.usable = curve != null;
+			EC_CURVE_MAP_BY_ID.put(code, this);
+		}
+
+		/**
+		 * Create supported group.
+		 * 
+		 * @param code code according IANA
+		 * @param keySizeInBytes public key size in bytes
+		 * @param algorithmName JRE name of key pair generator algorithm.
+		 *            Currently only "XDH" is implemented!
+		 * @param recommended {@code true}, for IANA recommeded curves,
+		 *            {@code false}, otherwise.
+		 */
+		private SupportedGroup(int code, int keySizeInBytes, String algorithmName, boolean recommended) {
+			this.id = code;
+			this.algorithmName = algorithmName;
+			this.keySizeInBytes = keySizeInBytes;
+			this.recommended = recommended;
+			boolean usable = false;
+			try {
+				KeyPairGenerator keyPairGenerator = XDH_KEYPAIR_GENERATOR.currentWithCause();
+				ECGenParameterSpec params = new ECGenParameterSpec(name());
+				keyPairGenerator.initialize(params);
+				keyPairGenerator.generateKeyPair();
+				usable = true;
+			} catch (GeneralSecurityException e) {
+				LOGGER.trace("Group [{}] is not supported by JRE! {}", name(), e.getMessage());
+			}
+			this.usable = usable;
+			EC_CURVE_MAP_BY_ID.put(code, this);
+		}
+
+		/**
+		 * Gets this group's official id as registered with IANA.
+		 * 
+		 * @return the id
+		 */
+		public int getId() {
+			return id;
+		}
+
+		public String getAlgorithmName() {
+			return algorithmName;
+		}
+
+		/**
+		 * Gets the group for a given id.
+		 * 
+		 * @param id the id
+		 * @return the group or {@code null} if no group with the given id
+		 *          is (currently) registered
+		 */
+		public static SupportedGroup fromId(int id) {
+			return EC_CURVE_MAP_BY_ID.get(id);
+		}
+
+		/**
+		 * Gets the group for a given public key.
+		 * 
+		 * @param publicKey the public key 
+		 * @return the group or {@code null}, if no group with the given id
+		 *          is (currently) registered
+		 */
+		public static SupportedGroup fromPublicKey(PublicKey publicKey) {
+			if (publicKey != null) {
+				if (publicKey instanceof ECPublicKey) {
+					ECParameterSpec params = ((ECPublicKey) publicKey).getParams();
+					return EC_CURVE_MAP_BY_CURVE.get(params.getCurve());
+				} else if (XECPublicKeyClass != null && XECPublicKeyClass.isInstance(publicKey)) {
+					try {
+						String name = getXECPublicKeyName(publicKey);
+						return SupportedGroup.valueOf(name);
+					} catch (GeneralSecurityException ex) {
+
+					}
+				}
+			}
+			return null;
+		}
+
+		public int getKeySizeInBytes() {
+			return keySizeInBytes;
+		}
+
+		/**
+		 * Checks whether this group can be used on this platform.
+		 * 
+		 * @return <code>true</code> if the group's domain params are known
+		 *            and the JRE's crypto provider supports it
+		 */
+		public boolean isUsable() {
+			return usable;
+		}
+
+		public boolean isRecommended() {
+			return recommended;
+		}
+
+		/**
+		 * Gets all <code>SupportedGroup</code>s that can be used on this
+		 * platform.
+		 * 
+		 * @return the supported groups as unmodifiable list.
+		 * @see #isUsable()
+		 */
+		public static List<SupportedGroup> getUsableGroups() {
+			return Initialize.USABLE_GROUPS;
+		}
+
+		/**
+		 * Gets the preferred <em>supported groups</em>.
+		 * 
+		 * @return the groups in order of preference as unmodifiable list.
+		 */
+		public static List<SupportedGroup> getPreferredGroups() {
+			return Initialize.PREFERRED_GROUPS;
+		}
+	}
+
+	/**
+	 * Prepare usable and preferred list of ec groups.
+	 */
+	private static class Initialize {
+
+		/**
+		 * Default preferred supported groups. Keep
+		 * {@link SupportedGroup#secp256r1} at the first position for backwards
+		 * compatibility, when the server doesn't receive the "supported
+		 * elliptic curves extension".
+		 */
+		private static final SupportedGroup PREFERRED[] = { SupportedGroup.secp256r1, SupportedGroup.X25519,
+				SupportedGroup.X448, SupportedGroup.secp384r1 };
+		private static final List<SupportedGroup> USABLE_GROUPS;
+		private static final List<SupportedGroup> PREFERRED_GROUPS;
+
+		static {
+			List<SupportedGroup> usableGroups = new ArrayList<>();
+			List<SupportedGroup> preferredGroups = new ArrayList<>();
+			for (SupportedGroup group : SupportedGroup.values()) {
+				if (group.isUsable()) {
+					usableGroups.add(group);
+				}
+			}
+			for (SupportedGroup group : PREFERRED) {
+				if (group.isUsable()) {
+					preferredGroups.add(group);
+				}
+			}
+			if (preferredGroups.isEmpty() && !usableGroups.isEmpty()) {
+				preferredGroups.add(usableGroups.get(0));
+			}
+			USABLE_GROUPS = Collections.unmodifiableList(usableGroups);
+			PREFERRED_GROUPS = Collections.unmodifiableList(preferredGroups);
+		}
+	}
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/util/SecretUtil.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/util/SecretUtil.java
@@ -55,7 +55,7 @@ public class SecretUtil {
 				destroyable.destroy();
 			} catch (DestroyFailedException e) {
 				// Using SecretIvParameterSpec or SecretKey created by this class
-				// should never throw whit. Using other Destroyable implementations
+				// should never throw it. Using other Destroyable implementations
 				// may throw it.
 				LOGGER.warn("Destroy on {} failed!", destroyable.getClass(), e);
 			}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
@@ -242,7 +242,7 @@ public class DTLSConnectorAdvancedTest {
 		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder()
 				.setRetransmissionTimeout(RETRANSMISSION_TIMEOUT_MS)
 				.setMaxRetransmissions(MAX_RETRANSMISSIONS)
-				.setMaxDeferredProcessedIncomingRecordsSize(128)
+				.setMaxDeferredProcessedIncomingRecordsSize(96)
 				.setConnectionIdGenerator(serverCidGenerator);
 		ConnectorHelper limitedServerHelper = new ConnectorHelper();
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -1008,8 +1008,9 @@ public class DTLSConnectorTest {
 		if (cipherSuites != null && cipherSuites.length > 0) {
 			list = Arrays.asList(cipherSuites);
 		}
-		ClientHello hello = new ClientHello(new ProtocolVersion(), list,
-				clientConfig.getIdentityCertificateTypes(), clientConfig.getTrustCertificateTypes(), clientEndpoint);
+		ClientHello hello = new ClientHello(new ProtocolVersion(), list, clientConfig.getSupportedSignatureAlgorithms(),
+				clientConfig.getIdentityCertificateTypes(), clientConfig.getTrustCertificateTypes(),
+				clientConfig.getSupportedGroups(), clientEndpoint);
 		hello.addCompressionMethod(CompressionMethod.NULL);
 		hello.setMessageSeq(0);
 		return hello;

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/config/DtlsConnectorConfigTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/config/DtlsConnectorConfigTest.java
@@ -153,6 +153,14 @@ public class DtlsConnectorConfigTest {
 	}
 
 	@Test(expected = IllegalStateException.class)
+	public void testBuilderDetectsNoCurveForCertificate() throws Exception {
+		builder.setSupportedCipherSuites(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8)
+				.setIdentity(DtlsTestTools.getPrivateKey(), DtlsTestTools.getPublicKey())
+				.setSupportedGroups("secp384r1")
+				.setRpkTrustAll().build();
+	}
+
+	@Test(expected = IllegalStateException.class)
 	public void testBuilderDetectsMissingIdentity() {
 		builder.setSupportedCipherSuites(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8).setRpkTrustAll().build();
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHelloTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHelloTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import org.eclipse.californium.scandium.category.Small;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -69,8 +70,10 @@ public class ClientHelloTest {
 
 		givenAClientHello(
 				Collections.singletonList(CipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA256),
+				Collections.<SignatureAndHashAlgorithm> emptyList(),
 				Collections.<CertificateType> emptyList(),
-				Collections.<CertificateType> emptyList());
+				Collections.<CertificateType> emptyList(),
+				Collections.singletonList(SupportedGroup.secp256r1));
 		assertNull(
 				"ClientHello should not contain elliptic_curves extension for non-ECC based cipher suites",
 				clientHello.getSupportedEllipticCurvesExtension());
@@ -88,8 +91,10 @@ public class ClientHelloTest {
 
 		givenAClientHello(
 				Collections.singletonList(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256),
+				Collections.<SignatureAndHashAlgorithm> emptyList(),
 				Collections.<CertificateType> emptyList(),
-				Collections.<CertificateType> emptyList());
+				Collections.<CertificateType> emptyList(),
+				Collections.singletonList(SupportedGroup.secp256r1));
 		assertNotNull(
 				"ClientHello should contain elliptic_curves extension for ECC based cipher suites",
 				clientHello.getSupportedEllipticCurvesExtension());
@@ -100,16 +105,17 @@ public class ClientHelloTest {
 
 	private void givenAClientHelloWithEmptyExtensions() {
 		clientHello = new ClientHello(new ProtocolVersion(), Collections.<CipherSuite> emptyList(),
-				null, null, peerAddress);
+				Collections.<SignatureAndHashAlgorithm> emptyList(), null, null,
+				Collections.<SupportedGroup> emptyList(), peerAddress);
 	}
 
-	private void givenAClientHello(
-			List<CipherSuite> supportedCipherSuites,
-			List<CertificateType> supportedClientCertTypes,
-			List<CertificateType> supportedServerCertTypes) {
+	private void givenAClientHello(List<CipherSuite> supportedCipherSuites,
+			List<SignatureAndHashAlgorithm> supportedSignatureAndHashAlgorithms,
+			List<CertificateType> supportedClientCertTypes, List<CertificateType> supportedServerCertTypes,
+			List<SupportedGroup> supportedGroups) {
 
-		clientHello = new ClientHello(new ProtocolVersion(), supportedCipherSuites, null, null,
-				peerAddress);
+		clientHello = new ClientHello(new ProtocolVersion(), supportedCipherSuites, supportedSignatureAndHashAlgorithms,
+				null, null, supportedGroups, peerAddress);
 	}
 	
 }

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchangeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchangeTest.java
@@ -20,9 +20,9 @@ import static org.junit.Assert.*;
 import java.net.InetSocketAddress;
 
 import org.eclipse.californium.scandium.category.Small;
-import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
-import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedGroup;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -30,20 +30,19 @@ import org.junit.experimental.categories.Category;
 @Category(Small.class)
 public class ECDHServerKeyExchangeTest {
 
-	ECDHServerKeyExchange msg;
+	EcdhEcdsaServerKeyExchange msg;
 	InetSocketAddress peerAddress = new InetSocketAddress(5000);
 
 	@Before
 	public void setUp() throws Exception {
 
-		SupportedGroup usableGroup = SupportedGroup.getUsableGroups()[0];
-		msg = new ECDHServerKeyExchange(
+		SupportedGroup usableGroup = SupportedGroup.getUsableGroups().get(0);
+		msg = new EcdhEcdsaServerKeyExchange(
 				new SignatureAndHashAlgorithm(SignatureAndHashAlgorithm.HashAlgorithm.SHA256, SignatureAndHashAlgorithm.SignatureAlgorithm.ECDSA),
-				ECDHECryptography.fromNamedCurveId(usableGroup.getId()),
+				new XECDHECryptography(usableGroup),
 				DtlsTestTools.getPrivateKey(),
 				new Random(),
 				new Random(),
-				usableGroup.getId(),
 				peerAddress);
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchangeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchangeTest.java
@@ -23,8 +23,8 @@ import java.net.InetSocketAddress;
 
 import org.eclipse.californium.scandium.category.Small;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
-import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
-import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedGroup;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -41,8 +41,8 @@ public class EcdhPskClientKeyExchangeTest {
 	public void setUp() throws Exception {
 
 		SupportedGroup usableGroup = SupportedGroup.secp256r1;
-		ECDHECryptography ecdhe = ECDHECryptography.fromNamedCurveId(usableGroup.getId());
-		msg = new EcdhPskClientKeyExchange(new PskPublicInformation("ID"), ecdhe.getPublicKey(), peerAddress);
+		XECDHECryptography ecdhe = new XECDHECryptography(usableGroup);
+		msg = new EcdhPskClientKeyExchange(new PskPublicInformation("ID"), ecdhe.getEncodedPoint(), peerAddress);
 		ephemeralKeyPointEncoded = msg.getEncodedPoint();
 		identity = msg.getIdentity();
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchangeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchangeTest.java
@@ -16,39 +16,36 @@
 package org.eclipse.californium.scandium.dtls;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.net.InetSocketAddress;
-import java.security.interfaces.ECPublicKey;
 
 import org.eclipse.californium.scandium.category.Small;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
-import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography;
-import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedGroup;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(Small.class)
 public class EcdhPskServerKeyExchangeTest {
-	
+
 	EcdhPskServerKeyExchange msg;
 	InetSocketAddress peerAddress = new InetSocketAddress(5000);
-	ECPublicKey ephemeralPubKey;
-	
+	byte[] ephemeralPubKey;
+
 	@Before
 	public void setUp() throws Exception {
 
 		SupportedGroup usableGroup = SupportedGroup.secp256r1;
 		msg = new EcdhPskServerKeyExchange(PskPublicInformation.EMPTY,
-				ECDHECryptography.fromNamedCurveId(usableGroup.getId()),
-				new Random(),
-				new Random(),
-				usableGroup.getId(),
+				new XECDHECryptography(usableGroup),
 				peerAddress);
-		ephemeralPubKey = msg.getPublicKey();
+		ephemeralPubKey = msg.getEncodedPoint();
 	}
-	
+
 	@Test
 	public void testInstanceToString() {
 		String toString = msg.toString();
@@ -60,8 +57,8 @@ public class EcdhPskServerKeyExchangeTest {
 		byte[] serializedMsg = msg.toByteArray();
 		HandshakeParameter parameter = new HandshakeParameter(KeyExchangeAlgorithm.ECDHE_PSK, CertificateType.X_509);
 		EcdhPskServerKeyExchange handshakeMsg = (EcdhPskServerKeyExchange)HandshakeMessage.fromByteArray(serializedMsg, parameter, peerAddress);
-		assertEquals(handshakeMsg.getCurveId(), SupportedGroup.secp256r1.getId());
+		assertEquals(handshakeMsg.getSupportedGroup().getId(), SupportedGroup.secp256r1.getId());
 		assertNotNull(ephemeralPubKey);
-		assertEquals(handshakeMsg.getPublicKey(), ephemeralPubKey);
+		assertArrayEquals(handshakeMsg.getEncodedPoint(), ephemeralPubKey);
 	}
 }

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
@@ -57,6 +57,7 @@ import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.cipher.RandomManager;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
 import org.eclipse.californium.scandium.dtls.rpkstore.InMemoryRpkTrustStore;
 import org.eclipse.californium.scandium.dtls.rpkstore.TrustedRpkStore;
 import org.eclipse.californium.scandium.dtls.x509.StaticCertificateVerifier;
@@ -400,7 +401,7 @@ public class HandshakerTest {
 	}
 
 	private static Record createClientHelloRecord(DTLSSession session, int epoch, long sequenceNo, int messageSeqNo) throws GeneralSecurityException {
-		ClientHello clientHello = new ClientHello(new ProtocolVersion(), session, null, null);
+		ClientHello clientHello = new ClientHello(new ProtocolVersion(), session, Collections.<SignatureAndHashAlgorithm> emptyList(), null, null, SupportedGroup.getPreferredGroups());
 		clientHello.setMessageSeq(messageSeqNo);
 		return getRecordForMessage(epoch, sequenceNo, clientHello);
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
@@ -45,7 +45,8 @@ import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.scandium.category.Medium;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
-import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedGroup;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
 import org.eclipse.californium.scandium.dtls.pskstore.StaticPskStore;
 import org.eclipse.californium.scandium.util.ServerName.NameType;
 import org.eclipse.californium.scandium.util.ServerNames;
@@ -382,7 +383,10 @@ public class ServerHandshakerTest {
 		Record certificateMsgRecord =  DtlsTestTools.getRecordForMessage(0, 1, certificateMsg, senderAddress);
 
 		// create client KEY_EXCHANGE msg
-		ECDHClientKeyExchange keyExchangeMsg = new ECDHClientKeyExchange(clientChain[0].getPublicKey(), endpoint);
+		SupportedGroup supportedGroup = XECDHECryptography.SupportedGroup.getPreferredGroups().get(0);
+		XECDHECryptography ecdhe = new XECDHECryptography(supportedGroup);
+		byte[] encoded = ecdhe.getEncodedPoint();
+		ECDHClientKeyExchange keyExchangeMsg = new ECDHClientKeyExchange(encoded, endpoint);
 		keyExchangeMsg.setMessageSeq(2);
 		Record keyExchangeRecord =  DtlsTestTools.getRecordForMessage(0, 2, keyExchangeMsg, senderAddress);
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/cipher/SupportedGroupTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/cipher/SupportedGroupTest.java
@@ -18,26 +18,92 @@ package org.eclipse.californium.scandium.dtls.cipher;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
-import org.eclipse.californium.scandium.category.Small;
-import org.eclipse.californium.scandium.dtls.cipher.ECDHECryptography.SupportedGroup;
+import java.security.GeneralSecurityException;
+import java.security.PublicKey;
+import java.util.List;
+
+import javax.crypto.SecretKey;
+
+import org.eclipse.californium.elements.util.StringUtil;
+import org.eclipse.californium.scandium.category.Medium;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-@Category(Small.class)
+@Category(Medium.class)
 public class SupportedGroupTest {
+
+	private static final int LOOPS = 10;
+
+	@Test
+	public void testGetSupportedGroupFromPublicKey() {
+		for (SupportedGroup group : SupportedGroup.getUsableGroups()) {
+				try {
+					XECDHECryptography ecdhe = new XECDHECryptography(group);
+					PublicKey publicKey = ecdhe.getPublicKey();
+					SupportedGroup groupFromPublicKey = SupportedGroup.fromPublicKey(publicKey);
+					assertThat(groupFromPublicKey, is(group));
+				} catch (GeneralSecurityException e) {
+					fail(e.getMessage());
+				}
+		}
+	}
+
+	@Test
+	public void testDheKeyExchange() {
+		for (SupportedGroup group : SupportedGroup.getUsableGroups()) {
+			for (int loop = 0; loop < LOOPS; ++loop) {
+				try {
+					XECDHECryptography ecdhe1 = new XECDHECryptography(group);
+					byte[] point1 = ecdhe1.getEncodedPoint();
+					assertThat(point1, is(notNullValue()));
+					byte[] asn1 = ecdhe1.getPublicKey().getEncoded();
+					check(group, point1, asn1);
+
+					XECDHECryptography ecdhe2 = new XECDHECryptography(group);
+					byte[] point2 = ecdhe2.getEncodedPoint();
+					assertThat(point2, is(notNullValue()));
+					byte[] asn2 = ecdhe2.getPublicKey().getEncoded();
+					check(group, point2, asn2);
+
+					SecretKey secret1 = ecdhe1.generateSecret(point2);
+					assertThat(secret1, is(notNullValue()));
+					SecretKey secret2 = ecdhe2.generateSecret(point1);
+					assertThat(secret2, is(notNullValue()));
+					assertThat("edhe failed!", secret1, is(secret2));
+				} catch (GeneralSecurityException e) {
+					fail(e.getMessage());
+				}
+			}
+		}
+	}
+
+	private static void check(SupportedGroup group, byte[] point, byte[] asn1) {
+		for (int index = 0; index < point.length; ++index) {
+			if (point[point.length - index - 1] != asn1[asn1.length - index - 1]) {
+				String s1 = StringUtil.byteArray2Hex(asn1);
+				String s2 = StringUtil.byteArray2Hex(point);
+				if (s2.length() < s1.length()) {
+					s2 = String.format("%" + s1.length() + "s", s2);
+				}
+				System.err.println("ASN encoded '" + s1 + "'");
+				System.err.println("DHE encoded '" + s2 + "'");
+				fail("DHE: failed to encoded point! " + group.name() + ", position: " + index);
+			}
+		}
+	}
 
 	@Test
 	public void testGetUsableGroupsReturnsOnlyGroupsWithKnownDomainParams() {
-		SupportedGroup[] usablegroups = SupportedGroup.getUsableGroups();
-		assertTrue(usablegroups.length > 0);
-		for (SupportedGroup group : usablegroups) {
-			assertThat(
-					"Elliptic curve [" + group.name() + "] is reported to be usable on current JRE " +
-					"but domain params are unknown, this should have been detected. Please file " +
-					"a bug report indicating your JRE and the name of the elliptic curve",
-					group.getEcParams(),
-					notNullValue());
-		}
+		int length = SupportedGroup.values().length;
+		List<SupportedGroup> usablegroups = SupportedGroup.getUsableGroups();
+		List<SupportedGroup> preferredgroups = SupportedGroup.getPreferredGroups();
+		assertTrue(usablegroups.size() > 0);
+		assertTrue(length >= usablegroups.size());
+		assertTrue(preferredgroups.size() > 0);
+		assertTrue(usablegroups.size() >= preferredgroups.size());
+		System.out.println(
+				"groups: " + length + ", usable: " + usablegroups.size() + ", preferred: " + preferredgroups.size());
 	}
 
 }


### PR DESCRIPTION
Introduce redesigned `ECDHECryptography`as `XECDHECryptography`.

Update implementation based on RFC 8422.
Simpliy and cleanup ECDH related handshake messages.
Add XDH (X25519/X448) support for ECHD (java 11 only!).
Add configuration for supported groups (curves).
Add sigAls and curves for openssl interoparability test.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>
