### PR TITLE
Remove create client from resource

### DIFF
--- a/MIGRATION_HINTS.md
+++ b/MIGRATION_HINTS.md
@@ -154,6 +154,10 @@ are removed and must be replaced by
 
 11) Change the return type of `MediaTypeRegistry.parseWildcard(String wildcard)` from `Integer[]` to `int[]`.
 
+12) Removed `Resource.getSecondaryExecutor()` and change the return type of `Resource.getExecutor()` from `ExecutorService` to the simpler `Executor`. Specific `Resource` implementation may maintain the executors as required by them.
+
+13) Removed `CoapResource.createClient(???)`. Though `Resource.getExecutor()` may return `null`, it depends on the implementation of the `Resource` not to return `null`, but that changes other executions. Therefore implement `createClient(???)` for the specific `Resources` and provide the executors there. 
+
 ### Californium-Proxy2:
 
 1) Update to http-client 5.0.3 and http-core 5.0.2. The apache http-components are not encapsulated. Therefore this update causes several API changes, where these classes are used. Please consider the migration information on the [apache http-components web-page](https://hc.apache.org/)

--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
@@ -37,8 +37,6 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -47,7 +45,6 @@ import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.coap.Response;
-import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.observe.ObserveNotificationOrderer;
 import org.eclipse.californium.core.observe.ObserveRelation;
@@ -132,7 +129,6 @@ import org.slf4j.LoggerFactory;
  * ResourceObserver is invoked whenever the name or path of a resource changes,
  * when a child resource is added or removed or when a CoAP observe relation is
  * added or canceled.
- * // TODO: make example with createClient().get() 
  */
 public  class CoapResource implements Resource {
 
@@ -353,46 +349,6 @@ public  class CoapResource implements Resource {
 			}
 			response.getOptions().setObserve(notificationOrderer.getCurrent());
 		} // ObserveLayer takes care of the else case
-	}
-
-	/**
-	 * Creates a {@link CoapClient} that uses the same executor as this resource
-	 * and the endpoint of the incoming exchange. The {@link CoapClient} is
-	 * detached from the executors of this resource, a
-	 * {@link CoapClient#shutdown()} will therefore not shutdown the resources
-	 * executor.
-	 * 
-	 * @param incoming incoming exchange to determine the endpoint for outgoing
-	 *            requests
-	 * @return the CoAP client.
-	 * @throws IllegalStateException if executors are not available
-	 * @since 3.0
-	 */
-	public CoapClient createClient(CoapExchange incoming) {
-		return createClient(incoming.advanced().getEndpoint());
-	}
-
-	/**
-	 * Creates a {@link CoapClient} that uses the same executor as this resource
-	 * and the provided endpoint. The endpoint may be accessed by
-	 * {@link Exchange#getEndpoint()}. The {@link CoapClient} is detached from
-	 * the executors of this resource, a {@link CoapClient#shutdown()} will
-	 * therefore not shutdown the resources executor.
-	 * 
-	 * @param outgoing endpoint for outgoing request.
-	 * @return the CoAP client.
-	 * @throws IllegalStateException if executors are not available
-	 * @since 3.0
-	 */
-	public CoapClient createClient(Endpoint outgoing) {
-		CoapClient client = new CoapClient();
-		try {
-			client.setExecutors(getExecutor(), getSecondaryExecutor(), true);
-		} catch (NullPointerException ex) {
-			throw new IllegalStateException("At least one executor is not availabe!");
-		}
-		client.setEndpoint(outgoing);
-		return client;
 	}
 
 	/* (non-Javadoc)
@@ -863,14 +819,9 @@ public  class CoapResource implements Resource {
 	/* (non-Javadoc)
 	 * @see org.eclipse.californium.core.server.resources.Resource#getExecutor()
 	 */
-	public ExecutorService getExecutor() {
+	public Executor getExecutor() {
 		final Resource parent = getParent();
 		return parent != null ? parent.getExecutor() : null;
-	}
-
-	public ScheduledThreadPoolExecutor getSecondaryExecutor() {
-		final Resource parent = getParent();
-		return parent != null ? parent.getSecondaryExecutor() : null;
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/ConcurrentCoapResource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/ConcurrentCoapResource.java
@@ -132,7 +132,7 @@ public class ConcurrentCoapResource extends CoapResource {
 	 * @see org.eclipse.californium.core.server.resources.CoapResource#getExecutor()
 	 */
 	@Override
-	public ExecutorService getExecutor() {
+	public Executor getExecutor() {
 		if (executor != null) return executor;
 		else return super.getExecutor();
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/Resource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/Resource.java
@@ -21,8 +21,6 @@ package org.eclipse.californium.core.server.resources;
 
 import java.util.Collection;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.network.Exchange;
@@ -245,20 +243,12 @@ public interface Resource {
 	 * @param relation the relation
 	 */
 	public void removeObserveRelation(ObserveRelation relation);
-	
+
 	/**
 	 * Gets the executor of this resource.
 	 *
-	 * @return the executor
+	 * @return the executor. {@code null}, if no executor is used.
 	 */
-	public ExecutorService getExecutor();
-
-	/**
-	 * Gets the scheduled executor of this resource. Generally used for rare
-	 * executing timers (e.g. cleanup tasks).
-	 *
-	 * @return the executor
-	 */
-	public ScheduledThreadPoolExecutor getSecondaryExecutor();
+	public Executor getExecutor();
 
 }

--- a/demo-apps/cf-benchmark-observe/src/main/java/org/eclipse/californium/benchmark/observe/AnnounceResource.java
+++ b/demo-apps/cf-benchmark-observe/src/main/java/org/eclipse/californium/benchmark/observe/AnnounceResource.java
@@ -20,6 +20,8 @@ package org.eclipse.californium.benchmark.observe;
 
 import java.net.InetSocketAddress;
 import java.util.HashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.californium.core.CoapClient;
@@ -29,24 +31,34 @@ import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapResponse;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 
 public class AnnounceResource extends CoapResource {
-	
+
 	private HashMap<InetSocketAddress, CoapObserveRelation> relationStorage;
 	private CoapHandler handler;
-	
-	public AnnounceResource (String name) {
+	private ExecutorService executor;
+	private ScheduledThreadPoolExecutor secondaryExecutor;
+
+	public AnnounceResource(String name, ExecutorService executor, ScheduledThreadPoolExecutor secondaryExecutor) {
 		super(name);
+		this.executor = executor;
+		this.secondaryExecutor = secondaryExecutor;
 		relationStorage = new HashMap<InetSocketAddress, CoapObserveRelation>();
 		handler = new CoapHandler() {
 			private AtomicBoolean testdump = new AtomicBoolean(false);
-			@Override public void onLoad(CoapResponse response) {
+
+			@Override
+			public void onLoad(CoapResponse response) {
 				if (response.getCode() == ResponseCode.NOT_FOUND) {
 					synchronized (relationStorage) {
 						if (!testdump.get()) {
 							testdump.set(true);
-							System.out.println("Used Memory: " + (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1024 + "kb (" + relationStorage.size() + " clients).");
+							System.out.println("Used Memory: "
+									+ (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1024
+									+ "kb (" + relationStorage.size() + " clients).");
 						}
 						InetSocketAddress peerAddress = response.advanced().getSourceContext().getPeerAddress();
 						CoapObserveRelation cor = relationStorage.remove(peerAddress);
@@ -60,27 +72,69 @@ public class AnnounceResource extends CoapResource {
 					return;
 				}
 			}
-			@Override public void onError() { }
+
+			@Override
+			public void onError() {
+			}
 		};
 	}
-	
+
 	@Override
 	public void handleGET(CoapExchange exchange) {
 		Response response = new Response(ResponseCode.CONTENT);
 		response.setPayload(new Integer(0).toString());
 		exchange.respond(response);
 	}
-	
+
 	@Override
 	public void handlePOST(CoapExchange exchange) {
 		CoapClient client = this.createClient(exchange);
 		client.setURI(exchange.getRequestText());
 		CoapObserveRelation relation = client.observe(handler);
-		synchronized(relationStorage) {
+		synchronized (relationStorage) {
 			relationStorage.put(exchange.getSourceSocketAddress(), relation);
 		}
-		
+
 		Response response = new Response(ResponseCode.VALID);
 		exchange.respond(response);
+	}
+
+	/**
+	 * Creates a {@link CoapClient} that uses the same executor as this resource and
+	 * the endpoint of the incoming exchange. The {@link CoapClient} is detached
+	 * from the executors of this resource, a {@link CoapClient#shutdown()} will
+	 * therefore not shutdown the resources executor.
+	 * 
+	 * @param incoming incoming exchange to determine the endpoint for outgoing
+	 *                 requests
+	 * @return the CoAP client.
+	 * @throws IllegalStateException if executors are not available
+	 * @since 3.0
+	 */
+	public CoapClient createClient(CoapExchange incoming) {
+		return createClient(incoming.advanced().getEndpoint());
+	}
+
+	/**
+	 * Creates a {@link CoapClient} that uses the same executor as this resource and
+	 * the provided endpoint. The endpoint may be accessed by
+	 * {@link Exchange#getEndpoint()}. The {@link CoapClient} is detached from the
+	 * executors of this resource, a {@link CoapClient#shutdown()} will therefore
+	 * not shutdown the resources executor.
+	 * 
+	 * @param outgoing endpoint for outgoing request.
+	 * @return the CoAP client.
+	 * @throws IllegalStateException if executors are not available
+	 * @since 3.0
+	 */
+	public CoapClient createClient(Endpoint outgoing) {
+		CoapClient client = new CoapClient();
+		try {
+			client.setExecutors(executor, secondaryExecutor, true);
+		} catch (NullPointerException ex) {
+			throw new IllegalStateException("At least one executor is not availabe!");
+		}
+		client.setEndpoint(outgoing);
+		return client;
 	}
 }

--- a/demo-apps/cf-benchmark-observe/src/main/java/org/eclipse/californium/benchmark/observe/ObserveBenchmarkClient.java
+++ b/demo-apps/cf-benchmark-observe/src/main/java/org/eclipse/californium/benchmark/observe/ObserveBenchmarkClient.java
@@ -21,6 +21,8 @@ package org.eclipse.californium.benchmark.observe;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import org.eclipse.californium.benchmark.observe.ObserveBenchmarkClient;
 import org.eclipse.californium.core.CoapServer;
@@ -32,31 +34,29 @@ public class ObserveBenchmarkClient {
 	public static final int CORES = Runtime.getRuntime().availableProcessors();
 	public static final String OS = System.getProperty("os.name");
 	public static final boolean WINDOWS = OS.startsWith("Windows");
-	
+
 	public static final String DEFAULT_ADDRESS = null;
 	public static final int DEFAULT_PORT = 5683;
-	
+
 	public static final int DEFAULT_PROTOCOL_STAGE_THREAD_COUNT = CORES;
-	
+
 	public static final int DEFAULT_SENDER_COUNT = WINDOWS ? CORES : 1;
 	public static final int DEFAULT_RECEIVER_COUNT = WINDOWS ? CORES : 1;
-	
-	
 
 	public static void main(String[] args) throws Exception {
 		System.out.println("Californium (Cf) Observe Benchmark Client");
 		System.out.println("(c) 2015, Institute for Pervasive Computing, ETH Zurich");
 		System.out.println();
-		System.out.println("This machine has "+CORES+" cores");
+		System.out.println("This machine has " + CORES + " cores");
 		System.out.println("Operating system: " + OS);
-		
+
 		String address = null;
 		int port = DEFAULT_PORT;
 		int udp_sender = DEFAULT_SENDER_COUNT;
 		int udp_receiver = DEFAULT_RECEIVER_COUNT;
 		int protocol_threads = DEFAULT_PROTOCOL_STAGE_THREAD_COUNT;
 		boolean use_executor = false;
-		
+
 		// Parse input
 		if (args.length > 0) {
 			int index = 0;
@@ -65,44 +65,45 @@ public class ObserveBenchmarkClient {
 				if ("-usage".equals(arg) || "-help".equals(arg) || "-h".equals(arg) || "-?".equals(arg)) {
 					printUsage();
 				} else if ("-t".equals(arg)) {
-					protocol_threads = Integer.parseInt(args[index+1]);
+					protocol_threads = Integer.parseInt(args[index + 1]);
 				} else if ("-s".equals(arg)) {
-					udp_sender = Integer.parseInt(args[index+1]);
+					udp_sender = Integer.parseInt(args[index + 1]);
 				} else if ("-r".equals(arg)) {
-					udp_receiver = Integer.parseInt(args[index+1]);
+					udp_receiver = Integer.parseInt(args[index + 1]);
 				} else if ("-p".equals(arg)) {
-					port = Integer.parseInt(args[index+1]);
+					port = Integer.parseInt(args[index + 1]);
 				} else if ("-a".equals(arg)) {
-					address = args[index+1];
+					address = args[index + 1];
 				} else if ("-use-executor".equals(arg)) {
 					use_executor = true;
 				} else {
-					System.err.println("Unknown arg "+arg);
+					System.err.println("Unknown arg " + arg);
 					printUsage();
 				}
 				index += 2;
 			}
 		}
-		
+
 		// Parse address
-		InetAddress addr = address!=null ? InetAddress.getByName(address) : null;
+		InetAddress addr = address != null ? InetAddress.getByName(address) : null;
 		InetSocketAddress sockAddr = new InetSocketAddress((InetAddress) addr, port);
-		
+
 		setBenchmarkConfiguration(udp_sender, udp_receiver);
-		
+
 		// Create server
 		CoapServer server = new CoapServer();
-
+		ScheduledExecutorService executor = Executors.newScheduledThreadPool(protocol_threads);
+		ScheduledThreadPoolExecutor secondaryExecutor = ExecutorsUtil
+				.newDefaultSecondaryScheduler("CoapServer(secondary)#");
 		if (use_executor) {
-			System.out.println("Using a scheduled thread pool with "+protocol_threads+" workers");
-			server.setExecutors(Executors.newScheduledThreadPool(protocol_threads), 
-					ExecutorsUtil.newDefaultSecondaryScheduler("CoapServer(secondary)#"), false);
+			System.out.println("Using a scheduled thread pool with " + protocol_threads + " workers");
+			server.setExecutors(executor, secondaryExecutor, false);
 		}
-		
-		System.out.println("Number of receiver/sender threads: "+udp_receiver+"/"+udp_sender);
-			
-		server.add(new AnnounceResource("announce"));
-		
+
+		System.out.println("Number of receiver/sender threads: " + udp_receiver + "/" + udp_sender);
+
+		server.add(new AnnounceResource("announce", executor, secondaryExecutor));
+
 		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setInetSocketAddress(sockAddr);
 		server.addEndpoint(builder.build());
@@ -110,33 +111,35 @@ public class ObserveBenchmarkClient {
 
 		System.out.println("Observe benchmark announcement server listening on " + sockAddr);
 	}
-	
+
 	private static void setBenchmarkConfiguration(int udp_sender, int udp_receiver) {
 
 		// Network configuration optimal for performance benchmarks
 		NetworkConfig.createStandardWithoutFile()
-			// Disable deduplication OR strongly reduce lifetime
-			.setString(NetworkConfig.Keys.DEDUPLICATOR, NetworkConfig.Keys.NO_DEDUPLICATOR)
-			.setInt(NetworkConfig.Keys.EXCHANGE_LIFETIME, 1500)
-			
-			// Increase buffer for network interface to 10 MB
-			.setInt(NetworkConfig.Keys.UDP_CONNECTOR_RECEIVE_BUFFER, 10*1024*1024)
-			.setInt(NetworkConfig.Keys.UDP_CONNECTOR_SEND_BUFFER, 10*1024*1024)
-		
-			// Increase threads for receiving and sending packets through the socket
-			.setInt(NetworkConfig.Keys.NETWORK_STAGE_RECEIVER_THREAD_COUNT, udp_receiver)
-			.setInt(NetworkConfig.Keys.NETWORK_STAGE_SENDER_THREAD_COUNT, udp_sender);
+				// Disable deduplication OR strongly reduce lifetime
+				.setString(NetworkConfig.Keys.DEDUPLICATOR, NetworkConfig.Keys.NO_DEDUPLICATOR)
+				.setInt(NetworkConfig.Keys.EXCHANGE_LIFETIME, 1500)
+
+				// Increase buffer for network interface to 10 MB
+				.setInt(NetworkConfig.Keys.UDP_CONNECTOR_RECEIVE_BUFFER, 10 * 1024 * 1024)
+				.setInt(NetworkConfig.Keys.UDP_CONNECTOR_SEND_BUFFER, 10 * 1024 * 1024)
+
+				// Increase threads for receiving and sending packets through the socket
+				.setInt(NetworkConfig.Keys.NETWORK_STAGE_RECEIVER_THREAD_COUNT, udp_receiver)
+				.setInt(NetworkConfig.Keys.NETWORK_STAGE_SENDER_THREAD_COUNT, udp_sender);
 	}
-	
+
 	private static void printUsage() {
 		System.out.println();
 		System.out.println("SYNOPSIS");
-		System.out.println("	" + ObserveBenchmarkClient.class.getSimpleName() + " [-a ADDRESS] [-p PORT] [-t POOLSIZE] [-s SENDERS] [-r RECEIVERS]");
+		System.out.println("	" + ObserveBenchmarkClient.class.getSimpleName()
+				+ " [-a ADDRESS] [-p PORT] [-t POOLSIZE] [-s SENDERS] [-r RECEIVERS]");
 		System.out.println("OPTIONS");
 		System.out.println("	-a ADDRESS");
-		System.out.println("		Bind the server to a specific host IP address given by ADDRESS (default is wildcard address).");
+		System.out.println(
+				"		Bind the server to a specific host IP address given by ADDRESS (default is wildcard address).");
 		System.out.println("	-p PORT");
-		System.out.println("		Listen on UDP port PORT (default is "+DEFAULT_PORT+").");
+		System.out.println("		Listen on UDP port PORT (default is " + DEFAULT_PORT + ").");
 		System.out.println("	-t POOLSIZE");
 		System.out.println("		Use POOLSIZE worker threads in the endpoint (default is the number of cores).");
 		System.out.println("	-s SENDERS");
@@ -146,13 +149,16 @@ public class ObserveBenchmarkClient {
 		System.out.println("		Use RECEIVERS threads to copy messages from the UDP socket.");
 		System.out.println("		The default is number of cores on Windows and 1 otherwise.");
 		System.out.println("    -use-workers");
-		System.out.println("        Use a specialized queue for incoming requests that reduces synchronization of threads.");
+		System.out.println(
+				"        Use a specialized queue for incoming requests that reduces synchronization of threads.");
 		System.out.println("OPTIMIZATIONS");
 		System.out.println("	-Xms4096m -Xmx4096m");
 		System.out.println("		Set the Java heap size to 4 GiB.");
 		System.out.println("EXAMPLES");
-		System.out.println("	java -Xms4096m -Xmx4096m " + ObserveBenchmarkClient.class.getSimpleName() + " -p 5684 -t 16");
-		System.out.println("	java -Xms4096m -Xmx4096m -jar " + ObserveBenchmarkClient.class.getSimpleName() + ".jar -s 2 -r 2");
+		System.out.println(
+				"	java -Xms4096m -Xmx4096m " + ObserveBenchmarkClient.class.getSimpleName() + " -p 5684 -t 16");
+		System.out.println(
+				"	java -Xms4096m -Xmx4096m -jar " + ObserveBenchmarkClient.class.getSimpleName() + ".jar -s 2 -r 2");
 		System.exit(0);
 	}
 }

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseRequest.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/ReverseRequest.java
@@ -122,8 +122,8 @@ public class ReverseRequest extends CoapResource {
 		getAttributes().addContentType(TEXT_PLAIN);
 		getAttributes().addContentType(APPLICATION_OCTET_STREAM);
 		int healthStatusInterval = config.getInt(NetworkConfig.Keys.HEALTH_STATUS_INTERVAL, 60); // seconds
-		if (healthStatusInterval > 0 && HEALTH_LOGGER.isDebugEnabled() && getSecondaryExecutor() != null) {
-			getSecondaryExecutor().scheduleWithFixedDelay(new Runnable() {
+		if (healthStatusInterval > 0 && HEALTH_LOGGER.isDebugEnabled()) {
+			executor.scheduleWithFixedDelay(new Runnable() {
 
 				@Override
 				public void run() {


### PR DESCRIPTION
Though getExecutor() may return null, creating a CoapClient
from that will not work. Therefore a specific Resource must create a
CoapClient on it's own, if required.

Simplify the return type of Resource getExecutor() to Executor.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>
