### PR TITLE
Add --private-key to CLI.

### DIFF
--- a/cf-utils/cf-cli-tcp-netty/pom.xml
+++ b/cf-utils/cf-cli-tcp-netty/pom.xml
@@ -19,7 +19,6 @@
 	<description>Californium (Cf) Command Line Interface support for TCP using netty.io</description>
 
 	<properties>
-		<picocli.version>4.2.0</picocli.version>
 		<animal.sniffer.skip>true</animal.sniffer.skip>
 		<revapi.skip>true</revapi.skip>
 	</properties>

--- a/cf-utils/cf-cli-tcp-netty/src/main/java/org/eclipse/californium/cli/tcp/netty/Initialize.java
+++ b/cf-utils/cf-cli-tcp-netty/src/main/java/org/eclipse/californium/cli/tcp/netty/Initialize.java
@@ -17,6 +17,8 @@ package org.eclipse.californium.cli.tcp.netty;
 
 import org.eclipse.californium.cli.ClientInitializer;
 import org.eclipse.californium.core.coap.CoAP;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Initialize {@link ClientInitializer}.
@@ -26,10 +28,19 @@ import org.eclipse.californium.core.coap.CoAP;
  * @since 2.4
  */
 public class Initialize {
+	protected static final Logger LOGGER = LoggerFactory.getLogger(Initialize.class);
 
 	static {
-		ClientInitializer.registerConnectorFactory(CoAP.PROTOCOL_TCP, new TcpConnectorFactory());
-		ClientInitializer.registerConnectorFactory(CoAP.PROTOCOL_TLS, new TlsConnectorFactory());
+		try {
+			ClientInitializer.registerConnectorFactory(CoAP.PROTOCOL_TCP, new TcpConnectorFactory());
+		} catch (Throwable t) {
+			LOGGER.error(CoAP.PROTOCOL_TCP, t);
+		}
+		try {
+			ClientInitializer.registerConnectorFactory(CoAP.PROTOCOL_TLS, new TlsConnectorFactory());
+		} catch (Throwable t) {
+			LOGGER.error(CoAP.PROTOCOL_TLS, t);
+		}
 	}
 
 }

--- a/cf-utils/cf-cli/README.md
+++ b/cf-utils/cf-cli/README.md
@@ -64,3 +64,6 @@ Alternatively adapt the dependency from "cf-cli" to "cf-cli-tcp-netty" in the cl
   </dependencies>
 ```
 
+## Eclipse IDE - Run As - Java Application
+
+The Eclipse IDE requires the "cf-cli-tcp-netty" project as well. Add that using the context menu "Properties" of the project, select in the left list the topic "Java Build Path" and there the tab "Projects". Add here the project "cf-cli-tcp-netty".

--- a/cf-utils/cf-cli/pom.xml
+++ b/cf-utils/cf-cli/pom.xml
@@ -19,7 +19,6 @@
 	<description>Californium (Cf) Command Line Interface</description>
 
 	<properties>
-		<picocli.version>4.2.0</picocli.version>
 		<animal.sniffer.skip>true</animal.sniffer.skip>
 		<revapi.skip>true</revapi.skip>
 	</properties>

--- a/demo-apps/cf-extplugtest-client/pom.xml
+++ b/demo-apps/cf-extplugtest-client/pom.xml
@@ -1,10 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <project
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
 	<modelVersion>4.0.0</modelVersion>
-	
+
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
@@ -16,6 +17,10 @@
 	<description>Californium (Cf) extended ETSI Plugtest client</description>
 
 	<properties>
+		<!-- explicitly skip unit test! The eclipse IDE seems to create a test 
+			folder, if am additional project dependency to "cf-cli-tcp-netty" is added 
+			in order to execute the demo from the IDE with tcp-support -->
+		<maven.test.skip>true</maven.test.skip>
 		<assembly.mainClass>org.eclipse.californium.extplugtests.Client</assembly.mainClass>
 	</properties>
 
@@ -30,7 +35,7 @@
 			<artifactId>cf-unix-health</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+
 		<!-- runtime dependencies -->
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/demo-apps/cf-plugtest-checker/pom.xml
+++ b/demo-apps/cf-plugtest-checker/pom.xml
@@ -17,6 +17,10 @@
 	<description>Californium (Cf) ETSI Plugtest server checker</description>
 
 	<properties>
+		<!-- explicitly skip unit test! The eclipse IDE seems to create a test 
+			folder, if am additional project dependency to "cf-cli-tcp-netty" is added 
+			in order to execute the demo from the IDE with tcp-support -->
+		<maven.test.skip>true</maven.test.skip>
 		<assembly.mainClass>org.eclipse.californium.plugtests.PlugtestChecker</assembly.mainClass>
 	</properties>
 

--- a/demo-apps/cf-plugtest-client/pom.xml
+++ b/demo-apps/cf-plugtest-client/pom.xml
@@ -16,6 +16,10 @@
 	<description>Californium (Cf) ETSI Plugtest client</description>
 
 	<properties>
+		<!-- explicitly skip unit test! The eclipse IDE seems to create a test 
+			folder, if am additional project dependency to "cf-cli-tcp-netty" is added 
+			in order to execute the demo from the IDE with tcp-support -->
+		<maven.test.skip>true</maven.test.skip>
 		<assembly.mainClass>org.eclipse.californium.plugtests.PlugtestClient</assembly.mainClass>
 	</properties>
 


### PR DESCRIPTION
Supports private key also in separate file.
Improve logging for protocol-modules loading.
Explicitly disable unit-tests for some demos, which are using the
tcp-module, but don't have tests (support project dependency to the
tcp-module in eclipse ide).

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>