### PR TITLE
Respond with BAD_REQUEST instead of BAD_OPTION

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAPMessageFormatException.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAPMessageFormatException.java
@@ -15,6 +15,8 @@
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+
 /**
  * Indicates a problem while parsing the binary representation of a CoAP
  * message.
@@ -30,10 +32,13 @@ public class CoAPMessageFormatException extends MessageFormatException {
 	private final int mid;
 	private final int code;
 	private final Token token;
+	private final ResponseCode errorCode;
 	private final boolean confirmable;
 
 	/**
 	 * Creates an exception for a description and message properties.
+	 * 
+	 * Use {@link ResponseCode#BAD_OPTION} as response error code.
 	 * 
 	 * @param description a description of the error cause.
 	 * @param token the Token of the message. Maybe {@code null}, if the message
@@ -44,11 +49,30 @@ public class CoAPMessageFormatException extends MessageFormatException {
 	 * @since 2.3
 	 */
 	public CoAPMessageFormatException(String description, Token token, int mid, int code, boolean confirmable) {
+		this(description, token, mid, code, confirmable, ResponseCode.BAD_OPTION);
+	}
+
+	/**
+	 * Creates an exception for a description, message properties, and error
+	 * response code.
+	 * 
+	 * @param description a description of the error cause.
+	 * @param token the Token of the message. Maybe {@code null}, if the message
+	 *            has no token (ACK or RST).
+	 * @param mid the message ID.
+	 * @param code the message code.
+	 * @param confirmable whether the message has been transferred reliably.
+	 * @param errorCode error response code.
+	 * @since 3.0
+	 */
+	public CoAPMessageFormatException(String description, Token token, int mid, int code, boolean confirmable,
+			ResponseCode errorCode) {
 		super(description);
 		this.token = token;
 		this.mid = mid;
 		this.code = code;
 		this.confirmable = confirmable;
+		this.errorCode = errorCode;
 	}
 
 	/**
@@ -87,6 +111,16 @@ public class CoAPMessageFormatException extends MessageFormatException {
 	 */
 	public final int getCode() {
 		return code;
+	}
+
+	/**
+	 * Get the error code for a response.
+	 * 
+	 * @return the error code
+	 * @since 3.0
+	 */
+	public final ResponseCode getErrorCode() {
+		return errorCode;
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -89,7 +89,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.californium.core.coap.CoAP;
-import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.Message.OffloadMode;
 import org.eclipse.californium.core.coap.CoAPMessageFormatException;
@@ -1068,7 +1067,7 @@ public class CoapEndpoint implements Endpoint {
 		}
 
 		private void responseBadOption(final RawData raw, final CoAPMessageFormatException cause) {
-			Response response = new Response(ResponseCode.BAD_OPTION);
+			Response response = new Response(cause.getErrorCode());
 			response.setDestinationContext(raw.getEndpointContext());
 			response.setToken(cause.getToken());
 			response.setMID(cause.getMid());

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/DataParser.java
@@ -27,6 +27,7 @@
 package org.eclipse.californium.core.network.serialization;
 
 import org.eclipse.californium.core.coap.*;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.util.DatagramReader;
 
@@ -85,6 +86,8 @@ public abstract class DataParser {
 				message.setBytes(msg);
 				return message;
 			}
+		} catch (CoAPMessageFormatException e) {
+			throw e;
 		} catch (MessageFormatException e) {
 			/** use message to add CoAP message specific information */
 			errorMsg = e.getMessage();
@@ -201,7 +204,7 @@ public abstract class DataParser {
 			assertValidOptions(message.getOptions());
 		} catch (IllegalArgumentException ex) {
 			throw new CoAPMessageFormatException(ex.getMessage(), message.getToken(), message.getMID(),
-					message.getRawCode(), message.isConfirmable());
+					message.getRawCode(), message.isConfirmable(), ResponseCode.BAD_REQUEST);
 		}
 		if (nextByte == PAYLOAD_MARKER) {
 			// the presence of a marker followed by a zero-length payload must be processed as a message format error

--- a/californium-core/src/test/java/org/eclipse/californium/core/coap/TestOption.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/coap/TestOption.java
@@ -15,7 +15,18 @@
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
+import static org.eclipse.californium.core.coap.CoAP.MessageFormat.CODE_BITS;
+import static org.eclipse.californium.core.coap.CoAP.MessageFormat.MESSAGE_ID_BITS;
+import static org.eclipse.californium.core.coap.CoAP.MessageFormat.TOKEN_LENGTH_BITS;
+import static org.eclipse.californium.core.coap.CoAP.MessageFormat.TYPE_BITS;
+import static org.eclipse.californium.core.coap.CoAP.MessageFormat.VERSION;
+import static org.eclipse.californium.core.coap.CoAP.MessageFormat.VERSION_BITS;
+
 import java.util.Arrays;
+
+import org.eclipse.californium.core.network.serialization.DataSerializer;
+import org.eclipse.californium.core.network.serialization.MessageHeader;
+import org.eclipse.californium.elements.util.DatagramWriter;
 
 /**
  * A utility to test malicious options.
@@ -37,4 +48,32 @@ public final class TestOption {
 		return new Option(number).setValueUnchecked(value);
 	}
 
+	/**
+	 * Test {@link DataSerializer} to serialize malformed messages for tests.
+	 */
+	public static class TestDataSerializer extends DataSerializer {
+
+		protected void serializeMessage(DatagramWriter writer, Message message) {
+			int mid = message.getMID();
+			if (mid == Message.NONE) {
+				IllegalArgumentException ex = new IllegalArgumentException("MID required for UDP serialization!");
+				throw ex;
+			}
+			MessageHeader header = new MessageHeader(CoAP.VERSION, message.getType(), message.getToken(),
+					message.getRawCode(), mid, -1);
+			serializeHeader(writer, header);
+			writer.writeCurrentByte();
+			serializeOptionsAndPayload(writer, message.getOptions(), message.getPayload());
+		}
+
+		@Override 
+		protected void serializeHeader(final DatagramWriter writer, final MessageHeader header) {
+			writer.write(VERSION, VERSION_BITS);
+			writer.write(header.getType().value, TYPE_BITS);
+			writer.write(header.getToken().length(), TOKEN_LENGTH_BITS);
+			writer.write(header.getCode(), CODE_BITS);
+			writer.write(header.getMID(), MESSAGE_ID_BITS);
+			writer.writeBytes(header.getToken().getBytes());
+		}
+	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MaliciousClientTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MaliciousClientTest.java
@@ -27,12 +27,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.californium.TestTools;
 import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.OptionNumberRegistry;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.TestOption;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
@@ -114,6 +116,21 @@ public class MaliciousClientTest {
 
 		Message reject = waitForMessage(1000);
 		assertThat("malicous NON not ignored", reject, is(nullValue()));
+	}
+
+	@Test
+	public void testBertRequest() throws Exception {
+		BlockOption block = new BlockOption(BlockOption.BERT_SZX, false, 0);
+		Request get = newGet();
+		get.setConfirmable(true);
+		get.getOptions().setBlock2(block);
+		DataSerializer serializer = new TestOption.TestDataSerializer();
+		RawData rawData = serializer.serializeRequest(get);
+		clientConnector.send(rawData);
+
+		Response response = waitForResponse(1000);
+		assertThat("Response missing", response, is(notNullValue()));
+		assertThat("No BAD_REREQUEST response", response.getCode(), is(ResponseCode.BAD_REQUEST));
 	}
 
 	@Test


### PR DESCRIPTION
Respond with BAD_REQUEST instead of BAD_OPTION, if BERT is received for UDP.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>