### PR TITLE
Bugfix for retransmission of a separate NON response

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ReliabilityLayer.java
@@ -219,8 +219,10 @@ public class ReliabilityLayer extends AbstractLayer {
 					if (request.isConfirmable()) {
 						// resend ACK,
 						// comply to RFC 7252, 4.2, cross-layer behavior
-						EmptyMessage ack = EmptyMessage.newACK(request);
-						sendEmptyMessage(exchange, ack);
+						if (request.acknowledge()) {
+							EmptyMessage ack = EmptyMessage.newACK(request);
+							sendEmptyMessage(exchange, ack);
+						}
 					}
 					if (type == Type.CON) {
 						// retransmission cycle
@@ -235,6 +237,11 @@ public class ReliabilityLayer extends AbstractLayer {
 							sendResponse(exchange, currentResponse);
 						}
 						return;
+					} else if (currentResponse.isNotification()) {
+						// notifications are kept in the exchange store, so
+						// prepare retransmission counter for retransmission
+						int failedCount = exchange.getFailedTransmissionCount() + 1;
+						exchange.setFailedTransmissionCount(failedCount);
 					}
 				}
 				LOGGER.debug("{} respond with the current response to the duplicate request", exchange);

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/LockstepEndpoint.java
@@ -264,6 +264,10 @@ public class LockstepEndpoint {
 		return expectResponse().type(type).code(code).token(token).mid(mid);
 	}
 
+	public ResponseExpectation expectSeparateResponse(Type type, ResponseCode code, Token token) {
+		return expectResponse().type(type).code(code).token(token);
+	}
+
 	public EmptyMessageExpectation expectEmpty(Type type, int mid) {
 		return new EmptyMessageExpectation(type, mid);
 	}
@@ -1148,6 +1152,21 @@ public class LockstepEndpoint {
 				public void check(Response response) {
 					assertTrue("Has no observe option", response.getOptions().hasObserve());
 					storage.put(key, response.getOptions().getObserve());
+				}
+			});
+			return this;
+		}
+
+		public ResponseExpectation sameObserve(final String var) {
+			expectations.add(new Expectation<Response>() {
+
+				@Override
+				public void check(final Response response) {
+					assertTrue("Response has no observer", response.getOptions().hasObserve());
+					Object obj = storage.get(var);
+					assertThat("Object stored under " + var + " is not an observe option", obj, is(instanceOf(Integer.class)));
+					assertThat("Response contains wrong observe option", (Integer) obj,
+							is(response.getOptions().getObserve()));
 				}
 			});
 			return this;


### PR DESCRIPTION
Bugfix for retransmission of a separate NON message as response for a duplicated observe request.

Responses with observe option are kept in the exchange store even if
their type is NON. So their retransmission requires to increment the
failed transmissons counter.

Add unit test as well.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>