### PR TITLE
Fix dependency convergence failures.

### DIFF
--- a/californium-proxy/pom.xml
+++ b/californium-proxy/pom.xml
@@ -72,6 +72,10 @@
 					<groupId>commons-codec</groupId>
 					<artifactId>commons-codec</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpcore</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		

--- a/californium-proxy2/pom.xml
+++ b/californium-proxy2/pom.xml
@@ -22,10 +22,10 @@
 		<httpasyncclient.version.spec>
 			version="[${versionmask;==;${httpasyncclient.version}},${versionmask;+;${httpasyncclient.version}})"
 		</httpasyncclient.version.spec>
-		<httpclient.version>4.5.11</httpclient.version>
+		<httpclient.version>4.5.6</httpclient.version>
 		<httpclient.version.spec>version="[${versionmask;==;${httpclient.version}},${versionmask;+;${httpclient.version}})"</httpclient.version.spec>
 		<!-- use same version for httpcore and httpcore-nio -->
-		<httpcore.version>4.4.13</httpcore.version>
+		<httpcore.version>4.4.10</httpcore.version>
 		<httpcore.version.spec>version="[${versionmask;==;${httpcore.version}},${versionmask;+;${httpcore.version}})"</httpcore.version.spec>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -413,6 +413,7 @@
 						</goals>
 						<configuration>
 							<rules>
+								<dependencyConvergence/>
 								<requireMavenVersion>
 									<version>3.0.5</version>
 								</requireMavenVersion>


### PR DESCRIPTION
For californium-proxy exclude the older httpcore of the httpclient.
For californium-proxy2 use the modules in version, which a depends on
each other.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>