### PR TITLE
Fix advancedhandshaketest

### DIFF
--- a/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestNameLoggerRule.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/rule/TestNameLoggerRule.java
@@ -31,4 +31,9 @@ public class TestNameLoggerRule extends TestWatcher {
 	protected void starting(Description description) {
 		LOGGER.info("Test {}", description.getMethodName());
 	}
+
+	@Override
+	protected void finished(Description description) {
+		LOGGER.info("Test {}", description.getMethodName());
+	}
 }


### PR DESCRIPTION
Cleanup advanced handshake tests.
Assert intended session states.
Add finish message to test name logger rule.
Add more logging in dtls for dropped messages.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>
