### PR TITLE
RFC7967

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/NoResponseOption.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/NoResponseOption.java
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO.GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.coap;
+
+import org.eclipse.californium.elements.util.Bytes;
+
+/**
+ * NoResponseOption.
+ * 
+ * This option is used to suppress responses by their code class. If errors are
+ * not suppressed, this overrides the multicast behavior to not respond with
+ * errors, as defined by the RFC 7967, page 6.
+ * 
+ * <pre>
+ * The server MUST send back responses of the classes for which the
+ * client has not expressed any disinterest. There may be instances
+ * where a server, on its own, decides to suppress responses. An
+ * example is suppression of responses by multicast servers as described
+ * in Section 2.7 of [RFC7390]. If such a server receives a request
+ * with a No-Response option showing ’interest’ in specific response
+ * classes (i.e., not expressing disinterest for these options), then
+ * any default behavior of suppressing responses, if present, MUST be
+ * overridden to deliver those responses that are of interest to the
+ * client.
+ * </pre>
+ * 
+ * @see <a href="https://tools.ietf.org/html/rfc7967">RFC7967 - No Server
+ *      Response</a>.
+ * @since 3.0
+ */
+public final class NoResponseOption {
+
+	/**
+	 * Bit to suppress success responses.
+	 * 
+	 * @see CodeClass#SUCCESS_RESPONSE
+	 */
+	public static final int SUPPRESS_SUCCESS = 0b00000010;
+	/**
+	 * Bit to suppress client error responses.
+	 * 
+	 * @see CodeClass#ERROR_RESPONSE
+	 */
+	public static final int SUPPRESS_CLIENT_ERROR = 0b00001000;
+	/**
+	 * Bit to suppress server error responses.
+	 * 
+	 * @see CodeClass#SERVER_ERROR_RESPONSE
+	 */
+	public static final int SUPPRESS_SERVER_ERROR = 0b00010000;
+	/**
+	 * Suppress all responses.
+	 */
+	public static final int SUPPRESS_ALL = SUPPRESS_SUCCESS | SUPPRESS_CLIENT_ERROR | SUPPRESS_SERVER_ERROR;
+
+	/**
+	 * Bit mask with suppressed code classes.
+	 */
+	private final int mask;
+
+	/**
+	 * Create no-response option.
+	 * 
+	 * If used and errors are not suppressed, this overrides the multicast
+	 * behavior to not respond with errors.
+	 * 
+	 * @param mask bit mask. Use a bitwise or combinations of
+	 *            {@link #SUPPRESS_SUCCESS}, {@link #SUPPRESS_CLIENT_ERROR}, or
+	 *            {@link #SUPPRESS_SERVER_ERROR}. {@code 0} does not suppress
+	 *            any response.
+	 */
+	public NoResponseOption(int mask) {
+		if (mask < 0 || mask > 255) {
+			throw new IllegalArgumentException("No-Response option " + mask + " must be between 0 and 255 inclusive");
+		}
+		this.mask = mask;
+	}
+
+	/**
+	 * Get encoded option value.
+	 * 
+	 * @return byte array with encoded option value
+	 */
+	public byte[] getValue() {
+		if (mask == 0) {
+			return Bytes.EMPTY;
+		} else {
+			return new byte[] { (byte) mask };
+		}
+	}
+
+	/**
+	 * Gets the bit mask of suppress response code classes.
+	 *
+	 * @return the mask
+	 * @see #SUPPRESS_SUCCESS
+	 * @see #SUPPRESS_CLIENT_ERROR
+	 * @see #SUPPRESS_SERVER_ERROR
+	 */
+	public int getMask() {
+		return mask;
+	}
+
+	/**
+	 * Check, if response with the code must be suppressed.
+	 * 
+	 * If errors are not suppressed, this overrides the multicast behavior to
+	 * not respond with errors.
+	 * 
+	 * @param code raw response code.
+	 * @return {@code true}, if response must be suppressed, {@code false},
+	 *         otherwise.
+	 */
+	public boolean suppress(int code) {
+		int bit = 1 << (CoAP.getCodeClass(code) - 1);
+		return (mask & bit) != 0;
+	}
+
+	/**
+	 * Check, if response with the code must be suppressed.
+	 * 
+	 * If errors are not suppressed, this overrides the multicast behavior to
+	 * not respond with errors.
+	 * 
+	 * @param code response code.
+	 * @return {@code true}, if response must be suppressed, {@code false},
+	 *         otherwise.
+	 */
+	public boolean suppress(CoAP.ResponseCode code) {
+		int bit = 1 << (code.codeClass - 1);
+		return (mask & bit) != 0;
+	}
+
+	/**
+	 * Convert to generic {@link Option}.
+	 * 
+	 * @return generic option.
+	 */
+	public Option toOption() {
+		return new Option(OptionNumberRegistry.NO_RESPONSE, getValue());
+	}
+
+	@Override
+	public String toString() {
+		if ((mask & SUPPRESS_ALL) != 0) {
+			StringBuilder text = new StringBuilder("NO ");
+			if ((mask & SUPPRESS_SUCCESS) != 0) {
+				text.append("SUCCESS,");
+			}
+			if ((mask & SUPPRESS_CLIENT_ERROR) != 0) {
+				text.append("CLIENT_ERROR,");
+			}
+			if ((mask & SUPPRESS_SERVER_ERROR) != 0) {
+				text.append("SERVER_ERROR,");
+			}
+			text.setLength(text.length() - 1);
+			return text.toString();
+		} else {
+			return "ALL";
+		}
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (!(o instanceof NoResponseOption)) {
+			return false;
+		}
+		NoResponseOption option = (NoResponseOption) o;
+		return mask == option.mask;
+	}
+
+	@Override
+	public int hashCode() {
+		return mask;
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Option.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Option.java
@@ -391,15 +391,21 @@ public class Option implements Comparable<Option> {
 		}
 		switch (OptionNumberRegistry.getFormatByNr(number)) {
 		case INTEGER:
-			if (number==OptionNumberRegistry.ACCEPT || number==OptionNumberRegistry.CONTENT_FORMAT) return "\""+MediaTypeRegistry.toString(getIntegerValue())+"\"";
-			else if (number==OptionNumberRegistry.BLOCK1 || number==OptionNumberRegistry.BLOCK2) return "\""+ new BlockOption(value) +"\"";
-			else return Integer.toString(getIntegerValue());
+			if (number == OptionNumberRegistry.BLOCK1 || number == OptionNumberRegistry.BLOCK2)
+				return "\"" + new BlockOption(value) + "\"";
+			int iValue = getIntegerValue();
+			if (number == OptionNumberRegistry.ACCEPT || number == OptionNumberRegistry.CONTENT_FORMAT)
+				return "\"" + MediaTypeRegistry.toString(iValue) + "\"";
+			else if (number == OptionNumberRegistry.NO_RESPONSE)
+				return "\"" + new NoResponseOption(iValue) + "\"";
+			else
+				return Long.toString(getLongValue());
 		case STRING:
-			return "\""+this.getStringValue()+"\"";
+			return "\"" + this.getStringValue() + "\"";
 		case EMPTY:
 			return "";
 		default:
-			return "0x" + StringUtil.byteArray2Hex(this.getValue());
+			return "0x" + StringUtil.byteArray2Hex(value);
 		}
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/OptionNumberRegistry.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/OptionNumberRegistry.java
@@ -20,8 +20,12 @@
 package org.eclipse.californium.core.coap;
 
 /**
- * This class describes the CoAP Option Number Registry as defined in
- * RFC 7252, Section 12.2 and other CoAP extensions.
+ * This class describes the CoAP Option Number Registry as defined in RFC 7252,
+ * Section 12.2 and other CoAP extensions.
+ * 
+ * <a href=
+ * "https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#option-numbers">
+ * IANA - CoAP Option Numbers</a>.
  */
 public final class OptionNumberRegistry {
 	public static final int UNKNOWN			= -1;
@@ -48,36 +52,39 @@ public final class OptionNumberRegistry {
 	public static final int RESERVED_3		= 136;
 	public static final int RESERVED_4		= 140;
 
-	// draft-ietf-core-observe-14
+	// RFC 7641
 	public static final int OBSERVE			= 6;
 
-	// draft-ietf-core-block-14
+	// RFC 7959
 	public static final int BLOCK2			= 23;
 	public static final int BLOCK1			= 27;
 	public static final int SIZE2			= 28;
 
-	//TODO temporary assignment
+	// RFC 8613
 	public static final int OSCORE			= 9;
+
+	// RFC 7967
+	public static final int NO_RESPONSE		= 258;
 
 	/**
 	 * Option names.
 	 */
 	public static class Names {
-		public static final String Reserved 		= "Reserved";
+		public static final String Reserved			= "Reserved";
 
-		public static final String If_Match 		= "If-Match";
-		public static final String Uri_Host 		= "Uri-Host";
-		public static final String ETag 			= "ETag";
-		public static final String If_None_Match 	= "If-None-Match";
-		public static final String Uri_Port 		= "Uri-Port";
-		public static final String Location_Path 	= "Location-Path";
-		public static final String Uri_Path 		= "Uri-Path";
+		public static final String If_Match			= "If-Match";
+		public static final String Uri_Host			= "Uri-Host";
+		public static final String ETag				= "ETag";
+		public static final String If_None_Match	= "If-None-Match";
+		public static final String Uri_Port			= "Uri-Port";
+		public static final String Location_Path	= "Location-Path";
+		public static final String Uri_Path			= "Uri-Path";
 		public static final String Content_Format	= "Content-Format";
-		public static final String Max_Age 			= "Max-Age";
-		public static final String Uri_Query 		= "Uri-Query";
-		public static final String Accept 			= "Accept";
-		public static final String Location_Query 	= "Location-Query";
-		public static final String Proxy_Uri 		= "Proxy-Uri";
+		public static final String Max_Age			= "Max-Age";
+		public static final String Uri_Query		= "Uri-Query";
+		public static final String Accept			= "Accept";
+		public static final String Location_Query	= "Location-Query";
+		public static final String Proxy_Uri		= "Proxy-Uri";
 		public static final String Proxy_Scheme		= "Proxy-Scheme";
 		public static final String Size1			= "Size1";
 
@@ -87,7 +94,9 @@ public final class OptionNumberRegistry {
 		public static final String Block1			= "Block1";
 		public static final String Size2			= "Size2";
 
-		public static final String Object_Security  = "Object-Security";
+		public static final String Object_Security	= "Object-Security";
+
+		public static final String No_Response		= "No-Response";
 	}
 
 	/**
@@ -124,6 +133,7 @@ public final class OptionNumberRegistry {
 		case SIZE2:
 		case SIZE1:
 		case ACCEPT:
+		case NO_RESPONSE:
 			return optionFormats.INTEGER;
 		case IF_NONE_MATCH:
 			return optionFormats.EMPTY;
@@ -201,6 +211,14 @@ public final class OptionNumberRegistry {
 		 * When an option is not Unsafe, it is not a Cache-Key (NoCacheKey) if
 		 * and only if bits 3-5 are all set to 1; all other bit combinations
 		 * mean that it indeed is a Cache-Key
+		 * 
+		 * https://tools.ietf.org/html/rfc7252#page-40
+		 * 
+		 * Critical = (onum & 1);
+		 * UnSafe = (onum & 2);
+		 * NoCacheKey = ((onum & 0x1e) == 0x1c);
+		 * 
+		 *    Figure 11: Determining Characteristics from an Option Number
 		 */
 		return (optionNumber & 0x1E) == 0x1C;
 	}
@@ -239,6 +257,7 @@ public final class OptionNumberRegistry {
 		case BLOCK2:
 		case SIZE1:
 		case SIZE2:
+		case NO_RESPONSE:
 		default:
 			return true;
 		case ETAG:
@@ -306,6 +325,9 @@ public final class OptionNumberRegistry {
 		case CONTENT_FORMAT:
 		case ACCEPT:
 			max = 2;
+			break;
+		case NO_RESPONSE:
+			max = 1;
 			break;
 		case URI_PATH:
 		case URI_QUERY:
@@ -417,11 +439,13 @@ public final class OptionNumberRegistry {
 			return Names.Size1;
 		case OSCORE:
 			return Names.Object_Security;
+		case NO_RESPONSE:
+			return Names.No_Response;
 		default:
 			return String.format("Unknown (%d)", optionNumber);
 		}
 	}
-	
+
 	public static int toNumber(String name) {
 		if (Names.If_Match.equals(name))			return IF_MATCH;
 		else if (Names.Uri_Host.equals(name))		return URI_HOST;
@@ -443,6 +467,7 @@ public final class OptionNumberRegistry {
 		else if (Names.Size2.equals(name))			return SIZE2;
 		else if (Names.Size1.equals(name))			return SIZE1;
 		else if (Names.Object_Security.equals(name)) return OSCORE;
+		else if (Names.No_Response.equals(name))	return NO_RESPONSE;
 		else return UNKNOWN;
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/OptionSet.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/OptionSet.java
@@ -81,13 +81,14 @@ public final class OptionSet {
 	private Integer      size2;
 	private Integer      observe;
 	private byte[]       oscore;
+	private NoResponseOption no_response;
 
 	// Arbitrary options
 	private List<Option> others;
 
 	/**
-	 * {@code true} if URI-path or URI-query are set independent from
-	 * {@link Request#setURI}. Preserve them from being cleand up, if the URI
+	 * {@code true}, if URI-path or URI-query are set independent from
+	 * {@link Request#setURI}. Preserve them from being cleaned up, if the URI
 	 * doesn't contain them.
 	 */
 	private boolean explicitUriOptions;
@@ -119,6 +120,7 @@ public final class OptionSet {
 		size2               = null;
 		observe             = null;
 		oscore              = null;
+		no_response         = null;
 
 		others              = null; // new LinkedList<>();
 	}
@@ -156,6 +158,7 @@ public final class OptionSet {
 		if(origin.oscore != null) {
 			oscore          = origin.oscore.clone();
 		}
+		no_response         = origin.no_response;
 		others              = copyList(origin.others);
 	}
 
@@ -189,6 +192,7 @@ public final class OptionSet {
 		size2 = null;
 		observe = null;
 		oscore = null;
+		no_response = null;
 		if (others != null)
 			others.clear();
 	}
@@ -1420,7 +1424,62 @@ public final class OptionSet {
 	}
 
 	/**
-	 * Checks if an arbitrary option is present.
+	 * Gets the NoResponse option.
+	 * 
+	 * @return the NoResponse option, or, {@code null}, if the option is not present
+	 * @since 3.0
+	 */
+	public NoResponseOption getNoResponse() {
+		return no_response;
+	}
+
+	/**
+	 * Checks, if the NoResponse option is present.
+	 * 
+	 * @return {@code true}, if present
+	 * @since 3.0
+	 */
+	public boolean hasNoResponse() {
+		return no_response != null;
+	}
+
+	/**
+	 * Sets the NoResponse option value.
+	 * 
+	 * @param noResponse the NoResponse pattern
+	 * @return this OptionSet for a fluent API.
+	 * @since 3.0
+	 */
+	public OptionSet setNoResponse(int noResponse) {
+		this.no_response = new NoResponseOption(noResponse);
+		return this;
+	}
+
+	/**
+	 * Sets the NoResponse option value.
+	 * 
+	 * @param noResponse the NoResponse option
+	 * @return this OptionSet for a fluent API.
+	 * @since 3.0
+	 */
+	public OptionSet setNoResponse(NoResponseOption noResponse) {
+		this.no_response = noResponse;
+		return this;
+	}
+
+	/**
+	 * Removes the NoResponse option.
+	 * 
+	 * @return this OptionSet for a fluent API.
+	 * @since 3.0
+	 */
+	public OptionSet removeNoResponse() {
+		this.no_response = null;
+		return this;
+	}
+
+	/**
+	 * Checks, if an arbitrary option is present.
 	 * 
 	 * @param number the option number
 	 * @return {@code true}, if present
@@ -1510,6 +1569,8 @@ public final class OptionSet {
 			options.add(new Option(OptionNumberRegistry.SIZE2, getSize2()));
 		if (hasOscore())
 			options.add(new Option(OptionNumberRegistry.OSCORE, getOscore()));
+		if (hasNoResponse())
+			options.add(getNoResponse().toOption());
 
 		if (others != null)
 			options.addAll(others);
@@ -1595,6 +1656,9 @@ public final class OptionSet {
 			break;
 		case OptionNumberRegistry.OSCORE:
 			setOscore(option.getValue());
+			break;
+		case OptionNumberRegistry.NO_RESPONSE:
+			setNoResponse(option.getIntegerValue());
 			break;
 		default:
 			getOthersInternal().add(option);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ExchangeCleanupLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ExchangeCleanupLayer.java
@@ -17,12 +17,12 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
-
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,14 +35,14 @@ public class ExchangeCleanupLayer extends AbstractLayer {
 	static final Logger LOGGER = LoggerFactory.getLogger(ExchangeCleanupLayer.class);
 
 	/**
-	 * Multicast lifetime in milliseconds.
+	 * Multicast and NoResponse lifetime in milliseconds.
 	 */
-	private final int multicastLifetime;
+	private final int lifetime;
 
 	public ExchangeCleanupLayer(final NetworkConfig config) {
-		this.multicastLifetime = config.getInt(NetworkConfig.Keys.NON_LIFETIME)
-				+ config.getInt(NetworkConfig.Keys.MAX_LATENCY)
-				+ config.getInt(NetworkConfig.Keys.MAX_SERVER_RESPONSE_DELAY);
+		this.lifetime = config.getInt(Keys.NON_LIFETIME)
+				+ config.getInt(Keys.MAX_LATENCY)
+				+ config.getInt(Keys.MAX_SERVER_RESPONSE_DELAY);
 	}
 
 	/**
@@ -56,9 +56,13 @@ public class ExchangeCleanupLayer extends AbstractLayer {
 	@Override
 	public void sendRequest(final Exchange exchange, final Request request) {
 		if (request.isMulticast()) {
-			request.addMessageObserver(new MulticastCleanupMessageObserver(exchange, executor, multicastLifetime));
+			request.addMessageObserver(new MulticastCleanupMessageObserver(exchange, executor, lifetime));
 		} else {
-			request.addMessageObserver(new CleanupMessageObserver(exchange));
+			if (request.getOptions().hasNoResponse()) {
+				request.addMessageObserver(new NoResponseCleanupMessageObserver(exchange, executor, lifetime));
+			} else {
+				request.addMessageObserver(new CleanupMessageObserver(exchange));
+			}
 		}
 		super.sendRequest(exchange, request);
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/NoResponseCleanupMessageObserver.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/NoResponseCleanupMessageObserver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2021 Bosch.IO GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -11,8 +11,7 @@
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  * 
  * Contributors:
- *    Bosch Software Innovations GmbH - initial creation
- *                                      extracted from ExchangeCleanupLayer
+ *    Bosch IO.GmbH - initial creation
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
@@ -26,59 +25,60 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Cleanup multicast exchange by time to enable request for multiple responses.
+ * Cleanup no-response exchange also by time.
+ * 
+ * @since 3.0
  */
 @NoPublicAPI
-public class MulticastCleanupMessageObserver extends CleanupMessageObserver {
+public class NoResponseCleanupMessageObserver extends CleanupMessageObserver {
 
-	static final Logger LOGGER = LoggerFactory.getLogger(MulticastCleanupMessageObserver.class);
+	static final Logger LOGGER = LoggerFactory.getLogger(NoResponseCleanupMessageObserver.class);
 
 	/**
 	 * Scheduler for time based exchange completion.
 	 */
 	private final ScheduledExecutorService scheduledExecutor;
 	/**
-	 * Multicast lifetime in milliseconds.
+	 * Request lifetime in milliseconds.
 	 */
-	private final long multicastLifetime;
+	private final long lifetime;
 	/**
 	 * Future for cleanup task.
 	 */
 	private volatile ScheduledFuture<?> cleanup;
 
 	/**
-	 * Create multicast cleanup observer.
+	 * Create no-response cleanup observer.
 	 * 
-	 * @param exchange exchange for multicast request
+	 * @param exchange exchange for no-response request
 	 * @param scheduledExecutor scheduler for time based cleanup
-	 * @param multicastLifetime multicast lifetime in milliseconds.
+	 * @param lifetime lifetime in milliseconds.
 	 */
-	public MulticastCleanupMessageObserver(Exchange exchange, ScheduledExecutorService scheduledExecutor,
-			long multicastLifetime) {
+	public NoResponseCleanupMessageObserver(Exchange exchange, ScheduledExecutorService scheduledExecutor,
+			long lifetime) {
 		super(exchange);
 		this.scheduledExecutor = scheduledExecutor;
-		this.multicastLifetime = multicastLifetime;
+		this.lifetime = lifetime;
+		LOGGER.warn("no-response observer");
 	}
 
 	@Override
 	public void onSent(boolean retransmission) {
+		LOGGER.warn("no-response sent");
 		if (!retransmission) {
 			cleanup = scheduledExecutor.schedule(new Runnable() {
-
+	
 				@Override
 				public void run() {
 					exchange.execute(new Runnable() {
 						@Override
 						public void run() {
-							if (exchange.getResponse() == null) {
-								exchange.getRequest().setCanceled(true);
-							} else {
-								exchange.setComplete();
-							}
+							LOGGER.warn("no-response-timeout");
+							exchange.getRequest().setTimedOut(true);
 						}
 					});
 				}
-			}, multicastLifetime, TimeUnit.MILLISECONDS);
+			}, lifetime, TimeUnit.MILLISECONDS);
 		}
 	}
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
@@ -29,6 +29,7 @@ import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.NoResponseOption;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.Exchange;
@@ -275,19 +276,41 @@ public class CoapExchange {
 	}
 
 	/**
-	 * Respond a overload.
+	 * Respond a overload caused by this specific client.
 	 * 
-	 * Current implementation use 5.03. May be changed, if RFC
-	 * "https://draft-ietf-core-too-many-reqs" gets adopted.
-	 *
-	 * Note: since 2.3, error responses for multicast requests are not sent. (See
+	 * Note: this error response is not sent for multicast requests. (See
 	 * {@link UdpMulticastConnector} for receiving multicast requests).
+	 * {@link NoResponseOption} is considered as well, what may cause to send
+	 * this error responses also for multicast requests.
+	 * 
+	 * @param seconds estimated time in seconds after which the client may retry
+	 *            to send requests.
+	 * 
+	 * @see Exchange#sendResponse(Response)
+	 * @see <a href="https://tools.ietf.org/html/rfc8516">RFC8516 - Too Many
+	 *      Requests</a>.
+	 * @since 3.0
+	 */
+	public void respondClientOverload(int seconds) {
+		setMaxAge(seconds);
+		respond(ResponseCode.TOO_MANY_REQUESTS);
+	}
+
+	/**
+	 * Respond a overload caused by a general server overload.
+	 * 
+	 * Note: since 2.3, this error response is not sent for multicast requests.
+	 * (See {@link UdpMulticastConnector} for receiving multicast requests).
+	 * 
+	 * Note: since 3.0, {@link NoResponseOption} is considered. That may cause
+	 * to send this error responses also for multicast requests.
 	 * 
 	 * @param seconds estimated time in seconds after which the client may retry
 	 *            to send requests.
 	 * 
 	 * @see Exchange#sendResponse(Response)
 	 * @since 2.3 error responses for multicast requests are not sent
+	 * @since 3.0 {@link NoResponseOption} is considered
 	 */
 	public void respondOverload(int seconds) {
 		setMaxAge(seconds);
@@ -310,10 +333,14 @@ public class CoapExchange {
 	 * Note: since 2.3, error responses for multicast requests are not sent. (See
 	 * {@link UdpMulticastConnector} for receiving multicast requests).
 	 * 
+	 * Note: since 3.0, {@link NoResponseOption} is considered. That may cause
+	 * to send error responses also for multicast requests.
+	 * 
 	 * @param code the response code
 	 * 
 	 * @see Exchange#sendResponse(Response)
 	 * @since 2.3 error responses for multicast requests are not sent
+	 * @since 3.0 {@link NoResponseOption} is considered
 	 */
 	public void respond(ResponseCode code) {
 		respond(new Response(code));
@@ -325,7 +352,10 @@ public class CoapExchange {
 	 * Fills in {@link #locationPath}, {@link #locationQuery}, {@link #maxAge},
 	 * and/or {@link #eTag}, if set before.
 	 * 
+	 * Note: since 3.0, {@link NoResponseOption} is considered.
+	 * 
 	 * @param payload the payload as string
+	 * @since 3.0 {@link NoResponseOption} is considered
 	 */
 	public void respond(String payload) {
 		respond(ResponseCode.CONTENT, payload);
@@ -346,11 +376,15 @@ public class CoapExchange {
 	 * Note: since 2.3, error responses for multicast requests are not sent. (See
 	 * {@link UdpMulticastConnector} for receiving multicast requests).
 	 * 
+	 * Note: since 3.0, {@link NoResponseOption} is considered. That may cause
+	 * to send error responses also for multicast requests.
+	 * 
 	 * @param code the response code
 	 * @param payload the payload
 	 * 
 	 * @see Exchange#sendResponse(Response)
 	 * @since 2.3 error responses for multicast requests are not sent
+	 * @since 3.0 {@link NoResponseOption} is considered
 	 */
 	public void respond(ResponseCode code, String payload) {
 		Response response = new Response(code);
@@ -374,11 +408,15 @@ public class CoapExchange {
 	 * Note: since 2.3, error responses for multicast requests are not sent. (See
 	 * {@link UdpMulticastConnector} for receiving multicast requests).
 	 *
+	 * Note: since 3.0, {@link NoResponseOption} is considered. That may cause
+	 * to send error responses also for multicast requests.
+	 * 
 	 * @param code the response code
 	 * @param payload the payload
 	 * 
 	 * @see Exchange#sendResponse(Response)
 	 * @since 2.3 error responses for multicast requests are not sent
+	 * @since 3.0 {@link NoResponseOption} is considered
 	 */
 	public void respond(ResponseCode code, byte[] payload) {
 		Response response = new Response(code);
@@ -401,12 +439,16 @@ public class CoapExchange {
 	 * Note: since 2.3, error responses for multicast requests are not sent. (See
 	 * {@link UdpMulticastConnector} for receiving multicast requests).
 	 * 
+	 * Note: since 3.0, {@link NoResponseOption} is considered. That may cause
+	 * to send error responses also for multicast requests.
+	 * 
 	 * @param code the response code
 	 * @param payload the payload
 	 * @param contentFormat the Content-Format of the payload
 	 * 
 	 * @see Exchange#sendResponse(Response)
 	 * @since 2.3 error responses for multicast requests are not sent
+	 * @since 3.0 {@link NoResponseOption} is considered
 	 */
 	public void respond(ResponseCode code, byte[] payload, int contentFormat) {
 		Response response = new Response(code);
@@ -430,12 +472,16 @@ public class CoapExchange {
 	 * Note: since 2.3, error responses for multicast requests are not sent. (See
 	 * {@link UdpMulticastConnector} for receiving multicast requests).
 	 *
+	 * Note: since 3.0, {@link NoResponseOption} is considered. That may cause
+	 * to send error responses also for multicast requests.
+	 * 
 	 * @param code the response code
 	 * @param payload the payload
 	 * @param contentFormat the Content-Format of the payload
 	 * 
 	 * @see Exchange#sendResponse(Response)
 	 * @since 2.3 error responses for multicast requests are not sent
+	 * @since 3.0 {@link NoResponseOption} is considered
 	 */
 	public void respond(ResponseCode code, String payload, int contentFormat) {
 		Response response = new Response(code);
@@ -453,10 +499,14 @@ public class CoapExchange {
 	 * Note: since 2.3, error responses for multicast requests are not sent. (See
 	 * {@link UdpMulticastConnector} for receiving multicast requests).
 	 * 
+	 * Note: since 3.0, {@link NoResponseOption} is considered. That may cause
+	 * to send error responses also for multicast requests.
+	 * 
 	 * @param response the response
 	 * 
 	 * @see Exchange#sendResponse(Response)
 	 * @since 2.3 error responses for multicast requests are not sent
+	 * @since 3.0 {@link NoResponseOption} is considered
 	 */
 	public void respond(Response response) {
 		if (response == null)

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MessageExchangeStoreTool.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MessageExchangeStoreTool.java
@@ -126,6 +126,7 @@ public class MessageExchangeStoreTool {
 
 			@Override
 			public boolean isFulFilled() throws IllegalStateException {
+				System.out.println("check empty " + System.currentTimeMillis());
 				return endpoint.isEmpty() && endpoint.getRequestChecker().allRequestsTerminated();
 			}
 		});

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/NoResponseServerClientTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/NoResponseServerClientTest.java
@@ -1,0 +1,207 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO.GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.net.InetSocketAddress;
+
+import org.eclipse.californium.TestTools;
+import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.NoResponseOption;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.network.EndpointManager;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
+import org.eclipse.californium.core.server.MessageDeliverer;
+import org.eclipse.californium.core.test.MessageExchangeStoreTool.CoapTestEndpoint;
+import org.eclipse.californium.elements.AddressEndpointContext;
+import org.eclipse.californium.elements.category.Medium;
+import org.eclipse.californium.elements.rule.TestTimeRule;
+import org.eclipse.californium.rule.CoapNetworkRule;
+import org.eclipse.californium.rule.CoapThreadsRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * This is a small test that tests the exchange of one request and one response.
+ */
+@Category(Medium.class)
+public class NoResponseServerClientTest {
+
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT,
+			CoapNetworkRule.Mode.NATIVE);
+
+	private static String SERVER_RESPONSE = "server responds hi";
+
+	@Rule
+	public CoapThreadsRule cleanup = new CoapThreadsRule();
+
+	@Rule
+	public TestTimeRule time = new TestTimeRule();
+
+	private CoapTestEndpoint clientEndpoint;
+	private CoapTestEndpoint serverEndpoint;
+	private InetSocketAddress serverAddress;
+	private NetworkConfig config;
+
+	@Before
+	public void init() {
+		config = network.createStandardTestConfig().setInt(Keys.EXCHANGE_LIFETIME, 10000)
+				.setInt(Keys.MARK_AND_SWEEP_INTERVAL, 1000).setInt(Keys.NON_LIFETIME, 1000)
+				.setInt(Keys.MAX_LATENCY, 1000).setInt(Keys.MAX_SERVER_RESPONSE_DELAY, 1000);
+		cleanup.add(createSimpleServer());
+
+		clientEndpoint = new CoapTestEndpoint(TestTools.LOCALHOST_EPHEMERAL, config);
+		EndpointManager.getEndpointManager().setDefaultEndpoint(clientEndpoint);
+	}
+
+	@After
+	public void shutdown() {
+		MessageExchangeStoreTool.assertAllExchangesAreCompleted(serverEndpoint, time);
+		MessageExchangeStoreTool.assertAllExchangesAreCompleted(clientEndpoint, time);
+	}
+
+	@Test
+	public void testResponse() throws Exception {
+
+		// send request
+		Request request = new Request(CoAP.Code.POST);
+		request.setConfirmable(false);
+		request.setDestinationContext(new AddressEndpointContext(serverAddress));
+		request.setPayload("client says hi");
+		request.send();
+		System.out.println("client sent request");
+
+		// receive response and check
+		Response response = request.waitForResponse(1000);
+		assertNotNull("Client received no response", response);
+		System.out.println("client received response");
+		assertEquals(response.getPayloadString(), SERVER_RESPONSE);
+	}
+
+	@Test
+	public void testNoResponse() throws Exception {
+
+		// send request
+		Request request = new Request(CoAP.Code.POST);
+		request.setConfirmable(false);
+		request.setDestinationContext(new AddressEndpointContext(serverAddress));
+		request.setPayload("client says hi");
+		request.getOptions().setNoResponse(NoResponseOption.SUPPRESS_SUCCESS);
+		request.send();
+		System.out.println("client sent request with no-response for success");
+
+		// receive response and check
+		Response response = request.waitForResponse(1000);
+		assertNull("Client received unexpected response", response);
+	}
+
+	@Test
+	public void testNoErrorResponse() throws Exception {
+
+		// send request
+		Request request = new Request(CoAP.Code.POST);
+		request.setConfirmable(false);
+		request.setDestinationContext(new AddressEndpointContext(serverAddress));
+		request.setPayload("client says hi");
+		request.getOptions().setNoResponse(NoResponseOption.SUPPRESS_CLIENT_ERROR);
+		request.send();
+
+		// receive response and check
+		Response response = request.waitForResponse(1000);
+		assertNotNull("Client received no response", response);
+		System.out.println("client received response");
+		assertEquals(response.getPayloadString(), SERVER_RESPONSE);
+	}
+
+	@Test
+	public void testConNoResponse() throws Exception {
+
+		// send request
+		Request request = new Request(CoAP.Code.POST);
+		request.setConfirmable(true);
+		request.setDestinationContext(new AddressEndpointContext(serverAddress));
+		request.setPayload("client says hi");
+		request.getOptions().setNoResponse(NoResponseOption.SUPPRESS_SUCCESS);
+		request.send();
+		System.out.println("client sent request with no-response for success");
+
+		// receive response and check
+		Response response = request.waitForResponse(1000);
+		assertNotNull("Client received no response", response);
+		System.out.println("client received response");
+		assertEquals(response.getPayloadString(), SERVER_RESPONSE);
+	}
+
+	@Test
+	public void testConSeparateNoResponse() throws Exception {
+
+		// send request
+		Request request = new Request(CoAP.Code.POST);
+		request.setConfirmable(true);
+		request.setDestinationContext(new AddressEndpointContext(serverAddress));
+		request.getOptions().setUriPath("ack");
+		request.setPayload("client says hi");
+		request.getOptions().setNoResponse(NoResponseOption.SUPPRESS_SUCCESS);
+		request.send();
+		System.out.println("client sent request with no-response for success");
+
+		// receive response and check
+		Response response = request.waitForResponse(1000);
+		assertNull("Client received unexpected response", response);
+	}
+
+	private CoapServer createSimpleServer() {
+
+		serverEndpoint = new CoapTestEndpoint(TestTools.LOCALHOST_EPHEMERAL, config);
+		CoapServer server = new CoapServer(config);
+		server.addEndpoint(serverEndpoint);
+		server.setMessageDeliverer(new MessageDeliverer() {
+
+			@Override
+			public void deliverRequest(Exchange exchange) {
+				String path = exchange.getRequest().getOptions().getUriPathString();
+				System.out.println("server received request " + path);
+				if (path.equals("ack")) {
+					exchange.sendAccept();
+				}
+				Response response = new Response(ResponseCode.CONTENT);
+				response.setConfirmable(false);
+				response.setPayload(SERVER_RESPONSE);
+				exchange.sendResponse(response);
+			}
+
+			@Override
+			public void deliverResponse(Exchange exchange, Response response) {
+			}
+		});
+		server.start();
+		serverAddress = serverEndpoint.getAddress();
+		return server;
+	}
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/OptionTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/OptionTest.java
@@ -22,15 +22,18 @@ package org.eclipse.californium.core.test;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+import org.eclipse.californium.core.coap.NoResponseOption;
 import org.eclipse.californium.core.coap.Option;
 import org.eclipse.californium.core.coap.OptionNumberRegistry;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.elements.category.Small;
 import org.eclipse.californium.elements.rule.TestNameLoggerRule;
 import org.eclipse.californium.elements.util.Bytes;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -66,6 +69,8 @@ public class OptionTest {
 		assertTrue(OptionNumberRegistry.isCritical(OptionNumberRegistry.PROXY_URI));
 		assertTrue(OptionNumberRegistry.isCritical(OptionNumberRegistry.PROXY_SCHEME));
 		assertFalse(OptionNumberRegistry.isCritical(OptionNumberRegistry.SIZE1));
+		assertTrue(OptionNumberRegistry.isCritical(OptionNumberRegistry.OSCORE));
+		assertFalse(OptionNumberRegistry.isCritical(OptionNumberRegistry.NO_RESPONSE));
 	}
 
 	@Test
@@ -89,6 +94,8 @@ public class OptionTest {
 		assertFalse(OptionNumberRegistry.isElective(OptionNumberRegistry.PROXY_URI));
 		assertFalse(OptionNumberRegistry.isElective(OptionNumberRegistry.PROXY_SCHEME));
 		assertTrue(OptionNumberRegistry.isElective(OptionNumberRegistry.SIZE1));
+		assertFalse(OptionNumberRegistry.isElective(OptionNumberRegistry.OSCORE));
+		assertTrue(OptionNumberRegistry.isElective(OptionNumberRegistry.NO_RESPONSE));
 	}
 
 	@Test
@@ -112,6 +119,8 @@ public class OptionTest {
 		assertFalse(OptionNumberRegistry.isSafe(OptionNumberRegistry.PROXY_URI));
 		assertFalse(OptionNumberRegistry.isSafe(OptionNumberRegistry.PROXY_SCHEME));
 		assertTrue(OptionNumberRegistry.isSafe(OptionNumberRegistry.SIZE1));
+		assertTrue(OptionNumberRegistry.isSafe(OptionNumberRegistry.OSCORE));
+		assertFalse(OptionNumberRegistry.isSafe(OptionNumberRegistry.NO_RESPONSE));
 	}
 
 	@Test
@@ -135,6 +144,8 @@ public class OptionTest {
 		assertTrue(OptionNumberRegistry.isUnsafe(OptionNumberRegistry.PROXY_URI));
 		assertTrue(OptionNumberRegistry.isUnsafe(OptionNumberRegistry.PROXY_SCHEME));
 		assertFalse(OptionNumberRegistry.isUnsafe(OptionNumberRegistry.SIZE1));
+		assertFalse(OptionNumberRegistry.isUnsafe(OptionNumberRegistry.OSCORE));
+		assertTrue(OptionNumberRegistry.isUnsafe(OptionNumberRegistry.NO_RESPONSE));
 	}
 
 	@Test
@@ -158,6 +169,8 @@ public class OptionTest {
 		assertTrue(OptionNumberRegistry.isCacheKey(OptionNumberRegistry.PROXY_URI));
 		assertTrue(OptionNumberRegistry.isCacheKey(OptionNumberRegistry.PROXY_SCHEME));
 		assertFalse(OptionNumberRegistry.isCacheKey(OptionNumberRegistry.SIZE1));
+		assertTrue(OptionNumberRegistry.isCacheKey(OptionNumberRegistry.OSCORE));
+		assertTrue(OptionNumberRegistry.isCacheKey(OptionNumberRegistry.NO_RESPONSE));
 	}
 
 	@Test
@@ -181,6 +194,8 @@ public class OptionTest {
 		assertFalse(OptionNumberRegistry.isNoCacheKey(OptionNumberRegistry.PROXY_URI));
 		assertFalse(OptionNumberRegistry.isNoCacheKey(OptionNumberRegistry.PROXY_SCHEME));
 		assertTrue(OptionNumberRegistry.isNoCacheKey(OptionNumberRegistry.SIZE1));
+		assertFalse(OptionNumberRegistry.isNoCacheKey(OptionNumberRegistry.OSCORE));
+		assertFalse(OptionNumberRegistry.isNoCacheKey(OptionNumberRegistry.NO_RESPONSE));
 	}
 
 	@Test
@@ -227,6 +242,8 @@ public class OptionTest {
 		assertFalse(OptionNumberRegistry.isUriOption(OptionNumberRegistry.PROXY_URI));
 		assertFalse(OptionNumberRegistry.isUriOption(OptionNumberRegistry.PROXY_SCHEME));
 		assertFalse(OptionNumberRegistry.isUriOption(OptionNumberRegistry.SIZE1));
+		assertFalse(OptionNumberRegistry.isUriOption(OptionNumberRegistry.OSCORE));
+		assertFalse(OptionNumberRegistry.isUriOption(OptionNumberRegistry.NO_RESPONSE));
 	}
 
 	@Test
@@ -339,27 +356,27 @@ public class OptionTest {
 		OptionSet options = new OptionSet();
 
 		options.setUriPath("/foo/bar");
-		Assert.assertEquals("Uri-Path", "foo/bar", options.getUriPathString());
+		assertEquals("Uri-Path", "foo/bar", options.getUriPathString());
 
 		options.setUriPath("foo/bar");
-		Assert.assertEquals("Uri-Path", "foo/bar", options.getUriPathString());
+		assertEquals("Uri-Path", "foo/bar", options.getUriPathString());
 
 		options.setUriPath("//foo/bar");
-		Assert.assertEquals("Uri-Path", "/foo/bar", options.getUriPathString());
+		assertEquals("Uri-Path", "/foo/bar", options.getUriPathString());
 
 		options.setUriPath("/foo//bar");
-		Assert.assertEquals("Uri-Path", "foo//bar", options.getUriPathString());
+		assertEquals("Uri-Path", "foo//bar", options.getUriPathString());
 
 		options.clearUriPath();
 		options.addUriPath("foo");
 		options.addUriPath("bar");
-		Assert.assertEquals("Uri-Path", "foo/bar", options.getUriPathString());
+		assertEquals("Uri-Path", "foo/bar", options.getUriPathString());
 
 		options.clearUriPath();
 		options.addUriPath("foo");
 		options.addUriPath("");
 		options.addUriPath("bar");
-		Assert.assertEquals("Uri-Path", "foo//bar", options.getUriPathString());
+		assertEquals("Uri-Path", "foo//bar", options.getUriPathString());
 	}
 
 	@Test
@@ -367,27 +384,51 @@ public class OptionTest {
 		OptionSet options = new OptionSet();
 
 		options.setLocationPath("/foo/bar");
-		Assert.assertEquals("Uri-Path", "foo/bar", options.getLocationPathString());
+		assertEquals("Uri-Path", "foo/bar", options.getLocationPathString());
 
 		options.setLocationPath("foo/bar");
-		Assert.assertEquals("Uri-Path", "foo/bar", options.getLocationPathString());
+		assertEquals("Uri-Path", "foo/bar", options.getLocationPathString());
 
 		options.setLocationPath("//foo/bar");
-		Assert.assertEquals("Uri-Path", "/foo/bar", options.getLocationPathString());
+		assertEquals("Uri-Path", "/foo/bar", options.getLocationPathString());
 
 		options.setLocationPath("/foo//bar");
-		Assert.assertEquals("Uri-Path", "foo//bar", options.getLocationPathString());
+		assertEquals("Uri-Path", "foo//bar", options.getLocationPathString());
 
 		options.clearLocationPath();
 		options.addLocationPath("foo");
 		options.addLocationPath("bar");
-		Assert.assertEquals("Uri-Path", "foo/bar", options.getLocationPathString());
+		assertEquals("Uri-Path", "foo/bar", options.getLocationPathString());
 
 		options.clearLocationPath();
 		options.addLocationPath("foo");
 		options.addLocationPath("");
 		options.addLocationPath("bar");
-		Assert.assertEquals("Uri-Path", "foo//bar", options.getLocationPathString());
+		assertEquals("Uri-Path", "foo//bar", options.getLocationPathString());
+	}
+
+	@Test
+	public void testNoResponseOptions() {
+		OptionSet options = new OptionSet();
+
+		assertFalse(options.hasNoResponse());
+
+		options.setNoResponse(0);
+		assertTrue(options.hasNoResponse());
+
+		NoResponseOption noResponse = options.getNoResponse();
+		assertNotNull(noResponse);
+
+		assertEquals(0, noResponse.getMask());
+
+		noResponse = new NoResponseOption(NoResponseOption.SUPPRESS_CLIENT_ERROR);
+		options.setNoResponse(noResponse);
+		noResponse = options.getNoResponse();
+		assertNotNull(noResponse);
+
+		assertFalse(noResponse.suppress(ResponseCode.CONTENT));
+		assertTrue(noResponse.suppress(ResponseCode.BAD_REQUEST));
+		assertFalse(noResponse.suppress(ResponseCode.SERVICE_UNAVAILABLE));
 	}
 
 	@Test
@@ -401,20 +442,20 @@ public class OptionTest {
 		options.addOption(new Option(17, 1));
 
 		// Check that options are in the set
-		Assert.assertTrue(options.hasOption(OptionNumberRegistry.ETAG));
-		Assert.assertTrue(options.hasOption(OptionNumberRegistry.LOCATION_PATH));
-		Assert.assertTrue(options.hasOption(7));
-		Assert.assertTrue(options.hasOption(17));
-		Assert.assertTrue(options.hasOption(33));
-		Assert.assertTrue(options.hasOption(43));
+		assertTrue(options.hasOption(OptionNumberRegistry.ETAG));
+		assertTrue(options.hasOption(OptionNumberRegistry.LOCATION_PATH));
+		assertTrue(options.hasOption(7));
+		assertTrue(options.hasOption(17));
+		assertTrue(options.hasOption(33));
+		assertTrue(options.hasOption(43));
 
 		// Check that others are not
-		Assert.assertFalse(options.hasOption(19));
-		Assert.assertFalse(options.hasOption(53));
+		assertFalse(options.hasOption(19));
+		assertFalse(options.hasOption(53));
 
 		// Check that we can remove options
 		options.clearETags();
-		Assert.assertFalse(options.hasOption(OptionNumberRegistry.ETAG));
+		assertFalse(options.hasOption(OptionNumberRegistry.ETAG));
 	}
 
 	@Test
@@ -425,14 +466,26 @@ public class OptionTest {
 		options.addLocationPath("abc");
 		options.setUriPath("/this/is/a/test");
 
-		Assert.assertEquals(
+		assertEquals(
 				"{\"ETag\":[0x010203,0xBEEF], \"Location-Path\":\"abc\", \"Uri-Path\":[\"this\",\"is\",\"a\",\"test\"]}",
 				options.toString());
 
 		options.setMaxAge(77);
 
-		Assert.assertEquals(
+		assertEquals(
 				"{\"ETag\":[0x010203,0xBEEF], \"Location-Path\":\"abc\", \"Uri-Path\":[\"this\",\"is\",\"a\",\"test\"], \"Max-Age\":77}",
 				options.toString());
+
+		options = new OptionSet();
+		options.setBlock1(1, true, 4);
+		assertEquals("{\"Block1\":\"(szx=1/32, m=true, num=4)\"}", options.toString());
+
+		options = new OptionSet();
+		options.setAccept(MediaTypeRegistry.APPLICATION_VND_OMA_LWM2M_JSON);
+		assertEquals("{\"Accept\":\"application/vnd.oma.lwm2m+json\"}", options.toString());
+
+		options = new OptionSet();
+		options.setNoResponse(NoResponseOption.SUPPRESS_SERVER_ERROR | NoResponseOption.SUPPRESS_CLIENT_ERROR);
+		assertEquals("{\"No-Response\":\"NO CLIENT_ERROR,SERVER_ERROR\"}", options.toString());
 	}
 }

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapClientInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapClientInteroperabilityTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeNotNull;
 
@@ -31,6 +32,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.NoResponseOption;
 import org.eclipse.californium.elements.auth.PreSharedKeyIdentity;
 import org.eclipse.californium.elements.auth.X509CertPath;
 import org.eclipse.californium.elements.rule.TestNameLoggerRule;
@@ -128,6 +131,19 @@ public class LibCoapClientInteroperabilityTest {
 		processUtil.startupClient(DESTINATION_URL + "test", PSK, "Hello, CoAP!", cipherSuite);
 		connect("Hello, CoAP!", "Greetings!");
 		californiumUtil.assertPrincipalType(PreSharedKeyIdentity.class);
+	}
+
+	@Test
+	public void testLibCoapClientPskNoResponse() throws Exception {
+		CipherSuite cipherSuite = CipherSuite.TLS_PSK_WITH_AES_128_CCM_8;
+		californiumUtil.start(BIND, null, cipherSuite);
+		processUtil.setClientMessageType(CoAP.Type.NON);
+		processUtil.setClientOption(new NoResponseOption(NoResponseOption.SUPPRESS_SUCCESS).toOption());
+		processUtil.startupClient(DESTINATION_URL + "test", PSK, "Hello, CoAP!", cipherSuite);
+		californiumUtil.assertReceivedData("Hello, CoAP!", TIMEOUT_MILLIS);
+		assertFalse("unexpected \"Greetings!\" received", processUtil.waitConsole("Greetings!", TIMEOUT_MILLIS));
+		californiumUtil.assertPrincipalType(PreSharedKeyIdentity.class);
+		processUtil.stop(TIMEOUT_MILLIS);
 	}
 
 	@Test

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapProcessUtil.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapProcessUtil.java
@@ -30,6 +30,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.Option;
+import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.interoperability.test.ProcessUtil;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 
@@ -115,6 +119,9 @@ public class LibCoapProcessUtil extends ProcessUtil {
 	private String ca;
 	private String trusts;
 
+	private Option clientOption;
+	private CoAP.Type type;
+
 	private boolean serverMode;
 
 	/**
@@ -130,6 +137,9 @@ public class LibCoapProcessUtil extends ProcessUtil {
 		privateKey = null;
 		ca = null;
 		trusts = null;
+		clientOption = null;
+		type = null;
+		serverMode = false;
 	}
 
 	/**
@@ -320,6 +330,14 @@ public class LibCoapProcessUtil extends ProcessUtil {
 		this.trusts = trusts;
 	}
 
+	public void setClientOption(Option option) {
+		this.clientOption = option;
+	}
+
+	public void setClientMessageType(CoAP.Type type) {
+		this.type = type;
+	}
+
 	public void startupClient(String destination, LibCoapAuthenticationMode authMode, String message,
 			CipherSuite... ciphers) throws IOException, InterruptedException {
 		serverMode = false;
@@ -355,6 +373,14 @@ public class LibCoapProcessUtil extends ProcessUtil {
 				}
 				add(args, authMode);
 			}
+		}
+		if (clientOption != null) {
+			args.add("-O");
+			byte[] value = clientOption.getValue();
+			args.add(clientOption.getNumber() + ",0x" + StringUtil.byteArray2Hex(value));
+		}
+		if (type == Type.NON) {
+			args.add("-N");
 		}
 		args.add(destination);
 		print(args);


### PR DESCRIPTION
Add option NoResponse. Implement RFC7967.
Add libcoap interoperability test for no-response.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>