### PR TITLE
Prepare for reregistration even if response is not newer.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
@@ -63,7 +63,6 @@ import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.core.server.resources.Resource;
 import org.eclipse.californium.core.server.resources.ResourceAttributes;
 import org.eclipse.californium.core.server.resources.ResourceObserver;
-import org.eclipse.californium.core.server.resources.ResourceObserverAdapter;
 
 /**
  * CoapResource is a basic implementation of a resource. Extend this class to
@@ -350,22 +349,7 @@ public  class CoapResource implements Resource {
 
 			if (!relation.isEstablished()) {
 				relation.setEstablished();
-				// work-around for missing return value of addObserveRelation
-				// maybe replaced by next major version
-				ResourceObserver observer = new ResourceObserverAdapter() {
-
-					@Override
-					public void removedObserveRelation(ObserveRelation previous) {
-						if (previous.getKey().equals(relation.getKey())) {
-							// new observe number, if a old relation is
-							// replaced!
-							notificationOrderer.getNextObserveNumber();
-						}
-					}
-				};
-				addObserver(observer);
 				addObserveRelation(relation);
-				removeObserver(observer);
 			} else if (observeType != null) {
 				// The resource can control the message type of the notification
 				response.setType(observeType);

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveNotificationOrderer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveNotificationOrderer.java
@@ -83,10 +83,11 @@ public class ObserveNotificationOrderer {
 	}
 
 	/**
-	 * Returns true if the specified notification is newer than the current one.
+	 * Check, if the provided notification is newer than the current one.
 	 * 
 	 * @param response the notification
-	 * @return true if the notification is new
+	 * @return {@code true} if the notification is new, or the response is no
+	 *         notify
 	 */
 	public synchronized boolean isNew(Response response) {
 


### PR DESCRIPTION
A reregister request may get a response, which is not changed since the
last.
Reverts reregistration fix of PR #1221.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>