### PR TITLE
Keep principal unchanged

### DIFF
--- a/MIGRATION_HINTS.md
+++ b/MIGRATION_HINTS.md
@@ -51,6 +51,8 @@ The `SessionCache` and resumption handshake behavior is changed. `SessionCache` 
 
 Please Note: the new `SessionStore` feature is not well tested! If used and causing trouble, don't hesitate to create an issue.
 
+The `ApplicationLevelInfoSupplier.getinfo()` supports now to return `null` in order to not alter the additional information.
+
 ### Californium-Core:
 
 `MessageObserver.onAcknowledgement()`:

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/auth/ApplicationLevelInfoSupplier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/auth/ApplicationLevelInfoSupplier.java
@@ -31,7 +31,9 @@ public interface ApplicationLevelInfoSupplier {
 	 * 
 	 * @param peerIdentity The peer identity.
 	 * @param customArgument a custom argument.
-	 * @return The additional information about the peer.
+	 * @return The additional information about the peer. {@code null}, if no
+	 *         new additional information is available.
+	 * @since 3.0 add custom argument and definition of returning {@code null}
 	 */
 	AdditionalInfo getInfo(Principal peerIdentity, Object customArgument);
 

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Handshaker.java
@@ -2158,13 +2158,15 @@ public abstract class Handshaker implements Destroyable {
 			@SuppressWarnings("unchecked")
 			ExtensiblePrincipal<? extends Principal> extensibleClientIdentity = (ExtensiblePrincipal<? extends Principal>) peerIdentity;
 			AdditionalInfo additionalInfo = getAdditionalPeerInfo(peerIdentity);
-			session.setPeerIdentity(extensibleClientIdentity.amend(additionalInfo));
+			if (additionalInfo != null) {
+				session.setPeerIdentity(extensibleClientIdentity.amend(additionalInfo));
+			}
 		}
 	}
 
 	private AdditionalInfo getAdditionalPeerInfo(Principal peerIdentity) {
 		if (applicationLevelInfoSupplier == null || peerIdentity == null) {
-			return AdditionalInfo.empty();
+			return null;
 		} else {
 			return applicationLevelInfoSupplier.getInfo(peerIdentity, customArgument);
 		}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -115,6 +115,7 @@ public class ConnectorHelper {
 
 	static final ThreadFactory TEST_UDP_THREAD_FACTORY = new TestThreadFactory("TEST-UDP-");
 
+	boolean useSessionStore;
 	DTLSConnector server;
 	InetSocketAddress serverEndpoint;
 	DebugConnectionStore serverConnectionStore;
@@ -127,6 +128,14 @@ public class ConnectorHelper {
 	AlertCatcher serverAlertCatcher;
 
 	DtlsConnectorConfig serverConfig;
+
+	public ConnectorHelper() {
+		this(false);
+	}
+
+	public ConnectorHelper(boolean useSessionStore) {
+		this.useSessionStore = useSessionStore;
+	}
 
 	/**
 	 * Configures and starts a connector representing the <em>server side</em> of a DTLS connection.
@@ -204,7 +213,9 @@ public class ConnectorHelper {
 
 		serverConfig = builder.build();
 
-		serverSessionStore = new TestInMemorySessionStore();
+		if (useSessionStore) {
+			serverSessionStore = new TestInMemorySessionStore(false);
+		}
 		serverConnectionStore = new DebugConnectionStore(serverConfig.getMaxConnections(), serverConfig.getStaleConnectionThreshold(), serverSessionStore);
 		serverConnectionStore.setTag("server");
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
@@ -1968,8 +1968,10 @@ public class DTLSConnectorAdvancedTest {
 			boolean expectedCid = ConnectionId.useConnectionId(serverCidGenerator) && ConnectionId.supportsConnectionId(clientCidGenerator);
 			assertThat(serverSideConnection.expectCid(), is(expectedCid));
 
-			if (expectedCid) {
+			if (!serverHelper.useSessionStore || expectedCid) {
 				// with cid, the connection is still accessible and therefore not removed.
+				// without session store, a session-connection map is used and so the
+				// connection is still accessible and therefore not removed.
 				remain = serverHelper.serverConnectionStore.remainingCapacity();
 			}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorStartStopTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorStartStopTest.java
@@ -107,7 +107,7 @@ public class DTLSConnectorStartStopTest {
 		DtlsConnectorConfig.Builder builder = DtlsConnectorConfig.builder();
 		builder.setMaxConnections(1000);
 		builder.setStaleConnectionThreshold(10);
-		serverHelper = new ConnectorHelper();
+		serverHelper = new ConnectorHelper(true);
 		serverHelper.startServer(builder);
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStoreTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStoreTest.java
@@ -111,7 +111,7 @@ public class InMemoryConnectionStoreTest {
 	public void testFindRetrievesSharedConnection() {
 
 		// GIVEN an empty connection store with a session store shared by another node
-		SessionStore sessionStore = new TestInMemorySessionStore();
+		SessionStore sessionStore = new TestInMemorySessionStore(true);
 		sessionStore.put(con.getEstablishedSession());
 		store = new InMemoryConnectionStore(INITIAL_CAPACITY, 1000, sessionStore);
 
@@ -128,7 +128,7 @@ public class InMemoryConnectionStoreTest {
 
 		// GIVEN a connection store with a session store shared by another node
 		// and a (local) connection based on this session
-		SessionStore sessionStore = new TestInMemorySessionStore();
+		SessionStore sessionStore = new TestInMemorySessionStore(true);
 		sessionStore.put(con.getEstablishedSession());
 		store = new InMemoryConnectionStore(INITIAL_CAPACITY, 1000, sessionStore);
 		store.attach(null);


### PR DESCRIPTION
Extend dtls session resumption unit test to resume without application
info.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>