### PR TITLE
Add BERT support to block-option.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/EmptyMessage.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/EmptyMessage.java
@@ -87,6 +87,13 @@ public class EmptyMessage extends Message {
 		return false;
 	}
 
+	@Override
+	public void assertPayloadMatchsBlocksize() {
+		if (getPayloadSize() > 0) {
+			throw new IllegalStateException("Empty message contains " + getPayloadSize() + " bytes payload!");
+		}
+	}
+
 	/**
 	 * Create a new acknowledgment for the specified message.
 	 *

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Message.java
@@ -710,6 +710,15 @@ public abstract class Message {
 	}
 
 	/**
+	 * Check, if the payload size matches the {@link BlockOption#getSize()}.
+	 * 
+	 * @throw {@link IllegalStateException} if the {@link BlockOption} is
+	 *        provided but the payload exceeds that.
+	 * @since 3.0
+	 */
+	public abstract void assertPayloadMatchsBlocksize();
+
+	/**
 	 * Get destination endpoint context.
 	 * 
 	 * May be {@code null} for {@link Request} during it's construction.

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -321,6 +321,14 @@ public class Request extends Message {
 		return this;
 	}
 
+	@Override
+	public void assertPayloadMatchsBlocksize() {
+		BlockOption block1 = getOptions().getBlock1();
+		if (block1 != null) {
+			block1.assertPayloadSize(getPayloadSize());
+		}
+	}
+
 	/**
 	 * Sets this request's proxy URI.
 	 * <p>

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Response.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Response.java
@@ -108,6 +108,14 @@ public class Response extends Message {
 	}
 
 	@Override
+	public void assertPayloadMatchsBlocksize() {
+		BlockOption block2 = getOptions().getBlock2();
+		if (block2 != null) {
+			block2.assertPayloadSize(getPayloadSize());
+		}
+	}
+
+	@Override
 	public String toString() {
 		return toTracingString(code.toString());
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataSerializer.java
@@ -60,6 +60,8 @@ public abstract class DataSerializer {
 		if (message == null) {
 			throw new NullPointerException("message must not be null!");
 		}
+		assertValidOptions(message.getOptions());
+		message.assertPayloadMatchsBlocksize();
 		if (message.getRawCode() == 0) {
 			// simple serialization for empty message.
 			// https://tools.ietf.org/html/rfc7252#section-4.1
@@ -235,6 +237,18 @@ public abstract class DataSerializer {
 	}
 
 	/**
+	 * Assert, if options are supported for the specific protocol flavor.
+	 * 
+	 * @param options option set to validate.
+	 * @throws IllegalArgumentException if at least one option is not valid for
+	 *             the specific flavor.
+	 * @since 3.0
+	 */
+	protected void assertValidOptions(OptionSet options) {
+		// empty default implementation
+	}
+
+	/**
 	 * Serializes a message's <em>header</em> values to the wire format.
 	 * 
 	 * @param writer The writer to serialize the values to.
@@ -260,7 +274,7 @@ public abstract class DataSerializer {
 		if (optionSet == null) {
 			throw new NullPointerException("option-set must not be null!");
 		}
-		
+
 		int lastOptionNumber = 0;
 		for (Option option : optionSet.asSortedList()) {
 			byte[] value = option.getValue();

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/UdpDataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/UdpDataParser.java
@@ -25,10 +25,13 @@ package org.eclipse.californium.core.network.serialization;
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.CoAPMessageFormatException;
 import org.eclipse.californium.core.coap.MessageFormatException;
+import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.elements.util.DatagramReader;
 
 import static org.eclipse.californium.core.coap.CoAP.MessageFormat.*;
+
+import org.eclipse.californium.core.coap.BlockOption;
 
 /**
  * A parser for messages encoded following the standard CoAP encoding.
@@ -61,9 +64,32 @@ public final class UdpDataParser extends DataParser {
 		return new MessageHeader(version, CoAP.Type.valueOf(type), token, code, mid, 0);
 	}
 
+	@Override
+	protected void assertValidOptions(OptionSet options) {
+		assertValidUdpOptions(options);
+	}
+
 	private void assertCorrectVersion(int version) {
 		if (version != CoAP.VERSION) {
 			throw new MessageFormatException("UDP Message has invalid version: " + version);
+		}
+	}
+
+	/**
+	 * Assert, if options are supported for the UDP protocol flavor.
+	 * 
+	 * @param options option set to validate.
+	 * @throws IllegalArgumentException if one block option uses BERT.
+	 * @since 3.0
+	 */
+	public static void assertValidUdpOptions(OptionSet options) {
+		BlockOption block = options.getBlock1();
+		if (block != null && block.isBERT()) {
+			throw new IllegalArgumentException("Block1 BERT used for UDP!");
+		}
+		block = options.getBlock2();
+		if (block != null && block.isBERT()) {
+			throw new IllegalArgumentException("Block2 BERT used for UDP!");
 		}
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/UdpDataSerializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/UdpDataSerializer.java
@@ -26,6 +26,7 @@ import static org.eclipse.californium.core.coap.CoAP.MessageFormat.*;
 
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.Message;
+import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.elements.util.DatagramWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,5 +69,10 @@ public final class UdpDataSerializer extends DataSerializer {
 		writer.write(header.getCode(), CODE_BITS);
 		writer.write(header.getMID(), MESSAGE_ID_BITS);
 		writer.writeBytes(header.getToken().getBytes());
+	}
+
+	@Override
+	protected void assertValidOptions(OptionSet options) {
+		UdpDataParser.assertValidUdpOptions(options);
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -1030,7 +1030,7 @@ public class ObserveClientSideTest {
 	public void testCancelledWhileBlock2Notification() throws Exception {
 
 		System.out.println("cancelled block2 transfer:");
-		respPayload = generateRandomPayload(300);
+		respPayload = generateRandomPayload(45);
 		String path = "test";
 
 		// Established new observe relation with block2

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestDecryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestDecryptor.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Request;
-import org.eclipse.californium.core.network.serialization.DataParser;
+import org.eclipse.californium.core.network.serialization.UdpDataParser;
 import org.eclipse.californium.cose.Encrypt0Message;
 import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.CoAP.Code;
@@ -121,7 +121,7 @@ public class RequestDecryptor extends Decryptor {
 			ctx.setCoAPCode(Code.valueOf(reader.read(CoAP.MessageFormat.CODE_BITS)));
 			// resets option so eOptions gets priority during parse
 			request.setOptions(EMPTY);
-			DataParser.parseOptionsAndPayload(reader, request);
+			new UdpDataParser().parseOptionsAndPayload(reader, request);
 		} catch (Exception e) {
 			LOGGER.error(ErrorDescriptions.DECRYPTION_FAILED);
 			throw new CoapOSException(ErrorDescriptions.DECRYPTION_FAILED, ResponseCode.BAD_REQUEST);

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseDecryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseDecryptor.java
@@ -29,7 +29,7 @@ import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.Token;
-import org.eclipse.californium.core.network.serialization.DataParser;
+import org.eclipse.californium.core.network.serialization.UdpDataParser;
 import org.eclipse.californium.cose.Encrypt0Message;
 import org.eclipse.californium.elements.util.DatagramReader;
 
@@ -107,7 +107,7 @@ public class ResponseDecryptor extends Decryptor {
 			
 			// resets option so eOptions gets priority during parse
 			response.setOptions(EMPTY);
-			DataParser.parseOptionsAndPayload(reader, response);
+			new UdpDataParser().parseOptionsAndPayload(reader, response);
 		} catch (Exception e) {
 			LOGGER.error(ErrorDescriptions.DECRYPTION_FAILED);
 			throw new OSException(ErrorDescriptions.DECRYPTION_FAILED);


### PR DESCRIPTION
Verifies block options and payload size on message serialization and
parsing.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>