### PR TITLE
OSCORE: Updates the functionality for securely re-generating contexts

### DIFF
--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtx.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtx.java
@@ -510,6 +510,12 @@ public class OSCoreCtx {
 			throw new IllegalStateException("Context ID cannot be included for a context without one set.");
 		}
 		
+		// If Context ID is not to be included clear the overriding Context ID
+		// possibly set to be included in messages
+		if (!includeContextId) {
+			this.overrideContextId = null;
+		}
+
 		this.includeContextId = includeContextId;
 	}
 


### PR DESCRIPTION
This pull request updates the method described in Appendix B.2 of the OSCORE RFC for securely re-generating contexts:
https://tools.ietf.org/html/rfc8613#appendix-B.2

Changes done:
1. For messages exchanged during this procedure, the ID Contexts exchanged on the wire (kid_context) are now CBOR byte strings.
2. Fixed issue related to setting the sequence number to 0 in new contexts for the client. This was causing problems during integration into Leshan.