### PR TITLE
Rename write(DatagramWriter writer) into writeTo(DatagramWriter writer).

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
@@ -953,7 +953,7 @@ public final class Connection {
 	 * @since 3.0
 	 */
 	@WipAPI
-	public boolean write(DatagramWriter writer) {
+	public boolean writeTo(DatagramWriter writer) {
 		if (establishedDtlsContext == null || establishedDtlsContext.isMarkedAsClosed() || rootCause != null) {
 			return false;
 		}
@@ -969,7 +969,7 @@ public final class Connection {
 			writer.writeByte((byte) 1);
 			start.write(writer);
 		}
-		establishedDtlsContext.write(writer);
+		establishedDtlsContext.writeTo(writer);
 		writer.writeByte(cid != null && cid.equals(establishedDtlsContext.getReadConnectionId()) ? (byte) 1 : (byte) 0);
 		SerializationUtil.writeFinishedItem(writer, position, Short.SIZE);
 		return true;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
@@ -80,7 +80,7 @@ public abstract class DTLSConnectionState implements Destroyable {
 		}
 
 		@Override
-		public void write(DatagramWriter writer) {
+		public void writeTo(DatagramWriter writer) {
 			throw new RuntimeException("Not suppported!");
 		}
 
@@ -229,6 +229,6 @@ public abstract class DTLSConnectionState implements Destroyable {
 	 * @since 3.0
 	 */
 	@WipAPI
-	public abstract void write(DatagramWriter writer);
+	public abstract void writeTo(DatagramWriter writer);
 
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSContext.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSContext.java
@@ -788,20 +788,20 @@ public final class DTLSContext implements Destroyable {
 	 *         otherwise, if the dtls context is marked as closed.
 	 */
 	@WipAPI
-	public boolean write(DatagramWriter writer) {
+	public boolean writeTo(DatagramWriter writer) {
 		if (markedAsclosed) {
 			return false;
 		}
 		int position = SerializationUtil.writeStartItem(writer, VERSION, Short.SIZE);
 		writer.writeLong(handshakeTime, Long.SIZE);
-		session.write(writer);
+		session.writeTo(writer);
 		writer.write(readEpoch, Byte.SIZE);
 		if (readEpoch > 0) {
-			getReadState().write(writer);
+			getReadState().writeTo(writer);
 		}
 		writer.write(writeEpoch, Byte.SIZE);
 		if (writeEpoch > 0) {
-			getWriteState().write(writer);
+			getWriteState().writeTo(writer);
 		}
 		writer.writeVarBytes(writeConnectionId, Byte.SIZE);
 		writeSequenceNumbers(writer);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -805,7 +805,7 @@ public final class DTLSSession implements Destroyable {
 	 * @since 3.0
 	 */
 	@WipAPI
-	public void write(DatagramWriter writer) {
+	public void writeTo(DatagramWriter writer) {
 		int position = SerializationUtil.writeStartItem(writer, VERSION, Short.SIZE);
 		writer.writeLong(creationTime, Long.SIZE);
 		if (serverNames == null) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DtlsAeadConnectionState.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DtlsAeadConnectionState.java
@@ -191,7 +191,7 @@ public class DtlsAeadConnectionState extends DTLSConnectionState {
 	}
 
 	@Override
-	public void write(DatagramWriter writer) {
+	public void writeTo(DatagramWriter writer) {
 		SecretSerializationUtil.write(writer, encryptionKey);
 		SecretSerializationUtil.write(writer, iv);
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DtlsBlockConnectionState.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DtlsBlockConnectionState.java
@@ -124,7 +124,7 @@ public class DtlsBlockConnectionState extends DTLSConnectionState {
 	}
 
 	@Override
-	public void write(DatagramWriter writer) {
+	public void writeTo(DatagramWriter writer) {
 		SecretSerializationUtil.write(writer, macKey);
 		SecretSerializationUtil.write(writer, encryptionKey);
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -661,7 +661,7 @@ public class InMemoryConnectionStore implements ResumptionSupportingConnectionSt
 					LOGGER.trace("{}skip {} ts, {}s too quiet!", tag, updateNanos, quiet);
 				} else {
 					LOGGER.trace("{}write {} ts, {}s ", tag, updateNanos, quiet);
-					if (connection.getValue().write(writer)) {
+					if (connection.getValue().writeTo(writer)) {
 						writer.writeTo(out);
 						++count;
 					} else {

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -767,7 +767,7 @@ public class DTLSConnectorTest {
 		Connection connection = clientConnectionStore.get(serverHelper.serverEndpoint);
 		assertArrayEquals(sessionId, connection.getEstablishedSession().getSessionIdentifier().getBytes());
 		DatagramWriter writer = new DatagramWriter(128);
-		connection.write(writer);
+		connection.writeTo(writer);
 		DatagramReader reader = new DatagramReader(writer.toByteArray());
 		Connection connection2 = Connection.fromReader(reader, 0);
 		clientConnectionStore.remove(connection, true);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DTLSContextTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DTLSContextTest.java
@@ -221,7 +221,7 @@ public class DTLSContextTest {
 
 	private static DTLSContext reload(DTLSContext context) {
 		DatagramWriter writer = new DatagramWriter();
-		if (context.write(writer)) {
+		if (context.writeTo(writer)) {
 			DatagramReader reader = new DatagramReader(writer.toByteArray());
 			return DTLSContext.fromReader(reader);
 		}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DTLSSessionTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DTLSSessionTest.java
@@ -171,7 +171,7 @@ public class DTLSSessionTest {
 
 	private static DTLSSession reload(DTLSSession context) {
 		DatagramWriter writer = new DatagramWriter();
-		context.write(writer);
+		context.writeTo(writer);
 		DatagramReader reader = new DatagramReader(writer.toByteArray());
 		return DTLSSession.fromReader(reader);
 	}
@@ -184,7 +184,7 @@ public class DTLSSessionTest {
 
 	private static DTLSSession serialize(DTLSSession session) {
 		DatagramWriter writer = new DatagramWriter(true);
-		session.write(writer);
+		session.writeTo(writer);
 		byte[] ticketBytes = writer.toByteArray();
 		DatagramReader reader = new DatagramReader(ticketBytes);
 		DTLSSession result = DTLSSession.fromReader(reader);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/TestInMemorySessionStore.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/TestInMemorySessionStore.java
@@ -42,7 +42,7 @@ public class TestInMemorySessionStore implements SessionStore {
 	public void put(final DTLSSession session) {
 		if (session != null && !session.getSessionIdentifier().isEmpty()) {
 			DatagramWriter writer = new DatagramWriter(true);
-			session.write(writer);
+			session.writeTo(writer);
 			cache.put(session.getSessionIdentifier(), writer.toByteArray());
 			establishedSessionCounter.incrementAndGet();
 		}


### PR DESCRIPTION
Adapt name to common used name.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>