### PR TITLE
Fix wrong certificate verify for empty client certificate.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -164,6 +164,16 @@ public class ClientHandshaker extends Handshaker {
 	/** The server's {@link CertificateRequest}. Optional. */
 	protected CertificateRequest certificateRequest = null;
 
+	/**
+	 * Indicates, that a none-empty client certificate is sent.
+	 * 
+	 * If no matching client certificate is available for the request, an empty
+	 * certificate is sent. That case doesn't use a certificate verify message.
+	 * 
+	 * @since 2.6
+	 */
+	protected boolean sentClientCertificate;
+
 	/** The hash of all received handshake messages sent in the finished message. */
 	protected byte[] handshakeHash = null;
 
@@ -580,7 +590,7 @@ public class ClientHandshaker extends Handshaker {
 		/*
 		 * Third, send CertificateVerify message if necessary.
 		 */
-		if (certificateRequest != null && negotiatedSignatureAndHashAlgorithm != null) {
+		if (sentClientCertificate && certificateRequest != null && negotiatedSignatureAndHashAlgorithm != null) {
 			CertificateType clientCertificateType = session.sendCertificateType();
 			if (!isSupportedCertificateType(clientCertificateType, supportedClientCertificateTypes)) {
 				throw new HandshakeException(
@@ -674,6 +684,7 @@ public class ClientHandshaker extends Handshaker {
 			} else {
 				throw new IllegalArgumentException("Certificate type " + session.sendCertificateType() + " not supported!");
 			}
+			sentClientCertificate = clientCertificate.getMessageLength() > 3;
 			wrapMessage(flight, clientCertificate);
 		}
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -252,7 +252,9 @@ public class ConnectorHelper {
 	 */
 	public void destroyServer() {
 		cleanUpServer();
-		server.destroy();
+		if (server != null) {
+			server.destroy();
+		}
 	}
 
 	/**
@@ -266,10 +268,18 @@ public class ConnectorHelper {
 	 * </ul>
 	 */
 	public void cleanUpServer() {
-		serverConnectionStore.clear();
-		serverRawDataProcessor.clear();
-		serverRawDataChannel.setProcessor(serverRawDataProcessor);
-		server.setAlertHandler(null);
+		if (serverConnectionStore != null) {
+			serverConnectionStore.clear();
+		}
+		if (serverRawDataProcessor != null) {
+			serverRawDataProcessor.clear();
+		}
+		if (serverRawDataChannel != null) {
+			serverRawDataChannel.setProcessor(serverRawDataProcessor);
+		}
+		if (server != null) {
+			server.setAlertHandler(null);
+		}
 		sessionListenerMap.clear();
 	}
 


### PR DESCRIPTION
Add unit test to ensure, that the certificate verify is skipped.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>