### PR TITLE
Use the datagram buffer directly in the Record without copy.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramReader.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramReader.java
@@ -116,6 +116,28 @@ public final class DatagramReader {
 	}
 
 	/**
+	 * Creates a new reader for a range within an array of bytes.
+	 * 
+	 * The array is used directly and is not copied. If a copy is required, copy
+	 * the range and provide that to {@link #DatagramReader(byte[])}.
+	 * 
+	 * @param byteArray The byte array to read from.
+	 * @param offset starting offset of the range.
+	 * @param length length of the range.
+	 * 
+	 * @since 2.4
+	 */
+	public DatagramReader(final byte[] byteArray, int offset, int length) {
+		byteStream = new RangeInputStream(byteArray, offset, length);
+
+		// initialize bit buffer
+		currentByte = 0;
+		currentBitIndex = -1; // indicates that no byte read yet
+		markByte = currentByte;
+		markBitIndex = currentBitIndex;
+	}
+
+	/**
 	 * Creates a new reader for an bytes stream.
 	 * 
 	 * @param byteStream The byte stream to read from.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -132,7 +132,6 @@ import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.Principal;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -164,6 +163,7 @@ import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.RawDataChannel;
 import org.eclipse.californium.elements.util.ClockUtil;
 import org.eclipse.californium.elements.util.DaemonThreadFactory;
+import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.ExecutorsUtil;
 import org.eclipse.californium.elements.util.LeastRecentlyUsedCache;
 import org.eclipse.californium.elements.util.NamedThreadFactory;
@@ -817,7 +817,7 @@ public class DTLSConnector implements Connector, RecordLayer {
 				@Override
 				public void doWork() throws Exception {
 					MDC.clear();
-					packet.setData(receiverBuffer);
+					packet.setLength(inboundDatagramBufferSize);
 					receiveNextDatagramFromNetwork(packet);
 				}
 			};
@@ -1188,8 +1188,8 @@ public class DTLSConnector implements Connector, RecordLayer {
 		}
 		long timestamp = ClockUtil.nanoRealtime();
 
-		byte[] data = Arrays.copyOfRange(packet.getData(), packet.getOffset(), packet.getLength());
-		List<Record> records = Record.fromByteArray(data, peerAddress, connectionIdGenerator, timestamp);
+		DatagramReader reader = new DatagramReader(packet.getData(), packet.getOffset(), packet.getLength());
+		List<Record> records = Record.fromReader(reader, peerAddress, connectionIdGenerator, timestamp);
 		LOGGER.trace("Received {} DTLS records from {} using a {} byte datagram buffer",
 				records.size(), peerAddress, inboundDatagramBufferSize);
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -518,7 +518,7 @@ public class ConnectorHelper {
 		@Override
 		public void handleData(InetSocketAddress endpoint, byte[] data) {
 			try {
-				records.put(Record.fromByteArray(data, endpoint, cidGenerator, ClockUtil.nanoRealtime()));
+				records.put(DtlsTestTools.fromByteArray(data, endpoint, cidGenerator, ClockUtil.nanoRealtime()));
 			} catch (InterruptedException e) {
 			}
 		}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DtlsTestTools.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DtlsTestTools.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 
 import org.eclipse.californium.elements.util.ClockUtil;
+import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.elements.util.TestCertificatesTools;
 import org.eclipse.californium.scandium.util.ServerName;
@@ -39,7 +40,7 @@ public final class DtlsTestTools extends TestCertificatesTools {
 
 	public static Record getRecordForMessage(int epoch, int seqNo, DTLSMessage msg, InetSocketAddress peer) {
 		byte[] dtlsRecord = newDTLSRecord(msg.getContentType().getCode(), epoch, seqNo, msg.toByteArray());
-		List<Record> list = Record.fromByteArray(dtlsRecord, peer, null, ClockUtil.nanoRealtime());
+		List<Record> list = DtlsTestTools.fromByteArray(dtlsRecord, peer, null, ClockUtil.nanoRealtime());
 		assertFalse("Should be able to deserialize DTLS Record from byte array", list.isEmpty());
 		return list.get(0);
 	}
@@ -122,5 +123,30 @@ public final class DtlsTestTools extends TestCertificatesTools {
 		} else {
 			return (T) message;
 		}
+	}
+
+	/**
+	 * Parses a sequence of <em>DTLSCiphertext</em> structures into {@code Record} instances.
+	 * 
+	 * The binary representation is expected to comply with the <em>DTLSCiphertext</em> structure
+	 * defined in <a href="http://tools.ietf.org/html/rfc6347#section-4.3.1">RFC6347, Section 4.3.1</a>.
+	 * 
+	 * @param byteArray the raw binary representation containing one or more DTLSCiphertext structures
+	 * @param peerAddress the IP address and port of the peer from which the bytes have been
+	 *           received
+	 * @param cidGenerator the connection id generator. May be {@code null}.
+	 * @param receiveNanos uptime nanoseconds of receiving this record
+	 * @return the {@code Record} instances
+	 * @throws NullPointerException if either one of the byte array or peer address is {@code null}
+	 */
+	public static List<Record> fromByteArray(byte[] byteArray, InetSocketAddress peerAddress, ConnectionIdGenerator cidGenerator, long receiveNanos) {
+		if (byteArray == null) {
+			throw new NullPointerException("Byte array must not be null");
+		} else if (peerAddress == null) {
+			throw new NullPointerException("Peer address must not be null");
+		}
+	
+		DatagramReader reader = new DatagramReader(byteArray, false);
+		return Record.fromReader(reader, peerAddress, cidGenerator, receiveNanos);
 	}
 }

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
@@ -443,14 +443,14 @@ public class HandshakerTest {
 	private static Record getRecordForMessage(final int epoch, final long seqNo, final DTLSMessage msg) {
 		byte[] dtlsRecord = DtlsTestTools.newDTLSRecord(msg.getContentType().getCode(), epoch,
 				seqNo, msg.toByteArray());
-		List<Record> list = Record.fromByteArray(dtlsRecord, msg.getPeer(), null, ClockUtil.nanoRealtime());
+		List<Record> list = DtlsTestTools.fromByteArray(dtlsRecord, msg.getPeer(), null, ClockUtil.nanoRealtime());
 		assertFalse("Should be able to deserialize DTLS Record from byte array", list.isEmpty());
 		return list.get(0);
 
 	}
 	private static Record getRecordClone(final Record record) {
 		byte[] dtlsRecord = record.toByteArray();
-		List<Record> list = Record.fromByteArray(dtlsRecord, record.getPeerAddress(), null, ClockUtil.nanoRealtime());
+		List<Record> list = DtlsTestTools.fromByteArray(dtlsRecord, record.getPeerAddress(), null, ClockUtil.nanoRealtime());
 		assertFalse("Should be able to deserialize DTLS Record from byte array", list.isEmpty());
 		return list.get(0);
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordDecryptTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordDecryptTest.java
@@ -129,7 +129,7 @@ public class RecordDecryptTest {
 		Record record = new Record(ContentType.APPLICATION_DATA, EPOCH, session.getSequenceNumber(EPOCH),
 				new ApplicationMessage(payload, session.getPeer()), session, true, 0);
 		byte[] raw = record.toByteArray();
-		List<Record> list = Record.fromByteArray(raw, session.getPeer(), null, ClockUtil.nanoRealtime());
+		List<Record> list = DtlsTestTools.fromByteArray(raw, session.getPeer(), null, ClockUtil.nanoRealtime());
 		assertFalse("failed to decode raw message", list.isEmpty());
 		for (Record recv : list) {
 			recv.applySession(session);
@@ -242,7 +242,7 @@ public class RecordDecryptTest {
 		byte[] raw = record.toByteArray();
 		byte[] jraw = juggler.juggle(raw);
 		dumpDiff(raw, jraw);
-		List<Record> list = Record.fromByteArray(jraw, session.getPeer(), null, ClockUtil.nanoRealtime());
+		List<Record> list = DtlsTestTools.fromByteArray(jraw, session.getPeer(), null, ClockUtil.nanoRealtime());
 		for (Record recv : list) {
 			if (recv.getEpoch() != EPOCH) {
 				// skip
@@ -288,7 +288,7 @@ public class RecordDecryptTest {
 		byte[] jfragment = juggler.juggle(fragment);
 		dumpDiff(fragment, jfragment);
 		byte[] raw = toByteArray(record, jfragment);
-		List<Record> list = Record.fromByteArray(raw, session.getPeer(), null, ClockUtil.nanoRealtime());
+		List<Record> list = DtlsTestTools.fromByteArray(raw, session.getPeer(), null, ClockUtil.nanoRealtime());
 		for (Record recv : list) {
 			recv.applySession(session);
 			recv.getFragment();

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordTest.java
@@ -96,7 +96,7 @@ public class RecordTest {
 	@Test
 	public void testFromByteArrayRejectsIllformattedRecord() {
 		byte[] illformattedRecord = new byte[]{TYPE_APPL_DATA};
-		List<Record> recordList = Record.fromByteArray(illformattedRecord, session.getPeer(), null, ClockUtil.nanoRealtime());
+		List<Record> recordList = DtlsTestTools.fromByteArray(illformattedRecord, session.getPeer(), null, ClockUtil.nanoRealtime());
 		assertTrue("fromByteArray() should have detected malformed record", recordList.isEmpty());
 	}
 
@@ -104,7 +104,7 @@ public class RecordTest {
 	public void testFromByteArrayAcceptsKnownTypeCode() throws GeneralSecurityException {
 
 		byte[] application_record = DtlsTestTools.newDTLSRecord(TYPE_APPL_DATA, EPOCH, SEQUENCE_NO, newGenericAEADCipherFragment());
-		List<Record> recordList = Record.fromByteArray(application_record, session.getPeer(), null, ClockUtil.nanoRealtime());
+		List<Record> recordList = DtlsTestTools.fromByteArray(application_record, session.getPeer(), null, ClockUtil.nanoRealtime());
 		assertEquals(recordList.size(), 1);
 		Record record = recordList.get(0);
 		assertEquals(ContentType.APPLICATION_DATA, record.getType());
@@ -120,7 +120,7 @@ public class RecordTest {
 		byte[] application_record = DtlsTestTools.newDTLSRecord(TYPE_APPL_DATA, EPOCH, SEQUENCE_NO, newGenericAEADCipherFragment());
 		byte[] unsupported_dtls_record = DtlsTestTools.newDTLSRecord(55, EPOCH, SEQUENCE_NO, newGenericAEADCipherFragment());
 
-		List<Record> recordList = Record.fromByteArray(Bytes.concatenate(unsupported_dtls_record, application_record), session.getPeer(), null, ClockUtil.nanoRealtime());
+		List<Record> recordList = DtlsTestTools.fromByteArray(Bytes.concatenate(unsupported_dtls_record, application_record), session.getPeer(), null, ClockUtil.nanoRealtime());
 		Assert.assertTrue(recordList.size() == 1);
 		Assert.assertEquals(ContentType.APPLICATION_DATA, recordList.get(0).getType());
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
@@ -431,7 +431,7 @@ public class ServerHandshakerTest {
 		clientHelloMsg = newHandshakeMessage(HandshakeType.CLIENT_HELLO, messageSeq, clientHelloFragment);
 		byte[] dtlsRecord = DtlsTestTools.newDTLSRecord(ContentType.HANDSHAKE.getCode(), epoch,
 				sequenceNo, clientHelloMsg);
-		List<Record> list = Record.fromByteArray(dtlsRecord, endpoint, null, ClockUtil.nanoRealtime());
+		List<Record> list = DtlsTestTools.fromByteArray(dtlsRecord, endpoint, null, ClockUtil.nanoRealtime());
 		assertFalse("Should be able to deserialize DTLS Record from byte array", list.isEmpty());
 		Record record = list.get(0);
 		record.applySession(handshaker.getSession());

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/SimpleRecordLayer.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/SimpleRecordLayer.java
@@ -21,11 +21,11 @@ import java.net.DatagramPacket;
 import java.net.InetSocketAddress;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.californium.elements.util.ClockUtil;
+import org.eclipse.californium.elements.util.DatagramReader;
 
 public class SimpleRecordLayer implements RecordLayer {
 
@@ -42,8 +42,8 @@ public class SimpleRecordLayer implements RecordLayer {
 		long timestamp = ClockUtil.nanoRealtime();
 		for (DatagramPacket packet : datagrams) {
 			InetSocketAddress peerAddress = new InetSocketAddress(packet.getAddress(), packet.getPort());
-			byte[] data = Arrays.copyOfRange(packet.getData(), packet.getOffset(), packet.getLength());
-			List<Record> records = Record.fromByteArray(data, peerAddress, handshaker.connectionIdGenerator, timestamp);
+			DatagramReader reader = new DatagramReader(packet.getData(), packet.getOffset(), packet.getLength());
+			List<Record> records = Record.fromReader(reader, peerAddress, handshaker.connectionIdGenerator, timestamp);
 			for (Record record : records) {
 				try {
 					record.applySession(handshaker.getSession());

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/rule/DtlsNetworkRule.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/rule/DtlsNetworkRule.java
@@ -22,6 +22,7 @@ import org.eclipse.californium.elements.rule.NetworkRule;
 import org.eclipse.californium.elements.util.ClockUtil;
 import org.eclipse.californium.elements.util.DatagramFormatter;
 import org.eclipse.californium.scandium.dtls.ContentType;
+import org.eclipse.californium.scandium.dtls.DtlsTestTools;
 import org.eclipse.californium.scandium.dtls.HandshakeType;
 import org.eclipse.californium.scandium.dtls.Record;
 import org.slf4j.Logger;
@@ -69,7 +70,7 @@ public class DtlsNetworkRule extends NetworkRule {
 				return "[] (empty)";
 			}
 			try {
-				List<Record> records = Record.fromByteArray(data, ADDRESS, null, ClockUtil.nanoRealtime());
+				List<Record> records = DtlsTestTools.fromByteArray(data, ADDRESS, null, ClockUtil.nanoRealtime());
 				int max = records.size();
 				StringBuilder builder = new StringBuilder();
 				for (int index = 0; index < max;) {


### PR DESCRIPTION
Reduce heap consumption.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>