### PR TITLE
Replace random-access blockwise status by exchange detection.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Block2BlockwiseStatus.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.OptionSet;
-import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.observe.NotificationOrder;
@@ -115,29 +114,6 @@ public final class Block2BlockwiseStatus extends BlockwiseStatus {
 			// keep track of ETag included in response
 			status.etag = block.getOptions().getETags().get(0);
 		}
-		return status;
-	}
-
-	/**
-	 * Creates a new tracker for retrieving an arbitrary block of a resource.
-	 * 
-	 * @param exchange The message exchange the transfer is part of.
-	 * @param request The request for retrieving the block.
-	 * @return The tracker.
-	 * @throws IllegalArgumentException if the request does not contain a block2 option.
-	 */
-	public static Block2BlockwiseStatus forRandomAccessRequest(final Exchange exchange, final Request request) {
-
-		BlockOption block2 = request.getOptions().getBlock2();
-		if (block2 == null) {
-			throw new IllegalArgumentException("request must contain block2 option");
-		}
-		int contentFormat = request.getOptions().getContentFormat();
-		Block2BlockwiseStatus status = new Block2BlockwiseStatus(0, contentFormat);
-		status.randomAccess = true;
-		status.exchange = exchange;
-		status.setCurrentNum(block2.getNum());
-		status.setCurrentSzx(block2.getSzx());
 		return status;
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseStatus.java
@@ -50,7 +50,6 @@ public abstract class BlockwiseStatus {
 
 	private final int contentFormat;
 
-	protected boolean randomAccess;
 	protected final ByteBuffer buf;
 	protected Exchange exchange;
 	protected EndpointContext followUpEndpointContext;
@@ -277,17 +276,8 @@ public abstract class BlockwiseStatus {
 
 	@Override
 	public synchronized String toString() {
-		return String.format("[currentNum=%d, currentSzx=%d, bufferSize=%d, complete=%b, random access=%b]",
-				currentNum, currentSzx, getBufferSize(), complete, randomAccess);
-	}
-
-	/**
-	 * Checks whether this status object is used for tracking random block access only.
-	 * 
-	 * @return {@code true} if this tracker is used for random block access only.
-	 */
-	public final synchronized boolean isRandomAccess() {
-		return randomAccess;
+		return String.format("[currentNum=%d, currentSzx=%d, bufferSize=%d, complete=%b]",
+				currentNum, currentSzx, getBufferSize(), complete);
 	}
 
 	/**


### PR DESCRIPTION
Exchanges with request for random block2 are detected and processed
directly and do not longer require a random-access blockwise status.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>