### PR TITLE
Move anmial-sniffer to profile.

### DIFF
--- a/californium-core/pom.xml
+++ b/californium-core/pom.xml
@@ -158,17 +158,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>animal-sniffer-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<descriptorRefs>

--- a/cf-oscore/pom.xml
+++ b/cf-oscore/pom.xml
@@ -13,6 +13,10 @@
 	<name>Cf-OSCORE</name>
 	<description>Californium (Cf) OSCORE, Object Security for Constrained RESTful Environments</description>
 
+	<properties>
+		<revapi.skip>true</revapi.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -55,17 +59,9 @@
 					</descriptorRefs>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.revapi</groupId>
-				<artifactId>revapi-maven-plugin</artifactId>
-				<configuration>
-					<!-- not depolyed to repos -->
-					<skip>true</skip>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
-	
+
 	<profiles>
 		<profile>
 			<!-- maven compile would try to resolve test dependencies, 

--- a/cf-pubsub/pom.xml
+++ b/cf-pubsub/pom.xml
@@ -16,7 +16,7 @@
 	<description>Californium (Cf) PubSub, CoAP Publish-Subscribe implementation</description>
 
 	<properties>
-
+		<revapi.skip>true</revapi.skip>
 	</properties>
 
 	<dependencies>
@@ -40,14 +40,6 @@
 					<descriptorRefs>
 						<descriptorRef>enhanced-jar-with-licenses</descriptorRef>
 					</descriptorRefs>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.revapi</groupId>
-				<artifactId>revapi-maven-plugin</artifactId>
-				<configuration>
-					<!-- not depolyed to repos -->
-					<skip>true</skip>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/demo-apps/pom.xml
+++ b/demo-apps/pom.xml
@@ -53,6 +53,8 @@
 		 -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<gson.version>2.8.2</gson.version>
+		<animal.sniffer.skip>true</animal.sniffer.skip>
+		<revapi.skip>true</revapi.skip>
 	</properties>
 
 	<dependencyManagement>
@@ -115,13 +117,6 @@
 					<descriptorRefs>
 						<descriptorRef>enhanced-jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.revapi</groupId>
-				<artifactId>revapi-maven-plugin</artifactId>
-				<configuration>
-					<skip>true</skip>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/element-connector-tcp-netty/pom.xml
+++ b/element-connector-tcp-netty/pom.xml
@@ -112,17 +112,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>animal-sniffer-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<descriptorRefs>

--- a/element-connector/pom.xml
+++ b/element-connector/pom.xml
@@ -14,7 +14,7 @@
 
 	<name>Californium (Cf) Element Connector</name>
 	<description>Java socket abstraction for datagram transports (UDP, DTLS, etc.)</description>
-	
+
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -73,17 +73,6 @@
 						<goals>
 							<!-- export NetworkRule and RepeatingTestRunner for tests -->
 							<goal>test-jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>animal-sniffer-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -422,16 +422,6 @@
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>animal-sniffer-maven-plugin</artifactId>
 					<version>1.18</version>
-					<configuration>
-						<signature>
-							<groupId>net.sf.androidscents.signature</groupId>
-							<artifactId>android-api-level-16</artifactId>
-							<version>4.1.2_r5</version>
-						</signature>
-						<annotations>
-							<annotation>org.eclipse.californium.elements.util.NotForAndroid</annotation>
-						</annotations>
-					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
@@ -600,6 +590,20 @@
 					</analysisConfigurationFiles>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>animal-sniffer-maven-plugin</artifactId>
+				<configuration>
+					<signature>
+						<groupId>net.sf.androidscents.signature</groupId>
+						<artifactId>android-api-level-16</artifactId>
+						<version>4.1.2_r5</version>
+					</signature>
+					<annotations>
+						<annotation>org.eclipse.californium.elements.util.NotForAndroid</annotation>
+					</annotations>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
@@ -668,12 +672,38 @@
 			</properties>
 		</profile>
 		<profile>
+			<id>animalsniffer</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+				<property>
+					<name>animal.sniffer.skip</name>
+					<value>!true</value>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>animal-sniffer-maven-plugin</artifactId>
+						<executions>
+							<execution>
+								<goals>
+									<goal>check</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>revapi</id>
 			<activation>
 				<activeByDefault>false</activeByDefault>
 				<jdk>[1.8,)</jdk>
 				<property>
-					<name>!revapi.skip.check</name>
+					<name>revapi.skip</name>
+					<value>!true</value>
 				</property>
 			</activation>
 			<build>

--- a/scandium-core/pom.xml
+++ b/scandium-core/pom.xml
@@ -144,17 +144,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>animal-sniffer-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<descriptorRefs>


### PR DESCRIPTION
Skip revapi using properties.
Initially I wanted to skip the animal sniffer automatically, when java 11 is selected as target. That's not achieved. But anyway this PR demonstrates to use the skips configured in the properties instead of define a specialized plugin with skipped execution.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>