### PR TITLE
Dependency convergence

### DIFF
--- a/californium-proxy/pom.xml
+++ b/californium-proxy/pom.xml
@@ -18,13 +18,13 @@
 	<description>Cross-proxy module</description>
 
 	<properties>
-		<httpasyncclient.version>4.1.2</httpasyncclient.version>
+		<httpasyncclient.version>4.1.4</httpasyncclient.version>
 		<httpasyncclient.version.spec>
 			version="[${versionmask;==;${httpasyncclient.version}},${versionmask;+;${httpasyncclient.version}})"
 		</httpasyncclient.version.spec>
-		<httpcore.version>4.4.5</httpcore.version>
+		<httpcore.version>4.4.10</httpcore.version>
 		<httpcore.version.spec>version="[${versionmask;==;${httpcore.version}},${versionmask;+;${httpcore.version}})"</httpcore.version.spec>
-		<httpclient.version>4.5.2</httpclient.version>
+		<httpclient.version>4.5.6</httpclient.version>
 		<httpclient.version.spec>version="[${versionmask;==;${httpclient.version}},${versionmask;+;${httpclient.version}})"</httpclient.version.spec>
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 	</properties>

--- a/californium-proxy2/pom.xml
+++ b/californium-proxy2/pom.xml
@@ -22,10 +22,10 @@
 		<httpasyncclient.version.spec>
 			version="[${versionmask;==;${httpasyncclient.version}},${versionmask;+;${httpasyncclient.version}})"
 		</httpasyncclient.version.spec>
-		<httpclient.version>4.5.11</httpclient.version>
+		<httpclient.version>4.5.6</httpclient.version>
 		<httpclient.version.spec>version="[${versionmask;==;${httpclient.version}},${versionmask;+;${httpclient.version}})"</httpclient.version.spec>
 		<!-- use same version for httpcore and httpcore-nio -->
-		<httpcore.version>4.4.13</httpcore.version>
+		<httpcore.version>4.4.10</httpcore.version>
 		<httpcore.version.spec>version="[${versionmask;==;${httpcore.version}},${versionmask;+;${httpcore.version}})"</httpcore.version.spec>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -413,6 +413,7 @@
 						</goals>
 						<configuration>
 							<rules>
+                                <dependencyConvergence/>
 								<requireMavenVersion>
 									<version>3.0.5</version>
 								</requireMavenVersion>


### PR DESCRIPTION
In Leshan we activate some maven check about "dependency convergence".
See https://maven.apache.org/enforcer/enforcer-rules/dependencyConvergence.html for more details.

When working on https://github.com/eclipse/leshan/issues/866 I faced some issue with cf-proxy (and cf-proxy2 too)
```
[WARNING] 
Dependency convergence error for org.apache.httpcomponents:httpcore:4.4.5 paths to dependency are:
+-org.eclipse.californium:californium-proxy:2.4.0-SNAPSHOT
  +-org.apache.httpcomponents:httpasyncclient:4.1.2
    +-org.apache.httpcomponents:httpcore:4.4.5
and
+-org.eclipse.californium:californium-proxy:2.4.0-SNAPSHOT
  +-org.apache.httpcomponents:httpcore:4.4.5
and
+-org.eclipse.californium:californium-proxy:2.4.0-SNAPSHOT
  +-org.apache.httpcomponents:httpcore-nio:4.4.5
    +-org.apache.httpcomponents:httpcore:4.4.5
and
+-org.eclipse.californium:californium-proxy:2.4.0-SNAPSHOT
  +-org.apache.httpcomponents:httpclient:4.5.2
    +-org.apache.httpcomponents:httpcore:4.4.4

```
and 
```
[WARNING] 
Dependency convergence error for org.apache.httpcomponents:httpclient:4.5.6 paths to dependency are:
+-org.eclipse.californium:californium-proxy2:2.4.0-SNAPSHOT
  +-org.apache.httpcomponents:httpasyncclient:4.1.4
    +-org.apache.httpcomponents:httpclient:4.5.6
and
+-org.eclipse.californium:californium-proxy2:2.4.0-SNAPSHOT
  +-org.apache.httpcomponents:httpclient:4.5.11

[WARNING] 
Dependency convergence error for org.apache.httpcomponents:httpcore:4.4.10 paths to dependency are:
+-org.eclipse.californium:californium-proxy2:2.4.0-SNAPSHOT
  +-org.apache.httpcomponents:httpasyncclient:4.1.4
    +-org.apache.httpcomponents:httpcore:4.4.10
and
+-org.eclipse.californium:californium-proxy2:2.4.0-SNAPSHOT
  +-org.apache.httpcomponents:httpcore:4.4.13

[WARNING] 
Dependency convergence error for org.apache.httpcomponents:httpcore-nio:4.4.10 paths to dependency are:
+-org.eclipse.californium:californium-proxy2:2.4.0-SNAPSHOT
  +-org.apache.httpcomponents:httpasyncclient:4.1.4
    +-org.apache.httpcomponents:httpcore-nio:4.4.10
and
+-org.eclipse.californium:californium-proxy2:2.4.0-SNAPSHOT
  +-org.apache.httpcomponents:httpcore-nio:4.4.13
```

This PR activate dependency convergence checks and fix the cf-proxy and cf-proxy2 issue.

Issues are fixed using the less verbose way (meaning I choose the more recent version where all dependency converge meaning this is not the last version)
But there is other way like excluding some artifacts : 
```xml
    <dependency>
        <groupId>org.apache.httpcomponents</groupId>
        <artifactId>httpasyncclient</artifactId>
        <version>${httpasyncclient.version}</version>
        <exclusions>
            <exclusion>
                <groupId>org.apache.httpcomponents</groupId>
                <artifactId>httpcore</artifactId>
            </exclusion>
            <exclusion>
                <groupId>org.apache.httpcomponents</groupId>
                <artifactId>httpcore-nio</artifactId>
            </exclusion>
            <exclusion>
                <groupId>org.apache.httpcomponents</groupId>
                <artifactId>httpclient</artifactId>
            </exclusion>
        </exclusions>
    </dependency>
```

The benefits of having converging dependency is to exactly know which version of the artifact will be used.
This PR is just a proposition. Not a big deal to me if this is not accepted.