### PR TITLE
Rename cf-cli-netty-tcp to cf-cli-tcp-netty.

### DIFF
--- a/assembly/src/main/resources/assemblies/enhanced-jar-with-tcp-netty.xml
+++ b/assembly/src/main/resources/assemblies/enhanced-jar-with-tcp-netty.xml
@@ -17,9 +17,9 @@
 	 * Contributors:
 	 *    Bosch.IO GmbH - initial creation
 	-->
-	<id>jar-with-netty-tcp</id>
+	<id>jar-with-tcp-netty</id>
 
-	<!-- This descriptor includes all netty.io and californium-netty-tcp classes into one library -->
+	<!-- This descriptor includes all netty.io and californium-tcp-netty classes into one library -->
 	<formats>
 		<format>jar</format>
 	</formats>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -67,7 +67,7 @@
 			</dependency>
 			<dependency>
 				<groupId>${project.groupId}</groupId>
-				<artifactId>cf-cli-netty-tcp</artifactId>
+				<artifactId>cf-cli-tcp-netty</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>

--- a/cf-utils/cf-cli-tcp-netty/README.md
+++ b/cf-utils/cf-cli-tcp-netty/README.md
@@ -1,6 +1,6 @@
-# CLI-NETTY-TCP - Common Command Line Interface Netty TCP support
+# CLI-TCP-NETTY - Common Command Line Interface TCP Netty.IO support
 
-This module provides TCP support for the common command line interface.
+This module provides TCP support using netty.io for the common command line interface.
 
 If TCP is required, use it by copying the built library into the folder of the client's jar, either manually or by maven plugin in the client's pom:
 
@@ -18,7 +18,7 @@ If TCP is required, use it by copying the built library into the folder of the c
 					<artifactItems>
 						<artifactItem>
 							<groupId>${project.groupId}</groupId>
-							<artifactId>cf-cli-netty-tcp</artifactId>
+							<artifactId>cf-cli-tcp-netty</artifactId>
 							<version>${project.version}</version>
 							<type>${project.packaging}</type>
 						</artifactItem>
@@ -30,16 +30,33 @@ If TCP is required, use it by copying the built library into the folder of the c
 	</plugin>
 ```
 
-Alternatively adapt the dependency from "cf-cli" to "cf-cli-netty-tcp" in the client's pom.
+If the application is intended to be start by "java -jar xxx.jar", also a classpath entry in the manifest is required.
+
+```xml
+	<plugin>
+		<artifactId>maven-assembly-plugin</artifactId>
+		<configuration>
+			<archive>
+				<manifestEntries>
+					<!-- support tcp, if module library is available -->
+					<Class-Path>cf-cli-tcp-netty-${project.version}.jar</Class-Path>
+				</manifestEntries>
+			</archive>
+		</configuration>
+	</plugin>
+```
+
+Alternatively adapt the dependency from "cf-cli" to "cf-cli-tcp-netty" in the client's pom.
 
 ```xml
   <dependencies>
     ...
     <dependency>
             <groupId>org.eclipse.californium</groupId>
-            <artifactId>cf-cli-netty-tcp</artifactId>
+            <artifactId>cf-cli-tcp-netty</artifactId>
             <version>${project.version}</version>
     </dependency>
     ...
   </dependencies>
 ```
+

--- a/cf-utils/cf-cli-tcp-netty/pom.xml
+++ b/cf-utils/cf-cli-tcp-netty/pom.xml
@@ -12,11 +12,11 @@
 		<relativePath>../../bom</relativePath>
 	</parent>
 
-	<artifactId>cf-cli-netty-tcp</artifactId>
+	<artifactId>cf-cli-tcp-netty</artifactId>
 	<packaging>bundle</packaging>
 
-	<name>Cf-cli-netty-tcp</name>
-	<description>Californium (Cf) Command Line Interface support for netty TCP</description>
+	<name>Cf-cli-tcp-netty</name>
+	<description>Californium (Cf) Command Line Interface support for TCP using netty.io</description>
 
 	<properties>
 		<picocli.version>4.2.0</picocli.version>
@@ -44,7 +44,7 @@
 				<configuration>
 					<instructions>
 						<Export-Package>
-							org.eclipse.californium.cli.netty.tcp*
+							org.eclipse.californium.cli.tcp.netty*
 						</Export-Package>
 						<Import-Package>
 							*
@@ -57,7 +57,7 @@
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<descriptorRefs>
-						<descriptorRef>enhanced-jar-with-netty-tcp</descriptorRef>
+						<descriptorRef>enhanced-jar-with-tcp-netty</descriptorRef>
 					</descriptorRefs>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/cf-utils/cf-cli-tcp-netty/src/main/java/org/eclipse/californium/cli/tcp/netty/Initialize.java
+++ b/cf-utils/cf-cli-tcp-netty/src/main/java/org/eclipse/californium/cli/tcp/netty/Initialize.java
@@ -13,7 +13,7 @@
  * Contributors:
  *    Bosch.IO GmbH - initial creation
  ******************************************************************************/
-package org.eclipse.californium.cli.netty.tcp;
+package org.eclipse.californium.cli.tcp.netty;
 
 import org.eclipse.californium.cli.ClientInitializer;
 import org.eclipse.californium.core.coap.CoAP;

--- a/cf-utils/cf-cli-tcp-netty/src/main/java/org/eclipse/californium/cli/tcp/netty/TcpConnectorFactory.java
+++ b/cf-utils/cf-cli-tcp-netty/src/main/java/org/eclipse/californium/cli/tcp/netty/TcpConnectorFactory.java
@@ -13,7 +13,7 @@
  * Contributors:
  *    Bosch.IO GmbH - initial creation
  ******************************************************************************/
-package org.eclipse.californium.cli.netty.tcp;
+package org.eclipse.californium.cli.tcp.netty;
 
 import java.util.concurrent.ExecutorService;
 

--- a/cf-utils/cf-cli-tcp-netty/src/main/java/org/eclipse/californium/cli/tcp/netty/TlsConnectorFactory.java
+++ b/cf-utils/cf-cli-tcp-netty/src/main/java/org/eclipse/californium/cli/tcp/netty/TlsConnectorFactory.java
@@ -13,7 +13,7 @@
  * Contributors:
  *    Bosch.IO GmbH - initial creation
  ******************************************************************************/
-package org.eclipse.californium.cli.netty.tcp;
+package org.eclipse.californium.cli.tcp.netty;
 
 import java.security.GeneralSecurityException;
 import java.util.concurrent.ExecutorService;

--- a/cf-utils/cf-cli/README.md
+++ b/cf-utils/cf-cli/README.md
@@ -6,7 +6,7 @@ It applies the arguments and configure connectors and endpoints.
 
 This module supports coap (plain UDP) and coaps (over DTLS).
 
-For TCP support, a second module "cf-cli-netty-tcp" is provided. If TCP is required, use it by copying the built library of that "cf-cli-netty-tcp" into the folder of the client's jar, either manually or by maven plugin in the client's pom:
+For TCP support, a second module "cf-cli-tcp-netty" is provided. If TCP is required, use it by copying the built library of that "cf-cli-tcp-netty" into the folder of the client's jar, either manually or by maven plugin in the client's pom:
 
 ```xml
 	<plugin>
@@ -22,7 +22,7 @@ For TCP support, a second module "cf-cli-netty-tcp" is provided. If TCP is requi
 					<artifactItems>
 						<artifactItem>
 							<groupId>${project.groupId}</groupId>
-							<artifactId>cf-cli-netty-tcp</artifactId>
+							<artifactId>cf-cli-tcp-netty</artifactId>
 							<version>${project.version}</version>
 							<type>${project.packaging}</type>
 						</artifactItem>
@@ -34,16 +34,33 @@ For TCP support, a second module "cf-cli-netty-tcp" is provided. If TCP is requi
 	</plugin>
 ```
 
-Alternatively adapt the dependency from "cf-cli" to "cf-cli-netty-tcp" in the client's pom.
+If the application is intended to be start by "java -jar xxx.jar", also a classpath entry in the manifest is required.
+
+```xml
+	<plugin>
+		<artifactId>maven-assembly-plugin</artifactId>
+		<configuration>
+			<archive>
+				<manifestEntries>
+					<!-- support tcp, if module library is available -->
+					<Class-Path>cf-cli-tcp-netty-${project.version}.jar</Class-Path>
+				</manifestEntries>
+			</archive>
+		</configuration>
+	</plugin>
+```
+
+Alternatively adapt the dependency from "cf-cli" to "cf-cli-tcp-netty" in the client's pom.
 
 ```xml
   <dependencies>
     ...
     <dependency>
             <groupId>org.eclipse.californium</groupId>
-            <artifactId>cf-cli-netty-tcp</artifactId>
+            <artifactId>cf-cli-tcp-netty</artifactId>
             <version>${project.version}</version>
     </dependency>
     ...
   </dependencies>
 ```
+

--- a/cf-utils/cf-cli/src/main/java/org/eclipse/californium/cli/ClientInitializer.java
+++ b/cf-utils/cf-cli/src/main/java/org/eclipse/californium/cli/ClientInitializer.java
@@ -78,7 +78,7 @@ public class ClientInitializer {
 	 * 
 	 * @since 2.4
 	 */
-	private static final String DEFAULT_TCP_MODULE = "org.eclipse.californium.cli.netty.tcp.Initialize";
+	private static final String DEFAULT_TCP_MODULE = "org.eclipse.californium.cli.tcp.netty.Initialize";
 
 	private static final List<String> loadErrors = new ArrayList<>();
 	private static final Map<String, CliConnectorFactory> connectorFactories = new ConcurrentHashMap<>();

--- a/demo-apps/cf-extplugtest-client/pom.xml
+++ b/demo-apps/cf-extplugtest-client/pom.xml
@@ -48,7 +48,7 @@
 					<archive>
 						<manifestEntries>
 							<!-- support tcp, if module library is available -->
-							<Class-Path>cf-cli-netty-tcp-${project.version}.jar</Class-Path>
+							<Class-Path>cf-cli-tcp-netty-${project.version}.jar</Class-Path>
 						</manifestEntries>
 					</archive>
 				</configuration>
@@ -66,7 +66,7 @@
 							<artifactItems>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
-									<artifactId>cf-cli-netty-tcp</artifactId>
+									<artifactId>cf-cli-tcp-netty</artifactId>
 									<version>${project.version}</version>
 									<type>${project.packaging}</type>
 								</artifactItem>

--- a/demo-apps/cf-plugtest-checker/pom.xml
+++ b/demo-apps/cf-plugtest-checker/pom.xml
@@ -44,7 +44,7 @@
 					<archive>
 						<manifestEntries>
 							<!-- support tcp, if module library is available -->
-							<Class-Path>cf-cli-netty-tcp-${project.version}.jar</Class-Path>
+							<Class-Path>cf-cli-tcp-netty-${project.version}.jar</Class-Path>
 						</manifestEntries>
 					</archive>
 				</configuration>
@@ -62,7 +62,7 @@
 							<artifactItems>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
-									<artifactId>cf-cli-netty-tcp</artifactId>
+									<artifactId>cf-cli-tcp-netty</artifactId>
 									<version>${project.version}</version>
 									<type>${project.packaging}</type>
 								</artifactItem>

--- a/demo-apps/cf-plugtest-client/pom.xml
+++ b/demo-apps/cf-plugtest-client/pom.xml
@@ -58,7 +58,7 @@
 					<archive>
 						<manifestEntries>
 							<!-- support tcp, if module library is available -->
-							<Class-Path>cf-cli-netty-tcp-${project.version}.jar</Class-Path>
+							<Class-Path>cf-cli-tcp-netty-${project.version}.jar</Class-Path>
 						</manifestEntries>
 					</archive>
 				</configuration>
@@ -76,7 +76,7 @@
 							<artifactItems>
 								<artifactItem>
 									<groupId>${project.groupId}</groupId>
-									<artifactId>cf-cli-netty-tcp</artifactId>
+									<artifactId>cf-cli-tcp-netty</artifactId>
 									<version>${project.version}</version>
 									<type>${project.packaging}</type>
 								</artifactItem>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
 		<module>cf-utils/cf-nat</module>
 		<module>cf-utils/cf-unix-health</module>
 		<module>cf-utils/cf-cli</module>
-		<module>cf-utils/cf-cli-netty-tcp</module>
+		<module>cf-utils/cf-cli-tcp-netty</module>
 		<module>californium-tests</module>
 		<module>californium-proxy</module>
 		<module>californium-proxy2</module>


### PR DESCRIPTION
Align with the order tcp-netty of the element-connector.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>