### PR TITLE
Fix bits overflow checks in DatagramWriter.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataSerializerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/serialization/DataSerializerTest.java
@@ -89,6 +89,7 @@ public class DataSerializerTest {
 		Request req = Request.newGet();
 		req.setToken(new byte[] { 0x00 });
 		req.getOptions().setObserve(0);
+		req.setMID(1);
 
 		// WHEN serializing the request to a byte array
 		serializer.getByteArray(req);
@@ -107,6 +108,7 @@ public class DataSerializerTest {
 		Request req = Request.newGet();
 		req.setToken(new byte[] { 0x00 });
 		req.getOptions().setObserve(0);
+		req.setMID(1);
 		req.setDestinationContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
 
 		// WHEN serializing the request to a RawData object

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramWriter.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramWriter.java
@@ -85,15 +85,18 @@ public final class DatagramWriter {
 	/**
 	 * Writes a sequence of bits to the stream.
 	 * 
-	 * @param data
-	 *            A Long containing the bits to write.
-	 * 
-	 * @param numBits
-	 *            The number of bits to write.
+	 * @param data A Long containing the bits to write.
+	 * @param numBits The number of bits to write. 1 to 64.
+	 * @throws IllegalArgumentException if the number of bits is not in range
+	 *             1..64, or the provided data contains more bits than that
+	 *             number.
 	 */
 	public void writeLong(final long data, final int numBits) {
 
-		if (numBits < 64 && data >= (1L << numBits)) {
+		if (numBits < 0 || numBits > 64) {
+			throw new IllegalArgumentException(String.format("Number of bits must be 1 to 64, not %d", numBits));
+		}
+		if (numBits < 64 && (data >> numBits) != 0) {
 			throw new IllegalArgumentException(String.format("Truncating value %d to %d-bit integer", data, numBits));
 		}
 
@@ -126,15 +129,17 @@ public final class DatagramWriter {
 	/**
 	 * Writes a sequence of bits to the stream.
 	 * 
-	 * @param data
-	 *            An integer containing the bits to write.
-	 * 
-	 * @param numBits
-	 *            The number of bits to write.
+	 * @param data An integer containing the bits to write.
+	 * @param numBits The number of bits to write. 1 to 32.
+	 * @throws IllegalArgumentException if the number of bits is not in range
+	 *             1..32, or the provided data contains more bits than that
+	 *             number.
 	 */
 	public void write(final int data, final int numBits) {
-
-		if (numBits < 32 && data >= (1 << numBits)) {
+		if (numBits < 0 || numBits > 32) {
+			throw new IllegalArgumentException(String.format("Number of bits must be 1 to 32, not %d", numBits));
+		}
+		if (numBits < 32 && (data >> numBits) != 0) {
 			throw new IllegalArgumentException(String.format("Truncating value %d to %d-bit integer", data, numBits));
 		}
 
@@ -180,7 +185,7 @@ public final class DatagramWriter {
 		if (isBytePending()) {
 
 			for (int i = 0; i < bytes.length; i++) {
-				write(bytes[i], Byte.SIZE);
+				write(bytes[i] & 0xff, Byte.SIZE);
 			}
 
 		} else {
@@ -199,7 +204,7 @@ public final class DatagramWriter {
 	 */
 	public void writeByte(final byte b) {
 		if (isBytePending()) {
-			writeBytes(new byte[] { b });
+			write(b & 0xff, Byte.SIZE);
 		} else {
 			byteStream.write(b);
 		}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/DatagramWriterTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/DatagramWriterTest.java
@@ -1,0 +1,180 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class DatagramWriterTest {
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	DatagramWriter writer;
+
+	@Before
+	public void setUp() throws Exception {
+		writer = new DatagramWriter(32);
+	}
+
+	@Test
+	public void testWrite() {
+		writer.write(0x123456, 24);
+		byte[] data = writer.toByteArray();
+		assertEquals("123456", hex(data));
+	}
+
+	@Test
+	public void testWriteOdd() {
+		writer.write(0x8, 4);
+		writer.write(0x123456, 22);
+		byte[] data = writer.toByteArray();
+		assertEquals("848D1580", hex(data));
+	}
+
+	@Test
+	public void testWriteTooLarge() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Truncating");
+		writer.write(0x123456, 16);
+	}
+
+	@Test
+	public void testWriteTooLargeNegativeValue() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Truncating");
+		writer.write(-1, 16);
+	}
+
+	@Test
+	public void testWriteTooManyBits() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Number of bits ");
+		writer.write(1, 33);
+	}
+
+	@Test
+	public void testWriteFull() {
+		writer.write(-1, 32);
+		byte[] data = writer.toByteArray();
+		assertEquals("FFFFFFFF", hex(data));
+	}
+
+	@Test
+	public void testWriteLong() {
+		writer.writeLong(0x123456abcdL, 48);
+		byte[] data = writer.toByteArray();
+		assertEquals("00123456ABCD", hex(data));
+	}
+
+	@Test
+	public void testWriteLongOdd() {
+		writer.write(0x8, 4);
+		writer.writeLong(0x123456abcdL, 48);
+		byte[] data = writer.toByteArray();
+		assertEquals("800123456ABCD0", hex(data));
+	}
+
+	@Test
+	public void testWriteLongTooLarge() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Truncating");
+		writer.writeLong(0x123456abcdL, 36);
+	}
+
+	@Test
+	public void testWriteLongTooLargeNegativeValue() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Truncating");
+		writer.writeLong(-1L, 36);
+	}
+
+	@Test
+	public void testWriteLongTooManyBits() {
+		exception.expect(IllegalArgumentException.class);
+		exception.expectMessage("Number of bits ");
+		writer.writeLong(1L, 65);
+	}
+
+	@Test
+	public void testWriteFullLong() {
+		writer.writeLong(-1L, 64);
+		byte[] data = writer.toByteArray();
+		assertEquals("FFFFFFFFFFFFFFFF", hex(data));
+	}
+
+	@Test
+	public void testWriteByte() {
+		writer.writeByte((byte) 0x7a);
+		byte[] data = writer.toByteArray();
+		assertEquals("7A", hex(data));
+	}
+
+	@Test
+	public void testWriteByteOdd() {
+		writer.write(0x8, 6);
+		writer.writeByte((byte) 0x7a);
+		byte[] data = writer.toByteArray();
+		assertEquals("21E8", hex(data));
+	}
+
+	@Test
+	public void testWriteByteOddNegativeValue() {
+		writer.write(0x8, 6);
+		writer.writeByte((byte) -1);
+		byte[] data = writer.toByteArray();
+		assertEquals("23FC", hex(data));
+	}
+
+	@Test
+	public void testWriteBytes() {
+		byte[] data = bin("ab12def671223344556677890a");
+		writer.writeBytes(data);
+		byte[] wdata = writer.toByteArray();
+		assertEquals(hex(data), hex(wdata));
+	}
+
+	@Test
+	public void testWriteBytesOdd() {
+		writer.write(0x6, 4);
+		byte[] data = bin("ab12def671223344556677890a");
+		writer.writeBytes(data);
+		byte[] wdata = writer.toByteArray();
+		assertEquals("6" + hex(data) + "0", hex(wdata));
+	}
+
+	@Test
+	public void testWriteDatagramWriter() {
+		writer.writeBytes(bin("1234"));
+		DatagramWriter writer2 = new DatagramWriter(16);
+		writer2.writeBytes(bin("5678"));
+		writer.write(writer2);
+		byte[] data = writer.toByteArray();
+		assertEquals("12345678", hex(data));
+	}
+
+	private static byte[] bin(String hex) {
+		return StringUtil.hex2ByteArray(hex);
+	}
+
+	private static String hex(byte[] data) {
+		return StringUtil.byteArray2Hex(data);
+	}
+}


### PR DESCRIPTION
Additionally check range of provided number of bits.
Add unit tests.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>