### PR TITLE
Use exception for exhausted MID provider/tracker.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/GroupedMessageIdTracker.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/GroupedMessageIdTracker.java
@@ -23,7 +23,6 @@ package org.eclipse.californium.core.network;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.elements.util.ClockUtil;
 
@@ -117,12 +116,7 @@ public class GroupedMessageIdTracker implements MessageIdTracker {
 		Arrays.fill(midLease, ClockUtil.nanoRealtime() - 1000);
 	}
 
-	/**
-	 * Gets the next usable message ID.
-	 * 
-	 * @return a message ID or {@code -1} if all message IDs are in use
-	 *         currently.
-	 */
+	@Override
 	public int getNextMessageId() {
 		final long now = ClockUtil.nanoRealtime();
 		synchronized (this) {
@@ -136,7 +130,7 @@ public class GroupedMessageIdTracker implements MessageIdTracker {
 				return mid + min;
 			}
 		}
-		return Message.NONE;
+		throw new IllegalStateException("No MID available, all [" + min + "-" + (min + range) + ") MID-groups in use!");
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStore.java
@@ -221,11 +221,11 @@ public class InMemoryMessageExchangeStore implements MessageExchangeStore {
 		int mid = message.getMID();
 		if (Message.NONE == mid) {
 			InetSocketAddress dest = message.getDestinationContext().getPeerAddress();
-			mid = messageIdProvider.getNextMessageId(dest);
-			if (Message.NONE == mid) {
-				LOGGER.warn("{}cannot send message to {}, all MIDs are in use", tag, dest);
-			} else {
+			try {
+				mid = messageIdProvider.getNextMessageId(dest);
 				message.setMID(mid);
+			} catch(IllegalStateException ex) {
+				LOGGER.warn("{}cannot send message to {}, {}", tag, dest, ex.getMessage());
 			}
 		}
 		return mid;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageIdProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/InMemoryMessageIdProvider.java
@@ -26,7 +26,6 @@ package org.eclipse.californium.core.network;
 import java.net.InetSocketAddress;
 import java.util.Random;
 
-import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.elements.util.ClockUtil;
 import org.eclipse.californium.elements.util.LeastRecentlyUsedCache;
@@ -136,8 +135,7 @@ public class InMemoryMessageIdProvider implements MessageIdProvider {
 		MessageIdTracker tracker = getTracker(destination);
 		if (tracker == null) {
 			// we have reached the maximum number of active peers
-			// TODO: throw an exception?
-			return Message.NONE;
+			throw new IllegalStateException("No MID available, max. peers " + trackers.size() + " exhausted!");
 		} else {
 			return tracker.getNextMessageId();
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessageIdProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessageIdProvider.java
@@ -25,14 +25,17 @@ public interface MessageIdProvider {
 	/**
 	 * Gets a message ID for a destination endpoint.
 	 * <p>
-	 * Message IDs are guaranteed to not being issued twice within EXCHANGE_LIFETIME
-	 * as defined by the <a href="https://tools.ietf.org/html/rfc7252#section-4.4">CoAP spec</a>.
+	 * Message IDs are guaranteed to not being issued twice within
+	 * EXCHANGE_LIFETIME as defined by the
+	 * <a href="https://tools.ietf.org/html/rfc7252#section-4.4">CoAP spec</a>.
 	 * 
-	 * @param destination the destination that the message ID must be <em>free to use</em> for.
-	 *        This means that the message ID returned must not have been used in a message
-	 *        to this destination for at least EXCHANGE_LIFETIME.
-	 * @return a message ID or {@code -1} if there is no message ID available for the given destination
-	 *         at the moment.
+	 * @param destination the destination that the message ID must be <em>free
+	 *            to use</em> for. This means that the message ID returned must
+	 *            not have been used in a message to this destination for at
+	 *            least EXCHANGE_LIFETIME.
+	 * @return a message ID.
+	 * @throws IllegalStateException if no message ID is available for the given
+	 *             destination at the moment.
 	 */
 	int getNextMessageId(InetSocketAddress destination);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessageIdTracker.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessageIdTracker.java
@@ -29,8 +29,8 @@ public interface MessageIdTracker {
 	/**
 	 * Gets the next usable message ID.
 	 * 
-	 * @return a message ID or {@code -1} if all message IDs are in use
-	 *         currently.
+	 * @return a message ID.
+	 * @throws IllegalStateException if all message IDs are currently in use.
 	 */
 	int getNextMessageId();
 }

--- a/californium-core/src/test/java/org/eclipse/californium/TestTools.java
+++ b/californium-core/src/test/java/org/eclipse/californium/TestTools.java
@@ -17,16 +17,26 @@
  ******************************************************************************/
 package org.eclipse.californium;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.MessageObserver;
 import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.MessageIdTracker;
+import org.eclipse.californium.elements.util.TestCondition;
+import org.eclipse.californium.elements.util.TestConditionTools;
+import org.hamcrest.Matcher;
 
 /**
  * A collection of utility methods for implementing tests.
@@ -160,4 +170,25 @@ public final class TestTools {
 			}
 		}
 	}
+
+	public static int waitForNextMID(final MessageIdTracker tracker, final Matcher<Integer> midMatcher, long timeout, long interval, TimeUnit unit) throws InterruptedException {
+		final AtomicInteger mid = new AtomicInteger(-1);
+		TestConditionTools.waitForCondition(timeout, interval, unit, new TestCondition() {
+
+			@Override
+			public boolean isFulFilled() throws IllegalStateException {
+				try {
+					int nextMid = tracker.getNextMessageId();
+					assertThat(nextMid, is(midMatcher));
+					mid.set(nextMid);
+					return true;
+				} catch (IllegalStateException ex) {
+					assertThat(ex.getMessage(), containsString("No MID available, all"));
+					return false;
+				}
+			}
+		});
+		return mid.get();
+	}
+
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/GroupedMessageIdTrackerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/GroupedMessageIdTrackerTest.java
@@ -18,24 +18,25 @@ package org.eclipse.californium.core.network;
 
 import static org.eclipse.californium.core.network.MessageIdTracker.TOTAL_NO_OF_MIDS;
 import static org.eclipse.californium.elements.util.TestConditionTools.inRange;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.californium.TestTools;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.elements.category.Small;
-import org.eclipse.californium.elements.util.TestCondition;
-import org.eclipse.californium.elements.util.TestConditionTools;
+import org.eclipse.californium.elements.util.ExpectedExceptionWrapper;
 import org.eclipse.californium.rule.CoapNetworkRule;
 import org.eclipse.californium.rule.CoapThreadsRule;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 
 /**
  * Verifies that GroupedMessageIdTracker correctly marks MIDs as <em>in
@@ -53,6 +54,9 @@ public class GroupedMessageIdTrackerTest {
 	@Rule
 	public CoapThreadsRule cleanup = new CoapThreadsRule();
 
+	@Rule
+	public ExpectedException exception = ExpectedExceptionWrapper.none();
+
 	@Test
 	public void testGetNextMessageIdFailsIfAllMidsAreInUse() throws Exception {
 		// GIVEN a tracker whose MIDs are half in use
@@ -63,13 +67,13 @@ public class GroupedMessageIdTrackerTest {
 			assertThat(mid, is(not(-1)));
 		}
 		// THEN using the complete other half should not be possible
+		exception.expect(IllegalStateException.class);
+		exception.expectMessage(containsString("No MID available, all"));
+
 		for (int i = 0; i < TOTAL_NO_OF_MIDS / 2; i++) {
 			int mid = tracker.getNextMessageId();
-			if (0 > mid) {
-				return;
-			}
+			assertThat(mid, is(inRange(0, TOTAL_NO_OF_MIDS)));
 		}
-		fail("mids should run out.");
 	}
 
 	@Test
@@ -85,14 +89,13 @@ public class GroupedMessageIdTrackerTest {
 			assertThat(mid, is(inRange(minMid, maxMid)));
 		}
 		// THEN using the complete other half should not be possible
+		exception.expect(IllegalStateException.class);
+		exception.expectMessage(containsString("No MID available, all"));
+
 		for (int i = 0; i < rangeMid / 2; i++) {
 			int mid = tracker.getNextMessageId();
-			if (0 > mid) {
-				return;
-			}
 			assertThat(mid, is(inRange(minMid, maxMid)));
 		}
-		fail("mids should run out.");
 	}
 
 	@Test
@@ -106,11 +109,14 @@ public class GroupedMessageIdTrackerTest {
 
 		// WHEN retrieving all message IDs from the tracker
 		long start = System.nanoTime();
-		for (int i = 1; i < TOTAL_NO_OF_MIDS; i++) {
-			int nextMid = tracker.getNextMessageId();
-			if (nextMid < 0) {
-				break;
+		try {
+			for (int i = 1; i < TOTAL_NO_OF_MIDS; i++) {
+				int mid = tracker.getNextMessageId();
+				assertThat(mid, is(inRange(0, TOTAL_NO_OF_MIDS)));
 			}
+			fail("mids expected to run out.");
+		} catch (IllegalStateException ex) {
+			assertThat(ex.getMessage(), containsString("No MID available, all"));
 		}
 
 		// THEN the first message ID is re-used after EXCHANGE_LIFETIME has
@@ -121,20 +127,12 @@ public class GroupedMessageIdTrackerTest {
 			timeLeft = 100;
 		}
 
-		final AtomicInteger mid = new AtomicInteger(-1);
-		TestConditionTools.waitForCondition(timeLeft, 100, TimeUnit.MILLISECONDS, new TestCondition() {
-
-			@Override
-			public boolean isFulFilled() throws IllegalStateException {
-				mid.set(tracker.getNextMessageId());
-				return 0 <= mid.get();
-			}
-		});
-		assertThat(mid.get(), is(not(-1)));
+		int mid = TestTools.waitForNextMID(tracker, inRange(0, TOTAL_NO_OF_MIDS), timeLeft, 50 ,TimeUnit.MILLISECONDS);
+		assertThat(mid, is(inRange(0, TOTAL_NO_OF_MIDS)));
 
 		for (int i = 1; i < groupSize; i++) {
 			int nextMid = tracker.getNextMessageId();
-			assertThat(nextMid, is(not(-1)));
+			assertThat(nextMid, is(inRange(0, TOTAL_NO_OF_MIDS)));
 		}
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
@@ -125,14 +125,12 @@ public class InMemoryMessageExchangeStoreTest {
 	public void testShouldNotCreateInMemoryMessageExchangeStoreWithoutTokenProvider() {
 		// WHEN trying to create new InMemoryMessageExchangeStore without TokenProvider
 		store = new InMemoryMessageExchangeStore(config, null, null);
-		fail("should have thrown NullPointerException");
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void testShouldNotCreateInMemoryMessageExchangeStoreWithoutResolver() {
 		// WHEN trying to create new InMemoryMessageExchangeStore without TokenProvider
 		store = new InMemoryMessageExchangeStore(config, new RandomTokenGenerator(config), null);
-		fail("should have thrown NullPointerException");
 	}
 
 	public void testRegisterOutboundRequestAcceptsRetransmittedRequest() {

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageIdProviderMulticastTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageIdProviderMulticastTest.java
@@ -19,11 +19,9 @@ import static org.eclipse.californium.elements.util.TestConditionTools.inRange;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import java.net.InetSocketAddress;
 
-import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.elements.category.Small;
 import org.eclipse.californium.rule.CoapNetworkRule;
@@ -48,15 +46,15 @@ public class InMemoryMessageIdProviderMulticastTest {
 	private static final int PORT = 5683;
 
 	/**
-	 * this test verifies the miss configured network config file and returns no
-	 * Message Id
+	 * this test verifies the miss configured network config file and throws a 
+	 * IllegalArgumentException.
 	 */
-	@Test
+	@Test(expected = IllegalStateException.class)
 	public void testMulticastWithMissConfiguredNetworkConfig() {
 		NetworkConfig config = network.createStandardTestConfig();
 		config.setInt(NetworkConfig.Keys.MULTICAST_BASE_MID, 0);
 		InMemoryMessageIdProvider midProvider = new InMemoryMessageIdProvider(config);
-		assertEquals(midProvider.getNextMessageId(new InetSocketAddress(GROUP, PORT)), Message.NONE);
+		midProvider.getNextMessageId(new InetSocketAddress(GROUP, PORT));
 	}
 
 	@Test

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageIdProviderTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageIdProviderTest.java
@@ -18,6 +18,8 @@
 package org.eclipse.californium.core.network;
 
 import static org.eclipse.californium.core.network.MessageIdTracker.TOTAL_NO_OF_MIDS;
+import static org.eclipse.californium.elements.util.TestConditionTools.inRange;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,17 +27,21 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.elements.category.Small;
+import org.eclipse.californium.elements.rule.TestTimeRule;
+import org.eclipse.californium.elements.util.ExpectedExceptionWrapper;
 import org.eclipse.californium.rule.CoapNetworkRule;
 import org.eclipse.californium.rule.CoapThreadsRule;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 
 /**
  * Verifies behavior of {@code InMemoryMessageIdProvider}.
@@ -48,6 +54,12 @@ public class InMemoryMessageIdProviderTest {
 
 	@Rule
 	public CoapThreadsRule cleanup = new CoapThreadsRule();
+
+	@Rule
+	public ExpectedException exception = ExpectedExceptionWrapper.none();
+
+	@Rule
+	public TestTimeRule time = new TestTimeRule();
 
 	private NetworkConfig config = network.createStandardTestConfig();
 
@@ -63,7 +75,7 @@ public class InMemoryMessageIdProviderTest {
 		assertThat(mid1, is(not(mid2)));
 		for (int index = 0; index < TOTAL_NO_OF_MIDS * 2; ++index) {
 			int mid = provider.getNextMessageId(peerAddress);
-			assertThat(mid, is(not(Message.NONE)));
+			assertThat(mid, is(inRange(0, TOTAL_NO_OF_MIDS)));
 		}
 	}
 
@@ -88,14 +100,14 @@ public class InMemoryMessageIdProviderTest {
 		assertThat(mid1, is(not(Message.NONE)));
 		assertThat(mid2, is(not(Message.NONE)));
 		assertThat(mid1, is(not(mid2)));
-		int mid = provider.getNextMessageId(peerAddress);
+
+		exception.expect(IllegalStateException.class);
+		exception.expectMessage(containsString("No MID available, all"));
+
+		provider.getNextMessageId(peerAddress);
 		for (int index = 0; index < TOTAL_NO_OF_MIDS * 2; ++index) {
-			mid = provider.getNextMessageId(peerAddress);
-			if (Message.NONE == mid) {
-				break;
-			}
+			provider.getNextMessageId(peerAddress);
 		}
-		assertThat(mid, is(Message.NONE));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -125,10 +137,10 @@ public class InMemoryMessageIdProviderTest {
 		InMemoryMessageIdProvider provider = new InMemoryMessageIdProvider(config);
 		addPeers(provider, MAX_PEERS);
 
-		assertThat(
-				"Should not have been able to add more peers",
-				provider.getNextMessageId(getPeerAddress(MAX_PEERS + 1)),
-				is(-1));
+		exception.expect(IllegalStateException.class);
+		exception.expectMessage(containsString("No MID available, max."));
+
+		provider.getNextMessageId(getPeerAddress(MAX_PEERS + 1));
 	}
 
 	@Test
@@ -141,7 +153,7 @@ public class InMemoryMessageIdProviderTest {
 		InMemoryMessageIdProvider provider = new InMemoryMessageIdProvider(config);
 		addPeers(provider, MAX_PEERS);
 
-		Thread.sleep(MAX_PEER_INACTIVITY_PERIOD * 1200);
+		time.addTestTimeShift(MAX_PEER_INACTIVITY_PERIOD * 1200, TimeUnit.MILLISECONDS);
 
 		assertThat(provider.getNextMessageId(getPeerAddress(MAX_PEERS + 1)), is(not(-1)));
 	}


### PR DESCRIPTION
Reports, that either peers or MIDs are exhausted.
Adjust unit tests.
See issue #1487

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>