### PR TITLE
Adapt default signature and hash algorithms.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -2771,8 +2771,9 @@ public final class DtlsConnectorConfig {
 			}
 
 			if (ecc) {
-				if (!config.supportedSignatureAlgorithms.isEmpty()) {
-					verifySignatureAndHashAlgorithms();
+				if (config.supportedSignatureAlgorithms.isEmpty()) {
+					config.supportedSignatureAlgorithms = SignatureAndHashAlgorithm
+							.getDefaultSignatureAlgorithms(config.certChain);
 				}
 				if (config.supportedGroups.isEmpty()) {
 					config.supportedGroups = getDefaultSupportedGroups();
@@ -2810,6 +2811,7 @@ public final class DtlsConnectorConfig {
 					throw new IllegalStateException("certificate has no proper key usage!");
 				}
 			}
+			verifySignatureAndHashAlgorithms(config.supportedSignatureAlgorithms);
 			verifySupportedGroups(config.supportedGroups);
 			config.trustCertificateTypes = ListUtils.init(config.trustCertificateTypes);
 			config.identityCertificateTypes = ListUtils.init(config.identityCertificateTypes);
@@ -2908,15 +2910,13 @@ public final class DtlsConnectorConfig {
 			config.supportedCipherSuites = ciphers;
 		}
 
-		private void verifySignatureAndHashAlgorithms() {
+		private void verifySignatureAndHashAlgorithms(List<SignatureAndHashAlgorithm> list) {
 			if (config.publicKey != null) {
-				if (SignatureAndHashAlgorithm.getSupportedSignatureAlgorithm(config.supportedSignatureAlgorithms,
-						config.publicKey) == null) {
+				if (SignatureAndHashAlgorithm.getSupportedSignatureAlgorithm(list, config.publicKey) == null) {
 					throw new IllegalStateException("supported signature and hash algorithms doesn't match the public key!");
 				}
 				if (config.certChain != null) {
-					if (!SignatureAndHashAlgorithm.isSignedWithSupportedAlgorithms(config.supportedSignatureAlgorithms,
-							config.certChain)) {
+					if (!SignatureAndHashAlgorithm.isSignedWithSupportedAlgorithms(list, config.certChain)) {
 						throw new IllegalStateException(
 								"supported signature and hash algorithms doesn't match the certificate chain!");
 					}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -209,15 +209,7 @@ public class ServerHandshaker extends Handshaker {
 		// the server handshake uses the config with exchanged roles!
 		this.supportedClientCertificateTypes = config.getTrustCertificateTypes();
 		this.supportedServerCertificateTypes = config.getIdentityCertificateTypes();
-		List<SignatureAndHashAlgorithm> algorithms = config.getSupportedSignatureAlgorithms();
-		if (algorithms.isEmpty()) {
-			if (certificateChain == null) {
-				algorithms = SignatureAndHashAlgorithm.DEFAULT;
-			} else {
-				algorithms = SignatureAndHashAlgorithm.getSignatureAlgorithmsFromCertificateChain(certificateChain);
-			}
-		}
-		this.supportedSignatureAndHashAlgorithms = algorithms;
+		this.supportedSignatureAndHashAlgorithms = config.getSupportedSignatureAlgorithms();
 	}
 
 	// Methods ////////////////////////////////////////////////////////

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SignatureAndHashAlgorithm.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SignatureAndHashAlgorithm.java
@@ -165,7 +165,7 @@ public final class SignatureAndHashAlgorithm {
 	 * @since 2.3
 	 */
 	public static List<SignatureAndHashAlgorithm> DEFAULT = Collections
-			.unmodifiableList(Arrays.asList(SHA256_WITH_ECDSA));
+			.unmodifiableList(Arrays.asList(SHA256_WITH_ECDSA, SHA256_WITH_RSA));
 
 	/**
 	 * Get thread local signature.
@@ -214,21 +214,24 @@ public final class SignatureAndHashAlgorithm {
 	}
 
 	/**
-	 * Get list of signature and hash algorithms from certificate chain.
+	 * Get list of default signature and hash algorithms including the
+	 * algorithms used by the certificate chain.
 	 * 
-	 * @param certificateChain certificate chain
-	 * @return list list of signature and hash algorithms
+	 * @param certificateChain certificate chain. Maybe {@code null}.
+	 * @return list list of default signature and hash algorithms
 	 * 
 	 * @since 2.3
 	 */
-	public static List<SignatureAndHashAlgorithm> getSignatureAlgorithmsFromCertificateChain(
+	public static List<SignatureAndHashAlgorithm> getDefaultSignatureAlgorithms(
 			List<X509Certificate> certificateChain) {
-		List<SignatureAndHashAlgorithm> result = new ArrayList<>();
-		for (X509Certificate certificate : certificateChain) {
-			String sigAlgName = certificate.getSigAlgName();
-			SignatureAndHashAlgorithm signature = valueOf(sigAlgName);
-			if (signature != null && !result.contains(signature)) {
-				result.add(signature);
+		List<SignatureAndHashAlgorithm> result = new ArrayList<>(DEFAULT);
+		if (certificateChain != null) {
+			for (X509Certificate certificate : certificateChain) {
+				String sigAlgName = certificate.getSigAlgName();
+				SignatureAndHashAlgorithm signature = valueOf(sigAlgName);
+				if (signature != null && !result.contains(signature)) {
+					result.add(signature);
+				}
 			}
 		}
 		return result;

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/config/DtlsConnectorConfigTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/config/DtlsConnectorConfigTest.java
@@ -257,7 +257,7 @@ public class DtlsConnectorConfigTest {
 				.setRpkTrustAll()
 				.build();
 		assertNotNull(config.getSupportedSignatureAlgorithms());
-		assertTrue(config.getSupportedSignatureAlgorithms().isEmpty());
+		assertThat(config.getSupportedSignatureAlgorithms(), is(SignatureAndHashAlgorithm.DEFAULT));
 	}
 
 	@Test
@@ -267,7 +267,7 @@ public class DtlsConnectorConfigTest {
 				.setSupportedSignatureAlgorithms((String[]) null)
 				.build();
 		assertNotNull(config.getSupportedSignatureAlgorithms());
-		assertTrue(config.getSupportedSignatureAlgorithms().isEmpty());
+		assertThat(config.getSupportedSignatureAlgorithms(), is(SignatureAndHashAlgorithm.DEFAULT));
 	}
 
 	@Test
@@ -277,7 +277,7 @@ public class DtlsConnectorConfigTest {
 				.setSupportedSignatureAlgorithms(Collections.<SignatureAndHashAlgorithm>emptyList())
 				.build();
 		assertNotNull(config.getSupportedSignatureAlgorithms());
-		assertTrue(config.getSupportedSignatureAlgorithms().isEmpty());
+		assertThat(config.getSupportedSignatureAlgorithms(), is(SignatureAndHashAlgorithm.DEFAULT));
 	}
 
 	@Test


### PR DESCRIPTION
Use SHA256/Ecdsa and SHA2546/Rsa as defaults.
Add signature and hash algorithms of the certificate chain to the
defaults, if provided.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>