### PR TITLE
Remove Resource.getEndpoints().

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
@@ -659,10 +659,6 @@ public class CoapServer implements ServerInterface {
 			exchange.respond(ResponseCode.CONTENT, msg);
 		}
 
-		@Override
-		public List<Endpoint> getEndpoints() {
-			return CoapServer.this.getEndpoints();
-		}
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/Resource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/Resource.java
@@ -20,13 +20,11 @@
 package org.eclipse.californium.core.server.resources;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import org.eclipse.californium.core.CoapResource;
-import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.observe.ObserveRelation;
 import org.eclipse.californium.core.server.ServerMessageDeliverer;
@@ -263,13 +261,4 @@ public interface Resource {
 	 */
 	public ScheduledThreadPoolExecutor getSecondaryExecutor();
 
-	/**
-	 * Gets the endpoints this resource is bound to. As long as a resource is
-	 * not added to a server, it should return an empty list. After a resource
-	 * is added, it should return the endpoint list of its parent. The root of
-	 * the server will than return the actual list of endpoints.
-	 * 
-	 * @return the endpoints
-	 */
-	public List<Endpoint> getEndpoints();
 }

--- a/demo-apps/cf-benchmark-observe/src/main/java/org/eclipse/californium/benchmark/observe/AnnounceResource.java
+++ b/demo-apps/cf-benchmark-observe/src/main/java/org/eclipse/californium/benchmark/observe/AnnounceResource.java
@@ -73,7 +73,8 @@ public class AnnounceResource extends CoapResource {
 	
 	@Override
 	public void handlePOST(CoapExchange exchange) {
-		CoapClient client = this.createClient(exchange.getRequestText());
+		CoapClient client = this.createClient(exchange);
+		client.setURI(exchange.getRequestText());
 		CoapObserveRelation relation = client.observe(handler);
 		synchronized(relationStorage) {
 			relationStorage.put(exchange.getSourceSocketAddress(), relation);


### PR DESCRIPTION
Use Exchange.getEndpoint() instead.
Adapt CoapResource.createClient() adding a incoming exchange or
alternatively a outgoing endpoint.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>