### PR TITLE
Add detection for handshakes with itself.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
@@ -333,7 +333,7 @@ public final class Connection {
 				if (pendingHandshaker != null) {
 					if (establishedSession == null || pendingHandshaker.getSession() != establishedSession) {
 						// this will only call the listener, if no other cause was set before!
-						pendingHandshaker.handshakeFailed(new IOException(previous + " address changed!"));
+						pendingHandshaker.handshakeFailed(new IOException(previous + " address reused during handshake!"));
 					}
 				}
 			} else {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSFlight.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSFlight.java
@@ -35,6 +35,7 @@ import java.net.DatagramPacket;
 import java.net.InetSocketAddress;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -249,6 +250,22 @@ public class DTLSFlight {
 	 */
 	public int getNumberOfMessages() {
 		return dtlsMessages.size();
+	}
+
+	/**
+	 * Check, if the provided message is contained in this flight.
+	 * 
+	 * @param message message to check
+	 * @return {@code true}, if message is contained, {@code false}, if not.
+	 * @since 2.5
+	 */
+	public boolean contains(DTLSMessage message) {
+		for (EpochMessage epochMessage : dtlsMessages) {
+			if (Arrays.equals(message.toByteArray(), epochMessage.message.toByteArray())) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -901,8 +901,16 @@ public abstract class Handshaker implements Destroyable {
 			}
 
 			if (!expected) {
-				LOGGER.warn("Cannot process {} message from peer [{}], {} expected!", HandshakeState.toString(message),
-						getSession().getPeer(), expectedState);
+				// check for self addressed messages
+				// some cloud deployments may get easily mixed up
+				DTLSFlight flight = pendingFlight.get();
+				if (flight != null && flight.contains(message)) {
+					LOGGER.debug("Cannot process {} message from same peer [{}]!",
+							HandshakeState.toString(message), getSession().getPeer());
+				} else {
+					LOGGER.debug("Cannot process {} message from peer [{}], {} expected!",
+							HandshakeState.toString(message), getSession().getPeer(), expectedState);
+				}
 				AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.INTERNAL_ERROR,
 						session.getPeer());
 				throw new HandshakeException("Cannot process " + HandshakeState.toString(message)

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -338,8 +338,14 @@ public class InMemoryConnectionStore implements ResumptionSupportingConnectionSt
 				LOG.debug("{}connection: {} updated usage!", tag, connection.getConnectionId());
 			} else if (!connection.equalsPeerAddress(newPeerAddress)) {
 				InetSocketAddress oldPeerAddress = connection.getPeerAddress();
-				LOG.debug("{}connection: {} updated, address changed from {} to {}!", tag, connection.getConnectionId(),
-						oldPeerAddress, newPeerAddress);
+				if (LOG.isTraceEnabled()) {
+					LOG.trace("{}connection: {} updated, address changed from {} to {}!", tag,
+							connection.getConnectionId(), oldPeerAddress, newPeerAddress,
+							new Throwable("connection updated!"));
+				} else {
+					LOG.debug("{}connection: {} updated, address changed from {} to {}!", tag,
+							connection.getConnectionId(), oldPeerAddress, newPeerAddress);
+				}
 				if (oldPeerAddress != null) {
 					connectionsByAddress.remove(oldPeerAddress, connection);
 					connection.updatePeerAddress(null);


### PR DESCRIPTION
Some cloud deployments may get easily mixed up. A specific logging
message makes it easier to detect that.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>