### PR TITLE
Add max-resource-body-size to message.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapObserveRelation.java
@@ -191,6 +191,12 @@ public class CoapObserveRelation {
 			// copy options
 			refresh.setOptions(request.getOptions());
 
+			refresh.setMaxResourceBodySize(request.getMaxResourceBodySize());
+			if (request.isUnintendedPayload()) {
+				refresh.setUnintendedPayload();
+				refresh.setPayload(request.getPayload());
+			}
+
 			// use same message observers
 			for (MessageObserver observer : request.getMessageObservers()) {
 				if (observer instanceof InternalMessageObserver) {
@@ -234,6 +240,12 @@ public class CoapObserveRelation {
 		cancel.setOptions(request.getOptions());
 		// set Observe to cancel
 		cancel.setObserveCancel();
+
+		cancel.setMaxResourceBodySize(request.getMaxResourceBodySize());
+		if (request.isUnintendedPayload()) {
+			cancel.setUnintendedPayload();
+			cancel.setPayload(request.getPayload());
+		}
 
 		// use same message observers
 		for (MessageObserver observer : request.getMessageObservers()) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
@@ -145,6 +145,14 @@ public abstract class Message {
 	private boolean unintendedPayload;
 
 	/**
+	 * Maximum resource body size. For outgoing requests, this limits the size
+	 * of the response.
+	 * 
+	 * @since 2.3
+	 */
+	private int maxResourceBodySize;
+
+	/**
 	 * Message specific parameter. Overwrites then general ones from
 	 * {@link NetworkConfig}.
 	 */
@@ -543,6 +551,36 @@ public abstract class Message {
 	public Message setOptions(OptionSet options) {
 		this.options = new OptionSet(options);
 		return this;
+	}
+
+	/**
+	 * Get the maximum resource body size.
+	 * 
+	 * For incoming messages the protocol stack may set individual sizes. For
+	 * outgoing requests, this limits the size of the response.
+	 * 
+	 * @return maximum resource body size. {@code 0} to use the
+	 *         {@link NetworkConfig} value of
+	 *         {@link NetworkConfig#Keys#MAX_RESOURCE_BODY_SIZE}.
+	 * @since 2.3
+	 */
+	public int getMaxResourceBodySize() {
+		return maxResourceBodySize;
+	}
+
+	/**
+	 * Set the maximum resource body size.
+	 * 
+	 * For incoming messages the protocol stack may set individual sizes. For
+	 * outgoing requests, this limits the size of the response.
+	 * 
+	 * @param maxResourceBodySize maximum resouce body size. {@code 0} or
+	 *            default is defined by the {@link NetworkConfig} value of
+	 *            {@link NetworkConfig#Keys#MAX_RESOURCE_BODY_SIZE}.
+	 * @since 2.3
+	 */
+	public void setMaxResourceBodySize(int maxResourceBodySize) {
+		this.maxResourceBodySize = maxResourceBodySize;
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block1BlockwiseStatus.java
@@ -140,6 +140,7 @@ public final class Block1BlockwiseStatus extends BlockwiseStatus {
 		if (request.isUnintendedPayload()) {
 			block.setUnintendedPayload();
 		}
+		block.setMaxResourceBodySize(request.getMaxResourceBodySize());
 
 		int currentSize = getCurrentSize();
 		int from = num * currentSize;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
@@ -289,6 +289,7 @@ public final class Block2BlockwiseStatus extends BlockwiseStatus {
 		final Response block = new Response(response.getCode());
 		block.setDestinationContext(response.getDestinationContext());
 		block.setOptions(new OptionSet(response.getOptions()));
+		block.setMaxResourceBodySize(response.getMaxResourceBodySize());
 		block.addMessageObservers(response.getMessageObservers());
 		if (getCurrentNum() != 0) {
 			// observe option must only be included in first block

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -70,6 +70,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.MessageObserver;
 import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.OptionSet;
@@ -408,7 +409,7 @@ public class BlockwiseLayer extends AbstractLayer {
 	private void handleInboundBlockwiseUpload(final Exchange exchange, final Request request) {
 
 		if (requestExceedsMaxBodySize(request)) {
-
+			int maxResourceBodySize = getMaxResourceBodySize(request);
 			Response error = Response.createResponse(request, ResponseCode.REQUEST_ENTITY_TOO_LARGE);
 			error.setPayload(String.format("body too large, can process %d bytes max", maxResourceBodySize));
 			error.getOptions().setSize1(maxResourceBodySize);
@@ -662,7 +663,10 @@ public class BlockwiseLayer extends AbstractLayer {
 				}
 				return;
 			}
-
+			
+			if (response.getMaxResourceBodySize() == 0) {
+				response.setMaxResourceBodySize(exchange.getRequest().getMaxResourceBodySize());
+			}
 			KeyUri key = getKey(exchange, response);
 			Block2BlockwiseStatus status = getBlock2Status(key);
 			if (discardBlock2(key, status, exchange, response)) {
@@ -885,7 +889,7 @@ public class BlockwiseLayer extends AbstractLayer {
 
 		} else if (responseExceedsMaxBodySize(response)) {
 
-			LOGGER.debug("requested resource body exceeds max buffer size [{}], aborting request", maxResourceBodySize);
+			LOGGER.debug("requested resource body exceeds max buffer size [{}], aborting request", getMaxResourceBodySize(response));
 			exchange.getRequest().cancel();
 
 		} else {
@@ -1060,10 +1064,11 @@ public class BlockwiseLayer extends AbstractLayer {
 
 	private Block1BlockwiseStatus getInboundBlock1Status(final KeyUri key, final Exchange exchange, final Request request) {
 		Block1BlockwiseStatus status;
+		int maxPayloadSize = getMaxResourceBodySize(request);
 		synchronized (block1Transfers) {
 			status = block1Transfers.get(key);
 			if (status == null) {
-				status = Block1BlockwiseStatus.forInboundRequest(exchange, request, maxResourceBodySize);
+				status = Block1BlockwiseStatus.forInboundRequest(exchange, request, maxPayloadSize);
 				block1Transfers.put(key, status);
 				enableStatus = true;
 				LOGGER.debug("created tracker for inbound block1 transfer {}, transfers in progress: {}", status,
@@ -1110,11 +1115,11 @@ public class BlockwiseLayer extends AbstractLayer {
 	}
 
 	private Block2BlockwiseStatus getInboundBlock2Status(final KeyUri key, final Exchange exchange, final Response response) {
-
+		int maxPayloadSize = getMaxResourceBodySize(response);
 		synchronized (block2Transfers) {
 			Block2BlockwiseStatus status = block2Transfers.get(key);
 			if (status == null) {
-				status = Block2BlockwiseStatus.forInboundResponse(exchange, response, maxResourceBodySize);
+				status = Block2BlockwiseStatus.forInboundResponse(exchange, response, maxPayloadSize);
 				block2Transfers.put(key, status);
 				enableStatus = true;
 				LOGGER.debug("created tracker for {} inbound block2 transfer {}, transfers in progress: {}, {}", key,
@@ -1225,11 +1230,19 @@ public class BlockwiseLayer extends AbstractLayer {
 	}
 
 	private boolean responseExceedsMaxBodySize(final Response response) {
-		return response.getOptions().hasSize2() && response.getOptions().getSize2() > maxResourceBodySize;
+		return response.getOptions().hasSize2() && response.getOptions().getSize2() > getMaxResourceBodySize(response);
 	}
 
 	private boolean requestExceedsMaxBodySize(final Request request) {
-		return request.getOptions().hasSize1() && request.getOptions().getSize1() > maxResourceBodySize;
+		return request.getOptions().hasSize1() && request.getOptions().getSize1() > getMaxResourceBodySize(request);
+	}
+
+	private int getMaxResourceBodySize(final Message message) {
+		int maxPayloadSize = message.getMaxResourceBodySize();
+		if (maxPayloadSize == 0) {
+			maxPayloadSize = maxResourceBodySize; 
+		}
+		return maxPayloadSize;
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationUtil.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservationUtil.java
@@ -48,6 +48,7 @@ public final class ObservationUtil {
 		clonedRequest.setOptions(request.getOptions());
 		clonedRequest.setPayload(request.getPayload());
 		clonedRequest.setUserContext(request.getUserContext());
+		clonedRequest.setMaxResourceBodySize(request.getMaxResourceBodySize());
 		return new Observation(clonedRequest, observation.getContext());
 	}
 }


### PR DESCRIPTION
Enables to limit the blockwise payload individual for all blockwise
transfers.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>