### PR TITLE
Handle ENTITY TOO LARGE for transparent blockwise transfert

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -208,6 +208,24 @@ public final class NetworkConfig {
 		 */
 		public static final String BLOCKWISE_STRICT_BLOCK2_OPTION = "BLOCKWISE_STRICT_BLOCK2_OPTION";
 
+		/**
+		 * Property to automatically handle 4.13 Entity too large error with
+		 * transparent blockwise transfer.
+		 * <p>
+		 * The default value is :
+		 * {@link NetworkConfigDefaults#DEFAULT_BLOCKWISE_ENTITY_TOO_LARGE_AUTO_FAILOVER }.
+		 * <p>
+		 * When activated ({@code true}), CoAP client will try to use block mode
+		 * or adapt the block size when receiving a 4.13 Entity too large
+		 * response code.
+		 * <p>
+		 * See https://tools.ietf.org/html/rfc7959#section-2.9.3 for more
+		 * details.
+		 * 
+		 * @since 2.4
+		 */
+		public static final String BLOCKWISE_ENTITY_TOO_LARGE_AUTO_FAILOVER = "BLOCKWISE_ENTITY_TOO_LARGE_AUTO_FAILOVER";
+
 		public static final String NOTIFICATION_CHECK_INTERVAL_TIME = "NOTIFICATION_CHECK_INTERVAL";
 		public static final String NOTIFICATION_CHECK_INTERVAL_COUNT = "NOTIFICATION_CHECK_INTERVAL_COUNT";
 		public static final String NOTIFICATION_REREGISTRATION_BACKOFF = "NOTIFICATION_REREGISTRATION_BACKOFF";

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfigDefaults.java
@@ -71,7 +71,10 @@ public class NetworkConfigDefaults {
 	 * The default value is false, which indicate that the server will not include the Block2 option.
 	 */
 	public static final boolean DEFAULT_BLOCKWISE_STRICT_BLOCK2_OPTION = false;
-	
+
+	/** @since 2.4 */
+	public static final boolean DEFAULT_BLOCKWISE_ENTITY_TOO_LARGE_AUTO_FAILOVER = true;
+
 	/**
 	 * The default value for {@link Keys#PREFERRED_BLOCK_SIZE}
 	 */
@@ -219,6 +222,7 @@ public class NetworkConfigDefaults {
 		config.setInt(Keys.MAX_RESOURCE_BODY_SIZE, DEFAULT_MAX_RESOURCE_BODY_SIZE);
 		config.setInt(Keys.BLOCKWISE_STATUS_LIFETIME, DEFAULT_BLOCKWISE_STATUS_LIFETIME); // [ms]
 		config.setBoolean(Keys.BLOCKWISE_STRICT_BLOCK2_OPTION, DEFAULT_BLOCKWISE_STRICT_BLOCK2_OPTION);
+		config.setBoolean(Keys.BLOCKWISE_ENTITY_TOO_LARGE_AUTO_FAILOVER, DEFAULT_BLOCKWISE_ENTITY_TOO_LARGE_AUTO_FAILOVER);
 
 		
 		config.setLong(Keys.NOTIFICATION_CHECK_INTERVAL_TIME, 24 * 60 * 60 * 1000); //24 [ms]

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -791,7 +791,7 @@ public class BlockwiseLayer extends AbstractLayer {
 			newSize = currentSize;
 			newSzx = status.getCurrentSzx();
 		}
-		int nextNum = status.getCurrentNum() + currentSize / newSize;
+		int nextNum = (status.getCurrentNum() + 1) * status.getCurrentSize() / newSize;
 		LOGGER.debug("sending next Block1 num={}", nextNum);
 		Request nextBlock = null;
 		try {


### PR DESCRIPTION
This is a WIP PR aiming to fix #395.

Triggered by [mailing list discussion](https://www.eclipse.org/lists/cf-dev/msg01762.html).

Currently, I only support that a block1 request with too large block size is negotiated into block1 request with smaller block size.

But we should also be able to handle a normal request (without block1) with too large payload which should be turned out in block1 request.

The [specification says](https://tools.ietf.org/html/rfc7959#section-2.9.3) : 
> It also allows  the server to return a 4.13 response to a request that does not
   employ Block1 as a hint for the client to try sending Block1.

But this is not clear how :thinking:  ?
1.  should the coap server add a block1 option 
2. or should we use the size1 option ?


solution 1.  sounds only used to answer to request with block1 option.
solution 2. sounds to so adapted as size1 is more about the whole payload size and this forces client to guess the block size to use.. 

Any thought about that ?