### PR TITLE
Send all supported signature and hash algorithms of the server.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -555,11 +555,7 @@ public class ServerHandshaker extends Handshaker {
 				&& selectedCipherSuiteParameters.getSelectedClientCertificateType() != null) {
 			CertificateRequest certificateRequest = new CertificateRequest(session.getPeer());
 			certificateRequest.addCertificateType(ClientCertificateType.ECDSA_SIGN);
-			// sort according the order of the server's 
-			// supported signatures and hash algorithms
-			List<SignatureAndHashAlgorithm> serverOrdered = SignatureAndHashAlgorithm.getCommonSignatureAlgorithms(
-					supportedSignatureAndHashAlgorithms, selectedCipherSuiteParameters.getSignatures());
-			certificateRequest.addSignatureAlgorithms(serverOrdered);
+			certificateRequest.addSignatureAlgorithms(supportedSignatureAndHashAlgorithms);
 			if (certificateVerifier != null) {
 				List<X500Principal> subjects = CertPathUtil
 						.toSubjects(Arrays.asList(certificateVerifier.getAcceptedIssuers()));


### PR DESCRIPTION
RFC 5246, 7.4.4.  Certificate Request

supported_signature_algorithms
      A list of the hash/signature algorithm pairs that the server is
      able to verify, listed in descending order of preference.

That doesn't refer the client's extension list, therefore not only the
common hash/signature algorithm pairs are to be sent.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>