### PR TITLE
Replace use-no-server-session-id by inverse use-server-session-id.

### DIFF
--- a/MIGRATION_HINTS.md
+++ b/MIGRATION_HINTS.md
@@ -128,6 +128,8 @@ are removed and must be replaced by
 
 13) The `ResumptionSupportingConnectionStore.find(SessionId)` returns now a new DTLSSession instead of a connection.
 
+14) Change `useNoServerSessionId` into `useServerSessionId` with inverse logic.
+
 ### Californium-Core:
 
 1) The `MessageObserver2` interface is integrated in `MessageObserver`.

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapClientGnuTlsInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapClientGnuTlsInteroperabilityTest.java
@@ -142,7 +142,7 @@ public class LibCoapClientGnuTlsInteroperabilityTest {
 	public void testLibCoapClientPskNoSessionId() throws Exception {
 		CipherSuite cipherSuite = CipherSuite.TLS_PSK_WITH_AES_128_CCM_8;
 		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();
-		builder.setNoServerSessionId(true);
+		builder.setUseServerSessionId(false);
 		californiumUtil.start(BIND, false, builder, null, cipherSuite);
 
 		processUtil.startupClient(DESTINATION_URL + "test", PSK, "Hello, CoAP!", cipherSuite);

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapClientInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapClientInteroperabilityTest.java
@@ -132,7 +132,7 @@ public class LibCoapClientInteroperabilityTest {
 	public void testLibCoapClientPskNoSessionId() throws Exception {
 		CipherSuite cipherSuite = CipherSuite.TLS_PSK_WITH_AES_128_CCM_8;
 		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();
-		builder.setNoServerSessionId(true);
+		builder.setUseServerSessionId(false);
 		californiumUtil.start(BIND, false, builder, null, cipherSuite);
 
 		processUtil.startupClient(DESTINATION_URL + "test", PSK, "Hello, CoAP!", cipherSuite);

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapClientMbedTlsInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapClientMbedTlsInteroperabilityTest.java
@@ -125,7 +125,7 @@ public class LibCoapClientMbedTlsInteroperabilityTest {
 	public void testLibCoapClientPskNoSessionId() throws Exception {
 		CipherSuite cipherSuite = CipherSuite.TLS_PSK_WITH_AES_128_CCM_8;
 		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();
-		builder.setNoServerSessionId(true);
+		builder.setUseServerSessionId(false);
 		californiumUtil.start(BIND, false, builder, null, cipherSuite);
 
 		processUtil.startupClient(DESTINATION_URL + "test", PSK, "Hello, CoAP!", cipherSuite);

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapClientTinyDtlsInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/libcoap/LibCoapClientTinyDtlsInteroperabilityTest.java
@@ -121,7 +121,7 @@ public class LibCoapClientTinyDtlsInteroperabilityTest {
 	public void testLibCoapClientTinyDtlsPskNoSessionId() throws Exception {
 		CipherSuite cipherSuite = CipherSuite.TLS_PSK_WITH_AES_128_CCM_8;
 		DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();
-		builder.setNoServerSessionId(true);
+		builder.setUseServerSessionId(false);
 		californiumUtil.start(BIND, false, builder, null, cipherSuite);
 
 		processUtil.startupClient(DESTINATION_URL + "test", PSK, "Hello, CoAP!", cipherSuite);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -426,10 +426,12 @@ public final class DtlsConnectorConfig {
 	private Integer verifyPeersOnResumptionThreshold;
 
 	/**
-	 * Indicates, that no session id is used by this server. The sessions are not
-	 * cached by this server and can not be resumed.
+	 * Indicates, that a session id is used by this server. The sessions are
+	 * cached by this server and can be resumed.
+	 * 
+	 * @since 3.0 (was useNoServerSessionId with inverse logic)
 	 */
-	private Boolean useNoServerSessionId;
+	private Boolean useServerSessionId;
 
 	/**
 	 * Use anti replay filter.
@@ -1154,13 +1156,16 @@ public final class DtlsConnectorConfig {
 	}
 
 	/**
-	 * Indicates, that no session id is used by this server and so session are
-	 * also not cached by this server and can not be resumed.
+	 * Indicates, that session id is used by this server and so session are
+	 * cached by this server and can be resumed.
 	 * 
-	 * @return {@code true} if no session id is used by this server.
+	 * @return {@code true}, if session id is used by this server,
+	 *         {@code false}, if no session id us used by this server and
+	 *         therefore the session can not be resumed. Default {@code true}.
+	 * @since 3.0 (was useNoServerSessionId with inverse logic)
 	 */
-	public Boolean useNoServerSessionId() {
-		return useNoServerSessionId;
+	public Boolean useServerSessionId() {
+		return useServerSessionId;
 	}
 
 	/**
@@ -1355,7 +1360,7 @@ public final class DtlsConnectorConfig {
 		cloned.sniEnabled = sniEnabled;
 		cloned.extendedMasterSecretMode = extendedMasterSecretMode;
 		cloned.verifyPeersOnResumptionThreshold = verifyPeersOnResumptionThreshold;
-		cloned.useNoServerSessionId = useNoServerSessionId;
+		cloned.useServerSessionId = useServerSessionId;
 		cloned.loggingTag = loggingTag;
 		cloned.useAntiReplayFilter = useAntiReplayFilter;
 		cloned.useExtendedWindowFilter = useExtendedWindowFilter;
@@ -1539,9 +1544,9 @@ public final class DtlsConnectorConfig {
 			} else if (config.clientAuthenticationRequired != null || config.clientAuthenticationWanted != null) {
 				throw new IllegalStateException(
 						"client only is in contradiction to server side client authentication!");
-			} else if (config.useNoServerSessionId != null && config.useNoServerSessionId.booleanValue()) {
+			} else if (config.useServerSessionId != null && !config.useServerSessionId.booleanValue()) {
 				throw new IllegalStateException(
-						"client only is in contradiction to server side 'no server session id'!");
+						"client only is in contradiction to server side 'server session id'!");
 			}
 			config.clientOnly = true;
 			return this;
@@ -2859,16 +2864,18 @@ public final class DtlsConnectorConfig {
 		/**
 		 * Set whether session id is used by this server or not.
 		 * 
-		 * @param flag {@code true} if no session id is used by this server.
+		 * @param flag {@code true} if session id is used by this server,
+		 *            {@code false}, if not. Default {@code true}.
 		 * @return this builder for command chaining.
 		 * @throws IllegalArgumentException if no session id should be used and
 		 *             the configuration is for client only.
+		 * @since 3.0 (was setNoServerSessionId with inverse logic)
 		 */
-		public Builder setNoServerSessionId(boolean flag) {
-			if (Boolean.TRUE.equals(config.clientOnly) && flag) {
+		public Builder setUseServerSessionId(boolean flag) {
+			if (Boolean.TRUE.equals(config.clientOnly) && !flag) {
 				throw new IllegalArgumentException("not applicable for client only!");
 			}
-			config.useNoServerSessionId = flag;
+			config.useServerSessionId = flag;
 			return this;
 		}
 
@@ -3099,8 +3106,8 @@ public final class DtlsConnectorConfig {
 					config.defaultHandshakeMode = DtlsEndpointContext.HANDSHAKE_MODE_AUTO;
 				}
 			}
-			if (config.useNoServerSessionId == null) {
-				config.useNoServerSessionId = Boolean.FALSE;
+			if (config.useServerSessionId == null) {
+				config.useServerSessionId = Boolean.TRUE;
 			}
 			if (config.outboundMessageBufferSize == null) {
 				config.outboundMessageBufferSize = 100000;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -108,7 +108,7 @@ public class ServerHandshaker extends Handshaker {
 	private final Logger LOGGER_NEGOTIATION = LoggerFactory.getLogger(LOGGER.getName() + ".negotiation");
 
 	/** Does the server use session id? */
-	private boolean useNoSessionId = false;
+	private boolean useSessionId = true;
 
 	/** Is the client wanted to authenticate itself? */
 	private boolean clientAuthenticationWanted = false;
@@ -233,7 +233,7 @@ public class ServerHandshaker extends Handshaker {
 
 		this.clientAuthenticationWanted = config.isClientAuthenticationWanted();
 		this.clientAuthenticationRequired = config.isClientAuthenticationRequired();
-		this.useNoSessionId = config.useNoServerSessionId();
+		this.useSessionId = config.useServerSessionId();
 
 		// the server handshake uses the config with exchanged roles!
 		this.supportedClientCertificateTypes = config.getTrustCertificateTypes();
@@ -505,11 +505,11 @@ public class ServerHandshaker extends Handshaker {
 		serverRandom = new Random();
 
 		DTLSSession session = getSession();
-		boolean useNoSessionId = this.useNoSessionId;
+		boolean useSessionId = this.useSessionId;
 		if (extendedMasterSecretMode.is(ExtendedMasterSecretMode.ENABLED) && !clientHello.hasExtendedMasterSecret()) {
-			useNoSessionId = true;
+			useSessionId = false;
 		}
-		SessionId sessionId = useNoSessionId ? SessionId.emptySessionId() : new SessionId();
+		SessionId sessionId = useSessionId ? new SessionId() : SessionId.emptySessionId();
 		session.setSessionIdentifier(sessionId);
 		session.setProtocolVersion(serverVersion);
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
@@ -810,7 +810,7 @@ public class DTLSConnectorAdvancedTest {
 		TestRecordLayer serverRecordLayer = new TestRecordLayer(rawServer);
 
 		DtlsConnectorConfig serverConfig = new DtlsConnectorConfig.Builder(serverHelper.serverConfig)
-				.setNoServerSessionId(true).build();
+				.setUseServerSessionId(false).build();
 
 		try {
 			// Start connector (Server)
@@ -1072,7 +1072,7 @@ public class DTLSConnectorAdvancedTest {
 		TestRecordLayer serverRecordLayer = new TestRecordLayer(rawServer);
 
 		DtlsConnectorConfig serverConfig = new DtlsConnectorConfig.Builder(serverHelper.serverConfig)
-				.setNoServerSessionId(true).build();
+				.setUseServerSessionId(false).build();
 
 		try {
 			// Start connector (Server)

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorHandshakeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorHandshakeTest.java
@@ -1053,7 +1053,7 @@ public class DTLSConnectorHandshakeTest {
 	@Test
 	public void testPskHandshakeWithoutSession() throws Exception {
 		DtlsConnectorConfig.Builder builder = DtlsConnectorConfig.builder().setClientAuthenticationRequired(false)
-				.setClientAuthenticationWanted(false).setSniEnabled(false).setNoServerSessionId(true)
+				.setClientAuthenticationWanted(false).setSniEnabled(false).setUseServerSessionId(false)
 				.setApplicationLevelInfoSupplier(clientInfoSupplier);
 		startServer(builder);
 		startClientPsk(false, null, null, PSK_STORE);
@@ -1068,7 +1068,7 @@ public class DTLSConnectorHandshakeTest {
 	public void testPskHandshakePskSecret() throws Exception {
 		serverPskStore = new AsyncAdvancedPskStore(PSK_STORE).setSecretMode(false);
 		DtlsConnectorConfig.Builder builder = DtlsConnectorConfig.builder().setClientAuthenticationRequired(false)
-				.setClientAuthenticationWanted(false).setSniEnabled(false).setNoServerSessionId(true)
+				.setClientAuthenticationWanted(false).setSniEnabled(false).setUseServerSessionId(false)
 				.setApplicationLevelInfoSupplier(clientInfoSupplier).setAdvancedPskStore(serverPskStore);
 		startServer(builder);
 		startClientPsk(false, null, null, PSK_STORE);
@@ -1083,7 +1083,7 @@ public class DTLSConnectorHandshakeTest {
 	public void testPskHandshakeMasterSecret() throws Exception {
 		serverPskStore = new AsyncAdvancedPskStore(PSK_STORE).setSecretMode(true);
 		DtlsConnectorConfig.Builder builder = DtlsConnectorConfig.builder().setClientAuthenticationRequired(false)
-				.setClientAuthenticationWanted(false).setSniEnabled(false).setNoServerSessionId(true)
+				.setClientAuthenticationWanted(false).setSniEnabled(false).setUseServerSessionId(false)
 				.setApplicationLevelInfoSupplier(clientInfoSupplier).setAdvancedPskStore(serverPskStore);
 		startServer(builder);
 		startClientPsk(false, null, null, PSK_STORE);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
@@ -966,7 +966,7 @@ public class DTLSConnectorResumeTest {
 		ConnectorHelper serverWithoutSessionId = new ConnectorHelper();
 		try {
 			DtlsConnectorConfig.Builder builder = DtlsConnectorConfig.builder()
-					.setNoServerSessionId(true)
+					.setUseServerSessionId(false)
 					.setSniEnabled(true);
 			serverWithoutSessionId.startServer(builder);
 


### PR DESCRIPTION
Signed-off-by: Achim Kraus <achim.kraus@bosch.io>