### PR TITLE
Reduce usage of GeneralSecurityException.

### DIFF
--- a/MIGRATION_HINTS.md
+++ b/MIGRATION_HINTS.md
@@ -19,17 +19,30 @@ If a 2.0.0 or newer is used, it's recommended to update first to 2.6.0 and clean
 
 ## Noteworthy Behavior Changes
 
-### Californium-Core:
-
-`MessageObserver.onAcknowledgement()`:
-
-Since 3.0 this is only called for separate ACKs, not longer for piggy-backed responses.
-
 ### Element-Connector:
 
 `Bytes.equals(Object other)`:
 
 Since 3.0 the sub-class may be ignored, depending on the provided value of the `useClassInEquals` parameter in `Bytes(byte[], int, boolean, boolean)`. The default behavior is changed to ignore the sub-class.
+
+### Scandium:
+
+Redesigned, may cause also unaware changes!
+
+The Alert during the handshakes are adapted (more) towards the definitions in 
+[RFC 5246, Section 7.2, Alert Protocol](https://tools.ietf.org/html/rfc5246#section-7.2).
+
+During the `CLIENT_HELLO` / `SERVER_HELLO` cipher suite and parameter negotiation a
+`HANDSHAKE_FAILURE` is sent, if no common cipher suite or parameter are available.
+If in later messages unsupported parameters are used, a `ILLEGAL_PARAMETER` is sent.
+For unexpected certificate types a `UNSUPPORTED_CERTIFICATE` is sent.
+If certificate verification fails, a `DECRYPT_ERROR` is sent.
+
+### Californium-Core:
+
+`MessageObserver.onAcknowledgement()`:
+
+Since 3.0 this is only called for separate ACKs, not longer for piggy-backed responses.
 
 ## Noteworthy API Changes
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -2327,6 +2327,7 @@ public class DTLSConnector implements Connector, PersistentConnector, RecordLaye
 			}
 			sendAlert(connection, handshakeContext, alert);
 			handshaker.handshakeFailed(cause);
+			reportAlertInternal(connection, alert);
 		}
 	}
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AlertMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AlertMessage.java
@@ -55,13 +55,9 @@ public final class AlertMessage implements DTLSMessage, Serializable {
 	 * 
 	 * @since 2.6
 	 */
-	private transient final ProtocolVersion protocolVersion;
+	private final ProtocolVersion protocolVersion;
 
 	// Constructors ///////////////////////////////////////////////////
-
-	protected AlertMessage() {
-		this(null, null, null);
-	}
 
 	/**
 	 * Create new instance of alert message.
@@ -109,6 +105,7 @@ public final class AlertMessage implements DTLSMessage, Serializable {
 	 * Messages</a> for the listing.
 	 */
 	public enum AlertLevel {
+
 		WARNING(1), FATAL(2);
 
 		private byte code;
@@ -125,7 +122,8 @@ public final class AlertMessage implements DTLSMessage, Serializable {
 		 * Gets the alert level for a given code.
 		 * 
 		 * @param code the code
-		 * @return the corresponding level or <code>null</code> if no alert level exists for the given code
+		 * @return the corresponding level or <code>null</code> if no alert
+		 *         level exists for the given code
 		 */
 		public static AlertLevel getLevelByCode(int code) {
 			switch (code) {
@@ -196,7 +194,8 @@ public final class AlertMessage implements DTLSMessage, Serializable {
 		 * Gets the alert description for a given code.
 		 * 
 		 * @param code the code
-		 * @return the corresponding description or <code>null</code> if no alert description exists for the given code
+		 * @return the corresponding description or <code>null</code> if no
+		 *         alert description exists for the given code
 		 */
 		public static AlertDescription getDescriptionByCode(int code) {
 			for (AlertDescription desc : values()) {
@@ -254,12 +253,10 @@ public final class AlertMessage implements DTLSMessage, Serializable {
 		AlertLevel level = AlertLevel.getLevelByCode(levelCode);
 		AlertDescription description = AlertDescription.getDescriptionByCode(descCode);
 		if (level == null) {
-			throw new HandshakeException(
-					String.format("Unknown alert level code [%d]", levelCode),
+			throw new HandshakeException(String.format("Unknown alert level code [%d]", levelCode),
 					new AlertMessage(AlertLevel.FATAL, AlertDescription.DECODE_ERROR));
 		} else if (description == null) {
-			throw new HandshakeException(
-					String.format("Unknown alert description code [%d]", descCode),
+			throw new HandshakeException(String.format("Unknown alert description code [%d]", descCode),
 					new AlertMessage(AlertLevel.FATAL, AlertDescription.DECODE_ERROR));
 		} else {
 			return new AlertMessage(level, description);
@@ -286,5 +283,26 @@ public final class AlertMessage implements DTLSMessage, Serializable {
 
 	public boolean isFatal() {
 		return AlertLevel.FATAL.equals(level);
+	}
+
+	@Override
+	public int hashCode() {
+		return level.code + (description.code & 0xff) << 8;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		} else if (obj == null) {
+			return false;
+		} else if (getClass() != obj.getClass()) {
+			return false;
+		}
+		AlertMessage other = (AlertMessage) obj;
+		if (description != other.description) {
+			return false;
+		}
+		return level == other.level;
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateVerify.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateVerify.java
@@ -174,7 +174,7 @@ public final class CertificateVerify extends HandshakeMessage {
 
 		return signatureBytes;
 	}
-	
+
 	/**
 	 * Tries to verify the client's signature contained in the CertificateVerify
 	 * message.
@@ -204,7 +204,7 @@ public final class CertificateVerify extends HandshakeMessage {
 			LOGGER.error("Could not verify the client's signature.", e);
 		}
 		String message = "The client's CertificateVerify message could not be verified.";
-		AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE);
+		AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.DECRYPT_ERROR);
 		throw new HandshakeException(message, alert);
 	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ChangeCipherSpecMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ChangeCipherSpecMessage.java
@@ -106,7 +106,7 @@ public final class ChangeCipherSpecMessage implements DTLSMessage {
 			return new ChangeCipherSpecMessage();
 		} else {
 			String message = "Unknown Change Cipher Spec code received: " + code;
-			AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE);
+			AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.ILLEGAL_PARAMETER);
 			throw new HandshakeException(message, alert);
 		}
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchange.java
@@ -110,7 +110,7 @@ public abstract class ECDHServerKeyExchange extends ServerKeyExchange {
 		if (group == null || !group.isUsable()) {
 			throw new HandshakeException(
 				String.format("Server used unsupported elliptic curve (%d) for ECDH", curveId),
-				new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE));
+				new AlertMessage(AlertLevel.FATAL, AlertDescription.ILLEGAL_PARAMETER));
 		}
 		byte[] encodedPoint = reader.readVarBytes(PUBLIC_LENGTH_BITS);
 		return new EcdhData(group, encodedPoint);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Finished.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Finished.java
@@ -112,7 +112,7 @@ public final class Finished extends HandshakeMessage {
 				msg.append(StringUtil.lineSeparator()).append("Received: ").append(StringUtil.byteArray2HexString(verifyData));
 			}
 			LOG.debug(msg.toString());
-			AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE);
+			AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.DECRYPT_ERROR);
 			throw new HandshakeException("Verification of FINISHED message failed", alert);
 		}
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
@@ -37,7 +37,6 @@
 ******************************************************************************/
 package org.eclipse.californium.scandium.dtls;
 
-import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -128,7 +127,7 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 	// Methods ////////////////////////////////////////////////////////
 
 	@Override
-	protected void doProcessMessage(HandshakeMessage message) throws HandshakeException, GeneralSecurityException {
+	protected void doProcessMessage(HandshakeMessage message) throws HandshakeException {
 		if (fullHandshake){
 			// handshake resumption was refused by the server
 			// we do a full handshake

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticNewAdvancedCertificateVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticNewAdvancedCertificateVerifier.java
@@ -124,7 +124,7 @@ public class StaticNewAdvancedCertificateVerifier implements NewAdvancedCertific
 			CertPath certChain = message.getCertificateChain();
 			if (certChain == null) {
 				if (trustedRPKs == null) {
-					AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.INTERNAL_ERROR);
+					AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.UNSUPPORTED_CERTIFICATE);
 					throw new HandshakeException("RPK verification not enabled!", alert);
 				}
 				PublicKey publicKey = message.getPublicKey();
@@ -139,7 +139,7 @@ public class StaticNewAdvancedCertificateVerifier implements NewAdvancedCertific
 				return new CertificateVerificationResult(cid, publicKey, null);
 			} else {
 				if (trustedCertificates == null) {
-					AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.INTERNAL_ERROR);
+					AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.UNSUPPORTED_CERTIFICATE);
 					throw new HandshakeException("x509 verification not enabled!", alert);
 				}
 				try {
@@ -164,7 +164,7 @@ public class StaticNewAdvancedCertificateVerifier implements NewAdvancedCertific
 					} else if (LOGGER.isDebugEnabled()) {
 						LOGGER.debug("Certificate validation failed due to {}", e.getMessage());
 					}
-					AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.BAD_CERTIFICATE);
+					AlertMessage alert = new AlertMessage(AlertLevel.FATAL, AlertDescription.DECRYPT_ERROR);
 					throw new HandshakeException("Certificate chain could not be validated", alert, e);
 				}
 			}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
@@ -475,7 +475,7 @@ public class HandshakerTest {
 		}
 
 		@Override
-		protected void doProcessMessage(HandshakeMessage message) throws GeneralSecurityException, HandshakeException {
+		protected void doProcessMessage(HandshakeMessage message) throws HandshakeException {
 			switch(message.getContentType()) {
 
 			case HANDSHAKE:


### PR DESCRIPTION
Adapt reported alerts for some failure cause.
Use DECRYPT_ERROR also for signing and finish errors (RFC5246).
Use UNSUPPORTED_CERTIFICATE, if the certificate type doesn't match.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>