### PR TITLE
Update android API minimum support level to 20.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -41,24 +41,24 @@ import java.util.List;
 import java.util.Properties;
 
 import org.eclipse.californium.core.coap.Message;
-import org.eclipse.californium.elements.util.NotForAndroid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * The configuration for a Californium server, endpoint and/or connector.
  * Depending on the environment, the configuration is stored and loaded from
- * properties files. When missing, californium will generated this properties
+ * properties files. When missing, Californium will generated this properties
  * file. If file access is not possible, there are variants, which are marked as
  * "WithoutFile" or variants, which use a {@link InputStream} to read the
  * properties. Please use such a variant, e.g.
- * {@link #createStandardWithoutFile()}, if you want californium to stop
+ * {@link #createStandardWithoutFile()}, if you want Californium to stop
  * generating a properties file.
  * 
  * Note: For Android it's recommended to use the AssetManager and pass in the
  * InputStream to the variants using that as parameter. Alternatively you may
  * chose to use the "WithoutFile" variant and, if required, adjust the defaults
- * in your code.
+ * in your code. If the "File" variants are used, ensure, that you have the
+ * android-os-permission to do so.
  */
 public final class NetworkConfig {
 
@@ -430,7 +430,6 @@ public final class NetworkConfig {
 	 * @param file the configuration file
 	 * @return the network configuration
 	 */
-	@NotForAndroid
 	public static NetworkConfig createStandardWithFile(final File file) {
 		standard = createWithFile(file, DEFAULT_HEADER, null);
 		return standard;
@@ -450,7 +449,6 @@ public final class NetworkConfig {
 	 * @param customHandler custom defaults handler. Maybe {@code null}.
 	 * @return the network configuration
 	 */
-	@NotForAndroid
 	public static NetworkConfig createWithFile(final File file, final String header,
 			final NetworkConfigDefaultHandler customHandler) {
 		NetworkConfig standard = new NetworkConfig();
@@ -493,7 +491,6 @@ public final class NetworkConfig {
 	 * @param file the file
 	 * @throws NullPointerException if the file is {@code null}.
 	 */
-	@NotForAndroid
 	public void load(final File file) {
 		if (file == null) {
 			throw new NullPointerException("file must not be null");
@@ -503,7 +500,7 @@ public final class NetworkConfig {
 				load(inStream);
 			} catch (IOException e) {
 				LOGGER.warn("cannot load properties from file {}: {}",
-						new Object[] { file.getAbsolutePath(), e.getMessage() });
+						file.getAbsolutePath(), e.getMessage());
 			}
 		}
 	}
@@ -525,12 +522,11 @@ public final class NetworkConfig {
 	/**
 	 * Stores the configuration to a file.
 	 * 
-	 * For available for Android!
+	 * Not intended for Android!
 	 *
 	 * @param file The file to write to.
 	 * @throws NullPointerException if the file is {@code null}.
 	 */
-	@NotForAndroid
 	public void store(final File file) {
 		store(file, DEFAULT_HEADER);
 	}
@@ -538,13 +534,12 @@ public final class NetworkConfig {
 	/**
 	 * Stores the configuration to a file using a given header.
 	 * 
-	 * For available for Android!
+	 * Not intended for Android!
 	 * 
 	 * @param file The file to write to.
 	 * @param header The header to write to the top of the file.
 	 * @throws NullPointerException if the file is {@code null}.
 	 */
-	@NotForAndroid
 	public void store(File file, String header) {
 		if (file == null) {
 			throw new NullPointerException("file must not be null");
@@ -554,7 +549,7 @@ public final class NetworkConfig {
 				properties.store(writer, header);
 			} catch (IOException e) {
 				LOGGER.warn("cannot write properties to file {}: {}",
-						new Object[] { file.getAbsolutePath(), e.getMessage() });
+						file.getAbsolutePath(), e.getMessage());
 			}
 		}
 	}
@@ -563,7 +558,7 @@ public final class NetworkConfig {
 	 * Gets the string value for a key.
 	 *
 	 * @param key the key to look up.
-	 * @return the value or {@code null} if this configuration does not contain
+	 * @return the value, or {@code null}, if this configuration does not contain
 	 *         the given key.
 	 */
 	public String getString(final String key) {

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/StringUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/StringUtil.java
@@ -85,7 +85,6 @@ public class StringUtil {
 		CALIFORNIUM_VERSION = StringUtil.class.getPackage().getImplementationVersion();
 	}
 
-	@NotForAndroid
 	private static String toHostString(InetSocketAddress address) {
 		return address.getHostString();
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -565,8 +565,8 @@
 				<configuration>
 					<signature>
 						<groupId>net.sf.androidscents.signature</groupId>
-						<artifactId>android-api-level-16</artifactId>
-						<version>4.1.2_r5</version>
+						<artifactId>android-api-level-20</artifactId>
+						<version>4.4W_r1</version>
 					</signature>
 					<annotations>
 						<annotation>org.eclipse.californium.elements.util.NotForAndroid</annotation>

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/AeadBlockCipher.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/AeadBlockCipher.java
@@ -21,8 +21,6 @@ import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 
-import org.eclipse.californium.elements.util.NotForAndroid;
-
 /**
  * A generic Authenticated Encryption with Associated Data block cipher mode.
  */
@@ -123,7 +121,6 @@ public class AeadBlockCipher {
 	 *             e.g. because the ciphertext's block size is not correct
 	 * @throws InvalidMacException if the message could not be authenticated
 	 */
-	@NotForAndroid
 	private final static byte[] jreDecrypt(CipherSuite suite, SecretKey key, byte[] nonce, byte[] additionalData,
 			byte[] crypted, int cryptedOffset, int cryptedLength) throws GeneralSecurityException {
 
@@ -148,7 +145,6 @@ public class AeadBlockCipher {
 	 * @throws GeneralSecurityException if the data could not be encrypted, e.g.
 	 *             because the JVM does not support the AES cipher algorithm
 	 */
-	@NotForAndroid
 	private final static byte[] jreEncrypt(int outputOffset, CipherSuite suite, SecretKey key, byte[] nonce,
 			byte[] additionalData, byte[] message) throws GeneralSecurityException {
 		Cipher cipher = suite.getThreadLocalCipher();


### PR DESCRIPTION
Remove NotForAndroid tag from methods, which are now supported by the
newer API.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>