### PR TITLE
Advanced multicast implementation.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.MulticastReceivers;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.MessageDeliverer;
 import org.eclipse.californium.core.server.ServerInterface;
@@ -248,6 +249,15 @@ public class CoapServer implements ServerInterface {
 		}
 
 		int started = 0;
+		for (Endpoint ep : endpoints) {
+			if (ep instanceof MulticastReceivers) {
+				try {
+					((MulticastReceivers)ep).startMulticastReceivers();
+				} catch (IOException e) {
+					LOGGER.error("cannot start server multicast receiver [{}]", ep.getAddress(), e);
+				}
+			}
+		}
 		for (Endpoint ep : endpoints) {
 			try {
 				ep.start();

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MulticastReceivers.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MulticastReceivers.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO.GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.network;
+
+import java.io.IOException;
+
+import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.UdpMulticastConnector;
+import org.eclipse.californium.elements.util.PublicAPIExtension;
+
+/**
+ * Extend {@link Endpoint} using multicast receivers.
+ * 
+ * Responses for multicast requests maybe sent using a different endpoint also
+ * on server side.
+ * 
+ * @since 2.3
+ */
+@PublicAPIExtension(type = Endpoint.class)
+public interface MulticastReceivers {
+
+	/**
+	 * Add connector as multicast receiver.
+	 * 
+	 * A multicast receiver must return a multicast address on
+	 * {@link Connector#getAddress()}. A {@link UdpMulticastConnector} maybe
+	 * used as multicast receiver, if it joins only one multicast group.
+	 * 
+	 * @param receiver multicast receiver to add
+	 * @throws NullPointerException if receiver is {@code null}
+	 * @throws IllegalArgumentException if receiver doesn't return a multicast
+	 *             address on {@link Connector#getAddress()}
+	 */
+	void addMulticastReceiver(Connector receiver);
+
+	/**
+	 * Remove connector from multicast receivers.
+	 * 
+	 * @param receiver multicast receiver to remove
+	 */
+	void removeMulticastReceiver(Connector receiver);
+
+	/**
+	 * Start multicast receivers to ensure, that all unicast connectors are
+	 * started afterwards.
+	 * 
+	 * @throws IOException if an i/o error occurred.
+	 */
+	void startMulticastReceivers() throws IOException;
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
@@ -32,6 +32,7 @@ import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.MulticastReceivers;
 import org.eclipse.californium.elements.DtlsEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.MapBasedEndpointContext;
@@ -120,6 +121,17 @@ public class CoapExchange {
 	}
 
 	/**
+	 * Check, if request is multicast request.
+	 * 
+	 * @return {@code true}, if request is multicast request, {@code false}, if
+	 *         request is unicast request.
+	 * @since 2.3
+	 */
+	public boolean isMulticastRequest() {
+		return exchange.getRequest().isMulticast();
+	}
+
+	/**
 	 * Gets the request code: <tt>GET</tt>, <tt>POST</tt>, <tt>PUT</tt> or
 	 * <tt>DELETE</tt>.
 	 * 
@@ -186,6 +198,13 @@ public class CoapExchange {
 	 * Reject the exchange if it is impossible to be processed, e.g. if it
 	 * carries an unknown critical option. In most cases, it is better to
 	 * respond with an error response code to bad requests though.
+	 * 
+	 * Note: since 2.3, rejects for multicast requests are not sent. (See
+	 * {@link MulticastReceivers#addMulticastReceiver(org.eclipse.californium.elements.Connector)
+	 * for receiving multicast requests}.
+	 * 
+	 * @see Exchange#sendReject(EndpointContext)
+	 * @since 2.3 rejects for multicast requests are not sent
 	 */
 	public void reject() {
 		exchange.sendReject(applyHandshakeMode());
@@ -251,8 +270,15 @@ public class CoapExchange {
 	 * Current implementation use 5.03. May be changed, if RFC
 	 * "https://draft-ietf-core-too-many-reqs" gets adopted.
 	 *
+	 * Note: since 2.3, error responses for multicast requests are not sent. (See
+	 * {@link MulticastReceivers#addMulticastReceiver(org.eclipse.californium.elements.Connector)
+	 * for receiving multicast requests}.
+	 * 
 	 * @param seconds estimated time in seconds after which the client may retry
 	 *            to send requests.
+	 * 
+	 * @see Exchange#sendResponse(Response)
+	 * @since 2.3 error responses for multicast requests are not sent
 	 */
 	public void respondOverload(int seconds) {
 		setMaxAge(seconds);
@@ -272,7 +298,14 @@ public class CoapExchange {
 	 * Fills in {@link #locationPath}, {@link #locationQuery}, {@link #maxAge},
 	 * and/or {@link #eTag}, if set before.
 	 *
+	 * Note: since 2.3, error responses for multicast requests are not sent. (See
+	 * {@link MulticastReceivers#addMulticastReceiver(org.eclipse.californium.elements.Connector)
+	 * for receiving multicast requests}.
+	 * 
 	 * @param code the response code
+	 * 
+	 * @see Exchange#sendResponse(Response)
+	 * @since 2.3 error responses for multicast requests are not sent
 	 */
 	public void respond(ResponseCode code) {
 		respond(new Response(code));
@@ -302,8 +335,15 @@ public class CoapExchange {
 	 * Fills in {@link #locationPath}, {@link #locationQuery}, {@link #maxAge},
 	 * and/or {@link #eTag}, if set before.
 	 * 
+	 * Note: since 2.3, error responses for multicast requests are not sent. (See
+	 * {@link MulticastReceivers#addMulticastReceiver(org.eclipse.californium.elements.Connector)
+	 * for receiving multicast requests}.
+	 * 
 	 * @param code the response code
 	 * @param payload the payload
+	 * 
+	 * @see Exchange#sendResponse(Response)
+	 * @since 2.3 error responses for multicast requests are not sent
 	 */
 	public void respond(ResponseCode code, String payload) {
 		Response response = new Response(code);
@@ -323,9 +363,16 @@ public class CoapExchange {
 	 *
 	 * Fills in {@link #locationPath}, {@link #locationQuery}, {@link #maxAge},
 	 * and/or {@link #eTag}, if set before.
+	 * 
+	 * Note: since 2.3, error responses for multicast requests are not sent. (See
+	 * {@link MulticastReceivers#addMulticastReceiver(org.eclipse.californium.elements.Connector)
+	 * for receiving multicast requests}.
 	 *
 	 * @param code the response code
 	 * @param payload the payload
+	 * 
+	 * @see Exchange#sendResponse(Response)
+	 * @since 2.3 error responses for multicast requests are not sent
 	 */
 	public void respond(ResponseCode code, byte[] payload) {
 		Response response = new Response(code);
@@ -345,9 +392,16 @@ public class CoapExchange {
 	 * Fills in {@link #locationPath}, {@link #locationQuery}, {@link #maxAge},
 	 * and/or {@link #eTag}, if set before.
 	 * 
+	 * Note: since 2.3, error responses for multicast requests are not sent. (See
+	 * {@link MulticastReceivers#addMulticastReceiver(org.eclipse.californium.elements.Connector)
+	 * for receiving multicast requests}.
+	 * 
 	 * @param code the response code
 	 * @param payload the payload
 	 * @param contentFormat the Content-Format of the payload
+	 * 
+	 * @see Exchange#sendResponse(Response)
+	 * @since 2.3 error responses for multicast requests are not sent
 	 */
 	public void respond(ResponseCode code, byte[] payload, int contentFormat) {
 		Response response = new Response(code);
@@ -368,9 +422,16 @@ public class CoapExchange {
 	 * Fills in {@link #locationPath}, {@link #locationQuery}, {@link #maxAge},
 	 * and/or {@link #eTag}, if set before.
 	 *
+	 * Note: since 2.3, error responses for multicast requests are not sent. (See
+	 * {@link MulticastReceivers#addMulticastReceiver(org.eclipse.californium.elements.Connector)
+	 * for receiving multicast requests}.
+	 *
 	 * @param code the response code
 	 * @param payload the payload
 	 * @param contentFormat the Content-Format of the payload
+	 * 
+	 * @see Exchange#sendResponse(Response)
+	 * @since 2.3 error responses for multicast requests are not sent
 	 */
 	public void respond(ResponseCode code, String payload, int contentFormat) {
 		Response response = new Response(code);
@@ -385,7 +446,14 @@ public class CoapExchange {
 	 * Fills in {@link #locationPath}, {@link #locationQuery}, {@link #maxAge},
 	 * and/or {@link #eTag}, if set before.
 	 * 
+	 * Note: since 2.3, error responses for multicast requests are not sent. (See
+	 * {@link MulticastReceivers#addMulticastReceiver(org.eclipse.californium.elements.Connector)
+	 * for receiving multicast requests}.
+	 * 
 	 * @param response the response
+	 * 
+	 * @see Exchange#sendResponse(Response)
+	 * @since 2.3 error responses for multicast requests are not sent
 	 */
 	public void respond(Response response) {
 		if (response == null)

--- a/demo-apps/cf-helloworld-client/src/main/resources/logback.xml
+++ b/demo-apps/cf-helloworld-client/src/main/resources/logback.xml
@@ -8,6 +8,10 @@
 		</encoder>
 	</appender>
 
+	<logger name="org.eclipse.californium.core.network.interceptors.HealthStatisticLogger" level="DEBUG" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+
 	<!-- Strictly speaking, the level attribute is not necessary since -->
 	<!-- the level of the root level is set to DEBUG by default. -->
 	<root level="INFO">

--- a/demo-apps/cf-helloworld-server/src/main/resources/logback.xml
+++ b/demo-apps/cf-helloworld-server/src/main/resources/logback.xml
@@ -8,6 +8,14 @@
 		</encoder>
 	</appender>
 
+	<logger name="org.eclipse.californium.elements.UDPConnector" level="DEBUG" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+
+	<logger name="org.eclipse.californium.elements.UdpMulticastConnector" level="DEBUG" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+
 	<!-- Strictly speaking, the level attribute is not necessary since -->
 	<!-- the level of the root level is set to DEBUG by default. -->
 	<root level="INFO">

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UdpEndpointContextMatcher.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UdpEndpointContextMatcher.java
@@ -67,13 +67,18 @@ public class UdpEndpointContextMatcher extends KeySetEndpointContextMatcher {
 		this.checkAddress = checkAddress;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @since 2.3 a response matches a multicast requests even if the ports are
+	 *        different.
+	 */
 	@Override
 	public boolean isResponseRelatedToRequest(EndpointContext requestContext, EndpointContext responseContext) {
 		if (checkAddress) {
 			InetSocketAddress peerAddress1 = requestContext.getPeerAddress();
 			InetSocketAddress peerAddress2 = responseContext.getPeerAddress();
-			if (peerAddress1.getPort() != peerAddress2.getPort() || (!peerAddress1.getAddress().isMulticastAddress()
-					&& !peerAddress1.getAddress().equals(peerAddress2.getAddress()))) {
+			if (!peerAddress1.getAddress().isMulticastAddress() && !peerAddress1.equals(peerAddress2)) {
 				LOGGER.info("request {}:{} doesn't match {}:{}!", peerAddress1.getAddress().getHostAddress(),
 						peerAddress1.getPort(), peerAddress2.getAddress().getHostAddress(), peerAddress2.getPort());
 				return false;

--- a/element-connector/src/test/java/org/eclipse/californium/elements/UdpEndpointContextMatcherTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/UdpEndpointContextMatcherTest.java
@@ -66,6 +66,6 @@ public class UdpEndpointContextMatcherTest {
 		assertThat(matcher.isResponseRelatedToRequest(messageContext, changedAddressContext), is(false));
 		assertThat(matcher.isResponseRelatedToRequest(changedAddressContext, messageContext), is(false));
 		assertThat(matcher.isResponseRelatedToRequest(multicastContext, messageContext), is(true));
-		assertThat(matcher.isResponseRelatedToRequest(multicastContext, changedAddressContext), is(false));
+		assertThat(matcher.isResponseRelatedToRequest(multicastContext, changedAddressContext), is(true));
 	}
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/DirectDatagramSocketImpl.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/DirectDatagramSocketImpl.java
@@ -530,8 +530,11 @@ public class DirectDatagramSocketImpl extends AbstractDatagramSocketImpl {
 			synchronized (multicast) {
 				return multicast.contains(destination);
 			}
+		} else {
+			synchronized (multicast) {
+				return multicast.isEmpty();
+			}
 		}
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
Adjust client to accept responses for multicast request from different
ports.
Add multicast recveiver for more flexible processing of multicast
requests.
Don't sent Rejects and error responses for multicast requests.
Adapt demo multicast server to use new multicast recveivers.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>