### PR TITLE
Fix CertPathGeneration without matching trust anchors.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/CertPathUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/CertPathUtil.java
@@ -254,9 +254,10 @@ public class CertPathUtil {
 	 * Remove self-signed top-level root certificate and truncate certificate
 	 * path at intermediate certificates from certificate authorities.
 	 * 
-	 * @param certificateChain list with chain of x509 certificates. Maybe
+	 * @param certificateChain list with chain of x509 certificates. May be
 	 *            empty.
 	 * @param certificateAuthorities list of received certificate authorities.
+	 *            May be empty.
 	 * @return generated certificate path
 	 * @throws NullPointerException if provided certificateChain is {@code null}
 	 */
@@ -266,7 +267,7 @@ public class CertPathUtil {
 			throw new NullPointerException("Certificate chain must not be null!");
 		}
 		int size = certificateChain.size();
-		if (size > 1) {
+		if (size > 0) {
 			int truncate = size;
 			if (certificateAuthorities != null && !certificateAuthorities.isEmpty()) {
 				truncate = 0;
@@ -278,12 +279,12 @@ public class CertPathUtil {
 					}
 				}
 			}
-			if (truncate == size) {
+			if (size > 1 && truncate == size) {
 				int last = size - 1;
 				X509Certificate cert = certificateChain.get(last);
 				if (cert.getIssuerX500Principal().equals(cert.getSubjectX500Principal())) {
-					// a self-signed top-level root certificate => reduce size
-					// to remove it
+					// a self-signed top-level root certificate
+					// => reduce size to remove it
 					truncate = last;
 				}
 			}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/CertPathUtilTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/CertPathUtilTest.java
@@ -79,7 +79,7 @@ public class CertPathUtilTest {
 	@Test
 	public void testGenerateTruncatedCertPath() throws Exception {
 
-		List<X509Certificate> truncated = new ArrayList<X509Certificate>(clientChainExtUsageList);
+		List<X509Certificate> truncated = new ArrayList<>(clientChainExtUsageList);
 		truncated.remove(truncated.size() - 1);
 		truncated.remove(truncated.size() - 1);
 		CertPath generateCertPath = CertPathUtil.generateCertPath(clientChainExtUsageList,
@@ -243,7 +243,7 @@ public class CertPathUtilTest {
 	@Test
 	public void testGenerateValidationCertPath() throws Exception {
 
-		List<X509Certificate> truncated = new ArrayList<X509Certificate>(clientChainExtUsageList);
+		List<X509Certificate> truncated = new ArrayList<>(clientChainExtUsageList);
 		truncated.remove(truncated.size() - 1);
 
 		CertPath generateCertPath = CertPathUtil.generateValidatableCertPath(clientChainExtUsageList, null);
@@ -252,9 +252,9 @@ public class CertPathUtilTest {
 
 	@Test
 	public void testGenerateValidationCertPathForIssuer() throws Exception {
-		List<X500Principal> certificateAuthorities = new ArrayList<X500Principal>();
+		List<X500Principal> certificateAuthorities = new ArrayList<>();
 		certificateAuthorities.add(clientChainExtUsage[1].getSubjectX500Principal());
-		List<X509Certificate> truncated = new ArrayList<X509Certificate>(clientChainExtUsageList);
+		List<X509Certificate> truncated = new ArrayList<>(clientChainExtUsageList);
 		truncated.remove(truncated.size() - 1);
 		truncated.remove(truncated.size() - 1);
 
@@ -266,11 +266,22 @@ public class CertPathUtilTest {
 
 	@Test
 	public void testGenerateValidationCertPathForUnknownIssuer() throws Exception {
-		List<X500Principal> certificateAuthorities = new ArrayList<X500Principal>();
+		List<X500Principal> certificateAuthorities = new ArrayList<>();
 		certificateAuthorities.add(clientSelfsigned[0].getSubjectX500Principal());
 
 		CertPath generateCertPath = CertPathUtil.generateValidatableCertPath(clientChainExtUsageList,
 				certificateAuthorities);
+		assertEquals(0, generateCertPath.getCertificates().size());
+	}
+
+	@Test
+	public void testGenerateValidationCertPathForSingleCertificateAndUnknownIssuer() throws Exception {
+		List<X509Certificate> path = new ArrayList<>();
+		path.add(clientChainExtUsageList.get(0));
+		List<X500Principal> certificateAuthorities = new ArrayList<>();
+		certificateAuthorities.add(clientSelfsigned[0].getSubjectX500Principal());
+
+		CertPath generateCertPath = CertPathUtil.generateValidatableCertPath(path, certificateAuthorities);
 		assertEquals(0, generateCertPath.getCertificates().size());
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -2330,8 +2330,8 @@ public final class DtlsConnectorConfig {
 		 * {@link #setCertificateVerifier(CertificateVerifier)} is already set.
 		 * 
 		 * @param trustedCerts the trusted root certificates. If empty (length
-		 *            of zero), trust all certificates and don't execute a
-		 *            certificate verification.
+		 *            of zero), trust all valid certificate chains without
+		 *            limiting the trust to specific trust anchors.
 		 * @return this builder for command chaining
 		 * @throws NullPointerException if the given array is <code>null</code>
 		 * @throws IllegalArgumentException if the array contains a non-X.509

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
@@ -143,8 +143,8 @@ public final class CertificateMessage extends HandshakeMessage {
 		if (LOGGER.isDebugEnabled()) {
 			int size = certPath.getCertificates().size();
 			if (size < certificateChain.size()) {
-				LOGGER.debug("created CERTIFICATE message with truncated certificate chain [length: {}]",
-						certPath.getCertificates().size());
+				LOGGER.debug("created CERTIFICATE message with truncated certificate chain [length: {}, full-length: {}]",
+						size, certificateChain.size());
 			} else {
 				LOGGER.debug("created CERTIFICATE message with certificate chain [length: {}]", size);
 			}


### PR DESCRIPTION
Use trust anchors also for certificate paths with exactly one
certificate. Update javadoc of "empty trusted certificates".

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>