### PR TITLE
Add simple endpoint-context-attributes serialization.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
@@ -378,7 +378,7 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 		}
 
 		/**
-		 * Add {@link Number} value with key.
+		 * Add {@link Integer} value with key.
 		 * 
 		 * Provides a fluent API to chain add functions.
 		 * 
@@ -390,7 +390,25 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 		 * @throws IllegalArgumentException if key is empty
 		 * @throws IllegalStateException if instance is locked
 		 */
-		public Attributes add(String key, Number value) {
+		public Attributes add(String key, Integer value) {
+			addObject(key, value);
+			return this;
+		}
+
+		/**
+		 * Add {@link Long} value with key.
+		 * 
+		 * Provides a fluent API to chain add functions.
+		 * 
+		 * @param key key to add
+		 * @param value value to add
+		 * @return this for chaining
+		 * @throws NullPointerException if key is {@code null}, or a critical
+		 *             value is {@code null}
+		 * @throws IllegalArgumentException if key is empty
+		 * @throws IllegalStateException if instance is locked
+		 */
+		public Attributes add(String key, Long value) {
 			addObject(key, value);
 			return this;
 		}
@@ -448,6 +466,24 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 				throw new IllegalArgumentException("key is empty");
 			}
 			return entries.remove(key) != null;
+		}
+
+		@Override
+		public int hashCode() {
+			return entries.hashCode();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (obj instanceof Attributes) {
+				Attributes other = (Attributes) obj;
+				return entries.equals(other.entries);
+			}
+			return false;
 		}
 	}
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/SerializationUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/SerializationUtil.java
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+import org.eclipse.californium.elements.MapBasedEndpointContext.Attributes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility to use serialize and deserialize standard type using
+ * {@link DatagramWriter} and {@link DatagramReader}.
+ * 
+ * @since 3.0
+ */
+public class SerializationUtil {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(SerializationUtil.class);
+
+	private static final int ADDRESS_VERSION = 1;
+	private static final int ADDRESS_NONE = 0;
+	private static final int ADDRESS_LITERAL = 1;
+	private static final int ADDRESS_NAME = 2;
+
+	/**
+	 * Version number for serialization of {@link Attributes}.
+	 */
+	private static final int ATTRIBUTES_VERSION = 1;
+	private static final int ATTRIBUTES_STRING = 0;
+	private static final int ATTRIBUTES_BYTES = 1;
+	private static final int ATTRIBUTES_INTEGER = 2;
+	private static final int ATTRIBUTES_LONG = 3;
+
+	/**
+	 * Write {@link String} using {@link StandardCharsets#UTF_8}.
+	 * 
+	 * @param writer writer to write to.
+	 * @param value value to write.
+	 * @param numBits number of bits for encoding the length.
+	 */
+	public static void write(DatagramWriter writer, String value, int numBits) {
+		writer.writeVarBytes(value == null ? null : value.getBytes(StandardCharsets.UTF_8), numBits);
+	}
+
+	/**
+	 * Read {@link String} using {@link StandardCharsets#UTF_8}.
+	 * 
+	 * @param reader reader to read
+	 * @param numBits number of bits for encoding the length.
+	 * @return String, or {@code null}, if size was {@code 0}.
+	 */
+	public static String readString(DatagramReader reader, int numBits) {
+		byte[] data = reader.readVarBytes(numBits);
+		if (data != null) {
+			return new String(data, StandardCharsets.UTF_8);
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Write inet socket address.
+	 * 
+	 * @param writer writer to write to.
+	 * @param address inet socket address.
+	 */
+	public static void write(DatagramWriter writer, InetSocketAddress address) {
+		writer.writeByte((byte) ADDRESS_VERSION);
+		if (address == null) {
+			writer.writeByte((byte) ADDRESS_NONE);
+		} else {
+			if (address.isUnresolved()) {
+				writer.writeByte((byte) ADDRESS_NAME);
+				write(writer, address.getHostName(), Byte.SIZE);
+			} else {
+				writer.writeByte((byte) ADDRESS_LITERAL);
+				writer.writeVarBytes(address.getAddress().getAddress(), Byte.SIZE);
+			}
+			writer.write(address.getPort(), Short.SIZE);
+		}
+	}
+
+	/**
+	 * Read inet socket address.
+	 * 
+	 * @param reader reader to read
+	 * @return read inet socket address, or {@code null}, if size was {@code 0}.
+	 */
+	public static InetSocketAddress readAddress(DatagramReader reader) {
+		int version = reader.readNextByte() & 0xff;
+		if (version != ADDRESS_VERSION) {
+			throw new IllegalArgumentException("Version " + ADDRESS_VERSION + " is required! Not " + version);
+		}
+		String name = null;
+		InetAddress address = null;
+		int type = reader.readNextByte() & 0xff;
+		switch (type) {
+		case ADDRESS_NAME:
+			name = readString(reader, Byte.SIZE);
+			break;
+		case ADDRESS_LITERAL:
+			byte[] data = reader.readVarBytes(Byte.SIZE);
+			try {
+				address = InetAddress.getByAddress(data);
+			} catch (UnknownHostException e) {
+			}
+			break;
+		default:
+			return null;
+		}
+		int port = reader.read(Short.SIZE);
+		if (name != null) {
+			return new InetSocketAddress(name, port);
+		} else if (address != null) {
+			return new InetSocketAddress(address, port);
+		}
+		return null;
+	}
+
+	public static void write(DatagramWriter writer, Map<String, Object> entries) {
+		writer.writeByte((byte) ATTRIBUTES_VERSION);
+		int position = writer.space(Short.SIZE);
+		for (Map.Entry<String, Object> entry : entries.entrySet()) {
+			write(writer, entry.getKey(), Byte.SIZE);
+			Object value = entry.getValue();
+			if (value instanceof String) {
+				writer.writeByte((byte) ATTRIBUTES_STRING);
+				write(writer, (String) value, Byte.SIZE);
+			} else if (value instanceof Bytes) {
+				writer.writeByte((byte) ATTRIBUTES_BYTES);
+				writer.writeVarBytes((Bytes) value, Byte.SIZE);
+			} else if (value instanceof Integer) {
+				writer.writeByte((byte) ATTRIBUTES_INTEGER);
+				writer.write((Integer) value, Integer.SIZE);
+			} else if (value instanceof Long) {
+				writer.writeByte((byte) ATTRIBUTES_LONG);
+				writer.writeLong((Long) value, Long.SIZE);
+			}
+		}
+		writer.writeSize(position, Short.SIZE);
+	}
+
+	public static Attributes readEndpointContexAttributes(DatagramReader reader) {
+		int version = reader.readNextByte() & 0xff;
+		if (version != ATTRIBUTES_VERSION) {
+			throw new IllegalArgumentException("Version " + ATTRIBUTES_VERSION + " is required! Not " + version);
+		}
+		int length = reader.read(Short.SIZE);
+		DatagramReader rangeReader = reader.createRangeReader(length);
+		Attributes attributes = new Attributes();
+		while (rangeReader.bytesAvailable()) {
+			String key = readString(rangeReader, Byte.SIZE);
+			try {
+				int type = rangeReader.readNextByte() & 0xff;
+				switch (type) {
+				case ATTRIBUTES_STRING:
+					String stringValue = readString(rangeReader, Byte.SIZE);
+					attributes.add(key, stringValue);
+					break;
+				case ATTRIBUTES_BYTES:
+					byte[] data = rangeReader.readVarBytes(Byte.SIZE);
+					attributes.add(key, new Bytes(data));
+					break;
+				case ATTRIBUTES_INTEGER:
+					int intValue = rangeReader.read(Integer.SIZE);
+					attributes.add(key, intValue);
+					break;
+				case ATTRIBUTES_LONG:
+					long longValue = rangeReader.readLong(Long.SIZE);
+					attributes.add(key, longValue);
+					break;
+				}
+			} catch (IllegalArgumentException ex) {
+				LOGGER.warn("Read attribute {}:", key, ex);
+			}
+		}
+		return attributes;
+	}
+
+}

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/DatagramWriterTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/DatagramWriterTest.java
@@ -161,6 +161,24 @@ public class DatagramWriterTest {
 	}
 
 	@Test
+	public void testWriteVarByteArray() {
+		byte[] data = bin("ab12def671223344556677890a");
+		writer.writeVarBytes(data, Byte.SIZE);
+		byte[] wdata = writer.toByteArray();
+		String expected = String.format("%02X%s", data.length, hex(data));
+		assertEquals(expected, hex(wdata));
+	}
+
+	@Test
+	public void testWriteVarBytes() {
+		byte[] data = bin("ab12def671223344556677890a0011");
+		writer.writeVarBytes(new Bytes(data), Short.SIZE);
+		byte[] wdata = writer.toByteArray();
+		String expected = String.format("%04X%s", data.length, hex(data));
+		assertEquals(expected, hex(wdata));
+	}
+
+	@Test
 	public void testWritePosition() {
 		byte[] data = bin("ab12def671223344556677890a");
 		writer.writeBytes(data);

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/SerializationUtilTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/SerializationUtilTest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+
+import org.eclipse.californium.elements.MapBasedEndpointContext;
+import org.eclipse.californium.elements.MapBasedEndpointContext.Attributes;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SerializationUtilTest {
+
+	DatagramWriter writer;
+	DatagramReader reader;
+
+	@Before
+	public void setUp() throws Exception {
+		writer = new DatagramWriter();
+	}
+
+	@Test
+	public void testStrings() {
+		String write = "Hallo!";
+		SerializationUtil.write(writer, write, Byte.SIZE);
+		swap();
+		String read = SerializationUtil.readString(reader, Byte.SIZE);
+		assertEquals(write, read);
+	}
+
+	@Test
+	public void testAddressIpv4() {
+		InetSocketAddress write = new InetSocketAddress("192.168.1.5", 5683);
+		SerializationUtil.write(writer, write);
+		swap();
+		InetSocketAddress read = SerializationUtil.readAddress(reader);
+		assertEquals(write, read);
+	}
+
+	@Test
+	public void testAddressUnresolved() {
+		InetSocketAddress write = new InetSocketAddress("non-existing.host", 11111);
+		SerializationUtil.write(writer, write);
+		swap();
+		InetSocketAddress read = SerializationUtil.readAddress(reader);
+		assertEquals(write, read);
+	}
+
+	@Test
+	public void testAddressIpv6() {
+		InetSocketAddress write = new InetSocketAddress("[2001::1]", 5684);
+		SerializationUtil.write(writer, write);
+		swap();
+		InetSocketAddress read = SerializationUtil.readAddress(reader);
+		assertEquals(write, read);
+	}
+
+	@Test
+	public void testEndpointContextAttributes() {
+		Attributes writeAttributes = new Attributes();
+		writeAttributes.add("K1", "String");
+		writeAttributes.add("K2", 10);
+		writeAttributes.add("K3", 1000L);
+		writeAttributes.add("K4", new Bytes("bytes".getBytes()));
+		InetSocketAddress dummy = new InetSocketAddress(0);
+		MapBasedEndpointContext context = new MapBasedEndpointContext(dummy, null, writeAttributes);
+		Map<String, Object> write = context.entries();
+		SerializationUtil.write(writer, write);
+		swap();
+		Attributes readAttributes = SerializationUtil.readEndpointContexAttributes(reader);
+		context = new MapBasedEndpointContext(dummy, null, readAttributes);
+		Map<String, Object> read = context.entries();
+		assertEquals(write, read);
+		assertEquals(writeAttributes, readAttributes);
+	}
+
+	private void swap() {
+		reader = new DatagramReader(writer.toByteArray());
+	}
+
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/auth/PrincipalSerializer.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/auth/PrincipalSerializer.java
@@ -29,7 +29,7 @@ import org.eclipse.californium.elements.auth.X509CertPath;
 import org.eclipse.californium.elements.util.Asn1DerDecoder;
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
-import org.eclipse.californium.scandium.util.SerializationUtil;
+import org.eclipse.californium.elements.util.SerializationUtil;
 
 /**
  * A helper for serializing and deserializing principals supported by Scandium.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
@@ -51,10 +51,10 @@ import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.elements.util.SerialExecutor;
 import org.eclipse.californium.elements.util.SerialExecutor.ExecutionListener;
+import org.eclipse.californium.elements.util.SerializationUtil;
 import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.elements.util.WipAPI;
 import org.eclipse.californium.scandium.ConnectionListener;
-import org.eclipse.californium.scandium.util.SerializationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -60,6 +60,7 @@ import org.eclipse.californium.elements.MapBasedEndpointContext;
 import org.eclipse.californium.elements.util.Bytes;
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.SerializationUtil;
 import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.elements.util.WipAPI;
 import org.eclipse.californium.scandium.auth.PrincipalSerializer;
@@ -67,7 +68,7 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
 import org.eclipse.californium.scandium.util.SecretIvParameterSpec;
 import org.eclipse.californium.scandium.util.SecretUtil;
-import org.eclipse.californium.scandium.util.SerializationUtil;
+import org.eclipse.californium.scandium.util.SecretSerializationUtil;
 import org.eclipse.californium.scandium.util.ServerName;
 import org.eclipse.californium.scandium.util.ServerNames;
 import org.eclipse.californium.scandium.util.ServerName.NameType;
@@ -1289,7 +1290,7 @@ public final class DTLSSession implements Destroyable {
 			getWriteState().write(writer);
 		}
 		writer.writeVarBytes(writeConnectionId, Byte.SIZE);
-		SerializationUtil.write(writer, masterSecret);
+		SecretSerializationUtil.write(writer, masterSecret);
 		if (peerIdentity == null) {
 			writer.write(0, Byte.SIZE);
 		} else {
@@ -1379,7 +1380,7 @@ public final class DTLSSession implements Destroyable {
 		if (data != null) {
 			writeConnectionId = new ConnectionId(data);
 		}
-		masterSecret = SerializationUtil.readSecretKey(reader);
+		masterSecret = SecretSerializationUtil.readSecretKey(reader);
 		if (reader.readNextByte() == 1) {
 			try {
 				peerIdentity = PrincipalSerializer.deserialize(reader);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DtlsAeadConnectionState.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DtlsAeadConnectionState.java
@@ -29,7 +29,7 @@ import org.eclipse.californium.scandium.dtls.cipher.AeadBlockCipher;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.util.SecretIvParameterSpec;
 import org.eclipse.californium.scandium.util.SecretUtil;
-import org.eclipse.californium.scandium.util.SerializationUtil;
+import org.eclipse.californium.scandium.util.SecretSerializationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -192,8 +192,8 @@ public class DtlsAeadConnectionState extends DTLSConnectionState {
 
 	@Override
 	public void write(DatagramWriter writer) {
-		SerializationUtil.write(writer, encryptionKey);
-		SerializationUtil.write(writer, iv);
+		SecretSerializationUtil.write(writer, encryptionKey);
+		SecretSerializationUtil.write(writer, iv);
 	}
 
 	/**
@@ -207,7 +207,7 @@ public class DtlsAeadConnectionState extends DTLSConnectionState {
 	 */
 	DtlsAeadConnectionState(CipherSuite cipherSuite, CompressionMethod compressionMethod, DatagramReader reader) {
 		super(cipherSuite, compressionMethod);
-		encryptionKey = SerializationUtil.readSecretKey(reader);
-		iv = SerializationUtil.readIv(reader);
+		encryptionKey = SecretSerializationUtil.readSecretKey(reader);
+		iv = SecretSerializationUtil.readIv(reader);
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DtlsBlockConnectionState.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DtlsBlockConnectionState.java
@@ -26,7 +26,7 @@ import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.scandium.dtls.cipher.CbcBlockCipher;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.util.SecretUtil;
-import org.eclipse.californium.scandium.util.SerializationUtil;
+import org.eclipse.californium.scandium.util.SecretSerializationUtil;
 
 /**
  * DTLS connection state for block cipher.
@@ -125,8 +125,8 @@ public class DtlsBlockConnectionState extends DTLSConnectionState {
 
 	@Override
 	public void write(DatagramWriter writer) {
-		SerializationUtil.write(writer, macKey);
-		SerializationUtil.write(writer, encryptionKey);
+		SecretSerializationUtil.write(writer, macKey);
+		SecretSerializationUtil.write(writer, encryptionKey);
 	}
 
 	/**
@@ -140,8 +140,8 @@ public class DtlsBlockConnectionState extends DTLSConnectionState {
 	 */
 	DtlsBlockConnectionState(CipherSuite cipherSuite, CompressionMethod compressionMethod, DatagramReader reader) {
 		super(cipherSuite, compressionMethod);
-		macKey = SerializationUtil.readSecretKey(reader);
-		encryptionKey = SerializationUtil.readSecretKey(reader);
+		macKey = SecretSerializationUtil.readSecretKey(reader);
+		encryptionKey = SecretSerializationUtil.readSecretKey(reader);
 	}
 
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SessionTicket.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SessionTicket.java
@@ -35,7 +35,7 @@ import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.scandium.auth.PrincipalSerializer;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.util.SecretUtil;
-import org.eclipse.californium.scandium.util.SerializationUtil;
+import org.eclipse.californium.scandium.util.SecretSerializationUtil;
 import org.eclipse.californium.scandium.util.ServerNames;
 
 /**
@@ -142,7 +142,7 @@ public final class SessionTicket implements Destroyable {
 		writer.write(compressionMethod.getCode(), CompressionMethod.COMPRESSION_METHOD_BITS);
 
 		// master_secret
-		SerializationUtil.write(writer, masterSecret);
+		SecretSerializationUtil.write(writer, masterSecret);
 
 		// client_identity
 		PrincipalSerializer.serialize(clientIdentity, writer);
@@ -194,7 +194,7 @@ public final class SessionTicket implements Destroyable {
 		}
 
 		// master_secret
-		SecretKey masterSecret = SerializationUtil.readSecretKey(source);
+		SecretKey masterSecret = SecretSerializationUtil.readSecretKey(source);
 
 		// client_identity
 		Principal identity = null;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/util/SecretSerializationUtil.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/util/SecretSerializationUtil.java
@@ -15,16 +15,12 @@
  ******************************************************************************/
 package org.eclipse.californium.scandium.util;
 
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
-
 import javax.crypto.SecretKey;
 
 import org.eclipse.californium.elements.util.Bytes;
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
-import org.eclipse.californium.elements.util.StandardCharsets;
+import org.eclipse.californium.elements.util.SerializationUtil;
 
 /**
  * Utility to use serialize and deserialize standard type using
@@ -32,68 +28,7 @@ import org.eclipse.californium.elements.util.StandardCharsets;
  * 
  * @since 3.0
  */
-public class SerializationUtil {
-
-	/**
-	 * Write {@link String} using {@link StandardCharsets#UTF_8}.
-	 * 
-	 * @param writer writer to write to.
-	 * @param value value to write.
-	 * @param numBits number of bits for encoding the length.
-	 */
-	public static void write(DatagramWriter writer, String value, int numBits) {
-		writer.writeVarBytes(value == null ? null : value.getBytes(StandardCharsets.UTF_8), numBits);
-	}
-
-	/**
-	 * Read {@link String} using {@link StandardCharsets#UTF_8}.
-	 * 
-	 * @param reader reader to read
-	 * @param numBits number of bits for encoding the length.
-	 * @return String, or {@code null}, if size was {@code 0}.
-	 */
-	public static String readString(DatagramReader reader, int numBits) {
-		byte[] data = reader.readVarBytes(numBits);
-		if (data != null) {
-			return new String(data, StandardCharsets.UTF_8);
-		} else {
-			return null;
-		}
-	}
-
-	/**
-	 * Write inet socket address.
-	 * 
-	 * @param writer writer to write to.
-	 * @param address inet socket address.
-	 */
-	public static void write(DatagramWriter writer, InetSocketAddress address) {
-		if (address == null) {
-			writer.write(0, Byte.SIZE);
-		} else {
-			writer.writeVarBytes(address.getAddress().getAddress(), Byte.SIZE);
-			writer.write(address.getPort(), Short.SIZE);
-		}
-	}
-
-	/**
-	 * Read inet socket address.
-	 * 
-	 * @param reader reader to read
-	 * @return read inet socket address, or {@code null}, if size was {@code 0}.
-	 */
-	public static InetSocketAddress readAddress(DatagramReader reader) {
-		byte[] data = reader.readVarBytes(Byte.SIZE);
-		if (data != null) {
-			int port = reader.read(Short.SIZE);
-			try {
-				InetAddress address = InetAddress.getByAddress(data);
-				return new InetSocketAddress(address, port);
-			} catch (UnknownHostException e) {
-			}
-		}
-		return null;
-	}
+public class SecretSerializationUtil {
 
 	/**
 	 * Write secret key.
@@ -108,7 +43,7 @@ public class SerializationUtil {
 			byte[] encoded = key.getEncoded();
 			writer.writeVarBytes(encoded, Byte.SIZE);
 			Bytes.clear(encoded);
-			write(writer, key.getAlgorithm(), Byte.SIZE);
+			SerializationUtil.write(writer, key.getAlgorithm(), Byte.SIZE);
 		}
 	}
 
@@ -121,7 +56,7 @@ public class SerializationUtil {
 	public static SecretKey readSecretKey(DatagramReader reader) {
 		byte[] data = reader.readVarBytes(Byte.SIZE);
 		if (data != null) {
-			String algo = readString(reader, Byte.SIZE);
+			String algo = SerializationUtil.readString(reader, Byte.SIZE);
 			SecretKey key = SecretUtil.create(data, algo.intern());
 			Bytes.clear(data);
 			return key;


### PR DESCRIPTION
In order to simplify serialization, adapt the Attributes to support only
Integer and Long, not all types of Numbers.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>