### PR TITLE
Fix deprecated psk store in dtls configuration.

### DIFF
--- a/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/CredentialsUtil.java
+++ b/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/CredentialsUtil.java
@@ -249,7 +249,7 @@ public class CredentialsUtil {
 		boolean plainPsk = modes.contains(Mode.PSK);
 		boolean psk = ecdhePsk || plainPsk;
 
-		if (psk && config.getIncompleteConfig().getPskStore() == null) {
+		if (psk && config.getIncompleteConfig().getAdvancedPskStore() == null) {
 			// Pre-shared secret keys
 			InMemoryPskStore pskStore = new InMemoryPskStore();
 			pskStore.setKey(PSK_IDENTITY, PSK_SECRET);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -163,7 +163,7 @@ public class ConnectorHelper {
 
 		DtlsConnectorConfig incompleteConfig = builder.getIncompleteConfig();
 
-		if (incompleteConfig.getAdvancedPskStore() == null && incompleteConfig.getPskStore() == null) {
+		if (incompleteConfig.getAdvancedPskStore() == null) {
 			InMemoryPskStore pskStore = new InMemoryPskStore();
 			pskStore.setKey(CLIENT_IDENTITY, CLIENT_IDENTITY_SECRET.getBytes());
 			pskStore.setKey(SCOPED_CLIENT_IDENTITY, SCOPED_CLIENT_IDENTITY_SECRET.getBytes(), SERVERNAME);


### PR DESCRIPTION
Create advanced psk store already in setter, not later in build.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>