### PR TITLE
Add explicit default version for hello-verify-request.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHandshaker.java
@@ -330,7 +330,13 @@ public class ClientHandshaker extends Handshaker {
 	 */
 	protected void receivedServerHello(ServerHello message) throws HandshakeException {
 		// store the negotiated values
+
 		usedProtocol = message.getServerVersion();
+		if (usedProtocol.compareTo(ProtocolVersion.VERSION_DTLS_1_2) != 0) {
+			AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.PROTOCOL_VERSION, session.getPeer());
+			throw new HandshakeException("The client only supports DTLS v1.2, not " + usedProtocol + "!", alert);
+		}
+
 		serverRandom = message.getRandom();
 		session.setSessionIdentifier(message.getSessionId());
 		CipherSuite cipherSuite = message.getCipherSuite();

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeException.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeException.java
@@ -25,13 +25,34 @@ public class HandshakeException extends Exception {
 
 	private final AlertMessage alert;
 
+	/**
+	 * Create handshake exception.
+	 * 
+	 * @param message message
+	 * @param alert related alert
+	 * @throws NullPointerException if alert is {@code null}
+	 */
 	public HandshakeException(String message, AlertMessage alert) {
 		super(message);
+		if (alert == null) {
+			throw new NullPointerException("Alert must not be null!");
+		}
 		this.alert = alert;
 	}
 
+	/**
+	 * Create handshake exception with cause.
+	 * 
+	 * @param message message
+	 * @param alert related alert
+	 * @param cause root cause
+	 * @throws NullPointerException if alert is {@code null}
+	 */
 	public HandshakeException(String message, AlertMessage alert, Throwable cause) {
 		super(message, cause);
+		if (alert == null) {
+			throw new NullPointerException("Alert must not be null!");
+		}
 		this.alert = alert;
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloVerifyRequest.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloVerifyRequest.java
@@ -26,9 +26,65 @@ import org.eclipse.californium.elements.util.StringUtil;
 
 /**
  * The server send this request after receiving a {@link ClientHello} message to
- * prevent Denial-of-Service Attacks. See
- * <a href="http://tools.ietf.org/html/rfc6347#section-4.2.1">RFC 6347</a> for
- * the definition.
+ * prevent Denial-of-Service Attacks.
+ * <p>
+ * See <a href="https://tools.ietf.org/html/rfc6347#section-4.2.1">RFC 6347</a>
+ * for the definition.
+ * </p>
+ * <p>
+ * It seems, that this definition is ambiguous about the server version to be
+ * used.
+ * </p>
+ * <pre>
+ * The server_version field ...
+ * DTLS 1.2 server implementations SHOULD use DTLS version 1.0 regardless
+ * of the version of TLS that is expected to be negotiated. ...
+ * The server MUST use the same version number in the HelloVerifyRequest
+ * that it would use when sending a ServerHello. ...
+ * </pre>
+ * <p>
+ * A DTLS 1.2 server can either (SHOULD) send a version 1.0, or (MUST use same
+ * version) 1.2. This question is pending in the IETF TLS mailing list, see
+ * <a href=
+ * "https://mailarchive.ietf.org/arch/msg/tls/rQ3El3ROKTN0rpzhRpJCaKOrUyU/">RFC
+ * 6347 - Section 4.2.1 - used version in a HelloVerifyReques</a>.
+ * </p>
+ * <p>
+ * There may be many assumptions about the intended behavior. One is to postpone
+ * the version negotiation according
+ * <a href= "https://tools.ietf.org/html/rfc5246#appendix-E.1">RFC 5246 - E.1 -
+ * Compatibility with TLS 1.0/1.1 and SSL 3.0</a> until the endpoint ownership is
+ * verified. That prevents sending protocol-version alerts to wrong clients.
+ * </p>
+ * 
+ * Behavior of other DTLS 1.2 implementations:
+ * <dl>
+ * <dt>openssl 1.1.1</dt>
+ * <dd>1.0</dd>
+ * <dt>gnutls 3.5.18</dt>
+ * <dd>1.0</dd>
+ * <dt>mbedtls 2.24.0</dt>
+ * <dd>1.2</dd>
+ * <dt>wolfssl 4.5</dt>
+ * <dd>1.2</dd>
+ * <dt>tinydtls 0.8.6</dt>
+ * <dd>1.0 protocol-version in record-header, 1.2 server version in
+ * hello-verify-request</dd>
+ * </dl>
+ * <p>
+ * All clients of these libraries are able to perform a dtls-handshake with both
+ * variants, 1.0 and 1.2. Some other clients seems to have trouble with 1.0. If
+ * interoperability is required, a client MUST comply with the definition there:
+ * </p>
+ * 
+ * <pre>
+ * DTLS 1.2 and 1.0 clients MUST use the version solely to
+ * indicate packet formatting (which is the same in both DTLS 1.2 and
+ * 1.0) and not as part of version negotiation.  In particular, DTLS 1.2
+ * clients MUST NOT assume that because the server uses version 1.0 in
+ * the HelloVerifyRequest that the server is not DTLS 1.2 or that it
+ * will eventually negotiate DTLS 1.0 rather than DTLS 1.2.
+ * </pre>
  */
 public final class HelloVerifyRequest extends HandshakeMessage {
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ProtocolVersion.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ProtocolVersion.java
@@ -208,4 +208,18 @@ public class ProtocolVersion implements Comparable<ProtocolVersion> {
 			return new ProtocolVersion(major, minor);
 		}
 	}
+
+	/**
+	 * Get protocol version value of the provided versions.
+	 * 
+	 * @param version textual version. e.g. "1.2".
+	 * @return protocol version
+	 * @since 2.6
+	 */
+	public static ProtocolVersion valueOf(String version) {
+		String[] split = version.split("\\.");
+		int major = 255 - Integer.parseInt(split[0]);
+		int minor = 255 - Integer.parseInt(split[1]);
+		return valueOf(major, minor);
+	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -690,18 +690,22 @@ public class ServerHandshaker extends Handshaker {
 	 * suggested by the client in the client hello and the highest supported by
 	 * the server.
 	 * 
-	 * @param clientVersion
-	 *            the suggested version by the client.
+	 * @param clientVersion the suggested version by the client.
 	 * @return the version to be used in the handshake.
-	 * @throws HandshakeException
-	 *             if the client's version is smaller than DTLS 1.2
+	 * @throws HandshakeException if the client's version is smaller than DTLS
+	 *             1.2
 	 */
 	private ProtocolVersion negotiateProtocolVersion(ProtocolVersion clientVersion) throws HandshakeException {
 		if (clientVersion.compareTo(ProtocolVersion.VERSION_DTLS_1_2) >= 0) {
 			return ProtocolVersion.VERSION_DTLS_1_2;
 		} else {
-			AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.PROTOCOL_VERSION, session.getPeer());
-			throw new HandshakeException("The server only supports DTLS v1.2", alert);
+			ProtocolVersion version = clientVersion;
+			if (version.compareTo(ProtocolVersion.VERSION_DTLS_1_0) < 0) {
+				version = ProtocolVersion.VERSION_DTLS_1_0;
+			}
+			AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.PROTOCOL_VERSION, version,
+					session.getPeer());
+			throw new HandshakeException("The server only supports DTLS v1.2, not " + clientVersion + "!", alert);
 		}
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DtlsTestTools.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DtlsTestTools.java
@@ -54,8 +54,12 @@ public final class DtlsTestTools extends TestCertificatesTools {
 	}
 
 	public static final byte[] newDTLSRecord(int typeCode, int epoch, long sequenceNo, byte[] fragment) {
+		return newDTLSRecord(typeCode, ProtocolVersion.VERSION_DTLS_1_2, epoch, sequenceNo, fragment);
+	}
 
-		ProtocolVersion protocolVer = ProtocolVersion.VERSION_DTLS_1_2;
+	public static final byte[] newDTLSRecord(int typeCode, ProtocolVersion protocolVer, int epoch, long sequenceNo,
+			byte[] fragment) {
+
 		// the record header contains a type code, version, epoch, sequenceNo, length
 		DatagramWriter writer = new DatagramWriter();
 		writer.write(typeCode, 8);


### PR DESCRIPTION
Switch back to 1.2.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>