### PR TITLE
Mitigate false findings of security code-scanner.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/AeadBlockCipher.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/AeadBlockCipher.java
@@ -43,16 +43,15 @@ public class AeadBlockCipher {
 	 */
 	public final static boolean isSupported(String transformation, int keyLength) {
 		try {
+			int keyLengthBits = keyLength * Byte.SIZE;
 			// check, if java-vm supports transformation
-			Cipher cipher;
 			if (AES_CCM.equals(transformation)) {
-				cipher = CCMBlockCipher.CIPHER.current();
+				if (CCMBlockCipher.isSupported()) {
+					return keyLengthBits <= CCMBlockCipher.getMaxAllowedKeyLength();
+				}
 			} else {
-				cipher = Cipher.getInstance(transformation);
-			}
-			if (cipher != null) {
-				int maxAllowedKeyLengthBits = Cipher.getMaxAllowedKeyLength(cipher.getAlgorithm());
-				return keyLength * 8 <= maxAllowedKeyLengthBits;
+				Cipher cipher = Cipher.getInstance(transformation);
+				return keyLengthBits <= Cipher.getMaxAllowedKeyLength(cipher.getAlgorithm());
 			}
 		} catch (GeneralSecurityException ex) {
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CCMBlockCipher.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CCMBlockCipher.java
@@ -23,6 +23,7 @@ package org.eclipse.californium.scandium.dtls.cipher;
 
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
 import javax.crypto.Cipher;
@@ -44,9 +45,17 @@ public class CCMBlockCipher {
 
 	/**
 	 * The underlying block cipher.
+	 * <p>
+	 * <b>Note:</b> code scanners seems to be limited in analyzing code.
+	 * Therefore some code scanners may report the use of "AES/ECB" as finding.
+	 * This implementation uses the basic form of AES ciphers (AES/ECB) to build
+	 * AES/CCM for older JREs. For more details, see
+	 * <a href="https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation"
+	 * target="_blank"> Wikipedia, Block cipher mode of operation</a>
+	 * </p>
 	 */
-	public static final String CIPHER_NAME = "AES/ECB/NoPadding";
-	public static final ThreadLocalCipher CIPHER = new ThreadLocalCipher(CIPHER_NAME);
+	private static final String CIPHER_NAME = "AES/ECB/NoPadding";
+	private static final ThreadLocalCipher CIPHER = new ThreadLocalCipher(CIPHER_NAME);
 
 	private static abstract class Block {
 
@@ -278,6 +287,33 @@ public class CCMBlockCipher {
 
 	}
 	// Static methods /////////////////////////////////////////////////
+
+	/**
+	 * Checks, if AES/CCM cipher is supported.
+	 * 
+	 * Checks, if the AES/ECB cipher is supported for this JRE in order to build
+	 * a AES/CCM cipher based on that.
+	 * 
+	 * @return {@code true}, if AES/CCM is supported, {@code false}, if not.
+	 * @since 3.0
+	 */
+	public static boolean isSupported() {
+		return CIPHER.isSupported();
+	}
+
+	/**
+	 * Returns the maximum key length for AES/CCM according to the installed JCE
+	 * jurisdiction policy files.
+	 * 
+	 * @return the maximum key length in bits or {@link Integer#MAX_VALUE}.
+	 * 
+	 * @throws NoSuchAlgorithmException if "AES/ECB" is not supported.
+	 * @see Cipher#getMaxAllowedKeyLength(String)
+	 * @since 3.0
+	 */
+	public static int getMaxAllowedKeyLength() throws NoSuchAlgorithmException {
+		return Cipher.getMaxAllowedKeyLength(CIPHER_NAME);
+	}
 
 	/**
 	 * See <a href="https://tools.ietf.org/html/rfc3610#section-2.5" target="_blank">RFC 3610</a>

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
@@ -769,7 +769,6 @@ public enum CipherSuite {
 	 */
 	private enum MACAlgorithm {
 		NULL(null, null, 0, 0, 0),
-		HMAC_MD5("HmacMD5", "MD5",16, 0, 0),
 		HMAC_SHA1("HmacSHA1", "SHA-1", 20, 8, 64),
 		HMAC_SHA256("HmacSHA256", "SHA-256", 32, 8, 64),
 		HMAC_SHA384("HmacSHA384", "SHA-384", 48, 16, 128),
@@ -916,7 +915,6 @@ public enum CipherSuite {
 		// key_length & record_iv_length as documented in RFC 5426, Appendix C
 		// see http://tools.ietf.org/html/rfc5246#appendix-C
 		NULL("NULL", CipherType.NULL, 0, 0, 0),
-		B_3DES_EDE_CBC("DESede/CBC/NoPadding", CipherType.BLOCK, 24, 0, 8), // don't know
 		AES_128_CBC("AES/CBC/NoPadding", CipherType.BLOCK, 16, 0, 16), // http://www.ietf.org/mail-archive/web/tls/current/msg08445.html
 		AES_256_CBC("AES/CBC/NoPadding", CipherType.BLOCK, 32, 0, 16),
 		AES_128_CCM_8(AeadBlockCipher.AES_CCM, CipherType.AEAD, 16, 4, 8, 8), // explicit nonce (record IV) length = 8


### PR DESCRIPTION
Add explanation to javadoc comments.
Remove unused crypto algorithms.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>