### PR TITLE
Fix coap-client observeAndWait

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
@@ -1205,6 +1205,8 @@ public class CoapClient {
 			CoapResponse response = synchronous(request, outEndpoint);
 			if (response == null || !response.advanced().getOptions().hasObserve()) {
 				relation.setCanceled(true);
+			} else {
+				relation.waitForResponse(2000);
 			}
 			return relation;
 		} else {


### PR DESCRIPTION
Fix race condition CoapObserveRelation.getCurrent() and Request.waitForResponse().

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>