### PR TITLE
Use version 1.0 for hello verify requests.

### DIFF
--- a/demo-apps/cf-unix-setup/src/main/resources/start-dtls.sh
+++ b/demo-apps/cf-unix-setup/src/main/resources/start-dtls.sh
@@ -23,7 +23,8 @@
 # IPv6 layer, RFC 2460, "next header" => currently not supported :-)  
 # UDP layer, RFC 768, 8 bytes
 # DTLS 1.2 header first 3 bytes "14 - 19 fe fd"
-# check for "1? fe fd" and "?4-?9"
+# DTLS 1.0 header first 3 bytes "16 fe ff", Hello Verify Request
+# check for "1? fe f(d|f)" and "?4-?9"
 #
 # Requires su rights, execute with sudo!
 
@@ -37,7 +38,8 @@ echo "Create DTLS_FILTER"
 iptables -N DTLS_FILTER
 echo "Prepare DTLS_FILTER"
 iptables -F DTLS_FILTER
-iptables -A DTLS_FILTER -m u32 ! --u32 "0>>22&0x3C@ 7&0xF0FFFF=0x10FEFD && 0>>22&0x3C@ 5&0x0F=4:9" -j DROP
+iptables -A DTLS_FILTER -m u32 ! --u32 "0>>22&0x3C@ 7&0xF0FFFD=0x10FEFD && 0>>22&0x3C@ 5&0x0F=4:9" -j DROP
+
 
 echo "Remove INPUT to DTLS filter $1"
 iptables -D INPUT ${INTERFACE} -p udp --dport 5684 -j DTLS_FILTER

--- a/demo-apps/cf-unix-setup/src/main/resources/startlvs.sh
+++ b/demo-apps/cf-unix-setup/src/main/resources/startlvs.sh
@@ -63,7 +63,7 @@ echo "Create DTLS_FILTER"
 iptables -t raw -N DTLS_FILTER
 echo "Prepare DTLS_FILTER"
 iptables -t raw -F DTLS_FILTER
-iptables -t raw -A DTLS_FILTER -m u32 ! --u32 "0>>22&0x3C@ 7&0xF0FFFF=0x10FEFD && 0>>22&0x3C@ 5&0x0F=4:9" -j DROP
+iptables -t raw -A DTLS_FILTER -m u32 ! --u32 "0>>22&0x3C@ 7&0xF0FFFD=0x10FEFD && 0>>22&0x3C@ 5&0x0F=4:9" -j DROP
 
 echo "Remove PREROUTING - DTLS FILTER $1"
 iptables -t raw -D PREROUTING ${INTERFACE} -p udp --dport 5684 -j DTLS_FILTER

--- a/scandium-core/api-changes.json
+++ b/scandium-core/api-changes.json
@@ -290,5 +290,18 @@
 				}
 			]
 		}
+	},
+	"2.5.0": {
+		"revapi": {
+			"ignore": [
+				{
+					"code": "java.method.numberOfParametersChanged",
+					"old": "method void org.eclipse.californium.scandium.dtls.Record::<init>(org.eclipse.californium.scandium.dtls.ContentType, long, org.eclipse.californium.scandium.dtls.DTLSMessage, java.net.InetSocketAddress)",
+					"new": "method void org.eclipse.californium.scandium.dtls.Record::<init>(org.eclipse.californium.scandium.dtls.ContentType, org.eclipse.californium.scandium.dtls.ProtocolVersion, long, org.eclipse.californium.scandium.dtls.DTLSMessage, java.net.InetSocketAddress)",
+					"justification": "not part of the public API",
+					"oldArchive": "org.eclipse.californium:scandium:jar:2.4.0"
+				}
+			]
+		}
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -61,6 +61,7 @@ import org.eclipse.californium.scandium.dtls.CertificateMessage;
 import org.eclipse.californium.scandium.dtls.CertificateRequest;
 import org.eclipse.californium.scandium.dtls.CertificateType;
 import org.eclipse.californium.scandium.dtls.ConnectionIdGenerator;
+import org.eclipse.californium.scandium.dtls.ProtocolVersion;
 import org.eclipse.californium.scandium.dtls.RecordLayer;
 import org.eclipse.californium.scandium.dtls.SessionCache;
 import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm;
@@ -204,6 +205,13 @@ public final class DtlsConnectorConfig {
 	 * @since 2.4
 	 */
 	private Boolean enableMultiHandshakeMessageRecords;
+	/**
+	 * Protocol version to use for sending a hello verify request. Default
+	 * {@link ProtocolVersion#VERSION_DTLS_1_0}.
+	 * 
+	 * @since 2.5
+	 */
+	private ProtocolVersion protocolVersionForHelloVerifyRequests;
 
 	/** The initial timer value for retransmission; rfc6347, section: 4.2.4.1 */
 	private Integer retransmissionTimeout;
@@ -522,6 +530,25 @@ public final class DtlsConnectorConfig {
 	 */
 	public Boolean useMultiHandshakeMessageRecords() {
 		return enableMultiHandshakeMessageRecords;
+	}
+
+	/**
+	 * Get protocol version for hello verify requests to send.
+	 * 
+	 * Before version 2.5.0, the protocol version 1.2 was used by Californium to
+	 * send hello verify requests. According
+	 * <a href="https://tools.ietf.org/html/rfc6347#section-4.2.1">RFC 6347,
+	 * 4.2.1. Denial-of-Service Countermeasures</a>, that hello verify request
+	 * should be sent using protocol version 1.0. That's now the default. In
+	 * order to provide backwards compatibility, it's also possible to configure
+	 * to use protocol version 1.2.
+	 * 
+	 * @return protocol version. Default
+	 *         {@link ProtocolVersion#VERSION_DTLS_1_0}.
+	 * @since 2.5
+	 */
+	public ProtocolVersion getProtocolVersionForHelloVerifyRequests() {
+		return protocolVersionForHelloVerifyRequests;
 	}
 
 	/**
@@ -1227,6 +1254,7 @@ public final class DtlsConnectorConfig {
 		cloned.maxFragmentedHandshakeMessageLength = maxFragmentedHandshakeMessageLength;
 		cloned.enableMultiRecordMessages = enableMultiRecordMessages;
 		cloned.enableMultiHandshakeMessageRecords = enableMultiHandshakeMessageRecords;
+		cloned.protocolVersionForHelloVerifyRequests = protocolVersionForHelloVerifyRequests;
 		cloned.retransmissionTimeout = retransmissionTimeout;
 		cloned.maxRetransmissions = maxRetransmissions;
 		cloned.maxTransmissionUnit = maxTransmissionUnit;
@@ -1571,6 +1599,26 @@ public final class DtlsConnectorConfig {
 		 */
 		public Builder setEnableMultiHandshakeMessageRecords(boolean enable) {
 			config.enableMultiHandshakeMessageRecords = enable;
+			return this;
+		}
+
+		/**
+		 * Set the protocol version to be used to send hello verify requests.
+		 * 
+		 * Before version 2.5.0, the protocol version 1.2 was used by
+		 * Californium to send the hello verify request. According
+		 * <a href="https://tools.ietf.org/html/rfc6347#section-4.2.1">RFC 6347,
+		 * 4.2.1. Denial-of-Service Countermeasures</a>, that hello verify
+		 * request should be sent using protocol version 1.0. That's now the
+		 * default. In order to provide backwards compatibility, it's also
+		 * possible to configure to use protocol version 1.2.
+		 * 
+		 * @param protocolVersion protocol version to send hello verify requests
+		 * @return this builder for command chaining
+		 * @since 2.5
+		 */
+		public Builder setProtocolVersionForHelloVerifyRequests(ProtocolVersion protocolVersion) {
+			config.protocolVersionForHelloVerifyRequests = protocolVersion;
 			return this;
 		}
 
@@ -2977,6 +3025,9 @@ public final class DtlsConnectorConfig {
 				} else {
 					config.defaultHandshakeMode = DtlsEndpointContext.HANDSHAKE_MODE_AUTO;
 				}
+			}
+			if (config.protocolVersionForHelloVerifyRequests == null) {
+				config.protocolVersionForHelloVerifyRequests = ProtocolVersion.VERSION_DTLS_1_0;
 			}
 			if (config.useNoServerSessionId == null) {
 				config.useNoServerSessionId = Boolean.FALSE;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloVerifyRequest.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloVerifyRequest.java
@@ -109,8 +109,7 @@ public final class HelloVerifyRequest extends HandshakeMessage {
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append(super.toString());
-		sb.append("\t\tServer Version: ").append(serverVersion.getMajor()).append(", ").append(serverVersion.getMinor())
-			.append(StringUtil.lineSeparator());
+		sb.append("\t\tServer Version: ").append(serverVersion).append(StringUtil.lineSeparator());
 		sb.append("\t\tCookie Length: ").append(cookie.length).append(StringUtil.lineSeparator());
 		sb.append("\t\tCookie: ").append(StringUtil.byteArray2HexString(cookie)).append(StringUtil.lineSeparator());
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ProtocolVersion.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ProtocolVersion.java
@@ -30,25 +30,57 @@ package org.eclipse.californium.scandium.dtls;
 public class ProtocolVersion implements Comparable<ProtocolVersion> {
 
 	/**
+	 * Major version for DTLS 1.x.
+	 * 
+	 * @since 2.5
+	 */
+	public static final int MAJOR_1 = 254;
+
+	/**
+	 * Minor version for DTLS x.2.
+	 * 
+	 * @since 2.5
+	 */
+	public static final int MINOR_2 = 253;
+
+	/**
+	 * Minor version for DTLS x.0.
+	 * 
+	 * @since 2.5
+	 */
+	public static final int MINOR_0 = 255;
+
+	/**
 	 * Major version for DTLS 1.2.
 	 * 
 	 * @since 2.4
+	 * @deprecated use {@link #MAJOR_1}
 	 */
-	public static final int MAJOR_1_2 = 254;
+	@Deprecated
+	public static final int MAJOR_1_2 = MAJOR_1;
 
 	/**
 	 * Minor version for DTLS 1.2.
 	 * 
 	 * @since 2.4
+	 * @deprecated use {@link #MINOR_2}
 	 */
-	public static final int MINOR_1_2 = 253;
+	@Deprecated
+	public static final int MINOR_1_2 = MINOR_2;
 
 	/**
 	 * Protocol version DTLS 1.2
 	 * 
 	 * @since 2.4
 	 */
-	public static final ProtocolVersion VERSION_DTLS_1_2 = new ProtocolVersion(MAJOR_1_2, MINOR_1_2);
+	public static final ProtocolVersion VERSION_DTLS_1_2 = new ProtocolVersion(MAJOR_1, MINOR_2);
+
+	/**
+	 * Protocol version DTLS 1.0
+	 * 
+	 * @since 2.5
+	 */
+	public static final ProtocolVersion VERSION_DTLS_1_0 = new ProtocolVersion(MAJOR_1, MINOR_0);
 
 	/** The minor. */
 	private final int minor;
@@ -66,8 +98,8 @@ public class ProtocolVersion implements Comparable<ProtocolVersion> {
 	 */
 	@Deprecated
 	public ProtocolVersion() {
-		this.major = MAJOR_1_2;
-		this.minor = MINOR_1_2;
+		this.major = MAJOR_1;
+		this.minor = MINOR_2;
 	}
 
 	/**
@@ -168,8 +200,10 @@ public class ProtocolVersion implements Comparable<ProtocolVersion> {
 	 * @return protocol version
 	 */
 	public static ProtocolVersion valueOf(int major, int minor) {
-		if (major == MAJOR_1_2 && minor == MINOR_1_2) {
+		if (major == MAJOR_1 && minor == MINOR_2) {
 			return VERSION_DTLS_1_2;
+		} else if (major == MAJOR_1 && minor == MINOR_0) {
+			return VERSION_DTLS_1_0;
 		} else {
 			return new ProtocolVersion(major, minor);
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Record.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Record.java
@@ -230,6 +230,7 @@ public class Record {
 	 * 
 	 * @param type the type of the record's payload. The new record type
 	 *            {@link ContentType#TLS12_CID} is not supported.
+	 * @param version the version
 	 * @param sequenceNumber the 48-bit sequence number
 	 * @param fragment the payload to send
 	 * @param peerAddress the IP address and port of the peer this record should
@@ -240,8 +241,8 @@ public class Record {
 	 * @throws NullPointerException if the given type, fragment or peer address
 	 *             is {@code null}.
 	 */
-	public Record(ContentType type, long sequenceNumber, DTLSMessage fragment, InetSocketAddress peerAddress) {
-		this(ProtocolVersion.VERSION_DTLS_1_2, 0, sequenceNumber, 0, peerAddress, false);
+	public Record(ContentType type, ProtocolVersion version, long sequenceNumber, DTLSMessage fragment, InetSocketAddress peerAddress) {
+		this(version, 0, sequenceNumber, 0, peerAddress, false);
 		if (fragment == null) {
 			throw new NullPointerException("Fragment must not be null");
 		} else if (peerAddress == null) {


### PR DESCRIPTION
Comply to recommendation RFC 6347, 4.2.1. Denial-of-Service Countermeasures.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>