### PR TITLE
Add  pending connects to benchmark

### DIFF
--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpClientConnector.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TcpClientConnector.java
@@ -219,7 +219,7 @@ public class TcpClientConnector implements Connector {
 				}
 				if (cause != null) {
 					if (cause instanceof ConnectTimeoutException) {
-						LOGGER.warn("{}", cause.getMessage());
+						LOGGER.debug("{}", cause.getMessage());
 					} else if (cause instanceof CancellationException) {
 						LOGGER.debug("{}", cause.getMessage());
 					} else {


### PR DESCRIPTION
Add pending connects to benchmark logs.
Reduce log-level in tcp client.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>
