### PR TITLE
Add target="_blank" to javadoc http-references.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/BlockOption.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/BlockOption.java
@@ -32,7 +32,7 @@ public final class BlockOption {
 	/**
 	 * SZX for BERT blockwise.
 	 * 
-	 * See <a href="https://tools.ietf.org/html/rfc8323#section-6">RFC8323, 6.
+	 * See <a href="https://tools.ietf.org/html/rfc8323#section-6" target="_blank">RFC8323, 6.
 	 * Block-Wise Transfer and Reliable Transports</a>.
 	 * 
 	 * @since 3.0
@@ -99,7 +99,7 @@ public final class BlockOption {
 	 * 
 	 * @return {@code true}, if BERT is used, {@code false}, otherwise.
 	 * @see #BERT_SZX See
-	 *      <a href="https://tools.ietf.org/html/rfc8323#section-6">RFC8323, 6.
+	 *      <a href="https://tools.ietf.org/html/rfc8323#section-6" target="_blank">RFC8323, 6.
 	 *      Block-Wise Transfer and Reliable Transports</a>.
 	 * @since 3.0
 	 */
@@ -241,7 +241,7 @@ public final class BlockOption {
 
 	/**
 	 * Gets the 3-bit SZX code for a block size as specified by
-	 * <a href="https://tools.ietf.org/html/rfc7959#section-2.2">RFC 7959, Section 2.2</a>:
+	 * <a href="https://tools.ietf.org/html/rfc7959#section-2.2" target="_blank">RFC 7959, Section 2.2</a>:
 	 * 
 	 * <pre>
 	 * 16 bytes = 2^4 --&gt; 0

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAP.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAP.java
@@ -97,12 +97,12 @@ public final class CoAP {
 	public static final InetAddress MULTICAST_IPV4 = new InetSocketAddress("224.0.1.187", 0).getAddress();
 	/**
 	 * IPv6 multicast address for CoAP, RFC 7252, 12.8., FF0X::FD, link-local.
-	 * See <a href="https://tools.ietf.org/html/rfc7346#section-2">RFC7346, IPv6 Multicast Address Scopes</a> 
+	 * See <a href="https://tools.ietf.org/html/rfc7346#section-2" target="_blank">RFC7346, IPv6 Multicast Address Scopes</a> 
 	 */
 	public static final InetAddress MULTICAST_IPV6_LINKLOCAL = new InetSocketAddress("[FF02::FD]", 0).getAddress();
 	/**
 	 * IPv6 multicast address for CoAP, RFC 7252, 12.8., FF0X::FD, site-local.
-	 * See <a href="https://tools.ietf.org/html/rfc7346#section-2">RFC7346, IPv6 Multicast Address Scopes</a> 
+	 * See <a href="https://tools.ietf.org/html/rfc7346#section-2" target="_blank">RFC7346, IPv6 Multicast Address Scopes</a> 
 	 */
 	public static final InetAddress MULTICAST_IPV6_SITELOCAL = new InetSocketAddress("[FF05::FD]", 0).getAddress();
 
@@ -485,11 +485,11 @@ public final class CoAP {
 		 * The custom code 30.
 		 * 
 		 * Support for openHAB custom CoAP extension, CoIoT, used for shelly binding.
-		 * <a href="https://shelly-api-docs.shelly.cloud/images/CoIoT%20for%20Shelly%20devices%20(rev%201.0)%20.pdf">CoIot Shelly</a>.
+		 * <a href="https://shelly-api-docs.shelly.cloud/images/CoIoT%20for%20Shelly%20devices%20(rev%201.0)%20.pdf" target="_blank">CoIot Shelly</a>.
 		 * 
-		 * Note: though this code is not assigned byt IANA, it may cause future incompatibilities.
+		 * Note: though this code is not assigned by IANA, it may cause future incompatibilities.
 		 * If the IANA assigns this value, this will get replaced!
-		 * <a href="https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#method-codes">IANA CoAP Codes</a>.
+		 * <a href="https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#method-codes" target="_blank">IANA CoAP Codes</a>.
 		 */
 		CUSTOM_30(30);
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/LinkFormat.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/LinkFormat.java
@@ -161,11 +161,11 @@ public class LinkFormat {
 	/**
 	 * Check whether the given resource matches the given list of queries.
 	 *
-	 * Queries are interpreted according to <a href="https://tools.ietf.org/html/rfc6690#section-4.1">RFC 6690</a>,
+	 * Queries are interpreted according to <a href="https://tools.ietf.org/html/rfc6690#section-4.1" target="_blank">RFC 6690</a>,
 	 * section 4.1, with the important difference that more than one query can be passed to the function. The
 	 * resource only matches the list of queries if the resource matches every query in the list. This functionality
 	 * is required to implement resource directory filtering according to the
-	 * <a href="https://tools.ietf.org/html/draft-ietf-core-resource-directory-11#section-7">Resource directory</a>
+	 * <a href="https://tools.ietf.org/html/draft-ietf-core-resource-directory-11#section-7" target="_blank">Resource directory</a>
 	 * draft, which requires support for matching multiple attributes.
 	 *
 	 * @param resource The resource to match.

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/NoResponseOption.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/NoResponseOption.java
@@ -38,7 +38,7 @@ import org.eclipse.californium.elements.util.Bytes;
  * client.
  * </pre>
  * 
- * @see <a href="https://tools.ietf.org/html/rfc7967" target="_top"> RFC7967 - No Server Response</a>
+ * @see <a href="https://tools.ietf.org/html/rfc7967" target="_blank"> RFC7967 - No Server Response</a>
  * @since 3.0
  */
 public final class NoResponseOption {

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -205,14 +205,14 @@ public class Request extends Message {
 	 * {@link OptionSet#setUriHost(String)} depends on the destination, it's not
 	 * supported to change the destination afterwards. Excludes to use a Proxy-URI,
 	 * see
-	 * <a href="https://tools.ietf.org/html/rfc7252#section-5.10.2">Proxy-URI</a>
+	 * <a href="https://tools.ietf.org/html/rfc7252#section-5.10.2" target="_blank">Proxy-URI</a>
 	 */
 	private boolean uri;
 	/**
 	 * Indicates, that {@link #setProxyUri(String)} was called.
 	 * 
 	 * Excludes to use a CoAP-URI, see
-	 * <a href="https://tools.ietf.org/html/rfc7252#section-5.10.2">Proxy-URI</a>
+	 * <a href="https://tools.ietf.org/html/rfc7252#section-5.10.2" target="_blank">Proxy-URI</a>
 	 */
 	private boolean proxyUri;
 	/**
@@ -220,7 +220,7 @@ public class Request extends Message {
 	 * 
 	 * Used with a CoAP-URI to build the effective destination URI.
 	 * Excludes to use a Proxy-URI, see
-	 * <a href="https://tools.ietf.org/html/rfc7252#section-5.10.2">Proxy-URI</a>
+	 * <a href="https://tools.ietf.org/html/rfc7252#section-5.10.2" target="_blank">Proxy-URI</a>
 	 */
 	private boolean proxyScheme;
 
@@ -337,7 +337,7 @@ public class Request extends Message {
 	 * Requires the proxy destination address provided by
 	 * {@link #setDestinationContext(EndpointContext)}. Using a Proxy-URI
 	 * excludes to use a CoAP-URI, see
-	 * <a href="https://tools.ietf.org/html/rfc7252#section-5.10.2">Proxy-URI</a>
+	 * <a href="https://tools.ietf.org/html/rfc7252#section-5.10.2" target="_blank">Proxy-URI</a>
 	 * To escape this strict Proxy-/CoAP-URI exclusion for backwards compatibility,
 	 * set the options directly in the options-set using {@link #getOptions()}.
 	 * </p>
@@ -381,7 +381,7 @@ public class Request extends Message {
 	 * 
 	 * Used with a CoAP-URI to build the effective destination URI.
 	 * Excludes to use a Proxy-URI, see
-	 * <a href="https://tools.ietf.org/html/rfc7252#section-5.10.2">Proxy-URI</a>
+	 * <a href="https://tools.ietf.org/html/rfc7252#section-5.10.2" target="_blank">Proxy-URI</a>
 	 * 
 	 * Provides a fluent API to chain setters.
 	 * 
@@ -423,7 +423,7 @@ public class Request extends Message {
 	 * Provides a fluent API to chain setters.
 	 * 
 	 * @param uri A CoAP URI as specified by
-	 *            <a href="https://tools.ietf.org/html/rfc7252#section-6">
+	 *            <a href="https://tools.ietf.org/html/rfc7252#section-6" target="_blank">
 	 *            Section 6 of RFC 7252</a>
 	 * @return This request for command chaining.
 	 * @throws NullPointerException if the URI is {@code null}.
@@ -513,7 +513,7 @@ public class Request extends Message {
 
 	/**
 	 * Sets this request's options from a given URI as defined in
-	 * <a href="https://tools.ietf.org/html/rfc7252#section-6.4">RFC 7252,
+	 * <a href="https://tools.ietf.org/html/rfc7252#section-6.4" target="_blank">RFC 7252,
 	 * Section 6.4</a>.
 	 * <p>
 	 * This method requires the <em>destination</em> to be set already because
@@ -585,9 +585,9 @@ public class Request extends Message {
 	 * will also be left empty, if the provided port matches the destination's
 	 * port.
 	 * 
-	 * See <a href="https://tools.ietf.org/html/rfc7252#section-6.4">Decomposing
+	 * See <a href="https://tools.ietf.org/html/rfc7252#section-6.4" target="_blank">Decomposing
 	 * URIs into Options</a> and <a href=
-	 * "https://tools.ietf.org/html/rfc7252#section-5.7.2">Forward-Proxies</a>
+	 * "https://tools.ietf.org/html/rfc7252#section-5.7.2" target="_blank">Forward-Proxies</a>
 	 * for proxy support.
 	 * 
 	 * @param uri The URI to set the options from.
@@ -699,7 +699,7 @@ public class Request extends Message {
 
 	/**
 	 * Gets a URI derived from this request's options and properties as defined
-	 * by <a href="https://tools.ietf.org/html/rfc7252#section-6.5">RFC 7252,
+	 * by <a href="https://tools.ietf.org/html/rfc7252#section-6.5" target="_blank">RFC 7252,
 	 * Section 6.5</a>.
 	 * <p>
 	 * This method falls back to using <em>localhost</em> as the host part in

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/GroupedMessageIdTracker.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/GroupedMessageIdTracker.java
@@ -31,7 +31,7 @@ import org.eclipse.californium.elements.util.ClockUtil;
  * A helper for keeping track of message IDs.
  * <p>
  * According to the
- * <a href="https://tools.ietf.org/html/rfc7252#section-4.4">CoAP spec</a>
+ * <a href="https://tools.ietf.org/html/rfc7252#section-4.4" target="_blank">CoAP spec</a>
  * 
  * <pre>
  * The same Message ID MUST NOT be reused (in communicating with the

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MapBasedMessageIdTracker.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MapBasedMessageIdTracker.java
@@ -35,7 +35,7 @@ import org.eclipse.californium.elements.util.ClockUtil;
  * A helper for keeping track of message IDs using a map.
  * <p>
  * According to the
- * <a href="https://tools.ietf.org/html/rfc7252#section-4.4">CoAP spec</a>
+ * <a href="https://tools.ietf.org/html/rfc7252#section-4.4" target="_blank">CoAP spec</a>
  * 
  * <pre>
  * The same Message ID MUST NOT be reused (in communicating with the

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/MessageIdProvider.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/MessageIdProvider.java
@@ -27,7 +27,7 @@ public interface MessageIdProvider {
 	 * <p>
 	 * Message IDs are guaranteed to not being issued twice within
 	 * EXCHANGE_LIFETIME as defined by the
-	 * <a href="https://tools.ietf.org/html/rfc7252#section-4.4">CoAP spec</a>.
+	 * <a href="https://tools.ietf.org/html/rfc7252#section-4.4" target="_blank">CoAP spec</a>.
 	 * 
 	 * @param destination the destination that the message ID must be <em>free
 	 *            to use</em> for. This means that the message ID returned must

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/NullMessageIdTracker.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/NullMessageIdTracker.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * A helper for keeping track of message IDs.
  * <p>
  * According to the
- * <a href="https://tools.ietf.org/html/rfc7252#section-4.4">CoAP spec</a>
+ * <a href="https://tools.ietf.org/html/rfc7252#section-4.4" target="_blank">CoAP spec</a>
  * 
  * <pre>
  * The same Message ID MUST NOT be reused (in communicating with the

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
  * Matcher that runs over reliable TCP/TLS protocol.
  * 
  * Based on
- * <a href="https://tools.ietf.org/html/draft-ietf-core-coap-tcp-tls-02">draft-ietf-core-coap-tcp-tls-02</a>.
+ * <a href="https://tools.ietf.org/html/draft-ietf-core-coap-tcp-tls-02" target="_blank">draft-ietf-core-coap-tcp-tls-02</a>.
  */
 public final class TcpMatcher extends BaseMatcher {
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/config/NetworkConfig.java
@@ -317,8 +317,8 @@ public final class NetworkConfig {
 		/**
 		 * DTLS connection id length.
 		 * 
-		 * <a href="https://tools.ietf.org/html/draft-ietf-tls-dtls-connection-id-02">
-		 * draft-ietf-tls-dtls-connection-id-02</a>
+		 * <a href="https://tools.ietf.org/html/draft-ietf-tls-dtls-connection-id-06" target="_blank">
+		 * draft-ietf-tls-dtls-connection-id-06</a>
 		 * 
 		 * <ul>
 		 * <li>{@code ""} disabled support for connection id.</li>

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataParser.java
@@ -33,7 +33,7 @@ import static org.eclipse.californium.core.coap.CoAP.MessageFormat.*;
 
 /**
  * A parser for messages encoded following the encoding defined by the
- * <a href="https://tools.ietf.org/html/draft-ietf-core-coap-tcp-tls-03">CoAP-over-TCP draft</a>.
+ * <a href="https://tools.ietf.org/html/draft-ietf-core-coap-tcp-tls-03" target="_blank">CoAP-over-TCP draft</a>.
  */
 public final class TcpDataParser extends DataParser {
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataSerializer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataSerializer.java
@@ -28,7 +28,7 @@ import org.eclipse.californium.elements.util.DatagramWriter;
 
 /**
  * The DataSerialized serializes outgoing messages to byte arrays based on CoAP TCP/TLS spec:
- * <a href="https://tools.ietf.org/html/draft-ietf-core-coap-tcp-tls-02">draft-ietf-core-coap-tcp-tls-02</a> 
+ * <a href="https://tools.ietf.org/html/draft-ietf-core-coap-tcp-tls-02" target="_blank">draft-ietf-core-coap-tcp-tls-02</a> 
  */
 public final class TcpDataSerializer extends DataSerializer {
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/congestioncontrol/Rto.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/congestioncontrol/Rto.java
@@ -19,7 +19,7 @@ package org.eclipse.californium.core.network.stack.congestioncontrol;
 /**
  * Retransmission timeout calculator.
  * 
- * @see <a href="https://tools.ietf.org/html/rfc6298" target="_top"> RFC6298 -
+ * @see <a href="https://tools.ietf.org/html/rfc6298" target="_blank"> RFC6298 -
  *      Computing TCP's Retransmission Timer</a>
  * @since 3.0
  */

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
@@ -287,7 +287,7 @@ public class CoapExchange {
 	 *            to send requests.
 	 * 
 	 * @see Exchange#sendResponse(Response)
-	 * @see <a href="https://tools.ietf.org/html/rfc8516" target="_top">RFC8516 - Too Many Requests</a>
+	 * @see <a href="https://tools.ietf.org/html/rfc8516" target="_blank">RFC8516 - Too Many Requests</a>
 	 * @since 3.0
 	 */
 	public void respondClientOverload(int seconds) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/Resource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/Resource.java
@@ -60,9 +60,9 @@ import org.eclipse.californium.core.server.ServerMessageDeliverer;
  * A resource is able to respond to CoAP requests. The requests are contained in
  * an instance of type {@link Exchange} that contains additional information
  * about the current exchange. The request will always be a complete request and
- * not only a block as defined in the CoAP draft (<a
- * href="http://tools.ietf.org/html/draft-ietf-core-block-12">
- * http://tools.ietf.org/html/draft-ietf-core-block-12</a>)
+ * not only a block as defined in the CoAP RFC7959 (<a
+ * href="https://tools.ietf.org/html/rfc7959" target="_blank">
+ * RFC 7959 - Block-Wise Transfers in the Constrained Application Protocol (CoAP)</a>)
  * </p><p>
  * When a request arrives at the server, the {@link ServerMessageDeliverer}
  * searches in the resource tree for the destination resource. It travels down

--- a/californium-core/src/test/java/org/eclipse/californium/core/coap/RequestTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/coap/RequestTest.java
@@ -63,7 +63,7 @@ public class RequestTest {
 	}
 
 	/**
-	 * Verifies that the URI examples from <a href="https://tools.ietf.org/html/rfc7252#section-6.3">
+	 * Verifies that the URI examples from <a href="https://tools.ietf.org/html/rfc7252#section-6.3" target="_blank">
 	 * RFC 7252, Section 6.3</a> result in the same option values.
 	 * @throws URISyntaxException 
 	 */

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -83,7 +83,7 @@ import org.junit.experimental.categories.Category;
 
 /**
  * Test cases verifying the client side behavior of the examples from
- * <a href="https://tools.ietf.org/html/rfc7959#section-3">RFC 7958, Section 3</em>.
+ * <a href="https://tools.ietf.org/html/rfc7959#section-3" target="_blank">RFC 7958, Section 3</em>.
  */
 @Category(Medium.class)
 public class BlockwiseClientSideTest {

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseServerSideTest.java
@@ -82,7 +82,7 @@ import org.junit.experimental.categories.Category;
 
 /**
  * Test cases verifying the server side behavior of the examples from
- * <a href="https://tools.ietf.org/html/rfc7959#section-3">RFC 7958, Section 3</em>.
+ * <a href="https://tools.ietf.org/html/rfc7959#section-3" target="_blank">RFC 7958, Section 3</em>.
  */
 @Category(Large.class)
 public class BlockwiseServerSideTest {

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/CongestionControlTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/CongestionControlTest.java
@@ -51,7 +51,7 @@ import org.junit.experimental.categories.Category;
 
 /**
  * Test cases verifying the client side behavior of the examples from
- * <a href="https://tools.ietf.org/html/rfc7959#section-3">RFC 7958, Section 3</em>.
+ * <a href="https://tools.ietf.org/html/rfc7959#section-3" target="_blank">RFC 7958, Section 3</em>.
  */
 @Category(Medium.class)
 public class CongestionControlTest {

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/ProxyCoapResource.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/ProxyCoapResource.java
@@ -35,11 +35,11 @@ import org.eclipse.californium.proxy2.TranslationException;
 /**
  * Resource that forwards a coap request.
  * 
- * According <a href="https://tools.ietf.org/html/rfc7252#section-5.7">RFC 7252,
+ * According <a href="https://tools.ietf.org/html/rfc7252#section-5.7" target="_blank">RFC 7252,
  * 5.7 Proxying</a> proxies are classified into <a href=
- * "https://tools.ietf.org/html/rfc7252#section-5.7.2">Forward-Proxies</a> and
+ * "https://tools.ietf.org/html/rfc7252#section-5.7.2" target="_blank">Forward-Proxies</a> and
  * <a href=
- * "https://tools.ietf.org/html/rfc7252#section-5.7.3">Reverse-Proxies</a>.
+ * "https://tools.ietf.org/html/rfc7252#section-5.7.3" target="_blank">Reverse-Proxies</a>.
  * 
  * The forward-proxies operates in a generic way. The destination to sent the
  * request by the proxy is contained in the request itself. It is provided in

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapClientGnuTlsInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapClientGnuTlsInteroperabilityTest.java
@@ -63,7 +63,7 @@ public class LibCoapClientGnuTlsInteroperabilityTest {
 
 	/**
 	 * Gnutls seems to require a encoded private key with the optional public
-	 * key. <a href="https://tools.ietf.org/html/rfc5915#section-3">RFC 5915 -
+	 * key. <a href="https://tools.ietf.org/html/rfc5915#section-3" target="_blank">RFC 5915 -
 	 * Section 3</a> Unclear, how to achieve that with openssl 1.1.1, seems to
 	 * be the output of openssl 1.0
 	 */

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapProcessUtil.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapProcessUtil.java
@@ -48,10 +48,10 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
  * 4.2.1 (maybe newer) and is intended to work with openssl as DTLS
  * implementation.
  * 
- * Check <a href="https://libcoap.net/">libcoap.net</a> for further information.
- * <a href="https://libcoap.net/install.html">install</a> describes how to build
+ * Check <a href="https://libcoap.net/" target="_blank">libcoap.net</a> for further information.
+ * <a href="https://libcoap.net/install.html" target="_blank">install</a> describes how to build
  * it locally, the sources are available at
- * <a href="https://github.com/obgm/libcoap">github -libcoap</a>.
+ * <a href="https://github.com/obgm/libcoap" target="_blank">github -libcoap</a>.
  * 
  * If tinydtls, mbedtls or gnutls should be also tested, prepare additional
  * configuration, build and installation

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapServerGnuTlsInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapServerGnuTlsInteroperabilityTest.java
@@ -68,7 +68,7 @@ public class LibCoapServerGnuTlsInteroperabilityTest {
 
 	/**
 	 * Gnutls seems to require a encoded private key with the optional public
-	 * key. <a href="https://tools.ietf.org/html/rfc5915#section-3">RFC 5915 -
+	 * key. <a href="https://tools.ietf.org/html/rfc5915#section-3" target="_blank">RFC 5915 -
 	 * Section 3</a> Unclear, how to achieve that with openssl 1.1.1, seems to
 	 * be the output of openssl 1.0
 	 */

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/openssl/OpenSslProcessUtil.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/openssl/OpenSslProcessUtil.java
@@ -39,11 +39,11 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
  * 
  * Requires external openssl installation, otherwise the tests are skipped. On
  * linux install just the openssl package (version 1.1.1). On windows you may
- * install git for windows, <a href="https://git-scm.com/download/win">git</a>
+ * install git for windows, <a href="https://git-scm.com/download/win" target="_blank">git</a>
  * and add the extra tools to your path ("Git/mingw64/bin", may also be done
  * using a installation option). Alternatively you may install openssl for
  * windows on it's own <a href=
- * "https://bintray.com/vszakats/generic/download_file?file_path=openssl-1.1.1c-win64-mingw.zip">OpenSsl
+ * "https://bintray.com/vszakats/generic/download_file?file_path=openssl-1.1.1c-win64-mingw.zip" target="_blank">OpenSsl
  * for Windows</a> and add that to your path.
  * 
  * Note: the windows version 1.1.1a to 1.1.1k of the openssl s_server seems to

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UdpMulticastConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UdpMulticastConnector.java
@@ -84,7 +84,7 @@ import org.slf4j.LoggerFactory;
  * Generally try to omit to use the "any" address at any place. Neither for the
  * unicast socket nor the multicast bind-address. For IPv6 - multicast with
  * link-scope, this may fail caused by
- * <a href="https://bugs.openjdk.java.net/browse/JDK-8210493">Bind to node- or
+ * <a href="https://bugs.openjdk.java.net/browse/JDK-8210493" target="_blank">Bind to node- or
  * linklocal ipv6 multicast address fails</a>. Please always check your server
  * logs for messages of the pattern "received request {} via different multicast
  * groups ({} != {})!". That indicates, that the multicast request is accidently
@@ -93,7 +93,7 @@ import org.slf4j.LoggerFactory;
  * </p>
  * <p>
  * <a href=
- * "https://stackoverflow.com/questions/19392173/multicastsocket-constructors-and-binding-to-port-or-socketaddress">
+ * "https://stackoverflow.com/questions/19392173/multicastsocket-constructors-and-binding-to-port-or-socketaddress" target="_blank">
  * Stackoverflow - MulticastSocket - Constructors binding to port or
  * socketaddress</a>
  * </p>

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentity.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/PreSharedKeyIdentity.java
@@ -50,7 +50,7 @@ public final class PreSharedKeyIdentity extends AbstractExtensiblePrincipal<PreS
 	 * @param identity the identity.
 	 * @throws NullPointerException if the identity is <code>null</code>
 	 * @throws IllegalArgumentException if virtual host is not a valid host name
-	 *             as per <a href="http://tools.ietf.org/html/rfc1123">RFC 1123</a>.
+	 *             as per <a href="http://tools.ietf.org/html/rfc1123" target="_blank">RFC 1123</a>.
 	 */
 	public PreSharedKeyIdentity(String virtualHost, String identity) {
 		this(true, virtualHost, identity, null);
@@ -66,7 +66,7 @@ public final class PreSharedKeyIdentity extends AbstractExtensiblePrincipal<PreS
 	 * @param additionalInformation Additional information for this principal.
 	 * @throws NullPointerException if the identity is <code>null</code>
 	 * @throws IllegalArgumentException if virtual host is not a valid host name
-	 *             as per <a href="http://tools.ietf.org/html/rfc1123">RFC
+	 *             as per <a href="http://tools.ietf.org/html/rfc1123" target="_blank">RFC
 	 *             1123</a>.
 	 */
 	private PreSharedKeyIdentity(boolean sni, String virtualHost, String identity, AdditionalInfo additionalInformation) {

--- a/element-connector/src/main/java/org/eclipse/californium/elements/auth/RawPublicKeyIdentity.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/auth/RawPublicKeyIdentity.java
@@ -167,7 +167,7 @@ public class RawPublicKeyIdentity extends AbstractExtensiblePrincipal<RawPublicK
 	 * 
 	 * The URI is created using the SHA-256 hash algorithm on the key's
 	 * <em>SubjectPublicKeyInfo</em> as described in
-	 * <a href="http://tools.ietf.org/html/rfc6920#section-2">RFC 6920, section 2</a>.
+	 * <a href="http://tools.ietf.org/html/rfc6920#section-2" target="_blank">RFC 6920, section 2</a>.
 	 * 
 	 * @return the named information URI
 	 */

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/Asn1DerDecoder.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/Asn1DerDecoder.java
@@ -44,13 +44,13 @@ import org.slf4j.LoggerFactory;
  * ASN.1 DER decoder for SEQUENCEs and OIDs.
  * <p>
  * To support EdDSA, either java 15, or java 11 with
- * <a href="https://github.com/str4d/ed25519-java">ed25519-java</a> is required
+ * <a href="https://github.com/str4d/ed25519-java" target="_blank">ed25519-java</a> is required
  * at runtime. Using java 15 to build Californium, leaves out {@code ed25519-java}, using
  * java 11 for building, includes {@code ed25519-java} by default. If
  * {@code ed25519-java} should <b>NOT</b> be included into the Californium's
  * jars, add {@code -Dno.net.i2p.crypto.eddsa=true} to maven's arguments. In
  * that case, it's still possible to use {@code ed25519-java}, if the <a href=
- * "https://repo1.maven.org/maven2/net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar">eddsa-0.3.0.jar</a>
+ * "https://repo1.maven.org/maven2/net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar" target="_blank">eddsa-0.3.0.jar</a>
  * is provided to the classpath separately.
  * </p>
  */
@@ -135,7 +135,7 @@ public class Asn1DerDecoder {
 	public static final String EDDSA = "EdDSA";
 	/**
 	 * ECPoint uncompressed.
-	 * <a href="https://tools.ietf.org/html/rfc5480#section-2.2">RFC 5480, Section 2.2</a>
+	 * <a href="https://tools.ietf.org/html/rfc5480#section-2.2" target="_blank">RFC 5480, Section 2.2</a>
 	 * 
 	 * @since 2.3
 	 */
@@ -279,7 +279,7 @@ public class Asn1DerDecoder {
 	 * Provider for EdDsa.
 	 * 
 	 * Either java 15 SunEC, or, for java version before, external java 7
-	 * <a href="https://github.com/str4d/ed25519-java">net.i2p.crypto.eddsa</a>.
+	 * <a href="https://github.com/str4d/ed25519-java" target="_blank">net.i2p.crypto.eddsa</a>.
 	 * 
 	 * @since 2.4
 	 */
@@ -391,7 +391,7 @@ public class Asn1DerDecoder {
 	 * Get EdDSA provider.
 	 * 
 	 * Either java 15 SunEC, or, for java version before, external java 7
-	 * <a href="https://github.com/str4d/ed25519-java">net.i2p.crypto.eddsa</a>.
+	 * <a href="https://github.com/str4d/ed25519-java" target="_blank">net.i2p.crypto.eddsa</a>.
 	 * 
 	 * To disable external java 7 EdDSA provider, set
 	 * "net_i2p_crypto_eddsa_disable" to true in environment or system
@@ -487,7 +487,7 @@ public class Asn1DerDecoder {
 	 * Read key algorithm from subjects public key encoded in ASN.1 DER.
 	 * 
 	 * <pre>
-	 * <a href="https://tools.ietf.org/html/rfc5480">RFC 5480</a>
+	 * <a href="https://tools.ietf.org/html/rfc5480" target="_blank">RFC 5480</a>
 	 * SubjectPublicKeyInfo ::= SEQUENCE { 
 	 *    algorithm AlgorithmIdentifier,
 	 *    subjectPublicKey BIT STRING 
@@ -525,7 +525,7 @@ public class Asn1DerDecoder {
 	 * Read public key from subjects public key encoded in ASN.1 DER.
 	 * 
 	 * <pre>
-	 * <a href="https://tools.ietf.org/html/rfc5480">RFC 5480</a>
+	 * <a href="https://tools.ietf.org/html/rfc5480" target="_blank">RFC 5480</a>
 	 * SubjectPublicKeyInfo ::= SEQUENCE { 
 	 *    algorithm AlgorithmIdentifier,
 	 *    subjectPublicKey BIT STRING 
@@ -565,7 +565,7 @@ public class Asn1DerDecoder {
 	 * Supports:
 	 * 
 	 * <pre>
-	 * v1 (PKCS8), <a href="https://tools.ietf.org/html/rfc5208">RFC 5208</a>
+	 * v1 (PKCS8), <a href="https://tools.ietf.org/html/rfc5208" target="_blank">RFC 5208</a>
 	 * PrivateKeyInfo ::= SEQUENCE {
 	 *  version                   Version,
 	 *  privateKeyAlgorithm       PrivateKeyAlgorithmIdentifier,
@@ -573,8 +573,8 @@ public class Asn1DerDecoder {
 	 *  attributes           [0]  IMPLICIT Attributes OPTIONAL }
 	 * 
 	 * v2 (PKCS12), 
-	 * <a href="https://tools.ietf.org/html/rfc5958">RFC 5958 - (EC only!)</a>,
-	 * <a href="https://tools.ietf.org/html/rfc8410">RFC 8410 - EdDSA</a>
+	 * <a href="https://tools.ietf.org/html/rfc5958" target="_blank">RFC 5958 - (EC only!)</a>,
+	 * <a href="https://tools.ietf.org/html/rfc8410" target="_blank">RFC 8410 - EdDSA</a>
 	 * OneAsymmetricKey ::= SEQUENCE {
 	 *  version                   Version,
 	 *  privateKeyAlgorithm       PrivateKeyAlgorithmIdentifier,
@@ -652,7 +652,7 @@ public class Asn1DerDecoder {
 	 * Supports:
 	 * 
 	 * <pre>
-	 * v1 (PKCS8), <a href="https://tools.ietf.org/html/rfc5208">RFC 5208</a>
+	 * v1 (PKCS8), <a href="https://tools.ietf.org/html/rfc5208" target="_blank">RFC 5208</a>
 	 * PrivateKeyInfo ::= SEQUENCE {
 	 *  version                   Version,
 	 *  privateKeyAlgorithm       PrivateKeyAlgorithmIdentifier,
@@ -660,8 +660,8 @@ public class Asn1DerDecoder {
 	 *  attributes           [0]  IMPLICIT Attributes OPTIONAL }
 	 * 
 	 * v2 (PKCS12), 
-	 * <a href="https://tools.ietf.org/html/rfc5958">RFC 5958 - (EC only!)</a>,
-	 * <a href="https://tools.ietf.org/html/rfc8410">RFC 8410 - EdDSA</a>
+	 * <a href="https://tools.ietf.org/html/rfc5958" target="_blank">RFC 5958 - (EC only!)</a>,
+	 * <a href="https://tools.ietf.org/html/rfc8410" target="_blank">RFC 8410 - EdDSA</a>
 	 * OneAsymmetricKey ::= SEQUENCE {
 	 *  version                   Version,
 	 *  privateKeyAlgorithm       PrivateKeyAlgorithmIdentifier,
@@ -755,7 +755,7 @@ public class Asn1DerDecoder {
 	 * Read EC public key from encoded ec public key.
 	 * 
 	 * <pre>
-	 * <a href="https://tools.ietf.org/html/rfc5480#section-2.2">RFC 5480, Section 2.2</a>
+	 * <a href="https://tools.ietf.org/html/rfc5480#section-2.2" target="_blank">RFC 5480, Section 2.2</a>
 	 *  byte[0]        : compression := 4 (not compressed)
 	 *  byte[1..n]     : x
 	 *  byte[n+1..n+n] : y
@@ -788,7 +788,7 @@ public class Asn1DerDecoder {
 	/**
 	 * Read EdDSA private key (and public key) from PKCS12 / RFC 8410 v2 format.
 	 * 
-	 * See <a href="https://tools.ietf.org/html/rfc8410">RFC 8410 - EdDSA</a>.
+	 * See <a href="https://tools.ietf.org/html/rfc8410" target="_blank">RFC 8410 - EdDSA</a>.
 	 * 
 	 * @param data eddsa private key encoded according RFC 8410 v2
 	 * @return keys with private and public key. {@code null}, if keys could not

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/CertPathUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/CertPathUtil.java
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
  * </dl>
  * 
  * References:
- * <a href="https://tools.ietf.org/html/rfc5246#section-7.4.2">RFC5246, Section
+ * <a href="https://tools.ietf.org/html/rfc5246#section-7.4.2" target="_blank">RFC5246, Section
  * 7.4.2, Server Certificate</a>
  * <p>
  * "Because certificate validation requires that root keys be distributed
@@ -68,7 +68,7 @@ import org.slf4j.LoggerFactory;
  * case."
  * </p>
  * 
- * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.6">RFC5246, Section
+ * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.6" target="_blank">RFC5246, Section
  * 7.4.6, Client Certificate </a>
  * <p>
  * "If the certificate_authorities list in the certificate request message was
@@ -76,7 +76,7 @@ import org.slf4j.LoggerFactory;
  * by one of the listed CAs."
  * </p>
  * 
- * <a href="https://tools.ietf.org/html/rfc5280#section-6">RFC5280, Section 6,
+ * <a href="https://tools.ietf.org/html/rfc5280#section-6" target="_blank">RFC5280, Section 6,
  * Certification Path Validation</a>
  * <p>
  * "Valid paths begin with certificates issued by a trust anchor." ... "The

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/StringUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/StringUtil.java
@@ -446,7 +446,7 @@ public class StringUtil {
 
 	/**
 	 * Checks if a given string is a valid host name as defined by
-	 * <a href="http://tools.ietf.org/html/rfc1123">RFC 1123</a>.
+	 * <a href="http://tools.ietf.org/html/rfc1123" target="_blank">RFC 1123</a>.
 	 * 
 	 * @param name The name to check.
 	 * @return {@code true} if the name is a valid host name.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/CookieGenerator.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/CookieGenerator.java
@@ -46,7 +46,7 @@ import org.eclipse.californium.scandium.util.SecretUtil;
  * </pre>
  *
  * as suggested
- * <a href="http://tools.ietf.org/html/rfc6347#section-4.2.1">here</a>.
+ * <a href="http://tools.ietf.org/html/rfc6347#section-4.2.1" target="_blank">here</a>.
  *
  * Note: redesigned in 2.3 to use {@link ThreadLocalMac} instead of
  * {@link Mac#clone()}.
@@ -144,7 +144,7 @@ public class CookieGenerator {
 	 * </pre>
 	 *
 	 * as suggested
-	 * <a href="http://tools.ietf.org/html/rfc6347#section-4.2.1">here</a>.
+	 * <a href="http://tools.ietf.org/html/rfc6347#section-4.2.1" target="_blank">here</a>.
 	 *
 	 * @param peer address of the peer
 	 * @param clientHello received client hello to generate a cookie for
@@ -176,7 +176,7 @@ public class CookieGenerator {
 	 * </pre>
 	 *
 	 * as suggested
-	 * <a href="http://tools.ietf.org/html/rfc6347#section-4.2.1">here</a>.
+	 * <a href="http://tools.ietf.org/html/rfc6347#section-4.2.1" target="_blank">here</a>.
 	 *
 	 * @param peer address of the peer
 	 * @param clientHello received client hello to generate a cookie for

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -226,7 +226,7 @@ import org.eclipse.californium.scandium.util.ServerNames;
 
 /**
  * A {@link Connector} using <em>Datagram TLS</em> (DTLS) as specified in
- * <a href="http://tools.ietf.org/html/rfc6347">RFC 6347</a> for securing data
+ * <a href="http://tools.ietf.org/html/rfc6347" target="_blank">RFC 6347</a> for securing data
  * exchanged between networked clients and a server application.
  * 
  * Note: using IPv6 interfaces with multiple addresses including permanent and
@@ -1007,7 +1007,7 @@ public class DTLSConnector implements Connector, PersistentConnector, RecordLaye
 	}
 
 	/**
-	 * Force connector to an abbreviated handshake. See <a href="https://tools.ietf.org/html/rfc5246#section-7.3">RFC 5246</a>.
+	 * Force connector to an abbreviated handshake. See <a href="https://tools.ietf.org/html/rfc5246#section-7.3" target="_blank">RFC 5246</a>.
 	 * 
 	 * The abbreviated handshake will be done next time data will be sent with {@link #send(RawData)}.
 	 * @param peer the peer for which we will force to do an abbreviated handshake
@@ -1021,7 +1021,7 @@ public class DTLSConnector implements Connector, PersistentConnector, RecordLaye
 
 	/**
 	 * Marks all established sessions currently maintained by this connector to be resumed by means
-	 * of an <a href="https://tools.ietf.org/html/rfc5246#section-7.3">abbreviated handshake</a> the
+	 * of an <a href="https://tools.ietf.org/html/rfc5246#section-7.3" target="_blank">abbreviated handshake</a> the
 	 * next time a message is being sent to the corresponding peer using {@link #send(RawData)}.
 	 * <p>
 	 * This method's execution time is proportional to the number of connections this connector maintains.
@@ -2953,7 +2953,7 @@ public class DTLSConnector implements Connector, PersistentConnector, RecordLaye
 	 * peer in a single DTLS record.
 	 * <p>
 	 * The value of this property serves as an upper boundary for the <em>DTLSPlaintext.length</em>
-	 * field defined in <a href="http://tools.ietf.org/html/rfc6347#section-4.3.1">DTLS 1.2 spec,
+	 * field defined in <a href="http://tools.ietf.org/html/rfc6347#section-4.3.1" target="_blank">DTLS 1.2 spec,
 	 * Section 4.3.1</a>. This means that an application can assume that any message containing at
 	 * most as many bytes as indicated by this method, will be delivered to the peer in a single
 	 * unfragmented datagram.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AlertMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/AlertMessage.java
@@ -33,7 +33,7 @@ import org.eclipse.californium.elements.util.StringUtil;
  * invalidated, preventing the failed session from being used to establish new
  * connections. Like other messages, alert messages are encrypted and
  * compressed, as specified by the current connection state. For further details
- * see <a href="http://tools.ietf.org/html/rfc5246#section-7.2">RFC 5246</a>.
+ * see <a href="http://tools.ietf.org/html/rfc5246#section-7.2" target="_blank">RFC 5246</a>.
  */
 public final class AlertMessage implements DTLSMessage, Serializable {
 
@@ -101,7 +101,7 @@ public final class AlertMessage implements DTLSMessage, Serializable {
 	// Alert Level Enum ///////////////////////////////////////////////
 
 	/**
-	 * See <a href="http://tools.ietf.org/html/rfc5246#appendix-A.3">Alert
+	 * See <a href="http://tools.ietf.org/html/rfc5246#appendix-A.3" target="_blank">Alert
 	 * Messages</a> for the listing.
 	 */
 	public enum AlertLevel {
@@ -142,7 +142,7 @@ public final class AlertMessage implements DTLSMessage, Serializable {
 	// Alert Description Enum /////////////////////////////////////////
 
 	/**
-	 * See <a href="http://tools.ietf.org/html/rfc5246#appendix-A.3">Alert
+	 * See <a href="http://tools.ietf.org/html/rfc5246#appendix-A.3" target="_blank">Alert
 	 * Messages</a> for the listing.
 	 */
 	public enum AlertDescription {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateMessage.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  * The server MUST send a Certificate message whenever the agreed-upon key
  * exchange method uses certificates for authentication. This message will
  * always immediately follow the {@link ServerHello} message. For details see <a
- * href="http://tools.ietf.org/html/rfc5246#section-7.4.2">RFC 5246</a>.
+ * href="http://tools.ietf.org/html/rfc5246#section-7.4.2" target="_blank">RFC 5246</a>.
  */
 public final class CertificateMessage extends HandshakeMessage {
 
@@ -67,13 +67,13 @@ public final class CertificateMessage extends HandshakeMessage {
 	// DTLS-specific constants ///////////////////////////////////////////
 
 	/**
-	 * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.2">RFC 5246</a>:
+	 * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.2" target="_blank">RFC 5246</a>:
 	 * <code>opaque ASN.1Cert<1..2^24-1>;</code>
 	 */
 	private static final int CERTIFICATE_LENGTH_BITS = 24;
 
 	/**
-	 * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.2">RFC 5246</a>:
+	 * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.2" target="_blank">RFC 5246</a>:
 	 * <code>ASN.1Cert certificate_list<0..2^24-1>;</code>
 	 */
 	private static final int CERTIFICATE_LIST_LENGTH_BITS = 24;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateRequest.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  * This message, if sent, will immediately follow the {@link ServerKeyExchange} message (if it is sent;
  * otherwise, this message follows the server's {@link CertificateMessage} message).
  * 
- * @see <a href="http://tools.ietf.org/html/rfc5246#section-7.4.4">RFC 5246, 7.4.4. Certificate Request</a>
+ * @see <a href="http://tools.ietf.org/html/rfc5246#section-7.4.4" target="_blank">RFC 5246, 7.4.4. Certificate Request</a>
  */
 @NoPublicAPI
 public final class CertificateRequest extends HandshakeMessage {
@@ -224,7 +224,7 @@ public final class CertificateRequest extends HandshakeMessage {
 
 	/**
 	 * Certificate types that the client may offer. See <a
-	 * href="http://tools.ietf.org/html/rfc5246#section-7.4.4">RFC 5246</a> for
+	 * href="http://tools.ietf.org/html/rfc5246#section-7.4.4" target="_blank">RFC 5246</a> for
 	 * details.
 	 */
 	public static enum ClientCertificateType {
@@ -252,7 +252,7 @@ public final class CertificateRequest extends HandshakeMessage {
 
 		/**
 		 * Gets this certificate type's binary code as defined by
-		 * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.4">RFC 5246, Section 7.4.4</a>.
+		 * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.4" target="_blank">RFC 5246, Section 7.4.4</a>.
 		 * 
 		 * @return The code.
 		 */
@@ -287,7 +287,7 @@ public final class CertificateRequest extends HandshakeMessage {
 
 		/**
 		 * Gets a certificate type by its code as defined by
-		 * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.4">RFC 5246, Section 7.4.4</a>.
+		 * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.4" target="_blank">RFC 5246, Section 7.4.4</a>.
 		 * 
 		 * @param code The code.
 		 * @return The certificate type or {@code null} if the given code is not defined.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateType.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateType.java
@@ -18,7 +18,7 @@ package org.eclipse.californium.scandium.dtls;
 
 /**
  * Certificate types as defined in the
- * <a href="http://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml">IANA registry</a>.
+ * <a href="http://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml" target="_blank">IANA registry</a>.
  */
 public enum CertificateType {
 	// values as defined by IANA TLS Certificate Types registry

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateTypeExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateTypeExtension.java
@@ -31,7 +31,7 @@ import org.eclipse.californium.scandium.util.ListUtils;
 
 /**
  * This represents the Certificate Type Extension. See <a
- * href="http://tools.ietf.org/html/rfc7250">RFC 7250</a> for
+ * href="http://tools.ietf.org/html/rfc7250" target="_blank">RFC 7250</a> for
  * details.
  */
 public abstract class CertificateTypeExtension extends HelloExtension {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateVerify.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateVerify.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * has signing capability (i.e., all certificates except those containing fixed
  * Diffie-Hellman parameters). When sent, it MUST immediately follow the
  * {@link ClientKeyExchange} message. For further details see <a
- * href="http://tools.ietf.org/html/rfc5246#section-7.4.8">RFC 5246</a>.
+ * href="http://tools.ietf.org/html/rfc5246#section-7.4.8" target="_blank">RFC 5246</a>.
  */
 public final class CertificateVerify extends HandshakeMessage {
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ChangeCipherSpecMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ChangeCipherSpecMessage.java
@@ -30,7 +30,7 @@ import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
  * ChangeCipherSpec message is sent by both the client and the server to notify
  * the receiving party that subsequent records will be protected under the newly
  * negotiated CipherSpec and keys. For further details see <a
- * href="http://tools.ietf.org/html/rfc5246#section-7.1">RFC 5246</a>.
+ * href="http://tools.ietf.org/html/rfc5246#section-7.1" target="_blank">RFC 5246</a>.
  */
 public final class ChangeCipherSpecMessage implements DTLSMessage {
 
@@ -51,7 +51,7 @@ public final class ChangeCipherSpecMessage implements DTLSMessage {
 	// Change Cipher Spec Enum ////////////////////////////////////////
 
 	/**
-	 * See <a href="http://tools.ietf.org/html/rfc5246#section-7.1">RFC 5246</a>
+	 * See <a href="http://tools.ietf.org/html/rfc5246#section-7.1" target="_blank">RFC 5246</a>
 	 * for specification.
 	 */
 	public enum CCSType {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHello.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHello.java
@@ -44,7 +44,7 @@ import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.Supported
  * ClientHello as its first message. The client can also send a ClientHello in
  * response to a {@link HelloRequest} or on its own initiative in order to
  * re-negotiate the security parameters in an existing connection. See
- * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.1.2">RFC 5246</a>.
+ * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.1.2" target="_blank">RFC 5246</a>.
  */
 @NoPublicAPI
 public final class ClientHello extends HandshakeMessage {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientKeyExchange.java
@@ -23,7 +23,7 @@ package org.eclipse.californium.scandium.dtls;
  * message sent by the client after it receives the {@link ServerHelloDone}
  * message. This is a super class for the different key exchange methods (i.e.
  * Diffie-Hellman, RSA, Elliptic Curve Diffie-Hellman). See <a
- * href="http://tools.ietf.org/html/rfc5246#section-7.4.7">RFC 5246</a>.
+ * href="http://tools.ietf.org/html/rfc5246#section-7.4.7" target="_blank">RFC 5246</a>.
  */
 public abstract class ClientKeyExchange extends HandshakeMessage {
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CompressionMethod.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CompressionMethod.java
@@ -32,7 +32,7 @@ import org.eclipse.californium.elements.util.DatagramWriter;
  * <p>
  * Instances of this enumeration do not implement any compression functionality.
  * They merely serve as an object representation of the identifiers defined
- * in <a href="http://tools.ietf.org/html/rfc3749">Transport Layer Security
+ * in <a href="http://tools.ietf.org/html/rfc3749" target="_blank">Transport Layer Security
  * Protocol Compression Methods</a>.
  * <p>
  * Note that only the {@link #NULL} compression method is supported at the

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ContentType.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ContentType.java
@@ -20,7 +20,7 @@ package org.eclipse.californium.scandium.dtls;
  * The content type represents a higher-level protocol to process the enclosed
  * fragment. It is one of the four types: ChangeCipherSpec, Alert, Handshake,
  * ApplicationData. For further details see <a
- * href="http://tools.ietf.org/html/rfc5246#appendix-A.1">RFC 5246</a>.
+ * href="http://tools.ietf.org/html/rfc5246#appendix-A.1" target="_blank">RFC 5246</a>.
  */
 public enum ContentType {
 
@@ -56,8 +56,8 @@ public enum ContentType {
 		case 23:
 			return ContentType.APPLICATION_DATA;
 		case 25:
-			/** See <a href="https://datatracker.ietf.org/doc/draft-ietf-tls-dtls-connection-id/">Draft dtls-connection-id</a> **/
-			/** See <a href="https://mailarchive.ietf.org/arch/msg/tls/3wCyihI6Y7ZlciwcSDaQ322myYY">IANA code point assignment</a> **/
+			/** See <a href="https://datatracker.ietf.org/doc/draft-ietf-tls-dtls-connection-id/" target="_blank">Draft dtls-connection-id</a> **/
+			/** See <a href="https://mailarchive.ietf.org/arch/msg/tls/3wCyihI6Y7ZlciwcSDaQ322myYY" target="_blank">IANA code point assignment</a> **/
 			return ContentType.TLS12_CID;
 
 		default:

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
@@ -38,7 +38,7 @@ import org.eclipse.californium.scandium.util.SecretIvParameterSpec;
  * A set of algorithms and corresponding security parameters that together
  * represent the <em>current read</em> or <em>write state</em> of a TLS connection.
  * <p>
- * According to the <a href="http://tools.ietf.org/html/rfc5246#section-6.1">TLS 1.2</a>
+ * According to the <a href="http://tools.ietf.org/html/rfc5246#section-6.1" target="_blank">TLS 1.2</a>
  * specification, a connection state <em>specifies a compression algorithm, an encryption
  * algorithm, and a MAC algorithm.  In addition, the parameters for these algorithms are
  * known: the MAC key and the bulk encryption keys for the connection in both the read and

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSContext.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSContext.java
@@ -117,7 +117,7 @@ public final class DTLSContext implements Destroyable {
 	 *            server, the sequence number to use in the SERVER_HELLO record
 	 *            MUST be the same as the one from the successfully validated
 	 *            CLIENT_HELLO record (see
-	 *            <a href="http://tools.ietf.org/html/rfc6347#section-4.2.1">
+	 *            <a href="http://tools.ietf.org/html/rfc6347#section-4.2.1" target="_blank">
 	 *            section 4.2.1 of RFC 6347 (DTLS 1.2)</a> for details)
 	 * @throws NullPointerException if session is {@code null}
 	 * @throws IllegalArgumentException if sequence number is out of the valid
@@ -392,7 +392,7 @@ public final class DTLSContext implements Destroyable {
 	 * <p>
 	 * The information in the current read state is used to de-crypt messages
 	 * received from a peer. See
-	 * <a href="http://tools.ietf.org/html/rfc5246#section-6.1"> RFC 5246 (TLS
+	 * <a href="http://tools.ietf.org/html/rfc5246#section-6.1" target="_blank"> RFC 5246 (TLS
 	 * 1.2)</a> for details.
 	 * <p>
 	 * The cipher suite of the returned object will be
@@ -410,7 +410,7 @@ public final class DTLSContext implements Destroyable {
 	 * 
 	 * The information in the current read state is used to de-crypt messages
 	 * received from a peer. See
-	 * <a href="http://tools.ietf.org/html/rfc5246#section-6.1"> RFC 5246 (TLS
+	 * <a href="http://tools.ietf.org/html/rfc5246#section-6.1" target="_blank"> RFC 5246 (TLS
 	 * 1.2)</a> for details.
 	 * 
 	 * The <em>pending</em> read state becomes the <em>current</em> read state
@@ -449,7 +449,7 @@ public final class DTLSContext implements Destroyable {
 	 * <p>
 	 * The information in the current write state is used to en-crypt messages
 	 * sent to a peer. See
-	 * <a href="http://tools.ietf.org/html/rfc5246#section-6.1"> RFC 5246 (TLS
+	 * <a href="http://tools.ietf.org/html/rfc5246#section-6.1" target="_blank"> RFC 5246 (TLS
 	 * 1.2)</a> for details.
 	 * <p>
 	 * The cipher suite of the returned object will be
@@ -482,7 +482,7 @@ public final class DTLSContext implements Destroyable {
 	 * 
 	 * The information in the current write state is used to en-crypt messages
 	 * sent to a peer. See
-	 * <a href="http://tools.ietf.org/html/rfc5246#section-6.1"> RFC 5246 (TLS
+	 * <a href="http://tools.ietf.org/html/rfc5246#section-6.1" target="_blank"> RFC 5246 (TLS
 	 * 1.2)</a> for details.
 	 * 
 	 * The <em>pending</em> write state becomes the <em>current</em> write state
@@ -573,7 +573,7 @@ public final class DTLSContext implements Destroyable {
 	 * current epoch.
 	 * 
 	 * The check is done based on a <em>sliding window</em> as described in
-	 * <a href="http://tools.ietf.org/html/rfc6347#section-4.1.2.6"> section
+	 * <a href="http://tools.ietf.org/html/rfc6347#section-4.1.2.6" target="_blank"> section
 	 * 4.1.2.6 of the DTLS 1.2 spec</a>.
 	 * 
 	 * @param sequenceNo the record's sequence number

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSFlight.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSFlight.java
@@ -62,7 +62,7 @@ import org.slf4j.LoggerFactory;
  * peer's next flight has arrived in its total. A flight needs not only consist
  * of {@code HandshakeMessage}s but may also contain {@code AlertMessage}s and
  * {@code ChangeCipherSpecMessage}s. See
- * <a href="http://tools.ietf.org/html/rfc6347#section-4.2.4">RFC 6347</a> for
+ * <a href="http://tools.ietf.org/html/rfc6347#section-4.2.4" target="_blank">RFC 6347</a> for
  * details.
  * 
  * Scandium offers also the possibility to stop the retransmission with

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSMessage.java
@@ -28,7 +28,7 @@ public interface DTLSMessage {
 
 	/**
 	 * Gets the number of bytes representing this message as defined
-	 * by <a href="http://tools.ietf.org/html/rfc5246#appendix-A">TLS 1.2, Appendix A</a>.
+	 * by <a href="http://tools.ietf.org/html/rfc5246#appendix-A" target="_blank">TLS 1.2, Appendix A</a>.
 	 * 
 	 * @return number of bytes
 	 * @since 2.4
@@ -37,7 +37,7 @@ public interface DTLSMessage {
 
 	/**
 	 * Gets the byte array representation of this message as defined
-	 * by <a href="http://tools.ietf.org/html/rfc5246#appendix-A">TLS 1.2, Appendix A</a>.
+	 * by <a href="http://tools.ietf.org/html/rfc5246#appendix-A" target="_blank">TLS 1.2, Appendix A</a>.
 	 * 
 	 * @return the byte array
 	 */

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -143,7 +143,7 @@ public final class DTLSSession implements Destroyable {
 	/**
 	 * Use extended master secret.
 	 * 
-	 * See <a href="https://tools.ietf.org/html/rfc7627">RFC 7627</a>.
+	 * See <a href="https://tools.ietf.org/html/rfc7627" target="_blank">RFC 7627</a>.
 	 * 
 	 * @since 3.0
 	 */
@@ -469,7 +469,7 @@ public final class DTLSSession implements Destroyable {
 	/**
 	 * Set use extended master secret.
 	 * 
-	 * See <a href="https://tools.ietf.org/html/rfc7627">RFC 7627</a>.
+	 * See <a href="https://tools.ietf.org/html/rfc7627" target="_blank">RFC 7627</a>.
 	 * 
 	 * @param enable {@code true}, to enable the use of the extended master
 	 *            secret, {@code false}, if the master secret (RFC 5246) is
@@ -483,7 +483,7 @@ public final class DTLSSession implements Destroyable {
 	/**
 	 * Gets use extended master secret.
 	 * 
-	 * See <a href="https://tools.ietf.org/html/rfc7627">RFC 7627</a>.
+	 * See <a href="https://tools.ietf.org/html/rfc7627" target="_blank">RFC 7627</a>.
 	 * 
 	 * @return {@code true}, to enable the use of the extended master secret,
 	 *         {@code false}, if the master secret (RFC 5246) is used.
@@ -514,7 +514,7 @@ public final class DTLSSession implements Destroyable {
 	 * @throws NullPointerException if the master secret is {@code null}
 	 * @throws IllegalArgumentException if the secret is not exactly 48 bytes
 	 *             (see
-	 *             <a href="http://tools.ietf.org/html/rfc5246#section-8.1"> RFC
+	 *             <a href="http://tools.ietf.org/html/rfc5246#section-8.1" target="_blank"> RFC
 	 *             5246 (TLS 1.2), section 8.1</a>)
 	 * @throws IllegalStateException if the master secret is already set
 	 */
@@ -563,7 +563,7 @@ public final class DTLSSession implements Destroyable {
 	 * <p>
 	 * The value of this property corresponds directly to the
 	 * <em>DTLSPlaintext.length</em> field as defined in
-	 * <a href="http://tools.ietf.org/html/rfc6347#section-4.3.1">DTLS 1.2 spec,
+	 * <a href="http://tools.ietf.org/html/rfc6347#section-4.3.1" target="_blank">DTLS 1.2 spec,
 	 * Section 4.3.1</a>.
 	 * <p>
 	 * The default value of this property is 2^14 bytes.
@@ -593,7 +593,7 @@ public final class DTLSSession implements Destroyable {
 	 * <p>
 	 * The value of this property serves as an upper boundary for the
 	 * <em>DTLSPlaintext.length</em> field defined in
-	 * <a href="http://tools.ietf.org/html/rfc6347#section-4.3.1">DTLS 1.2 spec,
+	 * <a href="http://tools.ietf.org/html/rfc6347#section-4.3.1" target="_blank">DTLS 1.2 spec,
 	 * Section 4.3.1</a>. This means that an application can assume that any
 	 * message containing at most as many bytes as indicated by this method,
 	 * will be delivered to the peer in a single unfragmented IP datagram.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DtlsHandshakeTimeoutException.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DtlsHandshakeTimeoutException.java
@@ -30,7 +30,7 @@ public class DtlsHandshakeTimeoutException extends DtlsException {
 	}
 
 	/**
-	 * For more details on flight numbers, see <a href="https://tools.ietf.org/html/rfc6347#section-4.2.4">RFC 6347 §4.2.4.  Timeout and Retransmission</a>.
+	 * For more details on flight numbers, see <a href="https://tools.ietf.org/html/rfc6347#section-4.2.4" target="_blank">RFC 6347 §4.2.4. Timeout and Retransmission</a>.
 	 * 
 	 * @return Number of the flight which timed-out.
 	 */

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHClientKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHClientKeyExchange.java
@@ -27,11 +27,11 @@ import org.eclipse.californium.elements.util.StringUtil;
 /**
  * {@link ClientKeyExchange} message for all ECDH based key exchange methods.
  * Contains the client's ephemeral public key as encoded point. See
- * <a href="http://tools.ietf.org/html/rfc4492#section-5.7">RFC 4492</a> for
+ * <a href="http://tools.ietf.org/html/rfc4492#section-5.7" target="_blank">RFC 4492</a> for
  * further details. It is assumed, that the client's ECDH public key is not in
  * the client's certificate, so it must be provided here.
  * 
- * According <a href= "https://tools.ietf.org/html/rfc8422#section-5.1.1">RFC
+ * According <a href= "https://tools.ietf.org/html/rfc8422#section-5.1.1" target="_blank">RFC
  * 8422, 5.1.1. Supported Elliptic Curves Extension</a> only "named curves" are
  * valid, the "prime" and "char2" curve descriptions are deprecated. Also only
  * "UNCOMPRESSED" as point format is valid, the other formats have been

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ECDHServerKeyExchange.java
@@ -35,11 +35,11 @@ import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.Supported
 /**
  * The server's ephemeral ECDH.
  * 
- * See <a href="http://tools.ietf.org/html/rfc4492#section-5.4">
+ * See <a href="http://tools.ietf.org/html/rfc4492#section-5.4" target="_blank">
  * RFC 4492, section 5.4 Server Key Exchange</a> for details regarding
  * the message format.
  * 
- * According <a href= "https://tools.ietf.org/html/rfc8422#section-5.1.1">RFC
+ * According <a href="https://tools.ietf.org/html/rfc8422#section-5.1.1" target="_blank">RFC
  * 8422, 5.1.1. Supported Elliptic Curves Extension</a> only "named curves" are
  * valid, the "prime" and "char2" curve descriptions are deprecated. Also only
  * "UNCOMPRESSED" as point format is valid, the other formats have been

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhEcdsaServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhEcdsaServerKeyExchange.java
@@ -38,11 +38,11 @@ import org.slf4j.LoggerFactory;
 /**
  * The server's ephemeral ECDH with ECDSA signatures.
  * 
- * See <a href="http://tools.ietf.org/html/rfc4492#section-5.4">
+ * See <a href="http://tools.ietf.org/html/rfc4492#section-5.4" target="_blank">
  * RFC 4492, section 5.4 Server Key Exchange</a> for details regarding
  * the message format.
  * 
- * According <a href= "https://tools.ietf.org/html/rfc8422#section-5.1.1">RFC
+ * According <a href= "https://tools.ietf.org/html/rfc8422#section-5.1.1" target="_blank">RFC
  * 8422, 5.1.1. Supported Elliptic Curves Extension</a> only "named curves" are
  * valid, the "prime" and "char2" curve descriptions are deprecated. Also only
  * "UNCOMPRESSED" as point format is valid, the other formats have been

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhPskClientKeyExchange.java
@@ -23,11 +23,11 @@ import org.eclipse.californium.elements.util.StringUtil;
 /**
  * {@link ClientKeyExchange} message for PSK-ECDH based key exchange methods.
  * Contains the client's ephemeral public key as encoded point and the PSK
- * idenity. See <a href="https://tools.ietf.org/html/rfc5489#section-2">RFC
+ * idenity. See <a href="https://tools.ietf.org/html/rfc5489#section-2" target="_blank">RFC
  * 5489</a> for details. It is assumed, that the client's ECDH public key is not
  * in the client's certificate, so it must be provided here.
  * 
- * According <a href= "https://tools.ietf.org/html/rfc8422#section-5.1.1">RFC
+ * According <a href= "https://tools.ietf.org/html/rfc8422#section-5.1.1" target="_blank">RFC
  * 8422, 5.1.1. Supported Elliptic Curves Extension</a> only "named curves" are
  * valid, the "prime" and "char2" curve descriptions are deprecated. Also only
  * "UNCOMPRESSED" as point format is valid, the other formats have been

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/EcdhPskServerKeyExchange.java
@@ -25,11 +25,11 @@ import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.Supported
 /**
  * {@link ServerKeyExchange} message for PSK-ECDH based key exchange methods.
  * Contains the server's ephemeral public key as encoded point and the PSK
- * hint. See <a href="https://tools.ietf.org/html/rfc5489#section-2">RFC
+ * hint. See <a href="https://tools.ietf.org/html/rfc5489#section-2" target="_blank">RFC
  * 5489</a> for details. It is assumed, that the server's ECDH public key is not
  * in the servers's certificate, so it must be provided here.
  * 
- * According <a href= "https://tools.ietf.org/html/rfc8422#section-5.1.1">RFC
+ * According <a href= "https://tools.ietf.org/html/rfc8422#section-5.1.1" target="_blank">RFC
  * 8422, 5.1.1. Supported Elliptic Curves Extension</a> only "named curves" are
  * valid, the "prime" and "char2" curve descriptions are deprecated. Also only
  * "UNCOMPRESSED" as point format is valid, the other formats have been

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ExtendedMasterSecretExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ExtendedMasterSecretExtension.java
@@ -21,7 +21,7 @@ import org.eclipse.californium.elements.util.DatagramWriter;
 /**
  * Extended master secret extension.
  * <p>
- * See <a href="https://tools.ietf.org/html/rfc7627">RFC 7627</a> and
+ * See <a href="https://tools.ietf.org/html/rfc7627" target="_blank">RFC 7627</a> and
  * {@link ExtendedMasterSecretMode}for additional details.
  * 
  * @since 3.0

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ExtendedMasterSecretMode.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ExtendedMasterSecretMode.java
@@ -18,14 +18,14 @@ package org.eclipse.californium.scandium.dtls;
 /**
  * Extended master secret mode.
  * <p>
- * See <a href="https://tools.ietf.org/html/rfc7627">RFC 7627</a> for additional
+ * See <a href="https://tools.ietf.org/html/rfc7627" target="_blank">RFC 7627</a> for additional
  * details.
  * </p>
  * <p>
- * <a href="https://tools.ietf.org/html/rfc7925#section-16">RFC7925, 16. Session
+ * <a href="https://tools.ietf.org/html/rfc7925#section-16" target="_blank">RFC7925, 16. Session
  * Hash</a> recommends to use this extension. Please, obey the different
  * behavior on session resumption according
- * <a href="https://tools.ietf.org/html/rfc7627#section-5.3">RFC 7627, 5.3.
+ * <a href="https://tools.ietf.org/html/rfc7627#section-5.3" target="_blank">RFC 7627, 5.3.
  * Client and Server Behavior: Abbreviated Handshake</a>, if one side doesn't
  * support this extension.
  * </p>

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Finished.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Finished.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * protected with the just negotiated algorithms, keys, and secrets. The value
  * handshake_messages includes all handshake messages starting at
  * {@link ClientHello} up to, but not including, this {@link Finished} message.
- * See <a href="http://tools.ietf.org/html/rfc5246#section-7.4.9">RFC 5246</a>.
+ * See <a href="http://tools.ietf.org/html/rfc5246#section-7.4.9" target="_blank">RFC 5246</a>.
  */
 public final class Finished extends HandshakeMessage {
 
@@ -57,7 +57,7 @@ public final class Finished extends HandshakeMessage {
 
 	/**
 	 * Generates the verify data according to <a
-	 * href="http://tools.ietf.org/html/rfc5246#section-7.4.9">RFC 5246</a>:<br>
+	 * href="http://tools.ietf.org/html/rfc5246#section-7.4.9" target="_blank">RFC 5246</a>:<br>
 	 * <code>PRF(master_secret, finished_label, Hash(handshake_messages))</code>.
 	 * 
 	 * @param hmac
@@ -85,7 +85,7 @@ public final class Finished extends HandshakeMessage {
 	// Methods ////////////////////////////////////////////////////////
 	
 	/**
-	 * See <a href="http://tools.ietf.org/html/rfc5246#section-7.4.9">RFC
+	 * See <a href="http://tools.ietf.org/html/rfc5246#section-7.4.9" target="_blank">RFC
 	 * 5246</a>: All of the data from all messages in this handshake (not
 	 * including any HelloRequest messages) up to, but not including, this
 	 * message. This is only data visible at the handshake layer and does not

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeMessage.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Represents a general handshake message and defines the common header. The
  * subclasses are responsible for the rest of the message body. See <a
- * href="http://tools.ietf.org/html/rfc6347#section-4.2.2">RFC 6347</a> for the
+ * href="http://tools.ietf.org/html/rfc6347#section-4.2.2" target="_blank">RFC 6347</a> for the
  * message format.
  */
 @NoPublicAPI

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeType.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HandshakeType.java
@@ -18,7 +18,7 @@ package org.eclipse.californium.scandium.dtls;
 
 /**
  * Represents the possible types of a handshake message. See <a
- * href="http://tools.ietf.org/html/rfc5246#section-7.4">RFC 5246</a> for
+ * href="http://tools.ietf.org/html/rfc5246#section-7.4" target="_blank">RFC 5246</a> for
  * details.
  */
 public enum HandshakeType {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -368,7 +368,7 @@ public abstract class Handshaker implements Destroyable {
 	private boolean certificateVerificationPending = false;
 	/**
 	 * Other secret for ECDHE-PSK cipher suites.
-	 * <a href="https://tools.ietf.org/html/rfc5489#page-4"> RFC 5489, other
+	 * <a href="https://tools.ietf.org/html/rfc5489#page-4" target="_blank"> RFC 5489, other
 	 * secret</a>
 	 */
 	private SecretKey otherSecret;
@@ -1102,7 +1102,7 @@ public abstract class Handshaker implements Destroyable {
 	 * block to generate the encryption, MAC and IV keys. Also set the master
 	 * secret to the session for resumption handshakes.
 	 * 
-	 * See <a href="http://tools.ietf.org/html/rfc5246#section-6.3">RFC5246</a>
+	 * See <a href="http://tools.ietf.org/html/rfc5246#section-6.3" target="_blank">RFC5246</a>
 	 * for further details about the keys.
 	 * 
 	 * @param masterSecret the master secret.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtension.java
@@ -27,11 +27,11 @@ import org.eclipse.californium.elements.util.DatagramWriter;
  * An abstract class representing the functionality for all possible defined
  * extensions.
  * <p>
- * See <a href="http://tools.ietf.org/html/rfc5246#section-7.4.1.4">RFC 5246</a>
+ * See <a href="http://tools.ietf.org/html/rfc5246#section-7.4.1.4" target="_blank">RFC 5246</a>
  * for the extension format.
  * <p>
  * In particular this class is an object representation of the <em>Extension</em>
- * struct defined in <a href="http://tools.ietf.org/html/rfc5246#section-7.4.1.4">
+ * struct defined in <a href="http://tools.ietf.org/html/rfc5246#section-7.4.1.4" target="_blank">
  * TLS 1.2, Section 7.4.1.4</a>:
  * 
  * <pre>
@@ -113,7 +113,7 @@ public abstract class HelloExtension {
 	 * representation.
 	 * 
 	 * The TLS spec is unspecific about how a server should handle extensions sent by a client
-	 * that it does not understand. However, <a href="http://tools.ietf.org/html/rfc7250#section-4.2">
+	 * that it does not understand. However, <a href="http://tools.ietf.org/html/rfc7250#section-4.2" target="_blank">
 	 * Section 4.2 of RFC 7250</a> mandates that a server implementation must simply ignore
 	 * extensions of type <em>client_certificate_type</em> or <em>server_certificate_type</em>
 	 * if it does not support these extensions.
@@ -192,10 +192,10 @@ public abstract class HelloExtension {
 		TRUNCATED_HMAC(4, "truncated_hmac"),
 		STATUS_REQUEST(5, "status_request"),
 
-		/** See <a href="https://tools.ietf.org/html/rfc4681">RFC 4681</a> */
+		/** See <a href="https://tools.ietf.org/html/rfc4681" target="_blank">RFC 4681</a> */
 		USER_MAPPING(6, "user_mapping"),
 
-		/** See <a href="https://www.iana.org/go/rfc5878">RFC 5878</a> */
+		/** See <a href="https://www.iana.org/go/rfc5878" target="_blank">RFC 5878</a> */
 		CLIENT_AUTHZ(7, "client_authz"),
 		SERVER_AUTHZ(8, "server_authz"),
 
@@ -207,64 +207,64 @@ public abstract class HelloExtension {
 		CERT_TYPE(9, "cert_type"),
 
 		/**
-		 * See <a href="https://tools.ietf.org/html/rfc4492#section-5.1">RFC
+		 * See <a href="https://tools.ietf.org/html/rfc4492#section-5.1" target="_blank">RFC
 		 * 4492</a>
 		 */
 		ELLIPTIC_CURVES(10, "elliptic_curves"),
 		EC_POINT_FORMATS(11, "ec_point_formats"),
 
-		/** See <a href="https://www.iana.org/go/rfc5054">RFC 5054</a> */
+		/** See <a href="https://www.iana.org/go/rfc5054" target="_blank">RFC 5054</a> */
 		SRP(12, "srp"),
 
 		/** See <a href="https://www.iana.org/go/rfc5246">RFC 5246</a> */
 		SIGNATURE_ALGORITHMS(13, "signature_algorithms"),
 
-		/** See <a href="https://www.iana.org/go/rfc5764">RFC 5764</a> */
+		/** See <a href="https://www.iana.org/go/rfc5764" target="_blank">RFC 5764</a> */
 		USE_SRTP(14, "use_srtp"),
 
-		/** See <a href="https://www.iana.org/go/rfc6520">RFC 6520</a> */
+		/** See <a href="https://www.iana.org/go/rfc6520" target="_blank">RFC 6520</a> */
 		HEARTBEAT(15, "heartbeat"),
 
-		/** See <a href="https://www.iana.org/go/draft-friedl-tls-applayerprotoneg">draft-friedl-tls-applayerprotoneg</a> */
+		/** See <a href="https://www.iana.org/go/draft-friedl-tls-applayerprotoneg" target="_blank">draft-friedl-tls-applayerprotoneg</a> */
 		APPLICATION_LAYER_PROTOCOL_NEGOTIATION(16, "application_layer_protocol_negotiation"),
 
-		/** See <a href="https://www.iana.org/go/draft-ietf-tls-multiple-cert-status-extension-08">draft-ietf-tls-multiple-cert-status-extension-08</a> */
+		/** See <a href="https://www.iana.org/go/draft-ietf-tls-multiple-cert-status-extension-08" target="_blank">draft-ietf-tls-multiple-cert-status-extension-08</a> */
 		STATUS_REQUEST_V2(17, "status_request_v2"),
 
-		/** See <a href="https://www.iana.org/go/draft-laurie-pki-sunlight-12">draft-laurie-pki-sunlight-12</a> */
+		/** See <a href="https://www.iana.org/go/draft-laurie-pki-sunlight-12" target="_blank">draft-laurie-pki-sunlight-12</a> */
 		SIGNED_CERTIFICATE_TIMESTAMP(18, "signed_certificate_timestamp"),
 
-		/** See <a href="https://tools.ietf.org/html/rfc7250">RFC 7250</a> */
+		/** See <a href="https://tools.ietf.org/html/rfc7250" target="_blank">RFC 7250</a> */
 		CLIENT_CERT_TYPE(19, "client_certificate_type"),
 		SERVER_CERT_TYPE(20, "server_certificate_type"),
 
-		/** See <a href="https://www.iana.org/go/rfc7366">RFC 7366</a> **/
+		/** See <a href="https://www.iana.org/go/rfc7366" target="_blank">RFC 7366</a> **/
 		ENCRYPT_THEN_MAC(22, "encrypt_then_mac"),
 
 		/**
-		 * See <a href="https://tools.ietf.org/html/rfc7627">RFC 7627</a>
+		 * See <a href="https://tools.ietf.org/html/rfc7627" target="_blank">RFC 7627</a>
 		 * 
 		 * @since 3.0
 		 **/
 		EXTENDED_MASTER_SECRET(23, "extended_master_secret"),
 
 		/**
-		 * See <a href="https://tools.ietf.org/html/rfc8449">RFC 8449</a>
+		 * See <a href="https://tools.ietf.org/html/rfc8449" target="_blank">RFC 8449</a>
 		 * 
 		 * @since 2.4
 		 **/
 		RECORD_SIZE_LIMIT(28, "record_size_limit"),
 
-		/** See <a href="https://www.iana.org/go/rfc4507">RFC 4507</a> **/
+		/** See <a href="https://www.iana.org/go/rfc4507" target="_blank">RFC 4507</a> **/
 		SESSION_TICKET_TLS(35, "SessionTicket TLS"),
 
 		/** 
-		 * See <a href="https://datatracker.ietf.org/doc/draft-ietf-tls-dtls-connection-id/">Draft dtls-connection-id</a>
-		 * See <a href="https://mailarchive.ietf.org/arch/msg/tls/3wCyihI6Y7ZlciwcSDaQ322myYY">IANA code point assignment</a>
+		 * See <a href="https://datatracker.ietf.org/doc/draft-ietf-tls-dtls-connection-id/" target="_blank">Draft dtls-connection-id</a>
+		 * See <a href="https://mailarchive.ietf.org/arch/msg/tls/3wCyihI6Y7ZlciwcSDaQ322myYY" target="_blank">IANA code point assignment</a>
 		 **/
 		CONNECTION_ID(53, "Connection ID"),
 
-		/** See <a href="https://www.iana.org/go/rfc5746">RFC 5746</a> **/
+		/** See <a href="https://www.iana.org/go/rfc5746" target="_blank">RFC 5746</a> **/
 		RENEGOTIATION_INFO(65281, "renegotiation_info");
 
 		private int id;
@@ -277,7 +277,7 @@ public abstract class HelloExtension {
 
 		/**
 		 * Gets an extension type by its numeric id as defined by <a href=
-		 * "http://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xml">IANA</a>
+		 * "http://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xml" target="_blank">IANA</a>
 		 * 
 		 * @param id
 		 *            the numeric id of the extension

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloRequest.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloRequest.java
@@ -26,7 +26,7 @@ import org.eclipse.californium.elements.util.Bytes;
  * {@link ClientHello} message when convenient. This message is not intended to
  * establish which side is the client or server but merely to initiate a new
  * negotiation. See <a
- * href="http://tools.ietf.org/html/rfc5246#section-7.4.1.1">RFC 5246</a> for
+ * href="http://tools.ietf.org/html/rfc5246#section-7.4.1.1" target="_blank">RFC 5246</a> for
  * details.
  */
 public final class HelloRequest extends HandshakeMessage {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloVerifyRequest.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloVerifyRequest.java
@@ -25,7 +25,7 @@ import org.eclipse.californium.elements.util.StringUtil;
  * The server send this request after receiving a {@link ClientHello} message to
  * prevent Denial-of-Service Attacks.
  * <p>
- * See <a href="https://tools.ietf.org/html/rfc6347#section-4.2.1">RFC 6347</a>
+ * See <a href="https://tools.ietf.org/html/rfc6347#section-4.2.1" target="_blank">RFC 6347</a>
  * for the definition.
  * </p>
  * <p>
@@ -43,13 +43,13 @@ import org.eclipse.californium.elements.util.StringUtil;
  * A DTLS 1.2 server can either (SHOULD) send a version 1.0, or (MUST use same
  * version) 1.2. This question is pending in the IETF TLS mailing list, see
  * <a href=
- * "https://mailarchive.ietf.org/arch/msg/tls/rQ3El3ROKTN0rpzhRpJCaKOrUyU/">RFC
+ * "https://mailarchive.ietf.org/arch/msg/tls/rQ3El3ROKTN0rpzhRpJCaKOrUyU/" target="_blank">RFC
  * 6347 - Section 4.2.1 - used version in a HelloVerifyReques</a>.
  * </p>
  * <p>
  * There may be many assumptions about the intended behavior. One is to postpone
  * the version negotiation according
- * <a href= "https://tools.ietf.org/html/rfc5246#appendix-E.1">RFC 5246 - E.1 -
+ * <a href= "https://tools.ietf.org/html/rfc5246#appendix-E.1" target="_blank">RFC 5246 - E.1 -
  * Compatibility with TLS 1.0/1.1 and SSL 3.0</a> until the endpoint ownership is
  * verified. That prevents sending protocol-version alerts to wrong clients.
  * </p>

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/MaxFragmentLengthExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/MaxFragmentLengthExtension.java
@@ -26,7 +26,7 @@ import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
  * <p>
  * Instances of this class can be serialized to and deserialized from the
  * <em>MaxFragmentLength</em> data structure defined in <a
- * href="http://tools.ietf.org/html/rfc6066#section-4">RFC 6066, Section 4</a>.
+ * href="http://tools.ietf.org/html/rfc6066#section-4" target="_blank">RFC 6066, Section 4</a>.
  */
 public class MaxFragmentLengthExtension extends HelloExtension {
 
@@ -57,7 +57,7 @@ public class MaxFragmentLengthExtension extends HelloExtension {
 
 	/**
 	 * Creates an instance from a <em>MaxFragmentLength</em> structure as defined
-	 * in <a href="http://tools.ietf.org/html/rfc6066#section-4">RFC 6066, Section 4</a>.
+	 * in <a href="http://tools.ietf.org/html/rfc6066#section-4" target="_blank">RFC 6066, Section 4</a>.
 	 * 
 	 * @param extensionDataReader the extension data struct containing the length code
 	 * @return the extension object

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PSKClientKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PSKClientKeyExchange.java
@@ -27,7 +27,7 @@ import org.eclipse.californium.elements.util.StringUtil;
  * to use by including a "PSK identity" in this message. The server can
  * potentially provide a "PSK identity hint" to help the client in selecting
  * which identity to use. See <a
- * href="http://tools.ietf.org/html/rfc4279#section-2">RFC 4279</a> for details.
+ * href="http://tools.ietf.org/html/rfc4279#section-2" target="_blank">RFC 4279</a> for details.
  */
 public final class PSKClientKeyExchange extends ClientKeyExchange {
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PSKServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PSKServerKeyExchange.java
@@ -26,7 +26,7 @@ import org.eclipse.californium.elements.util.StringUtil;
  * algorithm. To help the client in selecting which identity to use, the server
  * can provide a "PSK identity hint" in the ServerKeyExchange message. If no
  * hint is provided, the ServerKeyExchange message is omitted. See <a
- * href="http://tools.ietf.org/html/rfc4279#section-2">ServerKeyExchange</a> for
+ * href="http://tools.ietf.org/html/rfc4279#section-2" target="_blank">ServerKeyExchange</a> for
  * the message format.
  */
 public final class PSKServerKeyExchange extends ServerKeyExchange {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ProtocolVersion.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ProtocolVersion.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
  * complement of the corresponding DTLS version numbers, e.g. DTLS version 1.2
  * is represented as bytes {254, 253}.
  * 
- * See <a href="http://tools.ietf.org/html/rfc6347#section-4.1"> Datagram
+ * See <a href="http://tools.ietf.org/html/rfc6347#section-4.1" target="_blank"> Datagram
  * Transport Layer Security Version 1.2 (RFC 6347), Section 4.1</a> for details.
  */
 public class ProtocolVersion implements Comparable<ProtocolVersion>, Serializable {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PskPublicInformation.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/PskPublicInformation.java
@@ -26,7 +26,7 @@ import org.eclipse.californium.scandium.dtls.pskstore.AdvancedPskStore;
 /**
  * Implementation of byte array based PSK public information (hint or identity).
  * 
- * Note: <a href="https://tools.ietf.org/html/rfc4279#section-5.1">RFC 4279, Section
+ * Note: <a href="https://tools.ietf.org/html/rfc4279#section-5.1" target="_blank">RFC 4279, Section
  * 5.1</a> defines to use UTF-8 to encode the identities. However, some peers
  * seems to use non UTF-8 encoded identities. This byte array based
  * implementation allows to support such non-compliant clients. The string based

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Random.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Random.java
@@ -28,7 +28,7 @@ import org.eclipse.californium.scandium.dtls.cipher.RandomManager;
  * A 32-byte value provided by the client and the server in the
  * {@link ClientHello} respectively in the {@link ServerHello} used later in the
  * protocol to compute the premaster secret. See <a
- * href="http://tools.ietf.org/html/rfc5246#appendix-A.4.1">RFC 5246</a> for the
+ * href="http://tools.ietf.org/html/rfc5246#appendix-A.4.1" target="_blank">RFC 5246</a> for the
  * message format.
  */
 public class Random extends Bytes {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ReassemblingHandshakeMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ReassemblingHandshakeMessage.java
@@ -25,7 +25,7 @@ import org.eclipse.californium.elements.util.StringUtil;
  * Reassemble fragmented handshake messages.
  * 
  * According
- * <a href="https://datatracker.ietf.org/doc/rfc6347#section-4.2.3">RFC 6347,
+ * <a href="https://datatracker.ietf.org/doc/rfc6347#section-4.2.3" target="_blank">RFC 6347,
  * Section 4.2.3</a> "DTLS implementations MUST be able to handle overlapping
  * fragment ranges". Therefore the processing of overlapping fragments is
  * optimized by early testing, if it contains a new data-range and merging of

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Record.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Record.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  * An object representation of the DTLS <em>Record</em> layer data structure(s).
  * <p>
  * The <em>Datagram Transport Layer Security</em> specification defines
- * a set of data structures at the <a href="http://tools.ietf.org/html/rfc6347#section-4.3.1">
+ * a set of data structures at the <a href="http://tools.ietf.org/html/rfc6347#section-4.3.1" target="_blank">
  * Record</a> layer containing the data to be exchanged with peers.
  * <p>
  * This class is used to transform these data structures from their binary encoding
@@ -347,7 +347,7 @@ public class Record {
 	 * Parses a sequence of <em>DTLSCiphertext</em> structures into {@code Record} instances.
 	 * 
 	 * The binary representation is expected to comply with the <em>DTLSCiphertext</em> structure
-	 * defined in <a href="http://tools.ietf.org/html/rfc6347#section-4.3.1">RFC6347, Section 4.3.1</a>.
+	 * defined in <a href="http://tools.ietf.org/html/rfc6347#section-4.3.1" target="_blank">RFC6347, Section 4.3.1</a>.
 	 * 
 	 * @param reader a reader with the raw binary representation containing one or more DTLSCiphertext structures
 	 * @param cidGenerator the connection id generator. May be {@code null}.
@@ -468,7 +468,7 @@ public class Record {
 	/**
 	 * Generates the explicit part of the nonce to be used with the AEAD Cipher.
 	 * 
-	 * <a href="http://tools.ietf.org/html/rfc6655#section-3">RFC6655, Section 3</a>
+	 * <a href="http://tools.ietf.org/html/rfc6655#section-3" target="_blank">RFC6655, Section 3</a>
 	 * encourages the use of the session's 16bit epoch value concatenated
 	 * with a monotonically increasing 48bit sequence number as the explicit nonce. 
 	 * 
@@ -481,7 +481,7 @@ public class Record {
 	}
 
 	/**
-	 * See <a href="http://tools.ietf.org/html/rfc5246#section-6.2.3.3">RFC 5246</a>:
+	 * See <a href="http://tools.ietf.org/html/rfc5246#section-6.2.3.3" target="_blank">RFC 5246</a>:
 	 * 
 	 * <pre>
 	 * additional_data = seq_num + TLSCompressed.type +
@@ -491,7 +491,7 @@ public class Record {
 	 * where "+" denotes concatenation.
 	 * 
 	 * For the new tls_cid record, currently defined in
-	 * <a href="https://datatracker.ietf.org/doc/draft-ietf-tls-dtls-connection-id/">Draft dtls-connection-id</a>
+	 * <a href="https://datatracker.ietf.org/doc/draft-ietf-tls-dtls-connection-id/" target="_blank">Draft dtls-connection-id</a>
 	 * this is extended by the conneciton id:
 	 * 
 	 * <pre>

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordLayer.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordLayer.java
@@ -27,7 +27,7 @@ import org.eclipse.californium.elements.util.NoPublicAPI;
 /**
  * An abstraction of the DTLS record layer's capabilities for sending records to
  * peers. MTU values according
- * <a href="https://en.wikipedia.org/wiki/Maximum_transmission_unit">MTU - Wikipedia</a>.
+ * <a href="https://en.wikipedia.org/wiki/Maximum_transmission_unit" target="_blank">MTU - Wikipedia</a>.
  */
 @NoPublicAPI
 public interface RecordLayer {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordSizeLimitExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/RecordSizeLimitExtension.java
@@ -23,7 +23,7 @@ import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
 /**
  * Record size limit extension.
  * <p>
- * See <a href="http://tools.ietf.org/html/rfc8449">RFC 8449</a> for additional
+ * See <a href="http://tools.ietf.org/html/rfc8449" target="_blank">RFC 8449</a> for additional
  * details.
  * 
  * @since 2.4

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
@@ -52,7 +52,7 @@ import org.eclipse.californium.scandium.util.SecretUtil;
 /**
  * The resuming client handshaker executes a abbreviated handshake by adding a
  * valid session identifier into its ClientHello message. The message flow is
- * depicted in <a href="http://tools.ietf.org/html/rfc5246#section-7.3">Figure
+ * depicted in <a href="http://tools.ietf.org/html/rfc5246#section-7.3" target="_blank">Figure
  * 2</a>. The new keys will be generated from the master secret established from
  * a previous full handshake.
  * 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingServerHandshaker.java
@@ -46,7 +46,7 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
  * It checks whether such a session still exists and if so,
  * generates the new keys from the previously established master secret.
  * The message flow is depicted in <a
- * href="http://tools.ietf.org/html/rfc5246#section-7.3">Figure 2</a>.
+ * href="http://tools.ietf.org/html/rfc5246#section-7.3" target="_blank">Figure 2</a>.
  */
 @NoPublicAPI
 public class ResumingServerHandshaker extends ServerHandshaker {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -456,7 +456,7 @@ public class ServerHandshaker extends Handshaker {
 	 * 
 	 * Prepares the next flight (mandatory messages depend on the cipher suite / key exchange
 	 * algorithm). Mandatory messages are ServerHello and ServerHelloDone; see
-	 * <a href="http://tools.ietf.org/html/rfc5246#section-7.3">Figure 1.
+	 * <a href="http://tools.ietf.org/html/rfc5246#section-7.3" target="_blank">Figure 1.
 	 * Message flow for a full handshake</a> for details about the messages in
 	 * the next flight.
 	 * 
@@ -791,7 +791,7 @@ public class ServerHandshaker extends Handshaker {
 	 * </p>
 	 * <p>
 	 * The <em>SSL_NULL_WITH_NULL_NULL</em> cipher suite is <em>never</em>
-	 * negotiated as mandated by <a href="http://tools.ietf.org/html/rfc5246#appendix-A.5">
+	 * negotiated as mandated by <a href="http://tools.ietf.org/html/rfc5246#appendix-A.5" target="_blank">
 	 * RFC 5246 Appendix A.5</a>
 	 * </p>
 	 * 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHello.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHello.java
@@ -34,7 +34,7 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
  * The server will send this message in response to a {@link ClientHello}
  * message when it was able to find an acceptable set of algorithms. If it
  * cannot find such a match, it will respond with a handshake failure alert. See
- * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.1.3">RFC 5246</a> for
+ * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.1.3" target="_blank">RFC 5246</a> for
  * further details.
  */
 public final class ServerHello extends HandshakeMessage {
@@ -92,7 +92,7 @@ public final class ServerHello extends HandshakeMessage {
 
 	/**
 	 * Constructs a full <em>ServerHello</em> message.
-	 * See <a href="http://tools.ietf.org/html/rfc5246#section-7.4.1.3">
+	 * See <a href="http://tools.ietf.org/html/rfc5246#section-7.4.1.3" target="_blank">
 	 * RFC 5246 (TLS 1.2), Section 7.4.1.3. Server Hello</a> for details.
 	 * 
 	 * @param version

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHelloDone.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHelloDone.java
@@ -23,7 +23,7 @@ import org.eclipse.californium.elements.util.Bytes;
  * The ServerHelloDone message is sent by the server to indicate the end of the
  * {@link ServerHello} and associated messages. After sending this message, the
  * server will wait for a client response. See
- * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.5">RFC 5246</a> for
+ * <a href="http://tools.ietf.org/html/rfc5246#section-7.4.5" target="_blank">RFC 5246</a> for
  * details.
  */
 public final class ServerHelloDone extends HandshakeMessage {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerKeyExchange.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerKeyExchange.java
@@ -21,7 +21,7 @@ package org.eclipse.californium.scandium.dtls;
  * This message will be sent immediately after the server
  * {@link CertificateMessage} (or the {@link ServerHello} message, if this is an
  * anonymous negotiation). See <a
- * href="http://tools.ietf.org/html/rfc5246#section-7.4.3">RFC 5246</a> for
+ * href="http://tools.ietf.org/html/rfc5246#section-7.4.3" target="_blank">RFC 5246</a> for
  * details.
  */
 public abstract class ServerKeyExchange extends HandshakeMessage {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerNameExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerNameExtension.java
@@ -24,7 +24,7 @@ import org.eclipse.californium.scandium.util.ServerNames;
 /**
  * Conveys information specified by the <em>Server Name Indication</em> TLS extension.
  * <p>
- * See <a href="https://tools.ietf.org/html/rfc6066#section-3">RFC 6066, Section 3</a> for additional details.
+ * See <a href="https://tools.ietf.org/html/rfc6066#section-3" target="_blank">RFC 6066, Section 3</a> for additional details.
  *
  */
 public final class ServerNameExtension extends HelloExtension {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SignatureAndHashAlgorithm.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SignatureAndHashAlgorithm.java
@@ -28,22 +28,22 @@ import java.util.List;
 import org.eclipse.californium.scandium.dtls.cipher.ThreadLocalSignature;
 
 /**
- * See <a href="https://tools.ietf.org/html/rfc5246#appendix-A.4.1">RFC 5246</a>
+ * See <a href="https://tools.ietf.org/html/rfc5246#appendix-A.4.1" target="_blank">RFC 5246</a>
  * for details.
  * 
  * Since 2.4: added support for 
- * <a href="https://tools.ietf.org/html/rfc8422#section-5.1.3">RFC 8422</a>.
+ * <a href="https://tools.ietf.org/html/rfc8422#section-5.1.3" target="_blank">RFC 8422</a>.
  */
 public final class SignatureAndHashAlgorithm {
 
 	/**
 	 * Hash algorithms as defined by
-	 * <a href="https://tools.ietf.org/html/rfc5246#appendix-A.4.1">RFC 5246</a>.
+	 * <a href="https://tools.ietf.org/html/rfc5246#appendix-A.4.1" target="_blank">RFC 5246</a>.
 	 * <P>
 	 * Code is at most 255 (1 byte needed for representation).
 	 * 
 	 * Since 2.4: added {@link #INTRINSIC} defined by
-	 * <a href="https://tools.ietf.org/html/rfc8422#section-5.1.3">RFC 8422</a>.
+	 * <a href="https://tools.ietf.org/html/rfc8422#section-5.1.3" target="_blank">RFC 8422</a>.
 	 */
 	public static enum HashAlgorithm {
 
@@ -66,8 +66,8 @@ public final class SignatureAndHashAlgorithm {
 		 * 
 		 * @param code The algorithm's code.
 		 * @return The algorithm or {@code null} if no algorithm is defined for the given code by
-		 *         <a href="https://tools.ietf.org/html/rfc5246#appendix-A.4.1">RFC 5246, Appendix A.4.1</a>, or
-		 *         <a href="https://tools.ietf.org/html/rfc8422#section-5.1.3">RFC 8422, Section 5.1.3</a>.
+		 *         <a href="https://tools.ietf.org/html/rfc5246#appendix-A.4.1" target="_blank">RFC 5246, Appendix A.4.1</a>, or
+		 *         <a href="https://tools.ietf.org/html/rfc8422#section-5.1.3" target="_blank">RFC 8422, Section 5.1.3</a>.
 		 */
 		public static HashAlgorithm getAlgorithmByCode(int code) {
 			switch (code) {
@@ -95,8 +95,8 @@ public final class SignatureAndHashAlgorithm {
 
 		/**
 		 * Gets the code of this algorithm as defined by
-		 * <a href="https://tools.ietf.org/html/rfc5246#appendix-A.4.1">RFC 5246, Appendix A.4.1</a>, or
-		 * <a href="https://tools.ietf.org/html/rfc8422#section-5.1.3">RFC 8422, Section 5.1.3</a>.
+		 * <a href="https://tools.ietf.org/html/rfc5246#appendix-A.4.1" target="_blank">RFC 5246, Appendix A.4.1</a>, or
+		 * <a href="https://tools.ietf.org/html/rfc8422#section-5.1.3" target="_blank">RFC 8422, Section 5.1.3</a>.
 		 * 
 		 * @return The code.
 		 */
@@ -107,12 +107,12 @@ public final class SignatureAndHashAlgorithm {
 
 	/**
 	 * Signature algorithms as defined by
-	 * <a href="http://tools.ietf.org/html/rfc5246#appendix-A.4.1">RFC 5246</a>.
+	 * <a href="http://tools.ietf.org/html/rfc5246#appendix-A.4.1" target="_blank">RFC 5246</a>.
 	 * <p>
 	 * Code is at most 255 (1 byte needed for representation).
 	 * 
 	 * Since 2.4: added {@link #ED25519} and {@link #ED448} defined by
-	 * <a href="http://tools.ietf.org/html/rfc8422#section-5.1.3">RFC 8422</a>.
+	 * <a href="http://tools.ietf.org/html/rfc8422#section-5.1.3" target="_blank">RFC 8422</a>.
 	 */
 	public static enum SignatureAlgorithm {
 
@@ -143,8 +143,8 @@ public final class SignatureAndHashAlgorithm {
 		 * 
 		 * @param code The algorithm's code.
 		 * @return The algorithm or {@code null} if no algorithm is defined for the given code by
-		 *         <a href="https://tools.ietf.org/html/rfc5246#appendix-A.4.1">RFC 5246, Appendix A.4.1</a>, or
-		 *         <a href="https://tools.ietf.org/html/rfc8422#section-5.1.3">RFC 8422, Section 5.1.3</a>.
+		 *         <a href="https://tools.ietf.org/html/rfc5246#appendix-A.4.1" target="_blank">RFC 5246, Appendix A.4.1</a>, or
+		 *         <a href="https://tools.ietf.org/html/rfc8422#section-5.1.3" target="_blank">RFC 8422, Section 5.1.3</a>.
 		 */
 		public static SignatureAlgorithm getAlgorithmByCode(int code) {
 			switch (code) {
@@ -168,8 +168,8 @@ public final class SignatureAndHashAlgorithm {
 
 		/**
 		 * Gets the code of this algorithm as defined by
-		 * <a href="https://tools.ietf.org/html/rfc5246#appendix-A.4.1">RFC 5246, Appendix A.4.1</a>, or
-		 * <a href="https://tools.ietf.org/html/rfc8422#section-5.1.3">RFC 8422, Section 5.1.3</a>.
+		 * <a href="https://tools.ietf.org/html/rfc5246#appendix-A.4.1" target="_blank">RFC 5246, Appendix A.4.1</a>, or
+		 * <a href="https://tools.ietf.org/html/rfc8422#section-5.1.3" target="_blank">RFC 8422, Section 5.1.3</a>.
 		 * 
 		 * @return The code.
 		 */
@@ -548,7 +548,7 @@ public final class SignatureAndHashAlgorithm {
 	}
 
 	/**
-	 * Gets the <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#Signature">
+	 * Gets the <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#Signature" target="_blank">
 	 * JCA standard name</a> corresponding to this combination of hash and signature algorithm.
 	 * <p>
 	 * The name returned by this method can be used to instantiate a {@code java.security.Signature} object like this:

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SupportedPointFormatsExtension.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SupportedPointFormatsExtension.java
@@ -30,7 +30,7 @@ import org.eclipse.californium.elements.util.StringUtil;
 /**
  * The supported point formats extension.
  * 
- * According <a href= "https://tools.ietf.org/html/rfc8422#section-5.1.1">RFC
+ * According <a href= "https://tools.ietf.org/html/rfc8422#section-5.1.1" target="_blank">RFC
  * 8422, 5.1.1. Supported Elliptic Curves Extension</a> only only "UNCOMPRESSED"
  * as point format is valid, the other formats have been deprecated.
  */

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CCMBlockCipher.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CCMBlockCipher.java
@@ -31,7 +31,7 @@ import javax.crypto.ShortBufferException;
 
 /**
  * A generic authenticated encryption block cipher mode which uses the 128-bit
- * block cipher AES. See <a href="http://tools.ietf.org/html/rfc3610">RFC
+ * block cipher AES. See <a href="http://tools.ietf.org/html/rfc3610" target="_blank">RFC
  * 3610</a> for details.
  */
 public class CCMBlockCipher {
@@ -144,7 +144,7 @@ public class CCMBlockCipher {
 
 		/**
 		 * Computes CBC-MAC. See
-		 * <a href="http://tools.ietf.org/html/rfc3610#section-2.2">RFC 3610 -
+		 * <a href="http://tools.ietf.org/html/rfc3610#section-2.2" target="_blank">RFC 3610 -
 		 * Authentication</a> for details.
 		 * 
 		 * @param cipher the cipher.
@@ -280,7 +280,7 @@ public class CCMBlockCipher {
 	// Static methods /////////////////////////////////////////////////
 
 	/**
-	 * See <a href="http://tools.ietf.org/html/rfc3610#section-2.5">RFC 3610</a>
+	 * See <a href="http://tools.ietf.org/html/rfc3610#section-2.5" target="_blank">RFC 3610</a>
 	 * for details.
 	 * 
 	 * @param key the encryption key K.
@@ -300,7 +300,7 @@ public class CCMBlockCipher {
 	}
 
 	/**
-	 * See <a href="http://tools.ietf.org/html/rfc3610#section-2.5">RFC 3610</a>
+	 * See <a href="http://tools.ietf.org/html/rfc3610#section-2.5" target="_blank">RFC 3610</a>
 	 * for details.
 	 * 
 	 * @param key the encryption key K.
@@ -372,7 +372,7 @@ public class CCMBlockCipher {
 	}
 
 	/**
-	 * See <a href="http://tools.ietf.org/html/rfc3610#section-2.2">RFC 3610</a>
+	 * See <a href="http://tools.ietf.org/html/rfc3610#section-2.2" target="_blank">RFC 3610</a>
 	 * for details.
 	 * 
 	 * @param key the encryption key K.
@@ -390,7 +390,7 @@ public class CCMBlockCipher {
 	}
 
 	/**
-	 * See <a href="http://tools.ietf.org/html/rfc3610#section-2.2">RFC 3610</a>
+	 * See <a href="http://tools.ietf.org/html/rfc3610#section-2.2" target="_blank">RFC 3610</a>
 	 * for details.
 	 * 
 	 * @param outputOffset offset of the encrypted message within the resulting byte

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CbcBlockCipher.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CbcBlockCipher.java
@@ -45,7 +45,7 @@ public class CbcBlockCipher {
 	/**
 	 * Converts a given TLSCiphertext.fragment to a TLSCompressed.fragment
 	 * structure as defined by
-	 * <a href="http://tools.ietf.org/html/rfc5246#section-6.2.3.2"> RFC 5246,
+	 * <a href="http://tools.ietf.org/html/rfc5246#section-6.2.3.2" target="_blank"> RFC 5246,
 	 * section 6.2.3.2</a>:
 	 * 
 	 * <pre>
@@ -151,7 +151,7 @@ public class CbcBlockCipher {
 	/**
 	 * Converts a given TLSCompressed.fragment to a TLSCiphertext.fragment
 	 * structure as defined by
-	 * <a href="http://tools.ietf.org/html/rfc5246#section-6.2.3.2"> RFC 5246,
+	 * <a href="http://tools.ietf.org/html/rfc5246#section-6.2.3.2" target="_blank"> RFC 5246,
 	 * section 6.2.3.2</a>
 	 * 
 	 * <pre>
@@ -216,7 +216,7 @@ public class CbcBlockCipher {
 
 	/**
 	 * Calculates a MAC for use with CBC block ciphers as specified by
-	 * <a href="http://tools.ietf.org/html/rfc5246#section-6.2.3.2"> RFC 5246,
+	 * <a href="http://tools.ietf.org/html/rfc5246#section-6.2.3.2" target="_blank"> RFC 5246,
 	 * section 6.2.3.2</a>.
 	 * 
 	 * @param hmac mac function

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
@@ -51,9 +51,9 @@ import org.eclipse.californium.elements.util.DatagramWriter;
  * A cipher suite defines a key exchange algorithm, a bulk cipher algorithm, a
  * MAC algorithm, a pseudo random number (PRF) algorithm and a cipher type.
  * 
- * See <a href="http://tools.ietf.org/html/rfc5246#appendix-A.6">RFC 5246</a>
+ * See <a href="http://tools.ietf.org/html/rfc5246#appendix-A.6" target="_blank">RFC 5246</a>
  * for details.
- * See <a href="http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml">
+ * See <a href="http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml" target="_blank">
  * Transport Layer Security Parameters</a> for the official codes for the cipher
  * suites.
  */
@@ -86,7 +86,7 @@ public enum CipherSuite {
 
 	// PSK cipher suites, ordered by default preference, see getPskCiperSuites ///
 
-	/**See <a href="https://tools.ietf.org/html/rfc8442#section-3">RFC 8442</a> for details*/
+	/**See <a href="https://tools.ietf.org/html/rfc8442#section-3" target="_blank">RFC 8442</a> for details*/
 	/**Note: compatibility not tested! openssl 1.1.1 seems not supporting them */
 	TLS_ECDHE_PSK_WITH_AES_128_GCM_SHA256(0xD001, CertificateKeyAlgorithm.NONE, KeyExchangeAlgorithm.ECDHE_PSK, CipherSpec.AES_128_GCM, MACAlgorithm.NULL, true),
 	TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA378(0xD002, CertificateKeyAlgorithm.NONE, KeyExchangeAlgorithm.ECDHE_PSK, CipherSpec.AES_256_GCM, MACAlgorithm.NULL, true, PRFAlgorithm.TLS_PRF_SHA384),
@@ -100,7 +100,7 @@ public enum CipherSuite {
 	TLS_PSK_WITH_AES_128_CCM(0xC0A4, CertificateKeyAlgorithm.NONE, KeyExchangeAlgorithm.PSK, CipherSpec.AES_128_CCM, MACAlgorithm.NULL, true),
 	TLS_PSK_WITH_AES_256_CCM(0xC0A5, CertificateKeyAlgorithm.NONE, KeyExchangeAlgorithm.PSK, CipherSpec.AES_256_CCM, MACAlgorithm.NULL, true),
 
-	/**See <a href="https://tools.ietf.org/html/rfc5489#section-3.2">RFC 5489</a> for details*/
+	/**See <a href="https://tools.ietf.org/html/rfc5489#section-3.2" target="_blank">RFC 5489</a> for details*/
 	TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256(0xC037, CertificateKeyAlgorithm.NONE, KeyExchangeAlgorithm.ECDHE_PSK, CipherSpec.AES_128_CBC, MACAlgorithm.HMAC_SHA256, false),
 	TLS_PSK_WITH_AES_128_CBC_SHA256(0x00AE, CertificateKeyAlgorithm.NONE, KeyExchangeAlgorithm.PSK, CipherSpec.AES_128_CBC, MACAlgorithm.HMAC_SHA256, false),
 
@@ -130,7 +130,7 @@ public enum CipherSuite {
 
 	/**
 	 * 16 bit identification, i.e. 0x0000 for SSL_NULL_WITH_NULL_NULL, see <a
-	 * href="http://tools.ietf.org/html/rfc5246#appendix-A.5">RFC 5246</a>.
+	 * href="http://tools.ietf.org/html/rfc5246#appendix-A.5" target="_blank">RFC 5246</a>.
 	 */
 	private final int code;
 	private final CertificateKeyAlgorithm certificateKeyAlgorithm;
@@ -194,7 +194,7 @@ public enum CipherSuite {
 	 * 
 	 * The name can be used to instantiate a <code>javax.crypto.Cipher</code> object
 	 * (if a security provider is available in the JVM supporting the transformation).
-	 * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#Cipher">
+	 * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#Cipher" target="_blank">
 	 * Java Security Documentation</a>.
 	 * 
 	 * @return the transformation
@@ -216,7 +216,7 @@ public enum CipherSuite {
 	/**
 	 * Gets the 16-bit IANA assigned identification code of the cipher suite.
 	 * 
-	 * See <a href="http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4">
+	 * See <a href="http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4" target="_blank">
 	 * TLS Cipher Suite Registry</a>.
 	 * 
 	 * @return the identification code
@@ -299,7 +299,7 @@ public enum CipherSuite {
 	 * The name can be used to instantiate a <code>javax.crypto.Mac</code>
 	 * instance.
 	 * 
-	 * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#Mac">
+	 * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#Mac" target="_blank">
 	 * Java Security Documentation</a>.
 	 * 
 	 * @return the name or <code>null</code> for the <em>NULL</em> MAC
@@ -416,7 +416,7 @@ public enum CipherSuite {
 	 * The name can be used to instantiate a <code>javax.crypto.Mac</code>
 	 * instance.
 	 * 
-	 * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#Mac">
+	 * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#Mac" target="_blank">
 	 * Java Security Documentation</a>.
 	 * 
 	 * @return the name of the pseudo-random function
@@ -608,7 +608,7 @@ public enum CipherSuite {
 	 * Gets a cipher suite by its numeric code.
 	 * 
 	 * @param code the cipher's
-	 *    <a href="http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4">
+	 *    <a href="http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4" target="_blank">
 	 *    IANA assigned code</a>
 	 * @return the cipher suite or <code>null</code> if the code is unknown
 	 */
@@ -628,7 +628,7 @@ public enum CipherSuite {
 	 * Gets a cipher suite by its (official) name.
 	 * 
 	 * @param name the cipher's
-	 *    <a href="http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4">
+	 *    <a href="http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4" target="_blank">
 	 *    IANA assigned name</a>
 	 * @return the cipher suite or <code>null</code> if the name is unknown
 	 */
@@ -808,7 +808,7 @@ public enum CipherSuite {
 		 * The name can be used to instantiate a <code>javax.crypto.Mac</code>
 		 * instance.
 		 * 
-		 * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#Mac">
+		 * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#Mac" target="_blank">
 		 * Java Security Documentation</a>.
 		 * 
 		 * @return the name or <code>null</code> for the {@link #NULL} MAC
@@ -823,7 +823,7 @@ public enum CipherSuite {
 		 * The name can be used to instantiate a <code>java.security.MessageDigest</code>
 		 * instance.
 		 * 
-		 * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#MessageDigest">
+		 * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#MessageDigest" target="_blank">
 		 * Java Security Documentation</a>.
 		 * 
 		 * @return the name or <code>null</code> for the {@link #NULL} MAC
@@ -971,7 +971,7 @@ public enum CipherSuite {
 		 * 
 		 * The name can be used to instantiate a <code>javax.crypto.Cipher</code> object
 		 * (if a security provider is available in the JVM supporting the transformation).
-		 * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#Cipher">
+		 * See <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#Cipher" target="_blank">
 		 * Java Security Documentation</a>.
 		 * 
 		 * @return the transformation

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/PseudoRandomFunction.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/PseudoRandomFunction.java
@@ -30,7 +30,7 @@ import org.eclipse.californium.scandium.util.SecretUtil;
 /**
  * The Pseudo Random Function as defined in TLS 1.2.
  * 
- * @see <a href="http://tools.ietf.org/html/rfc5246#section-5">RFC 5246</a>
+ * @see <a href="http://tools.ietf.org/html/rfc5246#section-5" target="_blank">RFC 5246</a>
  */
 public final class PseudoRandomFunction {
 
@@ -94,7 +94,7 @@ public final class PseudoRandomFunction {
 
 	/**
 	 * Does the pseudo random function as defined in
-	 * <a href="http://tools.ietf.org/html/rfc5246#section-5">RFC 5246</a>.
+	 * <a href="http://tools.ietf.org/html/rfc5246#section-5" target="_blank">RFC 5246</a>.
 	 * 
 	 * @param hmac MAC algorithm.  e.g. HmacSHA256
 	 * @param secret the secret to use for the secure hash function
@@ -109,7 +109,7 @@ public final class PseudoRandomFunction {
 
 	/**
 	 * Does the pseudo random function as defined in <a
-	 * href="http://tools.ietf.org/html/rfc5246#section-5">RFC 5246</a>.
+	 * href="http://tools.ietf.org/html/rfc5246#section-5" target="_blank">RFC 5246</a>.
 	 * 
 	 * @param hmac MAC algorithm. e.g. HmacSHA256
 	 * @param secret the secret to use for the secure hash function
@@ -124,7 +124,7 @@ public final class PseudoRandomFunction {
 
 	/**
 	 * Performs the secret expansion as described in <a
-	 * href="http://tools.ietf.org/html/rfc5246#section-5">RFC 5246</a>.
+	 * href="http://tools.ietf.org/html/rfc5246#section-5" target="_blank">RFC 5246</a>.
 	 * 
 	 * @param hmac the cryptographic hash function to use for expansion.
 	 * @param label the label to use for creating the original data
@@ -217,7 +217,7 @@ public final class PseudoRandomFunction {
 	 *            EC Diffie-Hellman exchange (ECDHE_PSK).
 	 * @param pskSecret PSK secret.
 	 * @return byte array with generated premaster secret.
-	 * @see <a href="http://tools.ietf.org/html/rfc4279#section-2">RFC 4279</a>
+	 * @see <a href="http://tools.ietf.org/html/rfc4279#section-2" target="_blank">RFC 4279</a>
 	 */
 	public static SecretKey generatePremasterSecretFromPSK(SecretKey otherSecret, SecretKey pskSecret) {
 		/*

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/XECDHECryptography.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/XECDHECryptography.java
@@ -105,7 +105,7 @@ import javax.security.auth.Destroyable;
  * 
  * results in same secrets {@code secret1} and {@code secret2}.
  * 
- * @see <a href="https://tools.ietf.org/html/rfc7748">RFC 7748</a>
+ * @see <a href="https://tools.ietf.org/html/rfc7748" target="_blank">RFC 7748</a>
  * @since 2.3
  */
 public final class XECDHECryptography implements Destroyable {
@@ -120,7 +120,7 @@ public final class XECDHECryptography implements Destroyable {
 	 * The algorithm for the elliptic curve key pair generation.
 	 * 
 	 * See also <a href=
-	 * "http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#KeyPairGenerator"
+	 * "http://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#KeyPairGenerator" target="_blank"
 	 * >KeyPairGenerator Algorithms</a>.
 	 */
 	private static final String EC_KEYPAIR_GENERATOR_ALGORITHM = "EC";
@@ -514,10 +514,10 @@ public final class XECDHECryptography implements Destroyable {
 
 	/**
 	 * The <em>Supported Groups</em> as defined in the official
-	 * <a href="http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8">
+	 * <a href="http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8" target="_blank">
 	 * IANA Transport Layer Security (TLS) Parameters</a>.
 	 * 
-	 * Also see <a href="http://tools.ietf.org/html/rfc4492#section-5.1.1">RFC 4492,
+	 * Also see <a href="http://tools.ietf.org/html/rfc4492#section-5.1.1" target="_blank">RFC 4492,
 	 * Section 5.1.1 Supported Elliptic Curves Extension</a>.
 	 */
 	public enum SupportedGroup {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/pskstore/AdvancedPskStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/pskstore/AdvancedPskStore.java
@@ -109,7 +109,7 @@ public interface AdvancedPskStore {
 	 * @param hmacAlgorithm HMAC algorithm name for PRF.
 	 * @param otherSecret other secret from ECDHE, or {@code null}. Must be
 	 *            cloned for asynchronous use. See
-	 *            <a href="https://tools.ietf.org/html/rfc5489#page-4"> RFC
+	 *            <a href="https://tools.ietf.org/html/rfc5489#page-4" target="_blank"> RFC
 	 *            5489, other secret</a>
 	 * @param seed seed for PRF.
 	 * @param useExtendedMasterSecret If the master secret is created,

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/util/ServerName.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/util/ServerName.java
@@ -78,7 +78,7 @@ public class ServerName {
 	 * @return The new instance.
 	 * @throws NullPointerException if the host name is {@code null}.
 	 * @throws IllegalArgumentException if the given name is not a valid host name
-	 *               as per <a href="http://tools.ietf.org/html/rfc1123">RFC 1123</a>.
+	 *               as per <a href="http://tools.ietf.org/html/rfc1123" target="_blank">RFC 1123</a>.
 	 */
 	public static ServerName fromHostName(final String hostName) {
 		if (hostName == null) {

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -474,7 +474,7 @@ public class DTLSConnectorTest {
 	}
 
 	/**
-	 * Verifies behavior described in <a href="http://tools.ietf.org/html/rfc6347#section-4.2.8">
+	 * Verifies behavior described in <a href="http://tools.ietf.org/html/rfc6347#section-4.2.8" target="_blank">
 	 * section 4.2.8 of RFC 6347 (DTLS 1.2)</a>.
 	 *  
 	 * @throws Exception if test fails
@@ -544,7 +544,7 @@ public class DTLSConnectorTest {
 	}
 
 	/**
-	 * Verifies behavior described in <a href="http://tools.ietf.org/html/rfc6347#section-4.2.8">
+	 * Verifies behavior described in <a href="http://tools.ietf.org/html/rfc6347#section-4.2.8" target="_blank">
 	 * section 4.2.8 of RFC 6347 (DTLS 1.2)</a>.
 	 */
 	@Test
@@ -568,7 +568,7 @@ public class DTLSConnectorTest {
 	}
 
 	/**
-	 * Verifies behavior described in <a href="http://tools.ietf.org/html/rfc6347#section-4.2.8">
+	 * Verifies behavior described in <a href="http://tools.ietf.org/html/rfc6347#section-4.2.8" target="_blank">
 	 * section 4.2.8 of RFC 6347 (DTLS 1.2)</a>.
 	 */
 	@Test
@@ -650,7 +650,7 @@ public class DTLSConnectorTest {
 	}
 
 	/**
-	 * Verifies behavior described in <a href="http://tools.ietf.org/html/rfc6347#section-4.2.8">
+	 * Verifies behavior described in <a href="http://tools.ietf.org/html/rfc6347#section-4.2.8" target="_blank">
 	 * section 4.2.8 of RFC 6347 (DTLS 1.2)</a>.
 	 *  
 	 * @throws Exception if test fails

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DtlsTestTools.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DtlsTestTools.java
@@ -138,7 +138,7 @@ public final class DtlsTestTools extends TestCertificatesTools {
 	 * Parses a sequence of <em>DTLSCiphertext</em> structures into {@code Record} instances.
 	 * 
 	 * The binary representation is expected to comply with the <em>DTLSCiphertext</em> structure
-	 * defined in <a href="http://tools.ietf.org/html/rfc6347#section-4.3.1">RFC6347, Section 4.3.1</a>.
+	 * defined in <a href="http://tools.ietf.org/html/rfc6347#section-4.3.1" target="_blank">RFC6347, Section 4.3.1</a>.
 	 * 
 	 * @param byteArray the raw binary representation containing one or more DTLSCiphertext structures
 	 * @param cidGenerator the connection id generator. May be {@code null}.

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordCbcValidationTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/RecordCbcValidationTest.java
@@ -64,7 +64,7 @@ import org.junit.runners.Parameterized.Parameters;
  * 
  * Test idea:
  * 
- * <a href="http://www.isg.rhul.ac.uk/tls/TLStiming.pdf"> Lucky
+ * <a href="http://www.isg.rhul.ac.uk/tls/TLStiming.pdf" target="_blank"> Lucky
  * Thirteen:Breaking the TLS and DTLS Record Protocols</a>
  * 
  * Lucky 13 attacks claims to be able to use "timing side channel" in order to

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
@@ -449,7 +449,7 @@ public class ServerHandshakerTest {
 
 	/**
 	 * Creates a ClientHello message as defined by
-	 * <a href="http://tools.ietf.org/html/rfc5246#page-39">Client Hello</a>
+	 * <a href="http://tools.ietf.org/html/rfc5246#page-39" target="_blank">Client Hello</a>
 	 * 
 	 * @return the bytes of the message
 	 */

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/cipher/PseudoRandomFunctionTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/cipher/PseudoRandomFunctionTest.java
@@ -57,7 +57,7 @@ public class PseudoRandomFunctionTest {
 
 	/**
 	 * Verifies TLS1.2PRF-SHA256
-	 * <a href="http://www.ietf.org/mail-archive/web/tls/current/msg03416.html">
+	 * <a href="http://www.ietf.org/mail-archive/web/tls/current/msg03416.html" target="_blank">
 	 * test vector</a>.
 	 */
 	@Test


### PR DESCRIPTION
Some browsers will block hrefs to other pages, if the target is not
"_blank" or "_top".

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>