### PR TITLE
OSCORE: Use ID Context to disambiguate when retrieving contexts

### DIFF
--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
@@ -112,6 +112,7 @@ public class ContextRederivation {
 		OSCoreCtx newCtx = rederiveWithContextID(ctx, contextID1);
 		newCtx.setIncludeContextId(true);
 		newCtx.setContextRederivationPhase(ContextRederivation.PHASE.CLIENT_PHASE_1);
+		db.removeContext(ctx);
 		db.addContext(uri, newCtx);
 	}
 
@@ -160,6 +161,7 @@ public class ContextRederivation {
 
 			// Add the new context to the context DB (replacing the old)
 			newCtx.setContextRederivationPhase(PHASE.CLIENT_PHASE_2);
+			db.removeContext(ctx);
 			db.addContext(SCHEME + ctx.getUri(), newCtx);
 			return newCtx;
 		} else if (ctx.getContextRederivationPhase() == PHASE.INACTIVE) {
@@ -193,6 +195,7 @@ public class ContextRederivation {
 
 			// Add the new context to the context DB (replacing the old)
 			newCtx.setContextRederivationPhase(PHASE.CLIENT_PHASE_2);
+			db.removeContext(ctx);
 			db.addContext(SCHEME + ctx.getUri(), newCtx);
 			return newCtx;
 		}
@@ -237,6 +240,7 @@ public class ContextRederivation {
 			newCtx.setContextRederivationPhase(PHASE.CLIENT_PHASE_3);
 
 			// Add the new context to the context DB (replacing the old)
+			db.removeContext(ctx);
 			db.addContext(SCHEME + ctx.getUri(), newCtx);
 			return newCtx;
 		}
@@ -252,13 +256,26 @@ public class ContextRederivation {
 	 * @param db db the context db
 	 * @param ctx the context
 	 * @param contextID the context ID in the incoming request
+	 * @param RID the RID in the incoming request
 	 * @return an updated context
 	 * @throws OSException if context re-derivation fails
 	 */
-	static OSCoreCtx incomingRequest(OSCoreCtxDB db, OSCoreCtx ctx, byte[] contextID) throws OSException {
+	static OSCoreCtx incomingRequest(OSCoreCtxDB db, OSCoreCtx ctx, byte[] contextID, byte[] rid) throws OSException {
 
-		 // Check if context re-derivation is enabled for this context
-		 if (ctx.getContextRederivationEnabled() == false) {
+		// Try to retrieve the context based on the RID only if no context was
+		// found. Since the ID Context in the initial request will be a new one
+		// and not match existing contexts.
+		if (ctx == null) {
+			ctx = db.getContext(rid);
+		}
+
+		// No context found still
+		if (ctx == null) {
+			return null;
+		}
+
+		// Check if context re-derivation is enabled for this context
+		if (ctx.getContextRederivationEnabled() == false) {
 			LOGGER.debug("Context re-derivation not initiated due to it being disabled for this context");
 			return ctx;
 		 }
@@ -293,6 +310,7 @@ public class ContextRederivation {
 			newCtx.setContextRederivationPhase(PHASE.SERVER_PHASE_3);
 
 			// Add the new context to the context DB (replacing the old)
+			db.removeContext(ctx);
 			db.addContext(newCtx);
 
 			return newCtx;
@@ -319,6 +337,7 @@ public class ContextRederivation {
 			newCtx.setContextRederivationPhase(PHASE.SERVER_PHASE_1);
 
 			// Add the new context to the context DB (replacing the old)
+			db.removeContext(ctx);
 			db.addContext(newCtx);
 			return newCtx;
 		} else if (ctx.getContextRederivationPhase() == PHASE.SERVER_INITIATE) {
@@ -340,6 +359,7 @@ public class ContextRederivation {
 			newCtx.setContextRederivationPhase(PHASE.SERVER_PHASE_1);
 
 			// Add the new context to the context DB (replacing the old)
+			db.removeContext(ctx);
 			db.addContext(newCtx);
 			return newCtx;
 		}
@@ -412,6 +432,7 @@ public class ContextRederivation {
 			newCtx.setContextRederivationPhase(PHASE.SERVER_PHASE_2);
 
 			// Add the new context to the context DB (replacing the old)
+			db.removeContext(ctx);
 			db.addContext(newCtx);
 			return newCtx;
 		}

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ErrorDescriptions.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ErrorDescriptions.java
@@ -25,6 +25,7 @@ package org.eclipse.californium.oscore;
 public final class ErrorDescriptions {
 
 	public static final String CONTEXT_NOT_FOUND = "Security context not found";
+	public static final String CONTEXT_NOT_FOUND_IDCONTEXT = "Security context not found (resend with ID Context)";
 	public static final String FAILED_TO_DECODE_COSE = "Failed to decode COSE";
 	public static final String REPLAY_DETECT = "Replay detected";
 	public static final String DECRYPTION_FAILED = "Decryption failed";

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtxDB.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtxDB.java
@@ -33,6 +33,17 @@ public interface OSCoreCtxDB {
 	public OSCoreCtx getContext(byte[] cid);
 
 	/**
+	 * Retrieve a context also using the ID Context
+	 * 
+	 * @param cid the context identifier
+	 * @param IDContext the ID context
+	 * @return the OSCore context
+	 * @throws CoapOSException when retrieving with RID only and multiple
+	 *             matching contexts are found
+	 */
+	public OSCoreCtx getContext(byte[] cid, byte[] IDContext) throws CoapOSException;
+
+	/**
 	 * @param token the token of the request
 	 * @return the OSCore context
 	 */
@@ -57,6 +68,13 @@ public interface OSCoreCtxDB {
 	 * @param ctx the OSCore context
 	 */
 	public void addContext(OSCoreCtx ctx);
+
+	/**
+	 * Remove a context
+	 * 
+	 * @param ctx the OSCore context
+	 */
+	void removeContext(OSCoreCtx ctx);
 
 	/**
 	 * @param uri the recipient's uri

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OptionJuggle.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OptionJuggle.java
@@ -19,6 +19,7 @@
 package org.eclipse.californium.oscore;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -326,6 +327,75 @@ public class OptionJuggle {
 			}
 		}
 		return eOptions;
+	}
+
+	/**
+	 * Retrieve RID value from an OSCORE option.
+	 * 
+	 * @param oscoreOption the OSCORE option
+	 * @return the RID value
+	 */
+	static byte[] getRid(byte[] oscoreOption) {
+		if (oscoreOption.length == 0) {
+			return null;
+		}
+	
+		// Parse the flag byte
+		byte flagByte = oscoreOption[0];
+		int n = flagByte & 0x07;
+		int k = flagByte & 0x08;
+		int h = flagByte & 0x10;
+	
+		byte[] kid = null;
+		int index = 1;
+	
+		// Partial IV
+		index += n;
+	
+		// KID Context
+		if (h != 0) {
+			int s = oscoreOption[index];
+			index += s + 1;
+		}
+	
+		// KID
+		if (k != 0) {
+			kid = Arrays.copyOfRange(oscoreOption, index, oscoreOption.length);
+		}
+	
+		return kid;
+	}
+
+	/**
+	 * Retrieve ID Context value from an OSCORE option.
+	 * 
+	 * @param oscoreOption the OSCORE option
+	 * @return the ID Context value
+	 */
+	static byte[] getIDContext(byte[] oscoreOption) {
+		if (oscoreOption.length == 0) {
+			return null;
+		}
+
+		// Parse the flag byte
+		byte flagByte = oscoreOption[0];
+		int n = flagByte & 0x07;
+		int h = flagByte & 0x10;
+
+		byte[] kidContext = null;
+		int index = 1;
+
+		// Partial IV
+		index += n;
+
+		// KID Context
+		if (h != 0) {
+			int s = oscoreOption[index];
+			kidContext = Arrays.copyOfRange(oscoreOption, index + 1, index + 1 + s);
+			index += s + 1;
+		}
+
+		return kidContext;
 	}
 
 }

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/ContextRederivationTest.java
@@ -332,6 +332,10 @@ public class ContextRederivationTest {
 	 * @throws OSException
 	 */
 	public void createServer(boolean initiateRederivation) throws InterruptedException, OSException {
+
+		// Purge any old existing values from the server context database
+		dbServer.purge();
+
 		//Do not create server if it is already running
 		if(server != null) {
 			return;

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/DecryptorTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/DecryptorTest.java
@@ -78,7 +78,7 @@ public class DecryptorTest {
 		}
 		
 		//Decrypt the request message
-		Request decrypted = RequestDecryptor.decrypt(db, r);
+		Request decrypted = RequestDecryptor.decrypt(db, r, ctx);
 		decrypted.getOptions().removeOscore();
 		
 		//Serialize the request message to byte array

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreTest.java
@@ -48,6 +48,7 @@ import org.eclipse.californium.elements.util.Bytes;
 public class OSCoreTest {
 
 	private OSCoreCtxDB dbClient;
+	private OSCoreCtxDB dbServer;
 	private String uriId = "coap://localhost/";
 	private String uriFull = "coap://localhost:5683";
 	private byte[] key = { 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
@@ -64,6 +65,8 @@ public class OSCoreTest {
 		clientCtx = new OSCoreCtx(key, true);
 		dbClient.addContext(uriId, clientCtx);
 		serverCtx = new OSCoreCtx(key, false);
+		dbServer = new HashMapCtxDB();
+		dbServer.addContext(serverCtx);
 	}
 
 	@After
@@ -83,7 +86,7 @@ public class OSCoreTest {
 		try {
 			int seq = dbClient.getSeqByToken(token);
 			dbClientToServer();
-			ObjectSecurityLayer.prepareReceive(dbClient, request);
+			ObjectSecurityLayer.prepareReceive(dbServer, request, serverCtx);
 			Response response = sendResponse("it is thursday, citizen", serverCtx, token);
 			dbServerToClient(token, seq);
 			ObjectSecurityLayer.prepareReceive(dbClient, response);
@@ -336,7 +339,7 @@ public class OSCoreTest {
 		dbClientToServer();
 
 		try {
-			request = ObjectSecurityLayer.prepareReceive(dbClient, request);
+			request = ObjectSecurityLayer.prepareReceive(dbServer, request, serverCtx);
 		} catch (OSException e) {
 			e.printStackTrace();
 			assertTrue(false);
@@ -363,7 +366,7 @@ public class OSCoreTest {
 		dbClientToServer();
 
 		try {
-			ObjectSecurityLayer.prepareReceive(dbClient, request);
+			ObjectSecurityLayer.prepareReceive(dbServer, request, serverCtx);
 		} catch (OSException e) {
 			e.printStackTrace();
 			assertTrue(false);
@@ -390,7 +393,7 @@ public class OSCoreTest {
 		dbClientToServer();
 
 		try {
-			ObjectSecurityLayer.prepareReceive(dbClient, request1);
+			ObjectSecurityLayer.prepareReceive(dbServer, request1, serverCtx);
 			assertTrue("seq no:s incorrect", assertCtxState(serverCtx, 0, 0));
 			Response response1 = sendResponse("it is thursday, citizen", serverCtx, tokReq1);
 			assertTrue("seq no:s incorrect", assertCtxState(serverCtx, 0, 0));
@@ -432,8 +435,8 @@ public class OSCoreTest {
 
 		// receiving seq 0 twice
 		try {
-			ObjectSecurityLayer.prepareReceive(dbClient, request);
-			ObjectSecurityLayer.prepareReceive(dbClient, request2);
+			ObjectSecurityLayer.prepareReceive(dbServer, request, serverCtx);
+			ObjectSecurityLayer.prepareReceive(dbServer, request2, serverCtx);
 			fail("duplicate seq 0 not detected!");
 		} catch (OSException e) {
 		}
@@ -504,7 +507,7 @@ public class OSCoreTest {
 		// Test receive
 		boolean detectWrap = false;
 		try {
-			ObjectSecurityLayer.prepareReceive(dbClient, req);
+			ObjectSecurityLayer.prepareReceive(dbServer, req, serverCtx);
 		} catch (OSException e) {
 			detectWrap = true;
 		}


### PR DESCRIPTION
When retrieving an OSCORE context for an incoming request both the Recipient ID (RID/KID) and ID Context should be used. However the ID Context may not be included in a request (to save overhead). In such case the correct context can still be found if there is only 1 stored under that RID. If there are multiple contexts stored under that RID an error message will be returned and the client can retransmit the request now including an ID Context.