### PR TITLE
Adapt dtls-graceful-restart to use cipherstreams.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/PersistentConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/PersistentConnector.java
@@ -18,9 +18,6 @@ package org.eclipse.californium.elements;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.security.GeneralSecurityException;
-
-import javax.crypto.SecretKey;
 
 import org.eclipse.californium.elements.util.WipAPI;
 
@@ -37,38 +34,36 @@ public interface PersistentConnector {
 	 * Connector must be stopped before saving connections. The connections are
 	 * removed after saving.
 	 * 
-	 * Note: this "Work In Progress"; the encryption, the states and the format may change!
+	 * Note: this is "Work In Progress"; the stream will contain not encrypted
+	 * critical credentials. It is required to protect this data before
+	 * exporting it. The encoding of the content may also change in the future.
 	 * 
 	 * @param out output stream to save connections
-	 * @param password password for encryption
 	 * @param maxAgeInSeconds maximum age in seconds
-	 * @return number of save connections, {@code -1}, if not supported.
+	 * @return number of save connections.
 	 * @throws IOException if an io-error occurred
-	 * @throws GeneralSecurityException if an crypto error occurred
 	 * @throws IllegalStateException if connector is running
 	 */
 	@WipAPI
-	int saveConnections(OutputStream out, SecretKey password, long maxAgeInSeconds) throws IOException, GeneralSecurityException;
+	int saveConnections(OutputStream out, long maxAgeInSeconds) throws IOException;
 
 	/**
 	 * Load connections.
 	 * 
-	 * Note: this "Work In Progress"; the encryption, the states and the format
-	 * may change!
+	 * Note: this is "Work In Progress"; the stream will contain not encrypted
+	 * critical credentials. The encoding of the content may also change in the
+	 * future.
 	 * 
 	 * @param in input stream to load connections
-	 * @param password password for encryption
-	 * @return number of save connections, {@code -1}, if not supported.
+	 * @param detla adaption-delta for nano-uptime. In nanoseconds
+	 * @return number of loaded connections.
 	 * @throws IOException if an io-error occurred. Indicates, that further
 	 *             loading should be aborted.
-	 * @throws IllegalStateException if an reading error occurred. Continue to
-	 *             load other connection-stores may work, that may be not
-	 *             affected by this error.
-	 * @throws GeneralSecurityException if an crypto error occurred. Continue to
+	 * @throws IllegalArgumentException if an reading error occurred. Continue to
 	 *             load other connection-stores may work, that may be not
 	 *             affected by this error.
 	 */
 	@WipAPI
-	int loadConnections(InputStream in, SecretKey password) throws IOException, GeneralSecurityException;
+	int loadConnections(InputStream in, long delta) throws IOException;
 
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/DataStreamReader.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/DataStreamReader.java
@@ -18,12 +18,6 @@ package org.eclipse.californium.elements.util;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.GeneralSecurityException;
-import java.security.MessageDigest;
-import java.security.spec.AlgorithmParameterSpec;
-
-import javax.crypto.Cipher;
-import javax.crypto.SecretKey;
 
 /**
  * This class describes the functionality to read raw network-ordered data
@@ -81,16 +75,6 @@ public class DataStreamReader {
 						"requested " + count + " bytes exceeds available " + available + " bytes.");
 			}
 			return new RangeInputStream(buf, offset, count);
-		}
-
-		private void decrypt(Cipher cipher, AlgorithmParameterSpec parameterSpec, SecretKey key)
-				throws GeneralSecurityException {
-			cipher.init(Cipher.DECRYPT_MODE, key, parameterSpec);
-			count = cipher.doFinal(buf, pos, available(), buf, pos) + pos;
-		}
-
-		private void updateMessageDigest(MessageDigest md) {
-			md.update(buf, pos, available());
 		}
 
 	}
@@ -211,7 +195,7 @@ public class DataStreamReader {
 	 * 
 	 * @return A Long containing the bits read.
 	 * @throws IllegalArgumentException if provided numBits exceeds available
-	 *             bytes
+	 *             bytes, or that value is out of the range {@code [0...64]}.
 	 */
 	public long readLong(final int numBits) {
 		if (numBits < 0 || numBits > Long.SIZE) {
@@ -255,7 +239,7 @@ public class DataStreamReader {
 	 * 
 	 * @return An integer containing the bits read.
 	 * @throws IllegalArgumentException if provided numBits exceeds available
-	 *             bytes
+	 *             bytes, or that value is out of the range {@code [0...32]}.
 	 */
 	public int read(final int numBits) {
 		if (numBits < 0 || numBits > Integer.SIZE) {
@@ -360,43 +344,6 @@ public class DataStreamReader {
 			return null;
 		} else {
 			return readBytes(len);
-		}
-	}
-
-	/**
-	 * Decrypt content to read.
-	 * 
-	 * Requires reader created with {@link #createRangeReader(int)}.
-	 * 
-	 * @param cipher cipher to use
-	 * @param parameterSpec parameter spec for cipher
-	 * @param key key
-	 * @throws GeneralSecurityException if an crypto-error occurred or reader is
-	 *             not created with {@link #createRangeReader(int)}.
-	 */
-	public void decrypt(Cipher cipher, AlgorithmParameterSpec parameterSpec, SecretKey key)
-			throws GeneralSecurityException {
-		if (byteStream instanceof RangeInputStream) {
-			((RangeInputStream) byteStream).decrypt(cipher, parameterSpec, key);
-		} else {
-			throw new GeneralSecurityException("decrpyt requires range-reader!");
-		}
-	}
-
-	/**
-	 * Update message digest with available content.
-	 * 
-	 * Requires reader created with {@link #createRangeReader(int)}.
-	 * 
-	 * @param md message digest to use
-	 * @throws GeneralSecurityException if reader is not created with
-	 *             {@link #createRangeReader(int)}.
-	 */
-	public void updateMessageDigest(MessageDigest md) throws GeneralSecurityException {
-		if (byteStream instanceof RangeInputStream) {
-			((RangeInputStream) byteStream).updateMessageDigest(md);
-		} else {
-			throw new GeneralSecurityException("update message-digest requires range-reader!");
 		}
 	}
 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramReader.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramReader.java
@@ -131,15 +131,15 @@ public final class DatagramReader extends DataStreamReader {
 	/**
 	 * Assert, that all data is read.
 	 * 
-	 * @param message message to include in {@link IllegalStateException}
+	 * @param message message to include in {@link IllegalArgumentException}
 	 *            message.
-	 * @throws IllegalStateException if bits are left unread
+	 * @throws IllegalArgumentException if bits are left unread
 	 * @since 3.0
 	 */
 	public void assertFinished(String message) {
 		int left = bitsLeft();
 		if (left > 0) {
-			throw new IllegalStateException(message + " not finished! " + left + " bits left.");
+			throw new IllegalArgumentException(message + " not finished! " + left + " bits left.");
 		}
 	}
 

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramWriter.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/DatagramWriter.java
@@ -20,14 +20,8 @@ package org.eclipse.californium.elements.util;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.security.GeneralSecurityException;
-import java.security.MessageDigest;
-import java.security.spec.AlgorithmParameterSpec;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
-
-import javax.crypto.Cipher;
-import javax.crypto.SecretKey;
 
 /**
  * This class describes the functionality to write raw network-ordered datagrams
@@ -399,39 +393,6 @@ public final class DatagramWriter {
 
 		// return the byte array
 		return byteArray;
-	}
-
-	/**
-	 * Encrypt written content.
-	 * 
-	 * @param position starting position to encrypt
-	 * @param cipher cipher to use
-	 * @param parameterSpec parameter spec for cipher
-	 * @param key key
-	 * @throws GeneralSecurityException if an crypto-error occurred
-	 * @since 3.0
-	 */
-	public void encrypt(int position, Cipher cipher, AlgorithmParameterSpec parameterSpec, SecretKey key)
-			throws GeneralSecurityException {
-		cipher.init(Cipher.ENCRYPT_MODE, key, parameterSpec);
-		int length =  count - position;
-		int size = cipher.getOutputSize(length) + position;
-		if (size > buffer.length) {
-			int newSize = calculateBufferSize(size);
-			setBufferSize(newSize);
-		}
-		count = cipher.doFinal(buffer, position, length, buffer, position) + position;
-	}
-
-	/**
-	 * Update message digest with written content.
-	 * 
-	 * @param position starting position to update
-	 * @param md message digest to use
-	 * @since 3.0
-	 */
-	public void updateMessageDigest(int position, MessageDigest md) {
-		md.update(buffer, position, count - position);
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -155,8 +155,6 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import javax.crypto.SecretKey;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -1081,6 +1079,8 @@ public class DTLSConnector implements Connector, PersistentConnector, RecordLaye
 					recentHandshakeCleaner.cancel(false);
 					recentHandshakeCleaner = null;
 				}
+				// recent handshakes will be restored from connection store,
+				recentHandshakes.clear();
 				for (Thread t : receiverThreads) {
 					t.interrupt();
 				}
@@ -1160,19 +1160,17 @@ public class DTLSConnector implements Connector, PersistentConnector, RecordLaye
 
 	@WipAPI
 	@Override
-	public int saveConnections(OutputStream out, SecretKey password, long maxAgeInSeconds)
-			throws IOException, GeneralSecurityException {
+	public int saveConnections(OutputStream out, long maxAgeInSeconds) throws IOException {
 		if (isRunning()) {
 			throw new IllegalStateException("Connector is running, save not possible!");
 		}
-		return connectionStore.saveConnections(out, password, maxAgeInSeconds);
+		return connectionStore.saveConnections(out, maxAgeInSeconds);
 	}
 
 	@WipAPI
 	@Override
-	public int loadConnections(InputStream in, SecretKey password)
-			throws GeneralSecurityException, IOException {
-		return connectionStore.loadConnections(in, password);
+	public int loadConnections(InputStream in, long delta) throws IOException {
+		return connectionStore.loadConnections(in, delta);
 	}
 
 	/**

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -78,7 +78,6 @@ import org.eclipse.californium.elements.auth.RawPublicKeyIdentity;
 import org.eclipse.californium.elements.category.Medium;
 import org.eclipse.californium.elements.rule.TestNameLoggerRule;
 import org.eclipse.californium.elements.rule.ThreadsRule;
-import org.eclipse.californium.elements.util.ClockUtil;
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.elements.util.ExecutorsUtil;
@@ -770,7 +769,7 @@ public class DTLSConnectorTest {
 		DatagramWriter writer = new DatagramWriter(128);
 		connection.write(writer);
 		DatagramReader reader = new DatagramReader(writer.toByteArray());
-		Connection connection2 = Connection.fromReader(reader, 0, ClockUtil.nanoRealtime());
+		Connection connection2 = Connection.fromReader(reader, 0);
 		clientConnectionStore.remove(connection);
 		connection2.setExecutor(new SerialExecutor(executor));
 		clientConnectionStore.put(connection2);


### PR DESCRIPTION
Move encryption from DatagramReader and -Writer o cipherstreams.
Cleanup serialized auxiliary data.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>