### PR TITLE
Do not warn for Handshake without APP_DATA of evicted connection.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -458,8 +458,14 @@ public class DTLSConnector implements Connector, RecordLayer {
 						} else {
 							// failure after established (last FINISH),
 							// but before completed (first data)
-							LOGGER.warn("Handshake with [{}] failed after session was established!",
-									handshaker.getPeerAddress(), error);
+							// TODO a dedicated Exception should be created.
+							if (error instanceof RuntimeException && "Evicted!".equals(error.getMessage())) {
+								LOGGER.debug("Handshake with [{}] never get APPLICATION_DATA",
+										handshaker.getPeerAddress(), error);
+							} else {
+								LOGGER.warn("Handshake with [{}] failed after session was established!",
+										handshaker.getPeerAddress(), error);
+							}
 						}
 					} else if (connection.hasEstablishedSession()) {
 						LOGGER.warn("Handshake with [{}] failed, but has an established session!",


### PR DESCRIPTION
(For the fix in 2.3.x branch, I think we need to create a dedicated Exception for eviction)