### PR TITLE
Reduce and reorder sync section in blockwise layer.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -547,18 +547,22 @@ public class BlockwiseLayer extends AbstractLayer {
 			final KeyUri key, final Block2BlockwiseStatus status) {
 
 		Response block;
+		boolean complete;
 		synchronized (status) {
 
 			BlockOption block2 = request.getOptions().getBlock2();
 			block = status.getNextResponseBlock(block2);
-			if (status.isComplete()) {
-				// clean up blockwise status
-				LOGGER.debug("peer has requested last block of blockwise transfer: {}", status);
-				clearBlock2Status(key, status);
-			} else {
+			complete = status.isComplete();
+			if (!complete) {
 				prepareBlock2Cleanup(status, key);
 				LOGGER.debug("peer has requested intermediary block of blockwise transfer: {}", status);
 			}
+		}
+
+		if (complete) {
+			// clean up blockwise status
+			LOGGER.debug("peer has requested last block of blockwise transfer: {}", status);
+			clearBlock2Status(key, status);
 		}
 
 		exchange.setCurrentResponse(block);


### PR DESCRIPTION
Move clearBlock2Status out of the synchronized section of the
BlockwiseStatus.
ClearBlock2Status synchronizes on block2Transfers and must be called
within a synchronized section of a BlockwiseStatus.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>