### PR TITLE
Use introduced message local address for incoming request instead of

### DIFF
--- a/MIGRATION_HINTS.md
+++ b/MIGRATION_HINTS.md
@@ -31,6 +31,8 @@ Since 3.0, the value is not initialized and must be provided with a separate set
 
 `Request.setOnResponseError(Throwable error)` is not longer accompanied by `Request.setCanceled(boolean canceled)`.
 
+For incoming traffic `Message.localAddress` contains now the address of the receiving Connector. Before the `Message.destinationContext` was used. The `Message.localAddress` supportes `UDPCOnnector` with `MulticastReceivers`.
+
 ### Scandium:
 
 Redesigned! May cause also unaware changes! If you detect one, please create an issue on 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -1487,7 +1487,7 @@ public class CoapEndpoint implements Endpoint {
 			}
 			if (connector instanceof UdpMulticastConnector) {
 				if (((UdpMulticastConnector) connector).isMutlicastReceiver()) {
-					throw new IllegalStateException("cunnector must not be multicast receiver!");
+					throw new IllegalStateException("connector must not be a multicast receiver!");
 				}
 			}
 			this.connector = connector;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/UdpMatcher.java
@@ -236,12 +236,10 @@ public final class UdpMatcher extends BaseMatcher {
 				}
 			} else if (previousRequest.isMulticast() || request.isMulticast()) {
 				// check, if request is received via multiple interfaces
-				InetSocketAddress group = request.getDestinationContext() == null ? null
-						: request.getDestinationContext().getPeerAddress();
-				InetSocketAddress previousGroup = previousRequest.getDestinationContext() == null ? null
-						: previousRequest.getDestinationContext().getPeerAddress();
+				InetSocketAddress group = request.getLocalAddress();
+				InetSocketAddress previousGroup = previousRequest.getLocalAddress();
 				if (!NetworkInterfacesUtil.equals(group, previousGroup)) {
-					boolean differs = Bytes.equals(request.getToken(), previousRequest.getToken());
+					boolean differs = !Bytes.equals(request.getToken(), previousRequest.getToken());
 					long timeDiff = TimeUnit.NANOSECONDS
 							.toMillis(Math.abs(request.getNanoTimestamp() - previousRequest.getNanoTimestamp()));
 					if (differs) {


### PR DESCRIPTION
deprecated destination context.

Fixes detection for multiple received multicast requests.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>