### PR TITLE
Add message observer event for error on response handling.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserver2.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserver2.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sierra Wireless and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ ******************************************************************************/
+package org.eclipse.californium.core.coap;
+
+import org.eclipse.californium.elements.util.PublicAPIExtension;
+
+/**
+ * Extends MessageObserver to be notified when an error happens on response
+ * handling.
+ * 
+ * @since 2.3
+ */
+@PublicAPIExtension(type = MessageObserver.class)
+public interface MessageObserver2 extends MessageObserver {
+
+	/**
+	 * Invoked when an error happens during response handling.
+	 * 
+	 * @param cause The cause of the failure.
+	 */
+	void onResponseHandlingError(Throwable cause);
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserverAdapter.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/MessageObserverAdapter.java
@@ -47,7 +47,7 @@ import org.eclipse.californium.elements.EndpointContext;
  * An instance of the concrete message observer can then be registered with a
  * message using the message's <code>addMessageObserver</code> method.
  */
-public abstract class MessageObserverAdapter implements MessageObserver {
+public abstract class MessageObserverAdapter implements MessageObserver2 {
 
 	@Override
 	public void onRetransmission() {
@@ -101,6 +101,11 @@ public abstract class MessageObserverAdapter implements MessageObserver {
 
 	@Override
 	public void onSendError(Throwable error) {
+		failed();
+	}
+
+	@Override
+	public void onResponseHandlingError(Throwable error) {
 		failed();
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -889,7 +889,13 @@ public class BlockwiseLayer extends AbstractLayer {
 
 		} else if (responseExceedsMaxBodySize(response)) {
 
-			LOGGER.debug("requested resource body exceeds max buffer size [{}], aborting request", getMaxResourceBodySize(response));
+			String msg = String.format(
+					"requested resource body [%d bytes] exceeds max buffer size [%d bytes], aborting request",
+					response.getOptions().getSize2(), getMaxResourceBodySize(response));
+			LOGGER.debug(msg);
+			exchange.getRequest().setOnResponseError(new IllegalStateException(msg));
+			// TODO we keep the cancel event for backward compatibility but this
+			// should be removed in 3.x
 			exchange.getRequest().cancel();
 
 		} else {
@@ -915,7 +921,11 @@ public class BlockwiseLayer extends AbstractLayer {
 
 				} else if (!status.addBlock(response)) {
 
-					LOGGER.debug("cannot process payload of block2 response, aborting request");
+					String msg = "cannot process payload of block2 response, aborting request";
+					LOGGER.debug(msg);
+					exchange.getRequest().setOnResponseError(new IllegalStateException(msg));
+					// TODO we keep the cancel event for backward compatibility
+					// but this should be removed in 3.x
 					exchange.getRequest().cancel();
 					return;
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -156,6 +156,7 @@ public class BlockwiseClientSideTest {
 
 		request.waitForResponse(ERROR_TIMEOUT_IN_MS);
 		assertTrue("Request should have been cancelled", request.isCanceled());
+		assertNotNull("Request should have failed with error", request.getOnResponseError());
 	}
 
 	/**


### PR DESCRIPTION
A try about implementing  #1317.

I'm not strongly attached to class and method naming.
If it's available in 2.3 it's cool. If it's post-pone to 2.4 it's ok too.

There is probably some other way in the code where this event could be raised, If you know it feel free to add it.



