### PR TITLE
Redesign dtls recordlayer

### DIFF
--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/LibCoapClientInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/LibCoapClientInteroperabilityTest.java
@@ -97,6 +97,18 @@ public class LibCoapClientInteroperabilityTest {
 	}
 
 	@Test
+	public void testLibCoapClientPskMultiFragment() throws Exception {
+		CipherSuite cipherSuite = CipherSuite.TLS_PSK_WITH_AES_128_CCM_8;
+		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();
+		builder.setEnableMultiHandshakeMessageRecords(true);
+		californiumUtil.start(BIND, false, builder, null, cipherSuite);
+
+		processUtil.startupClient(DESTINATION_URL + "test", AuthenticationMode.PSK, "Hello, CoAP!",
+				cipherSuite);
+		connect("Hello, CoAP!", "Greetings!");
+	}
+
+	@Test
 	public void testLibCoapClientPskNoSessionId() throws Exception {
 		CipherSuite cipherSuite = CipherSuite.TLS_PSK_WITH_AES_128_CCM_8;
 		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/LibCoapClientTinyDtlsInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/LibCoapClientTinyDtlsInteroperabilityTest.java
@@ -34,6 +34,7 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -90,6 +91,19 @@ public class LibCoapClientTinyDtlsInteroperabilityTest {
 	public void testLibCoapClientTinyDtlsPsk() throws Exception {
 		CipherSuite cipherSuite = CipherSuite.TLS_PSK_WITH_AES_128_CCM_8;
 		californiumUtil.start(BIND, null, cipherSuite);
+
+		processUtil.startupClientTinyDtls(DESTINATION_URL + "test", AuthenticationMode.PSK, "Hello, CoAP!",
+				cipherSuite);
+		connect("Hello, CoAP!", "Greetings!");
+	}
+
+	@Ignore
+	@Test
+	public void testLibCoapClientTinyDtlsPskMultiFragment() throws Exception {
+		CipherSuite cipherSuite = CipherSuite.TLS_PSK_WITH_AES_128_CCM_8;
+		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();
+		builder.setEnableMultiHandshakeMessageRecords(true);
+		californiumUtil.start(BIND, false, builder, null, cipherSuite);
 
 		processUtil.startupClientTinyDtls(DESTINATION_URL + "test", AuthenticationMode.PSK, "Hello, CoAP!",
 				cipherSuite);

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/TestConditionTools.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/TestConditionTools.java
@@ -130,8 +130,8 @@ public final class TestConditionTools {
 	 * Assert, that a statistic counter reaches the matcher's criterias within
 	 * the provided timeout.
 	 * 
-	 * @param manager statisitc manager
-	 * @param name name os statisitc.
+	 * @param manager statistic manager
+	 * @param name name of statistic.
 	 * @param matcher matcher for statistic counter value
 	 * @param timeout timeout to match
 	 * @param unit unit of timeout
@@ -155,14 +155,58 @@ public final class TestConditionTools {
 	}
 
 	/**
-	 * Assert, that a statistic counter matches the provided criterias.
+	 * Assert, that a statistic counter reaches the matcher's criteria within
+	 * the provided timeout.
 	 * 
-	 * @param manager statisitc manager
-	 * @param name name os statisitc.
+	 * @param message message prepended to name
+	 * @param manager statistic manager
+	 * @param name name of statistic.
+	 * @param matcher matcher for statistic counter value
+	 * @param timeout timeout to match
+	 * @param unit unit of timeout
+	 * @throws InterruptedException if wait is interrupted.
+	 * @see TestConditionTools#assertStatisticCounter(CounterStatisticManager,
+	 *      String, Matcher)
+	 * @since 2.4
+	 */
+	public static void assertStatisticCounter(String message, final CounterStatisticManager manager, final String name,
+			final Matcher<? super Long> matcher, long timeout, TimeUnit unit) throws InterruptedException {
+		if (timeout > 0) {
+			long timeoutMillis = unit.toMillis(timeout);
+			waitForCondition(timeoutMillis, timeoutMillis / 10l, TimeUnit.MILLISECONDS, new TestCondition() {
+
+				@Override
+				public boolean isFulFilled() throws IllegalStateException {
+					return matcher.matches(manager.getCounter(name));
+				}
+			});
+		}
+		assertThat(message + "-" + name, manager.getCounter(name), matcher);
+	}
+
+	/**
+	 * Assert, that a statistic counter matches the provided criteria.
+	 * 
+	 * @param manager statistic manager
+	 * @param name name of statistic.
 	 * @param matcher matcher for statistic counter value
 	 */
 	public static void assertStatisticCounter(CounterStatisticManager manager, String name,
 			Matcher<? super Long> matcher) {
 		assertThat(name, manager.getCounter(name), matcher);
+	}
+
+	/**
+	 * Assert, that a statistic counter matches the provided criteria.
+	 * 
+	 * @param message message prepended to name
+	 * @param manager statistic manager
+	 * @param name name of statistic.
+	 * @param matcher matcher for statistic counter value
+	 * @since 2.4
+	 */
+	public static void assertStatisticCounter(String message, CounterStatisticManager manager, String name,
+			Matcher<? super Long> matcher) {
+		assertThat(message +"-" +  name, manager.getCounter(name), matcher);
 	}
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/TestScheduledExecutorService.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/TestScheduledExecutorService.java
@@ -1,0 +1,363 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * ScheduledExecutorService for unit tests.
+ * 
+ * Jobs are executed by calling {@link #executeJobs()}, not by time schedule.
+ * 
+ * @since 2.4
+ */
+public class TestScheduledExecutorService implements ScheduledExecutorService {
+
+	/**
+	 * List of pending jobs.
+	 */
+	private final List<Runnable> jobs = new ArrayList<Runnable>();
+	/**
+	 * Shutdown indicator.
+	 */
+	private volatile boolean shutdown;
+	/**
+	 * Termination indicator.
+	 */
+	private volatile boolean terminated;
+
+	/**
+	 * Create test scheduler.
+	 */
+	public TestScheduledExecutorService() {
+	}
+
+	@Override
+	public void shutdown() {
+		shutdown = true;
+	}
+
+	@Override
+	public List<Runnable> shutdownNow() {
+		this.shutdown = true;
+		synchronized (this.jobs) {
+			List<Runnable> jobs = new ArrayList<Runnable>(this.jobs);
+			this.jobs.clear();
+			this.terminated = true;
+			this.jobs.notifyAll();
+			return jobs;
+		}
+	}
+
+	@Override
+	public boolean isShutdown() {
+		return shutdown;
+	}
+
+	@Override
+	public boolean isTerminated() {
+		return terminated;
+	}
+
+	@Override
+	public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+		synchronized (this.jobs) {
+			if (!terminated) {
+				this.jobs.wait(unit.toMillis(timeout));
+			}
+		}
+		return terminated;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * Not implemented.
+	 * 
+	 * @throws RuntimeException "not supported!"
+	 */
+	@Override
+	public <T> Future<T> submit(Callable<T> task) {
+		throw new RuntimeException("not supported!");
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * Not implemented.
+	 * 
+	 * @throws RuntimeException "not supported!"
+	 */
+	@Override
+	public <T> Future<T> submit(Runnable task, T result) {
+		throw new RuntimeException("not supported!");
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * Not implemented.
+	 * 
+	 * @throws RuntimeException "not supported!"
+	 */
+	@Override
+	public Future<?> submit(Runnable task) {
+		throw new RuntimeException("not supported!");
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * Not implemented.
+	 * 
+	 * @throws RuntimeException "not supported!"
+	 */
+	@Override
+	public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+		throw new RuntimeException("not supported!");
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * Not implemented.
+	 * 
+	 * @throws RuntimeException "not supported!"
+	 */
+	@Override
+	public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+			throws InterruptedException {
+		throw new RuntimeException("not supported!");
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * Not implemented.
+	 * 
+	 * @throws RuntimeException "not supported!"
+	 */
+	@Override
+	public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+		throw new RuntimeException("not supported!");
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * Not implemented.
+	 * 
+	 * @throws RuntimeException "not supported!"
+	 */
+	@Override
+	public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+			throws InterruptedException, ExecutionException, TimeoutException {
+		throw new RuntimeException("not supported!");
+	}
+
+	@Override
+	public void execute(Runnable command) {
+		if (shutdown) {
+			throw new RejectedExecutionException("already shutdown!");
+		}
+		jobs.add(command);
+	}
+
+	@Override
+	public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+		if (shutdown) {
+			throw new RejectedExecutionException("already shutdown!");
+		}
+		ScheduledRunnable job = new ScheduledRunnable(command, delay, unit);
+		jobs.add(job);
+		return job;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * Not implemented.
+	 * 
+	 * @throws RuntimeException "not supported!"
+	 */
+	@Override
+	public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+		throw new RuntimeException("not supported!");
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * Not implemented.
+	 * 
+	 * @throws RuntimeException "not supported!"
+	 */
+	@Override
+	public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+		throw new RuntimeException("not supported!");
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * Not implemented.
+	 * 
+	 * @throws RuntimeException "not supported!"
+	 */
+	@Override
+	public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+		throw new RuntimeException("not supported!");
+	}
+
+	/**
+	 * Cancel all pending jobs.
+	 */
+	public void cancelAll() {
+		synchronized (jobs) {
+			jobs.clear();
+		}
+	}
+
+	/**
+	 * Execute all currently pending jobs.
+	 * 
+	 * @return number of executed jobs.
+	 */
+	public int executeJobs() {
+		int count = 0;
+		List<Runnable> currentJobs;
+		synchronized (jobs) {
+			currentJobs = new ArrayList<Runnable>(jobs);
+		}
+		for (Runnable run : currentJobs) {
+			if (!shutdown && isPending(run)) {
+				run.run();
+				++count;
+			}
+		}
+		synchronized (jobs) {
+			if (shutdown && jobs.isEmpty()) {
+				terminated = true;
+				jobs.notify();
+			}
+		}
+		return count;
+	}
+
+	/**
+	 * Test, if job is pending.
+	 * 
+	 * @param run job to test.
+	 * @return {@code true}, if job is pending, {@code false}, if job was
+	 *         canceled in the meantime.
+	 */
+	private boolean isPending(Runnable run) {
+		synchronized (jobs) {
+			if (jobs.remove(run)) {
+				if (run instanceof ScheduledFuture) {
+					@SuppressWarnings("unchecked")
+					ScheduledFuture<Void> future = (ScheduledFuture<Void>) run;
+					return !future.isCancelled();
+				}
+			}
+			return false;
+		}
+	}
+
+	/**
+	 * Implementation of {@link ScheduledFuture}.
+	 */
+	private class ScheduledRunnable implements Runnable, ScheduledFuture<Void> {
+
+		private final Runnable job;
+		private final long delay;
+		private final TimeUnit unit;
+		private volatile boolean completed;
+		private volatile boolean cancelled;
+
+		private ScheduledRunnable(Runnable job, long delay, TimeUnit unit) {
+			this.job = job;
+			this.delay = delay;
+			this.unit = unit;
+		}
+
+		@Override
+		public long getDelay(TimeUnit unit) {
+			return unit.convert(delay, this.unit);
+		}
+
+		@Override
+		public int compareTo(Delayed o) {
+			return (int) (getDelay(TimeUnit.NANOSECONDS) - o.getDelay(TimeUnit.NANOSECONDS));
+		}
+
+		@Override
+		public boolean cancel(boolean mayInterruptIfRunning) {
+			if (!completed && !cancelled) {
+				cancelled = true;
+				synchronized (jobs) {
+					jobs.remove(this);
+				}
+				if (mayInterruptIfRunning) {
+					Thread.currentThread().interrupt();
+				}
+			}
+			return cancelled;
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return cancelled;
+		}
+
+		@Override
+		public boolean isDone() {
+			return completed;
+		}
+
+		@Override
+		public Void get() throws InterruptedException, ExecutionException {
+			return null;
+		}
+
+		@Override
+		public Void get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+			return null;
+		}
+
+		@Override
+		public void run() {
+			if (!cancelled) {
+				this.job.run();
+				if (!cancelled) {
+					completed = true;
+				}
+			}
+		}
+
+	}
+}

--- a/scandium-core/api-changes.json
+++ b/scandium-core/api-changes.json
@@ -171,5 +171,118 @@
 				}
 			]
 		}
+	},
+	"2.4.0": {
+		"revapi": {
+			"ignore": [
+				{
+					"code": "java.method.removed",
+					"old": "method org.eclipse.californium.scandium.dtls.HandshakeMessage org.eclipse.californium.scandium.dtls.GenericHandshakeMessage::getSpecificHandshakeMessage(org.eclipse.californium.scandium.dtls.HandshakeParameter) throws org.eclipse.californium.scandium.dtls.HandshakeException",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.numberOfParametersChanged",
+					"old": "method org.eclipse.californium.scandium.dtls.HandshakeMessage org.eclipse.californium.scandium.dtls.HandshakeMessage::fromByteArray(byte[], org.eclipse.californium.scandium.dtls.HandshakeParameter, java.net.InetSocketAddress) throws org.eclipse.californium.scandium.dtls.HandshakeException",
+					"new": "method org.eclipse.californium.scandium.dtls.HandshakeMessage org.eclipse.californium.scandium.dtls.HandshakeMessage::fromByteArray(byte[], java.net.InetSocketAddress) throws org.eclipse.californium.scandium.dtls.HandshakeException",
+					"justification": "not part of the public API - requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method void org.eclipse.californium.scandium.dtls.DTLSFlight::addMessage(org.eclipse.californium.scandium.dtls.Record)",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method void org.eclipse.californium.scandium.dtls.DTLSFlight::setNewSequenceNumbers() throws java.security.GeneralSecurityException",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method void org.eclipse.californium.scandium.dtls.DTLSFlight::setTimeoutTask(java.util.concurrent.ScheduledFuture<?>)",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method java.net.InetSocketAddress org.eclipse.californium.scandium.dtls.DTLSFlight::getPeerAddress()",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method java.util.List<org.eclipse.californium.scandium.dtls.Record> org.eclipse.californium.scandium.dtls.DTLSFlight::getMessages()",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method void org.eclipse.californium.scandium.dtls.Record::updateSequenceNumber(long) throws java.security.GeneralSecurityException",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.numberOfParametersChanged",
+					"old": "method void org.eclipse.californium.scandium.dtls.Handshaker::<init>(boolean, int, org.eclipse.californium.scandium.dtls.DTLSSession, org.eclipse.californium.scandium.dtls.RecordLayer, org.eclipse.californium.scandium.dtls.Connection, org.eclipse.californium.scandium.config.DtlsConnectorConfig, int)",
+					"new": "method void org.eclipse.californium.scandium.dtls.Handshaker::<init>(boolean, int, org.eclipse.californium.scandium.dtls.DTLSSession, org.eclipse.californium.scandium.dtls.RecordLayer, java.util.concurrent.ScheduledExecutorService, org.eclipse.californium.scandium.dtls.Connection, org.eclipse.californium.scandium.config.DtlsConnectorConfig)",
+					"justification": "Constructor not part of the public API",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.numberOfParametersChanged",
+					"old": "method void org.eclipse.californium.scandium.dtls.ResumingServerHandshaker::<init>(int, org.eclipse.californium.scandium.dtls.DTLSSession, org.eclipse.californium.scandium.dtls.RecordLayer, org.eclipse.californium.scandium.dtls.Connection, org.eclipse.californium.scandium.config.DtlsConnectorConfig, int)",
+					"new": "method void org.eclipse.californium.scandium.dtls.ResumingServerHandshaker::<init>(int, org.eclipse.californium.scandium.dtls.DTLSSession, org.eclipse.californium.scandium.dtls.RecordLayer, java.util.concurrent.ScheduledExecutorService, org.eclipse.californium.scandium.dtls.Connection, org.eclipse.californium.scandium.config.DtlsConnectorConfig)",
+					"justification": "not part of the public API",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.numberOfParametersChanged",
+					"old": "method void org.eclipse.californium.scandium.dtls.ServerHandshaker::<init>(int, org.eclipse.californium.scandium.dtls.DTLSSession, org.eclipse.californium.scandium.dtls.RecordLayer, org.eclipse.californium.scandium.dtls.Connection, org.eclipse.californium.scandium.config.DtlsConnectorConfig, int)",
+					"new": "method void org.eclipse.californium.scandium.dtls.ServerHandshaker::<init>(int, org.eclipse.californium.scandium.dtls.DTLSSession, org.eclipse.californium.scandium.dtls.RecordLayer, java.util.concurrent.ScheduledExecutorService, org.eclipse.californium.scandium.dtls.Connection, org.eclipse.californium.scandium.config.DtlsConnectorConfig)",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method void org.eclipse.californium.scandium.dtls.Handshaker::setPendingFlight(org.eclipse.californium.scandium.dtls.DTLSFlight)",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method org.eclipse.californium.scandium.dtls.HandshakeMessage org.eclipse.californium.scandium.dtls.Handshaker::handleFragmentation(org.eclipse.californium.scandium.dtls.FragmentedHandshakeMessage) throws org.eclipse.californium.scandium.dtls.HandshakeException",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm org.eclipse.californium.scandium.dtls.Handshaker::getKeyExchangeAlgorithm()",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method org.eclipse.californium.scandium.dtls.HandshakeMessage org.eclipse.californium.scandium.dtls.Handshaker::handleFragmentation(org.eclipse.californium.scandium.dtls.FragmentedHandshakeMessage) throws org.eclipse.californium.scandium.dtls.HandshakeException",
+					"old": "method org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm org.eclipse.californium.scandium.dtls.Handshaker::getKeyExchangeAlgorithm()",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method org.eclipse.californium.scandium.dtls.DTLSSession org.eclipse.californium.scandium.dtls.DTLSFlight::getSession()",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				},
+				{
+					"code": "java.method.removed",
+					"old": "method int org.eclipse.californium.scandium.dtls.DTLSSession::getMaxDatagramSize()",
+					"justification": "not part of the public API - removed requires explicit ignore",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.3.0"
+				}
+			]
+		}
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AlertMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AlertMessage.java
@@ -212,6 +212,11 @@ public final class AlertMessage implements DTLSMessage, Serializable {
 
 	// Serialization //////////////////////////////////////////////////
 
+	@Override
+	public int size() {
+		return (2 * BITS) / Byte.SIZE;
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ApplicationMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ApplicationMessage.java
@@ -47,9 +47,13 @@ public final class ApplicationMessage extends AbstractMessage {
 	 * @param data byte array with the application data.
 	 * @param peerAddress the IP address and port the message is to be sent to
 	 *            or has been received from
+	 * @throws NullPointerException if peer or data is {@code null}
 	 */
 	public ApplicationMessage(byte[] data, InetSocketAddress peerAddress) {
 		super(peerAddress);
+		if (data == null) {
+			throw new NullPointerException("data must not be null!");
+		}
 		this.data = data;
 	}
 
@@ -68,6 +72,11 @@ public final class ApplicationMessage extends AbstractMessage {
 	}
 
 	// Serialization //////////////////////////////////////////////////
+
+	@Override
+	public int size() {
+		return data.length;
+	}
 
 	@Override
 	public byte[] toByteArray() {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ChangeCipherSpecMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ChangeCipherSpecMessage.java
@@ -70,23 +70,28 @@ public final class ChangeCipherSpecMessage extends AbstractMessage {
 			return code;
 		}
 	}
-	
+
 	// Methods ////////////////////////////////////////////////////////
 
 	@Override
 	public ContentType getContentType() {
 		return ContentType.CHANGE_CIPHER_SPEC;
 	}
-	
+
 	public CCSType getCCSProtocolType() {
 		return CCSProtocolType;
 	}
-	
+
 	@Override
 	public String toString() {
 		return "\tChange Cipher Spec Message\n";
 	}
-	
+
+	@Override
+	public int size() {
+		return CCS_BITS / Byte.SIZE;
+	}
+
 	// Serialization //////////////////////////////////////////////////
 
 	@Override

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
@@ -73,7 +73,7 @@ public final class Connection {
 	 * Random used by client to start the handshake. Maybe {@code null}, for
 	 * client side connections. Note: used outside of serial-execution!
 	 */
-	private Random startingClientHelloRandom;
+	private volatile Random startingClientHelloRandom;
 	private int startingClientHelloMessageSeq;
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
@@ -210,32 +210,4 @@ public abstract class DTLSConnectionState implements Destroyable {
 	int getRecordIvLength() {
 		return cipherSuite.getRecordIvLength();
 	}
-
-	/**
-	 * Gets the maximum number of bytes a <em>DTLSPlaintext.fragment</em> gets expanded
-	 * by when transforming it to a <em>DTLSCiphertext.fragment</em> using the cipher
-	 * algorithm held in this session's <em>current write state</em>.
-	 * <p>
-	 * The amount of expansion introduced depends on multiple factors like the bulk cipher
-	 * algorithm's block size, the MAC length and other parameters determined by the cipher
-	 * suite.
-	 * <p>
-	 * Clients can use this information to determine an upper boundary for the required
-	 * size of a datagram to hold the overall <em>DTLSCiphertext</em> structure created for
-	 * a given <em>DTLSPlaintext</em> structure like this:
-	 * <p>
-	 * <pre>
-	 *    size(DTLSCiphertext) <= DTLSPlaintext.length // length of the DTLSPlaintext.fragment
-	 *                               + ciphertext_expansion
-	 *                               + 13 // record headers
-	 *                               + 12 // message headers
-	 *                               + 8 // UDP headers
-	 *                               + 20 // IP headers
-	 * </pre>
-	 * 
-	 * @return the number of bytes
-	 */
-	final int getMaxCiphertextExpansion() {
-		return cipherSuite.getMaxCiphertextExpansion();
-	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSMessage.java
@@ -20,11 +20,22 @@ package org.eclipse.californium.scandium.dtls;
 
 import java.net.InetSocketAddress;
 
+import org.eclipse.californium.elements.util.NoPublicAPI;
 
 /**
  * The message contract as defined by the DTLS specification.
  */
+@NoPublicAPI
 public interface DTLSMessage {
+
+	/**
+	 * Gets the number of bytes representing this message as defined
+	 * by <a href="http://tools.ietf.org/html/rfc5246#appendix-A">TLS 1.2, Appendix A</a>.
+	 * 
+	 * @return number of bytes
+	 * @since 2.4
+	 */
+	int size();
 
 	/**
 	 * Gets the byte array representation of this message as defined
@@ -33,14 +44,14 @@ public interface DTLSMessage {
 	 * @return the byte array
 	 */
 	byte[] toByteArray();
-	
+
 	/**
 	 * Gets the message's content type.
 	 * 
 	 * @return the type
 	 */
 	ContentType getContentType();
-	
+
 	/**
 	 * Gets the IP address and port of the peer this message
 	 * has been received from or is to be sent to.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/GenericHandshakeMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/GenericHandshakeMessage.java
@@ -16,6 +16,9 @@
 package org.eclipse.californium.scandium.dtls;
 
 import java.net.InetSocketAddress;
+import java.util.Arrays;
+
+import org.eclipse.californium.elements.util.NoPublicAPI;
 
 /**
  * Generic handshake message.
@@ -25,6 +28,7 @@ import java.net.InetSocketAddress;
  * later creation of specific handshake messages, if the handshake parameters
  * are available.
  */
+@NoPublicAPI
 public class GenericHandshakeMessage extends HandshakeMessage {
 
 	/**
@@ -38,7 +42,7 @@ public class GenericHandshakeMessage extends HandshakeMessage {
 	 * @param type handshake type
 	 * @param peerAddress address of peer
 	 */
-	private GenericHandshakeMessage(HandshakeType type, InetSocketAddress peerAddress) {
+	protected GenericHandshakeMessage(HandshakeType type, InetSocketAddress peerAddress) {
 		super(peerAddress);
 		this.type = type;
 	}
@@ -50,28 +54,13 @@ public class GenericHandshakeMessage extends HandshakeMessage {
 
 	@Override
 	public int getMessageLength() {
-		return getRawMessage().length;
+		return getRawMessage().length - MESSAGE_HEADER_LENGTH_BYTES;
 	}
 
 	@Override
 	public byte[] fragmentToByteArray() {
-		return getRawMessage();
-	}
-
-	/**
-	 * Get specific handshake message.
-	 * 
-	 * @param parameter handshake parameter
-	 * @return specific handshake message
-	 * @throws NullPointerException if handshake parameter is {@code null}
-	 * @throws HandshakeException if specific handshake message could not be
-	 *             created
-	 */
-	public HandshakeMessage getSpecificHandshakeMessage(HandshakeParameter parameter) throws HandshakeException {
-		if (parameter == null) {
-			throw new NullPointerException("HandshakeParameter must not be null!");
-		}
-		return HandshakeMessage.fromByteArray(getRawMessage(), parameter, getPeer());
+		byte[] rawMessage = getRawMessage();
+		return Arrays.copyOfRange(rawMessage, MESSAGE_HEADER_LENGTH_BYTES, rawMessage.length);
 	}
 
 	/**
@@ -84,5 +73,4 @@ public class GenericHandshakeMessage extends HandshakeMessage {
 	public static GenericHandshakeMessage fromByteArray(HandshakeType type, InetSocketAddress peerAddress) {
 		return new GenericHandshakeMessage(type, peerAddress);
 	}
-
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/MultiHandshakeMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/MultiHandshakeMessage.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import java.net.InetSocketAddress;
+
+import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.NoPublicAPI;
+
+/**
+ * Multi handshake messages.
+ * 
+ * Accumulate multi handshake messages to be sent as one dtls record.
+ * 
+ * @since 2.4
+ */
+@NoPublicAPI
+public class MultiHandshakeMessage extends HandshakeMessage {
+
+	/**
+	 * Number of added handshake messages.
+	 */
+	private int count;
+	/**
+	 * Length of added handshake messages.
+	 */
+	private int length;
+	/**
+	 * Last added handshake message.
+	 */
+	private HandshakeMessage tail = this;
+
+	/**
+	 * Create multi handshake message.
+	 * 
+	 * @param peerAddress address of peer
+	 */
+	protected MultiHandshakeMessage(InetSocketAddress peerAddress) {
+		super(peerAddress);
+	}
+
+	/**
+	 * Get number of added handshake messages.
+	 * 
+	 * @return number of added handshake messages
+	 */
+	public int getNumberOfHandshakeMessages() {
+		return count;
+	}
+
+	/**
+	 * Add handshake message.
+	 * 
+	 * @param message additional handshake message
+	 */
+	public void add(HandshakeMessage message) {
+		tail.setNextHandshakeMessage(message);
+		tail = message;
+		length += message.size();
+		++count;
+	}
+
+	@Override
+	public HandshakeType getMessageType() {
+		HandshakeMessage message = getNextHandshakeMessage();
+		return message == null ? null : message.getMessageType();
+	}
+
+	@Override
+	public int getMessageLength() {
+		return length - MESSAGE_HEADER_LENGTH_BYTES;
+	}
+
+	@Override
+	public byte[] fragmentToByteArray() {
+		throw new RuntimeException("not supported!");
+	}
+
+	@Override
+	public byte[] toByteArray() {
+		DatagramWriter writer = new DatagramWriter(RecordLayer.DEFAULT_ETH_MTU);
+		HandshakeMessage message = getNextHandshakeMessage();
+		while (message != null) {
+			message.writeTo(writer);
+			message = message.getNextHandshakeMessage();
+		}
+		return writer.toByteArray();
+	}
+
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ReassemblingHandshakeMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ReassemblingHandshakeMessage.java
@@ -18,6 +18,7 @@ package org.eclipse.californium.scandium.dtls;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.californium.elements.util.NoPublicAPI;
 import org.eclipse.californium.elements.util.StringUtil;
 
 /**
@@ -30,7 +31,8 @@ import org.eclipse.californium.elements.util.StringUtil;
  * optimized by early testing, if it contains a new data-range and merging of
  * adjacent ranges afterwards.
  */
-public final class ReassemblingHandshakeMessage extends HandshakeMessage {
+@NoPublicAPI
+public final class ReassemblingHandshakeMessage extends GenericHandshakeMessage {
 
 	/** The reassembled fragments handshake body. */
 	private final byte[] reassembledBytes;
@@ -118,7 +120,7 @@ public final class ReassemblingHandshakeMessage extends HandshakeMessage {
 	 * @param message starting fragmented message
 	 */
 	public ReassemblingHandshakeMessage(FragmentedHandshakeMessage message) {
-		super(message.getPeer());
+		super(message.getMessageType(), message.getPeer());
 		setMessageSeq(message.getMessageSeq());
 		this.type = message.getMessageType();
 		this.reassembledBytes = new byte[message.getMessageLength()];

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordLayer.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordLayer.java
@@ -18,25 +18,96 @@
 package org.eclipse.californium.scandium.dtls;
 
 import java.io.IOException;
+import java.net.DatagramPacket;
+import java.util.List;
+
+import org.eclipse.californium.elements.util.NetworkInterfacesUtil;
+import org.eclipse.californium.elements.util.NoPublicAPI;
 
 /**
- * An abstraction of the DTLS record layer's capabilities for sending records to peers.
+ * An abstraction of the DTLS record layer's capabilities for sending records to
+ * peers. MTU values according
+ * <a href="https://en.wikipedia.org/wiki/Maximum_transmission_unit">MTU - Wikipedia</a>.
  */
+@NoPublicAPI
 public interface RecordLayer {
 
 	/**
-	 * Sends a set of records containing DTLS handshake messages to a peer.
+	 * Maximum MTU.
+	 * 
+	 * @since 2.4
+	 */
+	public final int MAX_MTU = NetworkInterfacesUtil.MAX_MTU;
+	/**
+	 * Default IPv6 MTU.
+	 * 
+	 * @since 2.4
+	 */
+	public final int DEFAULT_IPV6_MTU = NetworkInterfacesUtil.DEFAULT_IPV6_MTU;
+	/**
+	 * Default IPv4 MTU.
+	 * 
+	 * @since 2.4
+	 */
+	public final int DEFAULT_IPV4_MTU = NetworkInterfacesUtil.DEFAULT_IPV4_MTU;
+	/**
+	 * Default Ethernet MTU.
+	 * 
+	 * @since 2.4
+	 */
+	public final int DEFAULT_ETH_MTU = 1500;
+	/**
+	 * IPv4 header size.
+	 * 
+	 * @since 2.4
+	 */
+	public final int IPV4_HEADER_LENGTH = + 8 // bytes UDP headers
+			+ 20 // bytes IP headers
+			+ 36; // bytes optional IP options
+
+	/**
+	 * IPv6 header size.
+	 * 
+	 * @since 2.4
+	 */
+	public final int IPV6_HEADER_LENGTH = 128; // 1280 - 1152 bytes, assumption
+												// of RFC 7252, Section 4.6.,
+												// Message Size
+
+	/**
+	 * Returns execution state of record layer.
+	 * 
+	 * @return {@code true} if execution is running, {@code false}, otherwise.
+	 * 
+	 * @since 2.4
+	 */
+	boolean isRunning();
+
+	/**
+	 * Gets the maximum size of a UDP datagram that can be sent to this
+	 * session's peer without IP fragmentation.
+	 * 
+	 * @param ipv6 {@code true}, IPv6 destination, {@code false}, IPv4
+	 *            destination
+	 * @return the maximum datagram size in bytes
+	 * @since 2.4
+	 */
+	int getMaxDatagramSize(boolean ipv6);
+
+	/**
+	 * Sends a set of UDP datagrams containing DTLS records with handshake
+	 * messages to a peer.
 	 * <p>
-	 * The records are sent <em>as a whole</em>. In particular this means that all
-	 * records will be re-transmitted in case of a missing acknowledgement from the peer.
+	 * The set is sent <em>as a whole</em>. In particular this means that all
+	 * datagrams will be re-transmitted in case of a missing acknowledgement
+	 * from the peer.
 	 * </p>
 	 * 
-	 * @param flight the records to send. The properties of the flight are used to control the
-	 *                  timespan to wait between re-transmissions. 
-	 * @param connection to send the flight
+	 * @param datagrams list of UDP datagrams containing DTLS records to send.
 	 * @throws IOException if an io error occurs
+	 * @since 2.4
 	 */
-	void sendFlight(DTLSFlight flight, Connection connection) throws IOException;
+	void sendFlight(List<DatagramPacket> datagrams) throws IOException;
 
 	/**
 	 * Process received record.
@@ -45,4 +116,12 @@ public interface RecordLayer {
 	 * @param connection connection to process record.
 	 */
 	void processRecord(Record record, Connection connection);
+
+	/**
+	 * Report dropped record
+	 * 
+	 * @param record dropped record
+	 * @since 2.4
+	 */
+	void dropReceivedRecord(Record record);
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
@@ -39,6 +39,7 @@ package org.eclipse.californium.scandium.dtls;
 
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.californium.elements.util.NoPublicAPI;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
@@ -101,12 +102,12 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 	 *            the session to resume.
 	 * @param recordLayer
 	 *            the object to use for sending flights to the peer.
+	 * @param timer
+	 *            scheduled executor for flight retransmission (since 2.4).
 	 * @param connection
 	 *            the connection related with the session.
 	 * @param config
 	 *            the DTLS configuration parameters to use for the handshake.
-	 * @param maxTransmissionUnit
-	 *            the MTU value reported by the network interface the record layer is bound to.
 	 * @param probe {@code true} enable probing for this resumption handshake,
 	 *            {@code false}, not probing handshake.
 	 * @throws IllegalArgumentException
@@ -116,9 +117,9 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 	 * @throws NullPointerException
 	 *            if session, recordLayer or config is <code>null</code>
 	 */
-	public ResumingClientHandshaker(DTLSSession session, RecordLayer recordLayer, Connection connection,
-			DtlsConnectorConfig config, int maxTransmissionUnit, boolean probe) {
-		super(session, recordLayer, connection, config, maxTransmissionUnit);
+	public ResumingClientHandshaker(DTLSSession session, RecordLayer recordLayer, ScheduledExecutorService timer, Connection connection,
+			DtlsConnectorConfig config, boolean probe) {
+		super(session, recordLayer, timer, connection, config);
 		if (session.getSessionIdentifier() == null) {
 			throw new IllegalArgumentException("Session must contain the ID of the session to resume");
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingServerHandshaker.java
@@ -32,7 +32,9 @@ package org.eclipse.californium.scandium.dtls;
 
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
+import java.util.concurrent.ScheduledExecutorService;
 
+import org.eclipse.californium.elements.util.NoPublicAPI;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
@@ -47,6 +49,7 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
  * The message flow is depicted in <a
  * href="http://tools.ietf.org/html/rfc5246#section-7.3">Figure 2</a>.
  */
+@NoPublicAPI
 public class ResumingServerHandshaker extends ServerHandshaker {
 
 	// Members ////////////////////////////////////////////////////////
@@ -68,12 +71,12 @@ public class ResumingServerHandshaker extends ServerHandshaker {
 	 *            the session to negotiate with the client.
 	 * @param recordLayer
 	 *            the object to use for sending flights to the peer.
+	 * @param timer
+	 *            scheduled executor for flight retransmission (since 2.4).
 	 * @param connection
 	 *            the connection related with the session.
 	 * @param config
 	 *            the DTLS configuration parameters to use for the handshake.
-	 * @param maxTransmissionUnit
-	 *            the MTU value reported by the network interface the record layer is bound to.
 	 * @throws IllegalArgumentException
 	 *            if the given session does not contain an identifier.
 	 * @throws IllegalStateException
@@ -81,8 +84,8 @@ public class ResumingServerHandshaker extends ServerHandshaker {
 	 * @throws NullPointerException
 	 *            if session, recordLayer or config is <code>null</code>
 	 */
-	public ResumingServerHandshaker(int sequenceNumber, DTLSSession session, RecordLayer recordLayer, Connection connection, DtlsConnectorConfig config, int maxTransmissionUnit) {
-		super(sequenceNumber, session, recordLayer, connection, config, maxTransmissionUnit);
+	public ResumingServerHandshaker(int sequenceNumber, DTLSSession session, RecordLayer recordLayer, ScheduledExecutorService timer, Connection connection, DtlsConnectorConfig config) {
+		super(sequenceNumber, session, recordLayer, timer, connection, config);
 	}
 
 	// Methods ////////////////////////////////////////////////////////

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -912,18 +912,6 @@ public class DTLSConnectorTest {
 	}
 
 	@Test
-	public void testGetMaximumTransmissionUnitReturnsDefaultValue() {
-		// given a connector that has not been started yet
-		DTLSConnector connector = client;
-
-		// when retrieving the maximum transmission unit from the client
-		int mtu = connector.getMaximumTransmissionUnit();
-
-		// then the value is the IPv4 min. MTU
-		assertThat(mtu, is(DTLSConnector.DEFAULT_IPV4_MTU));
-	}
-
-	@Test
 	public void testGetMaximumFragmentLengthReturnsDefaultValueForUnknownPeer() {
 		// given an empty client side connection store
 		clientConnectionStore.clear();
@@ -933,7 +921,7 @@ public class DTLSConnectorTest {
 		int maxFragmentLength = client.getMaximumFragmentLength(unknownPeer);
 
 		// then the value is the minimum IPv4 MTU - DTLS/UDP/IP header overhead
-		assertThat(maxFragmentLength, is(DTLSConnector.DEFAULT_IPV4_MTU - DTLSSession.HEADER_LENGTH));
+		assertThat(maxFragmentLength, is(DTLSConnector.DEFAULT_IPV4_MTU - DTLSSession.DTLS_HEADER_LENGTH - DTLSConnector.IPV4_HEADER_LENGTH));
 	}
 
 	@Test

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/CertificateMessageTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/CertificateMessageTest.java
@@ -150,8 +150,7 @@ public class CertificateMessageTest {
 		PublicKey pk = message.getPublicKey();
 		assertNotNull(pk);
 		serializedMessage = message.toByteArray();
-		CertificateMessage msg = (CertificateMessage) HandshakeMessage.fromByteArray(
-				serializedMessage, parameter, peerAddress);
+		CertificateMessage msg = DtlsTestTools.fromByteArray(serializedMessage, parameter, peerAddress);
 		assertThat(msg.getPublicKey(), is(pk));
 	}
 
@@ -162,8 +161,8 @@ public class CertificateMessageTest {
 		PublicKey pk = message.getPublicKey();
 		assertNotNull(pk);
 		serializedMessage = message.toByteArray();
-		message = (CertificateMessage) HandshakeMessage.fromByteArray(serializedMessage, parameter, peerAddress);
-		assertThat(message.getPublicKey(), is(pk));
+		CertificateMessage msg = DtlsTestTools.fromByteArray(serializedMessage, parameter, peerAddress);
+		assertThat(msg.getPublicKey(), is(pk));
 	}
 
 	private void assertSerializedMessageLength(int length) {

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DTLSSessionTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DTLSSessionTest.java
@@ -63,27 +63,6 @@ public class DTLSSessionTest {
 	}
 
 	@Test
-	public void testMaxFragmentLengthIsAdjustedToMtu() {
-		// given an ethernet network interface
-		int mtu = 1500;
-
-		// when setting the session's maximumTransmissionUnit property
-		session.setMaxTransmissionUnit(mtu);
-
-		// then the maxFragmentLength is as adjusted so that a fragment
-		// fits into a single unfragmented UDP datagram
-		assertAnyFragmentFitsIntoUnfragmentedDatagram(mtu);
-	}
-
-	private void assertAnyFragmentFitsIntoUnfragmentedDatagram(int mtu) {
-		int datagramSize = session.getMaxFragmentLength()
-				+ session.getWriteState().getMaxCiphertextExpansion()
-				+ DTLSSession.HEADER_LENGTH;
-		assertTrue(datagramSize <= mtu);
-		assertThat(session.getMaxDatagramSize(), is(datagramSize));
-	}
-
-	@Test
 	public void testRecordFromPreviousEpochIsDiscarded() {
 		session.setReadEpoch(1);
 		assertFalse(session.isRecordProcessable(0, 15, false));

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchangeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchangeTest.java
@@ -56,7 +56,9 @@ public class ECDHServerKeyExchangeTest {
 	public void testDeserializedInstanceToString() throws HandshakeException {
 		byte[] serializedMsg = msg.toByteArray();
 		HandshakeParameter parameter = new HandshakeParameter(KeyExchangeAlgorithm.EC_DIFFIE_HELLMAN, CertificateType.RAW_PUBLIC_KEY);
-		HandshakeMessage handshakeMsg = HandshakeMessage.fromByteArray(serializedMsg, parameter, peerAddress);
+
+		HandshakeMessage handshakeMsg = DtlsTestTools.fromByteArray(serializedMsg, parameter, peerAddress);
+
 		assertNotNull(handshakeMsg.toString());
 	}
 }

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchangeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchangeTest.java
@@ -57,7 +57,7 @@ public class EcdhPskClientKeyExchangeTest {
 	public void testDeserializedMsg() throws HandshakeException {
 		byte[] serializedMsg = msg.toByteArray();
 		HandshakeParameter parameter = new HandshakeParameter(KeyExchangeAlgorithm.ECDHE_PSK, CertificateType.X_509);
-		EcdhPskClientKeyExchange handshakeMsg = (EcdhPskClientKeyExchange)HandshakeMessage.fromByteArray(serializedMsg, parameter, peerAddress);
+		EcdhPskClientKeyExchange handshakeMsg = DtlsTestTools.fromByteArray(serializedMsg, parameter, peerAddress);
 		assertTrue(handshakeMsg.getIdentity().equals(identity));
 		assertNotNull(ephemeralKeyPointEncoded);
 		assertArrayEquals(handshakeMsg.getEncodedPoint(), ephemeralKeyPointEncoded);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchangeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchangeTest.java
@@ -56,7 +56,7 @@ public class EcdhPskServerKeyExchangeTest {
 	public void testDeserializedMsg() throws HandshakeException {
 		byte[] serializedMsg = msg.toByteArray();
 		HandshakeParameter parameter = new HandshakeParameter(KeyExchangeAlgorithm.ECDHE_PSK, CertificateType.X_509);
-		EcdhPskServerKeyExchange handshakeMsg = (EcdhPskServerKeyExchange)HandshakeMessage.fromByteArray(serializedMsg, parameter, peerAddress);
+		EcdhPskServerKeyExchange handshakeMsg = DtlsTestTools.fromByteArray(serializedMsg, parameter, peerAddress);
 		assertEquals(handshakeMsg.getSupportedGroup().getId(), SupportedGroup.secp256r1.getId());
 		assertNotNull(ephemeralPubKey);
 		assertArrayEquals(handshakeMsg.getEncodedPoint(), ephemeralPubKey);


### PR DESCRIPTION
Support dtls records with multiple handshake-message.

Comply with RFC 6347, 4.2.3,
multiple handshake messages may be placed in the same DTLS record.

Reduce size of handshake records on retransmission,
comply with RFC 6347, 4.1.1.1, back-off with smaller record size.

Move handshake related functions from dtls connector and dtls record
into handshaker and dtls flight. Adapt message size estimation, extend
record layer, cleanup dtls record.

Add interoperability tests for multi-handshake-message-records.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>
