### PR TITLE
Reduce cache synchronization

### DIFF
--- a/scandium-core/api-changes.json
+++ b/scandium-core/api-changes.json
@@ -168,6 +168,11 @@
 					"old": "class org.eclipse.californium.scandium.dtls.PskUtil",
 					"justification": "not part of the public API - obsolete",
 					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0"
+				},{
+					"code": "java.method.addedToInterface",
+					"new": "method org.eclipse.californium.scandium.dtls.Connection org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore::get(java.net.InetSocketAddress, org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore.ConnectionMapper)",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.1.0",
+					"justification": "Performance improvement. Cache is responsible now for all synchronization"
 				}
 			]
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumptionSupportingConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumptionSupportingConnectionStore.java
@@ -32,6 +32,17 @@ import org.eclipse.californium.scandium.ConnectionListener;
  * @since 1.1
  */
 public interface ResumptionSupportingConnectionStore {
+
+	interface ConnectionMapper {
+		/**
+		 * Maps a connection to a potentially different connection, or the same connection
+		 *
+		 * @param existingConnection may be null
+		 * @return the mapped connection.
+		 */
+
+		Connection remapConnection(Connection existingConnection);
+	}
 	void setConnectionListener(ConnectionListener listener);
 
 	/**
@@ -119,6 +130,23 @@ public interface ResumptionSupportingConnectionStore {
 	 *         exists for the given address
 	 */
 	Connection get(InetSocketAddress peerAddress);
+
+
+	/**
+	 * Get a connection for the provided peer address.
+	 * The stored connection (or null) is passed to the remapper and if the remapper returns a different connection,
+	 * that connection is persisted and returned
+	 *
+	 * The remapper execution is synchronized per peer address
+	 *
+	 * The behavior is similar to {@link java.util.Map#compute}
+	 *
+	 * Implementations are responsible for synchronizing access to the remapper
+	 *
+	 * @param peerAddress the peer address
+	 * @return the mapped connection or <code>null</code> if there is no mapped connection or the mapped connection was not stored
+	 */
+	Connection get(InetSocketAddress peerAddress, ConnectionMapper remapper);
 
 	/**
 	 * Gets a connection by its connection id.


### PR DESCRIPTION
The InMemoryCache synchronization is taking too much locks. Even secondary cache lookups are were done in synchronized blocks. 
This commit moves all secondary cache read/updates out of synchronized blocks and also removes some other unnecessary synchronization. 