### PR TITLE
Certificate provider

### DIFF
--- a/MIGRATION_HINTS.md
+++ b/MIGRATION_HINTS.md
@@ -57,6 +57,8 @@ The `ApplicationLevelInfoSupplier.getInfo()` supports now to return `null` in or
 
 The `ResumingServerHandshaker` supports now a none-blocking `ResumptionVerifier` and a fall-back to a full handshake.
 
+The `CertificateProvider` introduces the possibility to use multiple certificates.
+
 The `SignatureAndHashAlgorithm` supports now `isRecommended` to address the upcoming 
 [draft-ietf-tls-md5-sha1-deprecate](https://datatracker.ietf.org/doc/draft-ietf-tls-md5-sha1-deprecate/).
 
@@ -141,6 +143,8 @@ are removed and must be replaced by
 
 15) To support [RFC 7627, Extended Master Secret](https://tools.ietf.org/html/rfc7627), a parameter `useExtendedMasterSecret` is added to
 `AdvancedPskStore.requestPskSecretResult`.
+
+16) Change `DtlsConnectorConfig.getPrivateKey`, `getPublicKey`, and `getCertificateChain` are replaced by the introduced `CertificateProvider`. `DtlsConnectorConfig.getCertificateIdentityProvider` is added to access the `CertificateProvider`. The `SingleCertificateProvider` is provided, if only  a single certificate based identity is required. The related setters in the `DtlsConnectorConfig.Builder` are replaced also by `setCertificateIdentityProvider`.
 
 ### Californium-Core:
 

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/ConnectorUtil.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/ConnectorUtil.java
@@ -40,6 +40,7 @@ import org.eclipse.californium.scandium.dtls.CertificateType;
 import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedSinglePskStore;
+import org.eclipse.californium.scandium.dtls.x509.SingleCertificateProvider;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier.Builder;
 
@@ -155,10 +156,10 @@ public class ConnectorUtil {
 					new AdvancedSinglePskStore(OpenSslUtil.OPENSSL_PSK_IDENTITY, OpenSslUtil.OPENSSL_PSK_SECRET));
 		}
 		if (CipherSuite.containsCipherSuiteRequiringCertExchange(suites)) {
-			if (credentials != null && dtlsBuilder.getIncompleteConfig().getPrivateKey() == null) {
+			if (credentials != null && dtlsBuilder.getIncompleteConfig().getCertificateIdentityProvider() == null) {
 				Credentials credentials = rsa ? this.credentialsRsa : this.credentials;
-				dtlsBuilder.setIdentity(credentials.getPrivateKey(), credentials.getCertificateChain(),
-						CertificateType.X_509, CertificateType.RAW_PUBLIC_KEY);
+				dtlsBuilder.setCertificateIdentityProvider(new SingleCertificateProvider(credentials.getPrivateKey(), credentials.getCertificateChain(),
+						CertificateType.X_509, CertificateType.RAW_PUBLIC_KEY));
 				Builder builder = StaticNewAdvancedCertificateVerifier.builder();
 				if (TRUST_CA.equals(trust)) {
 					builder.setTrustedCertificates(trustCa);

--- a/cf-utils/cf-cli/src/main/java/org/eclipse/californium/cli/ClientInitializer.java
+++ b/cf-utils/cf-cli/src/main/java/org/eclipse/californium/cli/ClientInitializer.java
@@ -59,6 +59,7 @@ import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedPskStore;
+import org.eclipse.californium.scandium.dtls.x509.SingleCertificateProvider;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier;
 import org.eclipse.californium.scandium.util.SecretUtil;
 import org.eclipse.californium.scandium.util.ServerNames;
@@ -362,9 +363,9 @@ public class ClientInitializer {
 			if (clientConfig.authentication != null && clientConfig.authentication.credentials != null) {
 				Credentials identity = clientConfig.authentication.credentials;
 				if (certificateTypes.contains(CertificateType.X_509)) {
-					dtlsConfig.setIdentity(identity.getPrivateKey(), identity.getCertificateChain(), certificateTypes);
+					dtlsConfig.setCertificateIdentityProvider(new SingleCertificateProvider(identity.getPrivateKey(), identity.getCertificateChain(), certificateTypes));
 				} else if (certificateTypes.contains(CertificateType.RAW_PUBLIC_KEY)) {
-					dtlsConfig.setIdentity(identity.getPrivateKey(), identity.getPubicKey());
+					dtlsConfig.setCertificateIdentityProvider(new SingleCertificateProvider(identity.getPrivateKey(), identity.getPubicKey()));
 				}
 			}
 

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
@@ -81,6 +81,7 @@ import org.eclipse.californium.scandium.dtls.CertificateType;
 import org.eclipse.californium.scandium.dtls.MultiNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.AsyncAdvancedPskStore;
+import org.eclipse.californium.scandium.dtls.x509.AsyncCertificateProvider;
 import org.eclipse.californium.scandium.dtls.x509.AsyncNewAdvancedCertificateVerifier;
 import org.eclipse.californium.scandium.util.SecretUtil;
 import org.eclipse.californium.unixhealth.NetStatLogger;
@@ -607,8 +608,11 @@ public class ExtendedTestServer extends AbstractTestServer {
 		dtlsConfigBuilder.setAddress(dtlsInterface);
 		dtlsConfigBuilder.setSupportedCipherSuites(CipherSuite.TLS_PSK_WITH_AES_128_CCM_8,
 				CipherSuite.TLS_ECDHE_PSK_WITH_AES_128_CCM_8_SHA256, CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);
-		dtlsConfigBuilder.setIdentity(serverCredentials.getPrivateKey(), serverCredentials.getCertificateChain(),
-				CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509);
+		AsyncCertificateProvider certificateProvider = new AsyncCertificateProvider(serverCredentials.getPrivateKey(),
+				serverCredentials.getCertificateChain(), CertificateType.RAW_PUBLIC_KEY,
+				CertificateType.X_509);
+		certificateProvider.setDelay(handshakeResultDelay);
+		dtlsConfigBuilder.setCertificateIdentityProvider(certificateProvider);
 		AsyncNewAdvancedCertificateVerifier.Builder verifierBuilder = AsyncNewAdvancedCertificateVerifier.builder();
 		if (cliConfig.trustall) {
 			verifierBuilder.setTrustAllCertificates();

--- a/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
+++ b/demo-apps/cf-plugtest-server/src/main/java/org/eclipse/californium/plugtests/AbstractTestServer.java
@@ -62,7 +62,7 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedPskStore;
 import org.eclipse.californium.scandium.dtls.pskstore.AsyncAdvancedPskStore;
 import org.eclipse.californium.scandium.dtls.resumption.AsyncResumptionVerifier;
-import org.eclipse.californium.scandium.dtls.resumption.ConnectionStoreResumptionVerifier;
+import org.eclipse.californium.scandium.dtls.x509.AsyncCertificateProvider;
 import org.eclipse.californium.scandium.dtls.x509.AsyncNewAdvancedCertificateVerifier;
 import org.eclipse.californium.scandium.util.SecretUtil;
 import org.eclipse.californium.scandium.util.ServerNames;
@@ -379,9 +379,11 @@ public abstract class AbstractTestServer extends CoapServer {
 							CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8, CipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA256,
 							CipherSuite.TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256,
 							CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256);
-					dtlsConfigBuilder.setIdentity(serverCredentials.getPrivateKey(),
+					AsyncCertificateProvider certificateProvider = new AsyncCertificateProvider(serverCredentials.getPrivateKey(),
 							serverCredentials.getCertificateChain(), CertificateType.RAW_PUBLIC_KEY,
 							CertificateType.X_509);
+					certificateProvider.setDelay(handshakeResultDelay);
+					dtlsConfigBuilder.setCertificateIdentityProvider(certificateProvider);
 					AsyncNewAdvancedCertificateVerifier.Builder verifierBuilder = AsyncNewAdvancedCertificateVerifier
 							.builder();
 					if (cliConfig.trustall) {

--- a/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/util/SecureEndpointPool.java
+++ b/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/util/SecureEndpointPool.java
@@ -33,6 +33,7 @@ import org.eclipse.californium.scandium.dtls.CertificateType;
 import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
+import org.eclipse.californium.scandium.dtls.x509.SingleCertificateProvider;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier.Builder;
 
@@ -103,8 +104,8 @@ public class SecureEndpointPool extends EndpointPool {
 		Certificate[] trustedCertificates = SslContextUtil.loadTrustedCertificates(
 				SslContextUtil.CLASSPATH_SCHEME + TRUST_STORE_LOCATION, null, TRUST_STORE_PASSWORD);
 		DtlsConnectorConfig.Builder dtlsConfig = new DtlsConnectorConfig.Builder();
-		dtlsConfig.setIdentity(clientCredentials.getPrivateKey(), clientCredentials.getCertificateChain(),
-				CertificateType.X_509, CertificateType.RAW_PUBLIC_KEY);
+		dtlsConfig.setCertificateIdentityProvider(new SingleCertificateProvider(clientCredentials.getPrivateKey(), clientCredentials.getCertificateChain(),
+				CertificateType.X_509, CertificateType.RAW_PUBLIC_KEY));
 		Builder verifierBuilder = StaticNewAdvancedCertificateVerifier.builder();
 		verifierBuilder.setTrustedCertificates(trustedCertificates);
 		verifierBuilder.setTrustAllRPKs();

--- a/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/CredentialsUtil.java
+++ b/demo-apps/cf-secure/src/main/java/org/eclipse/californium/examples/CredentialsUtil.java
@@ -30,6 +30,7 @@ import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedMultiPskStore;
+import org.eclipse.californium.scandium.dtls.x509.SingleCertificateProvider;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier.Builder;
 
@@ -308,7 +309,7 @@ public class CredentialsUtil {
 					} else if (rpk >= 0) {
 						types.add(CertificateType.RAW_PUBLIC_KEY);
 					}
-					config.setIdentity(serverCredentials.getPrivateKey(), serverCredentials.getCertificateChain(), types);
+					config.setCertificateIdentityProvider(new SingleCertificateProvider(serverCredentials.getPrivateKey(), serverCredentials.getCertificateChain(), types));
 				}
 			} catch (GeneralSecurityException e) {
 				e.printStackTrace();

--- a/demo-apps/sc-dtls-example-client/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSClient.java
+++ b/demo-apps/sc-dtls-example-client/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSClient.java
@@ -45,6 +45,7 @@ import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.CertificateType;
 import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedSinglePskStore;
+import org.eclipse.californium.scandium.dtls.x509.SingleCertificateProvider;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,8 +78,8 @@ public class ExampleDTLSClient {
 
 			DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder();
 			builder.setAdvancedPskStore(new AdvancedSinglePskStore("Client_identity", "secretPSK".getBytes()));
-			builder.setIdentity(clientCredentials.getPrivateKey(), clientCredentials.getCertificateChain(),
-					CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509);
+			builder.setCertificateIdentityProvider(new SingleCertificateProvider(clientCredentials.getPrivateKey(), clientCredentials.getCertificateChain(),
+					CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509));
 			builder.setAdvancedCertificateVerifier(StaticNewAdvancedCertificateVerifier.builder()
 					.setTrustedCertificates(trustedCertificates).setTrustAllRPKs().build());
 			builder.setConnectionIdGenerator(new SingleNodeConnectionIdGenerator(0));

--- a/demo-apps/sc-dtls-example-server/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSServer.java
+++ b/demo-apps/sc-dtls-example-server/src/main/java/org/eclipse/californium/scandium/examples/ExampleDTLSServer.java
@@ -31,6 +31,7 @@ import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.CertificateType;
 import org.eclipse.californium.scandium.dtls.SingleNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedMultiPskStore;
+import org.eclipse.californium.scandium.dtls.x509.SingleCertificateProvider;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,8 +64,8 @@ public class ExampleDTLSServer {
 			builder.setRecommendedCipherSuitesOnly(false);
 			builder.setAddress(new InetSocketAddress(DEFAULT_PORT));
 			builder.setAdvancedPskStore(pskStore);
-			builder.setIdentity(serverCredentials.getPrivateKey(), serverCredentials.getCertificateChain(),
-					CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509);
+			builder.setCertificateIdentityProvider(new SingleCertificateProvider(serverCredentials.getPrivateKey(), serverCredentials.getCertificateChain(),
+					CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509));
 			builder.setAdvancedCertificateVerifier(StaticNewAdvancedCertificateVerifier.builder()
 					.setTrustedCertificates(trustedCertificates).setTrustAllRPKs().build());
 			builder.setConnectionIdGenerator(new SingleNodeConnectionIdGenerator(6));

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
@@ -1253,7 +1253,8 @@ public class SslContextUtil {
 	}
 
 	/**
-	 * Credentials. Pair of private key and certificate trustedChain.
+	 * Credentials. Pair of private key and public key or certificate trust
+	 * chain. Or trusted certificates.
 	 */
 	public static class Credentials {
 
@@ -1266,7 +1267,7 @@ public class SslContextUtil {
 		 */
 		private final PublicKey publicKey;
 		/**
-		 * Certificate trustedChain.
+		 * Certificate trust chain.
 		 */
 		private final X509Certificate[] chain;
 		/**
@@ -1333,18 +1334,28 @@ public class SslContextUtil {
 		}
 
 		/**
-		 * Get certificate trustedChain.
+		 * Get certificate trust chain.
 		 * 
-		 * @return certificate trustedChain
+		 * @return certificate trust chain
 		 */
 		public X509Certificate[] getCertificateChain() {
 			return chain;
 		}
 
 		/**
-		 * Get certificate trusts.
+		 * Get certificate trust chain as list.
 		 * 
-		 * @return certificate trusts
+		 * @return certificate trust chain as list
+		 * @since 3.0
+		 */
+		public List<X509Certificate> getCertificateChainAsList() {
+			return chain == null ? null : Arrays.asList(chain);
+		}
+
+		/**
+		 * Get trusted certificates.
+		 * 
+		 * @return trusted certificates
 		 */
 		public Certificate[] getTrustedCertificates() {
 			return trusts;

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/TestCertificatesTools.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/TestCertificatesTools.java
@@ -86,14 +86,10 @@ public class TestCertificatesTools {
 			Certificate[] certificates = SslContextUtil.loadTrustedCertificates(
 					TRUST_STORE_URI, null, TRUST_STORE_PASSWORD);
 
-			KeyManager[] manager = SslContextUtil.loadKeyManager(KEY_STORE_URI, "server.*", KEY_STORE_PASSWORD, KEY_STORE_PASSWORD);
-			if (manager != null && manager.length > 0) {
-				serverKeyManager = (X509ExtendedKeyManager) manager[0];
-			}
+			KeyManager[] manager = SslContextUtil.loadKeyManager(EDDSA_KEY_STORE_URI, "server.*", KEY_STORE_PASSWORD, KEY_STORE_PASSWORD);
+			serverKeyManager = getX509KeyManager(manager);
 			manager = SslContextUtil.loadKeyManager(KEY_STORE_URI, "client", KEY_STORE_PASSWORD, KEY_STORE_PASSWORD);
-			if (manager != null && manager.length > 0) {
-				clientKeyManager = (X509ExtendedKeyManager) manager[0];
-			}
+			clientKeyManager = getX509KeyManager(manager);
 
 			trustedCertificates = SslContextUtil.asX509Certificates(certificates);
 			certificates = SslContextUtil.loadTrustedCertificates(
@@ -457,4 +453,14 @@ public class TestCertificatesTools {
 		return diff.toString();
 	}
 
+	private static X509ExtendedKeyManager getX509KeyManager(KeyManager[] managers) {
+		if (managers != null) {
+			for (KeyManager manager : managers) {
+				if (manager instanceof X509ExtendedKeyManager) {
+					return (X509ExtendedKeyManager) manager;
+				}
+			}
+		}
+		return null;
+	}
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -220,6 +220,7 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedPskStore;
 import org.eclipse.californium.scandium.dtls.resumption.ConnectionStoreResumptionVerifier;
 import org.eclipse.californium.scandium.dtls.resumption.ResumptionVerifier;
+import org.eclipse.californium.scandium.dtls.x509.CertificateProvider;
 import org.eclipse.californium.scandium.dtls.x509.NewAdvancedCertificateVerifier;
 import org.eclipse.californium.scandium.util.ServerNames;
 
@@ -510,6 +511,10 @@ public class DTLSConnector implements Connector, PersistentConnector, RecordLaye
 			AdvancedPskStore advancedPskStore = config.getAdvancedPskStore();
 			if (advancedPskStore != null) {
 				advancedPskStore.setResultHandler(handler);
+			}
+			CertificateProvider certificateIdentityProvider = config.getCertificateIdentityProvider();
+			if (certificateIdentityProvider != null) {
+				certificateIdentityProvider.setResultHandler(handler);
 			}
 			NewAdvancedCertificateVerifier certificateVerifier = config.getAdvancedCertificateVerifier();
 			if (certificateVerifier != null) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateIdentityResult.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/CertificateIdentityResult.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import org.eclipse.californium.scandium.auth.ApplicationLevelInfoSupplier;
+import org.eclipse.californium.scandium.dtls.x509.CertificateProvider;
+
+/**
+ * Result of certificate identity provider.
+ * 
+ * @see CertificateProvider
+ * @since 3.0
+ */
+public final class CertificateIdentityResult extends HandshakeResult {
+
+	private final PrivateKey privateKey;
+	private final PublicKey publicKey;
+	private final List<X509Certificate> certificateChain;
+
+	/**
+	 * Create result with {@link X509Certificate}.
+	 * 
+	 * @param cid connection id
+	 * @param privateKey private key of identity.
+	 * @param certificateChain certificate chain for identity
+	 * @param customArgument custom argument. May be {@code null}. Passed to
+	 *            {@link ApplicationLevelInfoSupplier} by the
+	 *            {@link Handshaker}, if a {@link ApplicationLevelInfoSupplier}
+	 *            is available.
+	 * @throws NullPointerException if cid, private key, or chain is
+	 *             {@code null}.
+	 * @throws IllegalArgumentException if chain is empty.
+	 */
+	public CertificateIdentityResult(ConnectionId cid, PrivateKey privateKey, List<X509Certificate> certificateChain,
+			Object customArgument) {
+		super(cid, customArgument);
+		if (privateKey == null) {
+			throw new NullPointerException("Private key must not be null!");
+		}
+		if (certificateChain == null) {
+			throw new NullPointerException("Certificate chain must not be null!");
+		}
+		if (certificateChain.isEmpty()) {
+			throw new IllegalArgumentException("Certificate chain must not be empty!");
+		}
+		this.privateKey = privateKey;
+		this.publicKey = certificateChain.get(0).getPublicKey();
+		this.certificateChain = certificateChain;
+	}
+
+	/**
+	 * Create result with RawPublicKey.
+	 * 
+	 * @param cid connection id
+	 * @param privateKey private key of identity.
+	 * @param publicKey public key for identity
+	 * @param customArgument custom argument. May be {@code null}. Passed to
+	 *            {@link ApplicationLevelInfoSupplier} by the
+	 *            {@link Handshaker}, if a {@link ApplicationLevelInfoSupplier}
+	 *            is available.
+	 * @throws NullPointerException if cid, private key, or public key is
+	 *             {@code null}.
+	 */
+	public CertificateIdentityResult(ConnectionId cid, PrivateKey privateKey, PublicKey publicKey,
+			Object customArgument) {
+		super(cid, customArgument);
+		if (privateKey == null) {
+			throw new NullPointerException("Private key must not be null!");
+		}
+		if (publicKey == null) {
+			throw new NullPointerException("Public key must not be null!");
+		}
+		this.privateKey = privateKey;
+		this.publicKey = publicKey;
+		this.certificateChain = null;
+	}
+
+	/**
+	 * Create result without matching identity.
+	 * 
+	 * @param cid connection id
+	 * @param customArgument custom argument. May be {@code null}. Passed to
+	 *            {@link ApplicationLevelInfoSupplier} by the
+	 *            {@link Handshaker}, if a {@link ApplicationLevelInfoSupplier}
+	 *            is available.
+	 * @throws NullPointerException if cid is {@code null}.
+	 */
+	public CertificateIdentityResult(ConnectionId cid, Object customArgument) {
+		super(cid, customArgument);
+		this.privateKey = null;
+		this.publicKey = null;
+		this.certificateChain = null;
+	}
+
+	/**
+	 * Get private key of certificate based identity
+	 * 
+	 * @return private key, or {@code null}, if no matching identity is
+	 *         available.
+	 */
+	public PrivateKey getPrivateKey() {
+		return privateKey;
+	}
+
+	/**
+	 * Get public key of certificate based identity
+	 * 
+	 * @return public key, or {@code null}, if no matching identity is
+	 *         available.
+	 */
+	public PublicKey getPublicKey() {
+		return publicKey;
+	}
+
+	/**
+	 * Get certificate chain of x509 based identity
+	 * 
+	 * @return certificate chain, or {@code null}, if no x509 identity is
+	 *         available or used.
+	 */
+	public List<X509Certificate> getCertificateChain() {
+		return certificateChain;
+	}
+
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ResumingClientHandshaker.java
@@ -179,23 +179,24 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 	}
 
 	/**
+	 * Check, if the server want an abbreviated or full handshake.
+	 * 
 	 * Stores the negotiated security parameters.
 	 * 
-	 * @param message
-	 *            the {@link ServerHello} message.
-	 * @throws HandshakeException if the ServerHello message cannot be processed,
-	 * 	e.g. because the server selected an unknown or unsupported cipher suite
+	 * @param message the {@link ServerHello} message.
+	 * @throws HandshakeException if the ServerHello message cannot be
+	 *             processed, e.g. because the server selected an unknown or
+	 *             unsupported cipher suite
 	 */
 	protected void receivedServerHello(ServerHello message) throws HandshakeException {
 		DTLSSession session = getSession();
-		if (!session.getSessionIdentifier().equals(message.getSessionId()))
-		{
+		if (!session.getSessionIdentifier().equals(message.getSessionId())) {
 			LOGGER.debug(
 					"Server [{}] refuses to resume session [{}], performing full handshake instead...",
 					peerToLog, session.getSessionIdentifier());
 			// Server refuse to resume the session, go for a full handshake
 			fullHandshake  = true;
-			SecretUtil.destroy(getDtlsContext());
+			SecretUtil.destroy(session);
 			super.receivedServerHello(message);
 		} else if (!message.getCompressionMethod().equals(session.getCompressionMethod())) {
 			throw new HandshakeException(
@@ -300,6 +301,7 @@ public class ResumingClientHandshaker extends ClientHandshaker {
 		addMaxFragmentLength(message);
 		addServerNameIndication(message);
 
+		// keep client_hello for a hello_verify_request.
 		clientHello = message;
 
 		flightNumber = 1;

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SignatureAndHashAlgorithm.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/SignatureAndHashAlgorithm.java
@@ -357,13 +357,13 @@ public final class SignatureAndHashAlgorithm {
 	}
 
 	/**
-	 * Ensure, that the defaults list contains a signature and hash algorithms
-	 * usable by the public key.
+	 * Ensure, that the list contains a signature and hash algorithms usable by
+	 * the public key.
 	 * 
 	 * Adds a signature and hash algorithms usable by the public key to the
-	 * defaults list, if missing.
+	 * list, if missing.
 	 * 
-	 * @param defaults list of default algorithms. If not already supported, a
+	 * @param algorithms list of default algorithms. If not already supported, a
 	 *            signature and hash algorithms usable by the public key is
 	 *            added to this list.
 	 * @param publicKey publicKey. May be {@code null}.
@@ -372,17 +372,19 @@ public final class SignatureAndHashAlgorithm {
 	 *             public key
 	 * @since 3.0
 	 */
-	public static void ensureDefaultSignatureAlgorithm(List<SignatureAndHashAlgorithm> defaults, PublicKey publicKey) {
+	public static void ensureSignatureAlgorithm(List<SignatureAndHashAlgorithm> algorithms, PublicKey publicKey) {
 		if (publicKey == null) {
 			throw new NullPointerException("Public key must not be null!");
 		}
-		if (getSupportedSignatureAlgorithm(DEFAULT, publicKey) != null) {
+		SignatureAndHashAlgorithm signAndHash = getSupportedSignatureAlgorithm(DEFAULT, publicKey);
+		if (signAndHash != null) {
+			ListUtils.addIfAbsent(algorithms, signAndHash);
 			return;
 		}
-		if (defaults == null) {
+		if (algorithms == null) {
 			throw new NullPointerException("The defaults list must not be null!");
 		}
-		if (getSupportedSignatureAlgorithm(defaults, publicKey) != null) {
+		if (getSupportedSignatureAlgorithm(algorithms, publicKey) != null) {
 			return;
 		}
 		boolean keyAlgorithmSupported = false;
@@ -390,19 +392,17 @@ public final class SignatureAndHashAlgorithm {
 			if (signatureAlgorithm.isSupported(publicKey.getAlgorithm())) {
 				keyAlgorithmSupported = true;
 				if (signatureAlgorithm.isIntrinsic) {
-					SignatureAndHashAlgorithm signAndHash = new SignatureAndHashAlgorithm(HashAlgorithm.INTRINSIC,
-							signatureAlgorithm);
+					signAndHash = new SignatureAndHashAlgorithm(HashAlgorithm.INTRINSIC, signatureAlgorithm);
 					if (signAndHash.isSupported(publicKey)) {
-						ListUtils.addIfAbsent(defaults, signAndHash);
+						ListUtils.addIfAbsent(algorithms, signAndHash);
 						return;
 					}
 				} else {
 					for (HashAlgorithm hashAlgorithm : HashAlgorithm.values()) {
 						if (hashAlgorithm != HashAlgorithm.INTRINSIC && hashAlgorithm.isRecommended()) {
-							SignatureAndHashAlgorithm signAndHash = new SignatureAndHashAlgorithm(hashAlgorithm,
-									signatureAlgorithm);
+							signAndHash = new SignatureAndHashAlgorithm(hashAlgorithm, signatureAlgorithm);
 							if (signAndHash.isSupported(publicKey)) {
-								ListUtils.addIfAbsent(defaults, signAndHash);
+								ListUtils.addIfAbsent(algorithms, signAndHash);
 								return;
 							}
 						}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuiteParameters.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuiteParameters.java
@@ -173,6 +173,28 @@ public class CipherSuiteParameters {
 		this.format = format;
 	}
 
+	/**
+	 * Create common cipher suites and parameters.
+	 * 
+	 * @param publicKey peer's public key. Maybe {@code null}.
+	 * @param certificateChain peer's certificate chain. Maybe {@code null}.
+	 * @param others other parameters
+	 * @since 3.0
+	 */
+	public CipherSuiteParameters(PublicKey publicKey, List<X509Certificate> certificateChain,
+			CipherSuiteParameters others) {
+		this.publicKey = publicKey;
+		this.certificateChain = certificateChain;
+		this.clientAuthenticationRequired = others.clientAuthenticationRequired;
+		this.clientAuthenticationWanted = others.clientAuthenticationWanted;
+		this.cipherSuites = others.cipherSuites;
+		this.serverCertTypes = others.serverCertTypes;
+		this.clientCertTypes = others.clientCertTypes;
+		this.supportedGroups = others.supportedGroups;
+		this.signatures = others.signatures;
+		this.format = others.format;
+	}
+
 	public List<CipherSuite> getCipherSuites() {
 		return cipherSuites;
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/AsyncCertificateProvider.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/AsyncCertificateProvider.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls.x509;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.eclipse.californium.elements.util.DaemonThreadFactory;
+import org.eclipse.californium.elements.util.ExecutorsUtil;
+import org.eclipse.californium.elements.util.NamedThreadFactory;
+import org.eclipse.californium.scandium.dtls.CertificateIdentityResult;
+import org.eclipse.californium.scandium.dtls.CertificateType;
+import org.eclipse.californium.scandium.dtls.ConnectionId;
+import org.eclipse.californium.scandium.dtls.HandshakeResultHandler;
+import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
+import org.eclipse.californium.scandium.util.ServerNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Asynchronous test implementation based on {@link SingleCertificateProvider}.
+ * 
+ * Use {@code 0} or negative delays for test with synchronous blocking behavior.
+ * And positive delays for test with asynchronous none-blocking behavior.
+ * 
+ * @since 3.0
+ */
+public class AsyncCertificateProvider extends SingleCertificateProvider {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(AsyncCertificateProvider.class);
+
+	/**
+	 * Thread factory.
+	 */
+	private static final NamedThreadFactory THREAD_FACTORY = new DaemonThreadFactory("AsyncPskStoreTimer#");
+	/**
+	 * Executor for asynchronous behaviour.
+	 */
+	private final ScheduledExecutorService executorService;
+	/**
+	 * Delay for certificate identity result. {@code 0} or negative delays for
+	 * test with synchronous blocking behaviour. Positive delays for test with
+	 * asynchronous none-blocking behaviour.
+	 */
+	private volatile int delayMillis = 1;
+	/**
+	 * Result handler set during initialization.
+	 * 
+	 * @see #setResultHandler(HandshakeResultHandler)
+	 */
+	private volatile HandshakeResultHandler resultHandler;
+
+	public AsyncCertificateProvider(PrivateKey privateKey, Certificate[] chain,
+			CertificateType... supportedCertificateTypes) {
+		super(privateKey, chain, supportedCertificateTypes);
+		this.executorService = ExecutorsUtil.newSingleThreadScheduledExecutor(THREAD_FACTORY); // $NON-NLS-1$
+	}
+
+	public AsyncCertificateProvider(PrivateKey privateKey, Certificate[] chain,
+			List<CertificateType> supportedCertificateTypes) {
+		super(privateKey, chain, supportedCertificateTypes);
+		this.executorService = ExecutorsUtil.newSingleThreadScheduledExecutor(THREAD_FACTORY); // $NON-NLS-1$
+	}
+
+	public AsyncCertificateProvider(PrivateKey privateKey, PublicKey publicKey) {
+		super(privateKey, publicKey);
+		this.executorService = ExecutorsUtil.newSingleThreadScheduledExecutor(THREAD_FACTORY); // $NON-NLS-1$
+	}
+
+	/**
+	 * Set delay milliseconds.
+	 * 
+	 * @param delayMillis delay in milliseconds to report result. {@code 0} or
+	 *            negative delays using synchronous blocking behaviour. Positive
+	 *            delays using asynchronous none-blocking behaviour.
+	 * @return this certificate provider for command chaining
+	 */
+	public AsyncCertificateProvider setDelay(int delayMillis) {
+		this.delayMillis = delayMillis;
+		if (delayMillis > 0) {
+			LOGGER.info("Asynchronous delayed certificate provider {}ms.", delayMillis);
+		} else if (delayMillis < 0) {
+			LOGGER.info("Synchronous delayed certificate provider {}ms.", -delayMillis);
+		} else {
+			LOGGER.info("Synchronous certificate provider.");
+		}
+		return this;
+	}
+
+	/**
+	 * Get delay milliseconds.
+	 * 
+	 * @return delay milliseconds. {@code 0} or negative delays using
+	 *         synchronous blocking behaviour. Positive delays using
+	 *         asynchronous none-blocking behaviour.
+	 */
+	public int getDelay() {
+		return delayMillis;
+	}
+
+	/**
+	 * Shutdown. Cleanup resources.
+	 */
+	public void shutdown() {
+		executorService.shutdown();
+	}
+
+	@Override
+	public CertificateIdentityResult requestCertificateIdentity(final ConnectionId cid, final boolean client,
+			final List<X500Principal> issuers, final ServerNames serverNames,
+			final List<SignatureAndHashAlgorithm> signatureAndHashAlgorithms, final List<SupportedGroup> curves) {
+
+		if (delayMillis <= 0) {
+			if (delayMillis < 0) {
+				try {
+					Thread.sleep(-delayMillis);
+				} catch (InterruptedException e) {
+				}
+			}
+			return super.requestCertificateIdentity(cid, client, issuers, serverNames, signatureAndHashAlgorithms,
+					curves);
+		} else {
+			executorService.schedule(new Runnable() {
+
+				@Override
+				public void run() {
+					CertificateIdentityResult result = AsyncCertificateProvider.super.requestCertificateIdentity(cid,
+							client, issuers, serverNames, signatureAndHashAlgorithms, curves);
+					resultHandler.apply(result);
+				}
+			}, delayMillis, TimeUnit.MILLISECONDS);
+			return null;
+		}
+	}
+
+	@Override
+	public void setResultHandler(HandshakeResultHandler resultHandler) {
+		if (this.resultHandler != null && resultHandler != null && this.resultHandler != resultHandler) {
+			throw new IllegalStateException("handshake result handler already set!");
+		}
+		this.resultHandler = resultHandler;
+	}
+
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/CertificateConfigurationHelper.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/CertificateConfigurationHelper.java
@@ -1,0 +1,283 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls.x509;
+
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.californium.elements.util.Asn1DerDecoder;
+import org.eclipse.californium.elements.util.CertPathUtil;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
+import org.eclipse.californium.scandium.util.ListUtils;
+
+/**
+ * Certificate configuration helper.
+ * 
+ * {@link DtlsConnectorConfig} generally tries, to find the best default values
+ * for the not provided configuration values using the provided ones. Estimating
+ * the proper signature and hash algorithms and the supported curves for
+ * ECDSA/ECDHE is implemented here.
+ * 
+ * For all public keys passed to
+ * {@link #addConfigurationDefaultsFor(PublicKey)}, the supported curve and a
+ * signature and hash algorithm is added to the default parameters.
+ *
+ * For all x509 certificate chains passed to
+ * {@link #addConfigurationDefaultsFor(List)}, the public key of the head
+ * certificate (node's certificate) is passed to
+ * {@link #addConfigurationDefaultsFor(PublicKey)}. Also all used signature and
+ * hash algorithms in the certificate chain are added to the defaults
+ * parameters. And all used curves of public keys in the chain are added to the
+ * default parameters as well.
+ * 
+ * For all trusted x509 certificates passed to
+ * {@link #addConfigurationDefaultsForTrusts(X509Certificate[])}, the supported
+ * curve and a signature and hash algorithms of all public keys are added to the
+ * default parameters.
+ * 
+ * @since 3.0
+ */
+public class CertificateConfigurationHelper {
+
+	/**
+	 * List of provided public keys.
+	 * 
+	 * @see #addConfigurationDefaultsFor(PublicKey)
+	 * @see #addConfigurationDefaultsFor(List))
+	 */
+	private final List<PublicKey> keys = new ArrayList<>();
+	/**
+	 * List of provided certificate chains.
+	 * 
+	 * @see #addConfigurationDefaultsFor(List))
+	 */
+	private final List<List<X509Certificate>> chains = new ArrayList<>();
+	/**
+	 * List of provided trusted certificates.
+	 * 
+	 * @see #addConfigurationDefaultsForTrust(X509Certificate[]))
+	 */
+	private final List<X509Certificate> trusts = new ArrayList<>();
+	/**
+	 * Indicates, that one of the node's certificates provided with
+	 * {@link #addConfigurationDefaultsFor(List)} supports the usage for
+	 * clients.
+	 */
+	private boolean clientUsage;
+	/**
+	 * Indicates, that one of the node's certificates provided with
+	 * {@link #addConfigurationDefaultsFor(List)} supports the usage for
+	 * servers.
+	 */
+	private boolean serverUsage;
+	/**
+	 * List of supported key algorithms.
+	 * 
+	 * Currently only EC is supported.
+	 */
+	private final List<String> supportedKeyAlgorithms = new ArrayList<>();
+	/**
+	 * List of supported signature and hash algorithms.
+	 */
+	private final List<SignatureAndHashAlgorithm> defaultSignatureAndHashAlgorithms = new ArrayList<>();
+	/**
+	 * List of supported groups.
+	 */
+	private final List<SupportedGroup> defaultSupportedGroups = new ArrayList<>();
+
+	/**
+	 * Add parameters for the provided public key.
+	 * 
+	 * The supported curve and a signature and hash algorithm is added to the
+	 * default parameters.
+	 * 
+	 * @param key the public key to add
+	 * @throws IllegalArgumentException if the public key is not supported
+	 */
+	public void addConfigurationDefaultsFor(PublicKey key) {
+		String algorithm = key.getAlgorithm();
+		if (!Asn1DerDecoder.isSupported(algorithm)) {
+			throw new IllegalArgumentException("Public key algorithm " + algorithm + " is not supported!");
+		}
+		SupportedGroup group = SupportedGroup.fromPublicKey(key);
+		if (group == null) {
+			throw new IllegalArgumentException("Public key's ec-group must be supported!");
+		}
+		ListUtils.addIfAbsent(supportedKeyAlgorithms, Asn1DerDecoder.EC);
+		ListUtils.addIfAbsent(defaultSupportedGroups, group);
+		SignatureAndHashAlgorithm.ensureSignatureAlgorithm(defaultSignatureAndHashAlgorithms, key);
+		ListUtils.addIfAbsent(keys, key);
+	}
+
+	/**
+	 * Add parameters for the provided certificate chain.
+	 * 
+	 * The public key of the head certificate (node's certificate) is passed to
+	 * {@link #addConfigurationDefaultsFor(PublicKey)}. Also all used signature
+	 * and hash algorithms in the certificate chain are added to the defaults
+	 * parameters. And all used curves of public keys in the chain are added to
+	 * the default parameters as well.
+	 * 
+	 * @param certificateChain the certificate chain to add
+	 * @throws IllegalArgumentException if a public key or signature and hash
+	 *             algorithm is not supported
+	 */
+	public void addConfigurationDefaultsFor(List<X509Certificate> certificateChain) {
+		if (!certificateChain.isEmpty()) {
+			X509Certificate certificate = certificateChain.get(0);
+			addConfigurationDefaultsFor(certificate.getPublicKey());
+			if (CertPathUtil.canBeUsedForAuthentication(certificate, false)) {
+				serverUsage = true;
+			}
+			if (CertPathUtil.canBeUsedForAuthentication(certificate, true)) {
+				clientUsage = true;
+			}
+			ListUtils.addIfAbsent(defaultSignatureAndHashAlgorithms,
+					SignatureAndHashAlgorithm.getSignatureAlgorithms(certificateChain));
+			for (int index = 1; index < certificateChain.size(); ++index) {
+				certificate = certificateChain.get(index);
+				PublicKey certPublicKey = certificate.getPublicKey();
+				if (Asn1DerDecoder.isSupported(certPublicKey.getAlgorithm())) {
+					SupportedGroup group = SupportedGroup.fromPublicKey(certPublicKey);
+					if (group == null) {
+						throw new IllegalArgumentException("CA's public key ec-group must be supported!");
+					}
+					ListUtils.addIfAbsent(defaultSupportedGroups, group);
+				}
+			}
+			chains.add(certificateChain);
+		}
+	}
+
+	/**
+	 * Add parameters for the provided trusted certificates.
+	 * 
+	 * The supported curve and a signature and hash algorithms of all public
+	 * keys are added to the default parameters.
+	 * 
+	 * @param trusts trusted certificates
+	 */
+	public void addConfigurationDefaultsForTrusts(X509Certificate[] trusts) {
+		if (trusts != null) {
+			for (X509Certificate certificate : trusts) {
+				PublicKey publicKey = certificate.getPublicKey();
+				SignatureAndHashAlgorithm.ensureSignatureAlgorithm(defaultSignatureAndHashAlgorithms, publicKey);
+				if (Asn1DerDecoder.isSupported(publicKey.getAlgorithm())) {
+					SupportedGroup group = SupportedGroup.fromPublicKey(publicKey);
+					if (group == null) {
+						throw new IllegalArgumentException("CA's public key ec-group must be supported!");
+					}
+					ListUtils.addIfAbsent(defaultSupportedGroups, group);
+				}
+				this.trusts.add(certificate);
+			}
+		}
+	}
+
+	/**
+	 * Gets list of supported key algorithms.
+	 * 
+	 * Currently only EC is supported.
+	 * 
+	 * @return list of supported key algorithms
+	 */
+	public List<String> getSupportedKeyAlgorithms() {
+		return supportedKeyAlgorithms;
+	}
+
+	/**
+	 * Gets list of signatures and hash algorithms for the provided public keys,
+	 * certificate chains and trusted certificates.
+	 * 
+	 * @return list of signatures and hash algorithms
+	 */
+	public List<SignatureAndHashAlgorithm> getDefaultSignatureAndHashAlgorithms() {
+		return defaultSignatureAndHashAlgorithms;
+	}
+
+	/**
+	 * Gets list of supported groups for the provided public keys, certificate
+	 * chains and trusted certificates.
+	 * 
+	 * @return list of supported groups
+	 */
+	public List<SupportedGroup> getDefaultSupportedGroups() {
+		return defaultSupportedGroups;
+	}
+
+	/**
+	 * Verify the provided algorithms match the added public key, certificate
+	 * chains and trusted certificates.
+	 * 
+	 * @param algorithms list of configured signature and hash algorithms
+	 */
+	public void verifySignatureAndHashAlgorithmsConfiguration(List<SignatureAndHashAlgorithm> algorithms) {
+		for (PublicKey key : keys) {
+			if (SignatureAndHashAlgorithm.getSupportedSignatureAlgorithm(algorithms, key) == null) {
+				throw new IllegalStateException(
+						"supported signature and hash algorithms doesn't match the public key!");
+			}
+		}
+		for (List<X509Certificate> chain : chains) {
+			if (!SignatureAndHashAlgorithm.isSignedWithSupportedAlgorithms(algorithms, chain)) {
+				throw new IllegalStateException(
+						"supported signature and hash algorithms doesn't match the certificate chain!");
+			}
+		}
+		for (X509Certificate trust : trusts) {
+			PublicKey publicKey = trust.getPublicKey();
+			if (SignatureAndHashAlgorithm.getSupportedSignatureAlgorithm(algorithms, publicKey) == null) {
+				throw new IllegalStateException(
+						"supported signature and hash algorithms doesn't match the trust's public key "
+								+ publicKey.getAlgorithm() + "!");
+			}
+		}
+	}
+
+	/**
+	 * Verify the provided groups match the added public key and trusted
+	 * certificates.
+	 * 
+	 * @param groups list of configured supported groups
+	 */
+	public void verifySupportedGroupsConfiguration(List<SupportedGroup> groups) {
+		for (SupportedGroup group : defaultSupportedGroups) {
+			if (!group.isUsable()) {
+				throw new IllegalStateException("public key used with unsupported group (curve) " + group.name() + "!");
+			}
+			if (!groups.contains(group)) {
+				throw new IllegalStateException(
+						"public key used with not configured group (curve) " + group.name() + "!");
+			}
+		}
+	}
+
+	/**
+	 * Checks, if one of the node certificates of the added chains can be used
+	 * in a specific role.
+	 * 
+	 * @param client {@code true}, for client role, {@code false}, for server
+	 *            role.
+	 * @return {@code true}, if role is supported, {@code false}, if not.
+	 */
+	public boolean canBeUsedForAuthentication(boolean client) {
+		return chains.isEmpty() || (client ? clientUsage : serverUsage);
+	}
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/CertificateProvider.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/CertificateProvider.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls.x509;
+
+import java.util.List;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.eclipse.californium.scandium.DTLSConnector;
+import org.eclipse.californium.scandium.dtls.CertificateIdentityResult;
+import org.eclipse.californium.scandium.dtls.CertificateType;
+import org.eclipse.californium.scandium.dtls.ConnectionId;
+import org.eclipse.californium.scandium.dtls.HandshakeResultHandler;
+import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm;
+import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
+import org.eclipse.californium.scandium.util.ServerNames;
+
+/**
+ * Certificate identity provider.
+ * <p>
+ * One of the complex functions in (D)TLS is the negotiation of the crypto
+ * parameters. That includes also to select the right certificate chain for the
+ * proposed parameters of the client. The large variety of these parameters
+ * makes it hard.
+ * </p>
+ * <p>
+ * For CoAP this is simplified by
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7252#section-9.1" target=
+ * "_blank">RFC 7252, 9.1 DTLS-Secured CoAP</a> using common sets of mandatory
+ * supported crypto parameter values for the different security cases. That
+ * makes it easier for clients to successfully negotiate a DTLS session and for
+ * the server to offer the right selection of supported parameters.
+ * </p>
+ * <p>
+ * If <a href="https://datatracker.ietf.org/doc/html/rfc7252#section-9.1.3.1"
+ * target= "_blank">PSK</a> is used, the cipher suite
+ * {@link CipherSuite#TLS_PSK_WITH_AES_128_CCM_8} is mandatory to implement.
+ * </p>
+ * <p>
+ * If <a href="https://datatracker.ietf.org/doc/html/rfc7252#section-9.1.3.2"
+ * target= "_blank">RPK</a> is used, the cipher suite
+ * {@link CipherSuite#TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8} is mandatory to
+ * implement. The Elliptic curve: secp256r1 (0x0017) and SHA256withECDSA are
+ * also mandatory to support.
+ * </p>
+ * <p>
+ * If <a href="https://datatracker.ietf.org/doc/html/rfc7252#section-9.1.3.3"
+ * target= "_blank">X509</a> is used, the cipher suite
+ * {@link CipherSuite#TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8} is mandatory to
+ * implement. The Elliptic curve: secp256r1 (0x0017) and SHA256withECDSA are
+ * also mandatory to support.
+ * </p>
+ * <p>
+ * For simple setups {@link SingleCertificateProvider} will do the job. But for
+ * several reason, the simple world of CoAP doesn't always fit into reality. On
+ * the "old" side, some certificates on the path may be RSA based, on the "new"
+ * Ed25519/Ed448 may be preferred. With that, it starts to get complex again,
+ * and a server may require more different certificate paths to support
+ * different clients. This provider interface helps to overcome this. It enables
+ * to select the used certificates based on the related crypto parameter, server
+ * name, and issuer.
+ * </p>
+ * <p>
+ * Using x509 comes also with some more asymmetry: to use a certificate chain
+ * for authentication, the sending peer is only required to support signing for
+ * the node certificate's public key. For the all the issuer signatures the
+ * support is only relevant for the receiving side. Californium's default
+ * configuration implementation does always a full check, regardless of only
+ * sending the certificates.
+ * </p>
+ * 
+ * @since 3.0
+ */
+public interface CertificateProvider {
+
+	/**
+	 * Get the list of supported certificate types in order of preference.
+	 * 
+	 * @return the list of supported certificate types.
+	 */
+	List<CertificateType> getSupportedCertificateTypes();
+
+	/**
+	 * Get the certificate identity.
+	 * 
+	 * @param cid connection ID
+	 * @param client {@code true}, for client side certificates, {@code false},
+	 *            for server side certificates.
+	 * @param issuers list of trusted issuers. May be {@code null}.
+	 * @param serverNames indicated server names. May be {@code null}.
+	 * @param signatureAndHashAlgorithms signatures and hash Algorithms. May be
+	 *            {@code null}.
+	 * @param curves ec-curves (supported groups). May be {@code null}.
+	 * @return certificate identity result, or {@code null}, if result is
+	 *         provided asynchronous.
+	 */
+	CertificateIdentityResult requestCertificateIdentity(ConnectionId cid, boolean client, List<X500Principal> issuers,
+			ServerNames serverNames, List<SignatureAndHashAlgorithm> signatureAndHashAlgorithms,
+			List<SupportedGroup> curves);
+
+	/**
+	 * Set the handler for asynchronous handshake results.
+	 * 
+	 * Called during initialization of the {@link DTLSConnector}. Synchronous
+	 * implementations may just ignore this using an empty implementation.
+	 * 
+	 * @param resultHandler handler for asynchronous master secret results. This
+	 *            handler MUST NOT be called from the thread calling
+	 *            {@link #requestCertificateIdentity(ConnectionId, boolean, List, ServerNames, List, List)},
+	 *            instead just return the result there.
+	 */
+	void setResultHandler(HandshakeResultHandler resultHandler);
+
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/ConfigurationHelperSetup.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/ConfigurationHelperSetup.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls.x509;
+
+/**
+ * Setup for certificate configuration helper.
+ * 
+ * {@link CertificateProvider} and {@link NewAdvancedCertificateVerifier}
+ * implementation may implement this interface as well in order to participate
+ * in the automatic default configuration and configuration verification.
+ * 
+ * @since 3.0
+ */
+public interface ConfigurationHelperSetup {
+
+	/**
+	 * Setup the helper.
+	 * 
+	 * Add all public key, certificate chains, or trusted certificates to the
+	 * provided helper.
+	 * 
+	 * @param helper configuration helper.
+	 */
+	void setupConfigurationHelper(CertificateConfigurationHelper helper);
+
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/KeyManagerCertificateProvider.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/KeyManagerCertificateProvider.java
@@ -1,0 +1,395 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls.x509;
+
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import javax.net.ssl.X509ExtendedKeyManager;
+import javax.security.auth.x500.X500Principal;
+
+import org.eclipse.californium.elements.util.Asn1DerDecoder;
+import org.eclipse.californium.scandium.dtls.CertificateIdentityResult;
+import org.eclipse.californium.scandium.dtls.CertificateType;
+import org.eclipse.californium.scandium.dtls.ConnectionId;
+import org.eclipse.californium.scandium.dtls.HandshakeResultHandler;
+import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
+import org.eclipse.californium.scandium.util.ListUtils;
+import org.eclipse.californium.scandium.util.ServerName;
+import org.eclipse.californium.scandium.util.ServerNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Example certificate identity provider based on a
+ * {@link X509ExtendedKeyManager}.
+ * <p>
+ * Selects the certificate based on the issuers and server name, if provided.
+ * The provided signature and hash algorithms and the supported curves are also
+ * considered. If more than one certificate fits, the provided signature and
+ * hash algorithms are used the select the best fit.
+ * </p>
+ * May be used as template to implement a solution for more specific use-cases.
+ * 
+ * @since 3.0
+ */
+public class KeyManagerCertificateProvider implements CertificateProvider, ConfigurationHelperSetup {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(KeyManagerCertificateProvider.class);
+
+	/**
+	 * Key type for credentials.
+	 */
+	private static final String[] KEY_TYPE_EC = { "EC" };
+	/**
+	 * Key type for credentials.
+	 */
+	private static final String[] KEY_TYPE_EC_EDDSA = { "EC", "EdDSA" };
+
+	/**
+	 * Default alias. May be {@code null}.
+	 */
+	private final String defaultAlias;
+
+	/**
+	 * Key manager.
+	 */
+	private final X509ExtendedKeyManager keyManager;
+
+	/**
+	 * List of supported certificate type in order of preference.
+	 */
+	private final List<CertificateType> supportedCertificateTypes;
+
+	/**
+	 * Create certificate provider based on key manager.
+	 * 
+	 * @param keyManager key manager with certificates and private keys
+	 * @param supportedCertificateTypes array of supported certificate types
+	 *            ordered by preference
+	 * @throws NullPointerException if the key manager is {@code null}
+	 * @throws IllegalArgumentException if list of certificate types is empty or
+	 *             contains unsupported types.
+	 */
+	public KeyManagerCertificateProvider(X509ExtendedKeyManager keyManager,
+			CertificateType... supportedCertificateTypes) {
+		this(null, keyManager, asList(supportedCertificateTypes));
+	}
+
+	/**
+	 * Create certificate provider based on key manager.
+	 * 
+	 * @param keyManager key manager with certificates and private keys
+	 * @param supportedCertificateTypes list of supported certificate types
+	 *            ordered by preference
+	 * @throws NullPointerException if the key manager is {@code null}
+	 * @throws IllegalArgumentException if list of certificate types is empty or
+	 *             contains unsupported types.
+	 */
+	public KeyManagerCertificateProvider(X509ExtendedKeyManager keyManager,
+			List<CertificateType> supportedCertificateTypes) {
+		this(null, keyManager, supportedCertificateTypes);
+	}
+
+	/**
+	 * Create certificate provider based on key manager with default alias.
+	 * 
+	 * @param defaultAlias default alias. May be {@code null}.
+	 * @param keyManager key manager with certificates and private keys
+	 * @param supportedCertificateTypes array of supported certificate types
+	 *            ordered by preference
+	 * @throws NullPointerException if the key manager is {@code null}
+	 * @throws IllegalArgumentException if list of certificate types is empty or
+	 *             contains unsupported types.
+	 */
+	public KeyManagerCertificateProvider(String defaultAlias, X509ExtendedKeyManager keyManager,
+			CertificateType... supportedCertificateTypes) {
+		this(defaultAlias, keyManager, asList(supportedCertificateTypes));
+	}
+
+	/**
+	 * Create certificate provider based on key manager with default alias.
+	 * 
+	 * @param defaultAlias default alias. May be {@code null}.
+	 * @param keyManager key manager with certificates and private keys
+	 * @param supportedCertificateTypes list of supported certificate types
+	 *            ordered by preference
+	 * @throws NullPointerException if the key manager is {@code null}
+	 * @throws IllegalArgumentException if list of certificate types is empty or
+	 *             contains unsupported types.
+	 */
+	public KeyManagerCertificateProvider(String defaultAlias, X509ExtendedKeyManager keyManager,
+			List<CertificateType> supportedCertificateTypes) {
+		if (keyManager == null) {
+			throw new NullPointerException("KeyManager must not be null!");
+		}
+		if (supportedCertificateTypes != null) {
+			if (supportedCertificateTypes.isEmpty()) {
+				throw new IllegalArgumentException("Certificate types must not be empty!");
+			}
+			for (CertificateType certificateType : supportedCertificateTypes) {
+				if (!certificateType.isSupported()) {
+					throw new IllegalArgumentException("Certificate type " + certificateType + " is not supported!");
+				}
+			}
+		}
+		this.defaultAlias = defaultAlias;
+		this.keyManager = keyManager;
+		if (supportedCertificateTypes == null) {
+			// default x509
+			supportedCertificateTypes = new ArrayList<>(1);
+			supportedCertificateTypes.add(CertificateType.X_509);
+		}
+		this.supportedCertificateTypes = Collections.unmodifiableList(supportedCertificateTypes);
+	}
+
+	@Override
+	public void setupConfigurationHelper(CertificateConfigurationHelper helper) {
+		List<String> aliases = getAliases(false, KEY_TYPE_EC_EDDSA, null);
+		for (String alias : aliases) {
+			X509Certificate[] certificateChain = keyManager.getCertificateChain(alias);
+			helper.addConfigurationDefaultsFor(Arrays.asList(certificateChain));
+		}
+		aliases = getAliases(true, KEY_TYPE_EC_EDDSA, null);
+		for (String alias : aliases) {
+			X509Certificate[] certificateChain = keyManager.getCertificateChain(alias);
+			helper.addConfigurationDefaultsFor(Arrays.asList(certificateChain));
+		}
+	}
+
+	@Override
+	public List<CertificateType> getSupportedCertificateTypes() {
+		return supportedCertificateTypes;
+	}
+
+	@Override
+	public CertificateIdentityResult requestCertificateIdentity(ConnectionId cid, boolean client,
+			List<X500Principal> issuers, ServerNames serverNames,
+			List<SignatureAndHashAlgorithm> signatureAndHashAlgorithms, List<SupportedGroup> curves) {
+		List<String> alias;
+		Principal[] principals = issuers == null ? null : issuers.toArray(new Principal[issuers.size()]);
+		if (signatureAndHashAlgorithms.contains(SignatureAndHashAlgorithm.INTRINSIC_WITH_ED25519)
+				|| signatureAndHashAlgorithms.contains(SignatureAndHashAlgorithm.INTRINSIC_WITH_ED448)) {
+			alias = getAliases(client, KEY_TYPE_EC_EDDSA, principals);
+		} else {
+			alias = getAliases(client, KEY_TYPE_EC, principals);
+		}
+		if (!alias.isEmpty()) {
+			List<String> matchingServerNames = new ArrayList<>();
+			List<String> matchingSignatures = new ArrayList<>();
+			List<String> matchingCurves = new ArrayList<>();
+			// after issuers, check the servernames
+			for (String id : alias) {
+				LOGGER.debug("try {} of {}", id, alias.size());
+				X509Certificate[] certificateChain = keyManager.getCertificateChain(id);
+				List<X509Certificate> chain = Arrays.asList(certificateChain);
+				if (serverNames != null && matchServerNames(serverNames, certificateChain[0])) {
+					matchingServerNames.add(id);
+				}
+				if (signatureAndHashAlgorithms != null
+						&& matchSignatureAndHashAlgorithms(signatureAndHashAlgorithms, chain)) {
+					matchingSignatures.add(id);
+				}
+				if (curves != null && matchCurves(curves, chain)) {
+					matchingCurves.add(id);
+				}
+			}
+			if (!matchingServerNames.isEmpty()) {
+				LOGGER.debug("{} selected by {}", matchingServerNames.size(), serverNames);
+				alias.retainAll(matchingServerNames);
+			}
+			if (signatureAndHashAlgorithms != null) {
+				LOGGER.debug("{} selected by signature and hash algorithms", matchingSignatures.size());
+				alias.retainAll(matchingSignatures);
+			}
+			if (curves != null) {
+				LOGGER.debug("{} selected by curves", matchingCurves.size());
+				alias.retainAll(matchingCurves);
+			}
+			if (alias.size() > 0) {
+				String id = null;
+				if (alias.size() > 1 && signatureAndHashAlgorithms != null && signatureAndHashAlgorithms.size() > 1) {
+					alias = selectPriorized(alias, signatureAndHashAlgorithms);
+				}
+				if (alias.size() > 1 && defaultAlias != null && alias.contains(defaultAlias)) {
+					id = defaultAlias;
+				} else {
+					id = alias.get(0);
+				}
+				X509Certificate[] certificateChain = keyManager.getCertificateChain(id);
+				List<X509Certificate> chain = Arrays.asList(certificateChain);
+				PrivateKey privateKey = keyManager.getPrivateKey(id);
+				return new CertificateIdentityResult(cid, privateKey, chain, id);
+			}
+		} else {
+			LOGGER.debug("no matching credentials");
+		}
+		return new CertificateIdentityResult(cid, null);
+	}
+
+	@Override
+	public void setResultHandler(HandshakeResultHandler resultHandler) {
+		// empty implementation
+	}
+
+	/**
+	 * Get aliases for matching credentials.
+	 * 
+	 * @param client {@code true}, for client side certificates, {@code false},
+	 *            for server side certificates.
+	 * @param keyTypes list of key types.
+	 * @param issuers list of trusted issuers. May be {@code null}.
+	 * @return list of aliases to matching credentials. Empty, if no matching
+	 *         credentials are found.
+	 */
+	private List<String> getAliases(boolean client, String[] keyTypes, Principal[] issuers) {
+		List<String> all = new ArrayList<>();
+		for (String keyType : keyTypes) {
+			String[] alias = null;
+			if (client) {
+				alias = keyManager.getClientAliases(keyType, issuers);
+			} else {
+				alias = keyManager.getServerAliases(keyType, issuers);
+			}
+			if (alias != null) {
+				LOGGER.debug("found {} {} keys", alias.length, keyType);
+				ListUtils.addIfAbsent(all, Arrays.asList(alias));
+			}
+		}
+		return all;
+	}
+
+	/**
+	 * Check, if provided node certificate matches the serverNames.
+	 * 
+	 * Checks, if the CN part of the subject DN or one of the subject
+	 * alternative names matches the server name (SNI).
+	 * 
+	 * @param serverNames server names
+	 * @param node node certificate
+	 * @return {@code true}, if matching, {@code true}, if not.
+	 */
+	private boolean matchServerNames(ServerNames serverNames, X509Certificate node) {
+		ServerName serverNname = serverNames.getServerName(ServerName.NameType.HOST_NAME);
+		String name = serverNname.getNameAsString();
+		X500Principal principal = node.getSubjectX500Principal();
+		if (principal.getName().endsWith("CN=" + name)) {
+			return true;
+		}
+		try {
+			Collection<List<?>> alternativeNames = node.getSubjectAlternativeNames();
+			if (alternativeNames != null) {
+				for (List<?> alternativeName : alternativeNames) {
+					Object value = alternativeName.get(1);
+					if (value instanceof String) {
+						if (value.equals(name)) {
+							return true;
+						}
+					}
+				}
+			}
+		} catch (CertificateParsingException e) {
+		}
+		return false;
+	}
+
+	/**
+	 * Checks, if provided certificate chain matches the signature and hash
+	 * algorithms.
+	 * 
+	 * @param signatureAndHashAlgorithms list of signature and hash algorithms
+	 * @param chain the certificate chain to check
+	 * @return {@code true}, if matching, {@code true}, if not.
+	 */
+	private boolean matchSignatureAndHashAlgorithms(List<SignatureAndHashAlgorithm> signatureAndHashAlgorithms,
+			List<X509Certificate> chain) {
+		if (SignatureAndHashAlgorithm.getSupportedSignatureAlgorithm(signatureAndHashAlgorithms,
+				chain.get(0).getPublicKey()) == null) {
+			return false;
+		}
+		if (!SignatureAndHashAlgorithm.isSignedWithSupportedAlgorithms(signatureAndHashAlgorithms, chain)) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Checks, if provided certificate chain matches the curves.
+	 * 
+	 * @param curves list of supported groups (curves)
+	 * @param chain the certificate chain to check
+	 * @return {@code true}, if matching, {@code true}, if not.
+	 */
+	private boolean matchCurves(List<SupportedGroup> curves, List<X509Certificate> chain) {
+		for (X509Certificate certificate : chain) {
+			PublicKey certPublicKey = certificate.getPublicKey();
+			if (Asn1DerDecoder.isSupported(certPublicKey.getAlgorithm())) {
+				SupportedGroup group = SupportedGroup.fromPublicKey(certPublicKey);
+				if (group == null) {
+					return false;
+				}
+				if (!curves.contains(group)) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Select the set of aliases, which node certificate matches the first
+	 * matching signature and hash algorithms.
+	 * 
+	 * @param alias preselected aliases
+	 * @param signatureAndHashAlgorithms list of signature and hash algorithms
+	 *            ordered by priority
+	 * @return (sub) set of aliases matching the first matching signature and
+	 *         hash algorithms in the ordered list.
+	 */
+	private List<String> selectPriorized(List<String> alias,
+			List<SignatureAndHashAlgorithm> signatureAndHashAlgorithms) {
+		List<String> result = new ArrayList<>();
+		for (SignatureAndHashAlgorithm signatureAndHashAlgorithm : signatureAndHashAlgorithms) {
+			for (String id : alias) {
+				LOGGER.debug("select sign {} - {}", id, signatureAndHashAlgorithm.getJcaName());
+				X509Certificate[] certificateChain = keyManager.getCertificateChain(id);
+				if (signatureAndHashAlgorithm.isSupported(certificateChain[0].getPublicKey())) {
+					result.add(id);
+				}
+			}
+			if (!result.isEmpty()) {
+				break;
+			}
+		}
+		return result;
+	}
+
+	private static List<CertificateType> asList(CertificateType[] types) {
+		if (types == null || types.length == 0) {
+			return null;
+		}
+		return Arrays.asList(types);
+	}
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/SingleCertificateProvider.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/SingleCertificateProvider.java
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls.x509;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.eclipse.californium.elements.util.SslContextUtil;
+import org.eclipse.californium.scandium.dtls.CertificateIdentityResult;
+import org.eclipse.californium.scandium.dtls.CertificateType;
+import org.eclipse.californium.scandium.dtls.ConnectionId;
+import org.eclipse.californium.scandium.dtls.HandshakeResultHandler;
+import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
+import org.eclipse.californium.scandium.util.ServerNames;
+
+/**
+ * Certificate identity provider based on a single certificate identity.
+ * 
+ * @since 3.0
+ */
+public class SingleCertificateProvider implements CertificateProvider, ConfigurationHelperSetup {
+
+	private final PrivateKey privateKey;
+	private final PublicKey publicKey;
+	private final List<X509Certificate> certificateChain;
+
+	/**
+	 * List of supported certificate type in order of preference.
+	 */
+	private final List<CertificateType> supportedCertificateTypes;
+
+	/**
+	 * Create static certificate provider from private key and certificate
+	 * chain.
+	 * 
+	 * @param privateKey private key of identity.
+	 * @param chain certificate chain for identity.
+	 * @param supportedCertificateTypes list of supported certificate types
+	 *            ordered by preference
+	 * @throws NullPointerException if the private key or certificate chain is
+	 *             {@code null}
+	 * @throws IllegalArgumentException if the certificate chain is empty
+	 */
+	public SingleCertificateProvider(PrivateKey privateKey, Certificate[] chain,
+			CertificateType... supportedCertificateTypes) {
+		this(privateKey, chain, asList(supportedCertificateTypes));
+	}
+
+	/**
+	 * Create static certificate provider from private key and certificate
+	 * chain.
+	 * 
+	 * @param privateKey private key of identity.
+	 * @param certificateChain certificate chain for identity.
+	 * @param supportedCertificateTypes list of supported certificate types
+	 *            ordered by preference
+	 * @throws NullPointerException if the private key or certificate chain is
+	 *             {@code null}
+	 * @throws IllegalArgumentException if the certificate chain is empty or the
+	 *             list of certificate types contains unsupported types.
+	 */
+	public SingleCertificateProvider(PrivateKey privateKey, Certificate[] certificateChain,
+			List<CertificateType> supportedCertificateTypes) {
+		if (privateKey == null) {
+			throw new NullPointerException("Private key must not be null!");
+		}
+		if (certificateChain == null) {
+			throw new NullPointerException("Certificate chain must not be null!");
+		}
+		if (certificateChain.length == 0) {
+			throw new IllegalArgumentException("Certificate chain must not be empty!");
+		}
+		if (supportedCertificateTypes != null) {
+			if (supportedCertificateTypes.isEmpty()) {
+				throw new IllegalArgumentException("Certificate types must not be empty!");
+			}
+			for (CertificateType certificateType : supportedCertificateTypes) {
+				if (!certificateType.isSupported()) {
+					throw new IllegalArgumentException("Certificate type " + certificateType + " is not supported!");
+				}
+			}
+		}
+
+		this.privateKey = privateKey;
+		this.publicKey = certificateChain[0].getPublicKey();
+		if (supportedCertificateTypes == null) {
+			// default x509
+			supportedCertificateTypes = new ArrayList<>(1);
+			supportedCertificateTypes.add(CertificateType.X_509);
+		}
+		if (supportedCertificateTypes.contains(CertificateType.X_509)) {
+			this.certificateChain = Arrays.asList(SslContextUtil.asX509Certificates(certificateChain));
+		} else {
+			this.certificateChain = null;
+		}
+		this.supportedCertificateTypes = Collections.unmodifiableList(supportedCertificateTypes);
+	}
+
+	/**
+	 * Create static certificate provider from private and public key.
+	 * 
+	 * Only supports {@link CertificateType#RAW_PUBLIC_KEY}.
+	 * 
+	 * @param privateKey private key of identity
+	 * @param publicKey public key of identity
+	 * @throws NullPointerException if the private or public key is {@code null}
+	 * @throws IllegalArgumentException if the public key doesn't use a
+	 *             supported group
+	 * @see SupportedGroup#fromPublicKey(PublicKey)
+	 */
+	public SingleCertificateProvider(PrivateKey privateKey, PublicKey publicKey) {
+		if (privateKey == null) {
+			throw new NullPointerException("Private key must not be null!");
+		}
+		if (publicKey == null) {
+			throw new NullPointerException("Public key must not be null!");
+		}
+		SupportedGroup group = SupportedGroup.fromPublicKey(publicKey);
+		if (group == null) {
+			throw new IllegalArgumentException("Public key's ec-group must be supported!");
+		}
+
+		this.privateKey = privateKey;
+		this.publicKey = publicKey;
+		this.certificateChain = null;
+		List<CertificateType> supportedCertificateTypes = new ArrayList<>(1);
+		supportedCertificateTypes.add(CertificateType.RAW_PUBLIC_KEY);
+		this.supportedCertificateTypes = Collections.unmodifiableList(supportedCertificateTypes);
+	}
+
+	@Override
+	public void setupConfigurationHelper(CertificateConfigurationHelper helper) {
+		if (certificateChain != null) {
+			helper.addConfigurationDefaultsFor(this.certificateChain);
+		} else {
+			helper.addConfigurationDefaultsFor(this.publicKey);
+		}
+	}
+
+	@Override
+	public List<CertificateType> getSupportedCertificateTypes() {
+		return supportedCertificateTypes;
+	}
+
+	@Override
+	public CertificateIdentityResult requestCertificateIdentity(ConnectionId cid, boolean client,
+			List<X500Principal> issuers, ServerNames serverNames,
+			List<SignatureAndHashAlgorithm> signatureAndHashAlgorithms, List<SupportedGroup> curves) {
+		if (certificateChain != null) {
+			return new CertificateIdentityResult(cid, privateKey, certificateChain, null);
+		} else {
+			return new CertificateIdentityResult(cid, privateKey, publicKey, null);
+		}
+	}
+
+	@Override
+	public void setResultHandler(HandshakeResultHandler resultHandler) {
+		// empty implementation
+	}
+
+	private static List<CertificateType> asList(CertificateType[] types) {
+		if (types == null || types.length == 0) {
+			return null;
+		}
+		return Arrays.asList(types);
+	}
+}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticNewAdvancedCertificateVerifier.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/x509/StaticNewAdvancedCertificateVerifier.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  * 
  * @since 2.5
  */
-public class StaticNewAdvancedCertificateVerifier implements NewAdvancedCertificateVerifier {
+public class StaticNewAdvancedCertificateVerifier implements NewAdvancedCertificateVerifier, ConfigurationHelperSetup {
 
 	protected final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
@@ -112,6 +112,11 @@ public class StaticNewAdvancedCertificateVerifier implements NewAdvancedCertific
 				: Arrays.copyOf(trustedCertificates, trustedCertificates.length);
 		this.trustedRPKs = trustedRPKs == null ? null : new HashSet<>(Arrays.asList(trustedRPKs));
 		this.supportedCertificateTypes = Collections.unmodifiableList(supportedCertificateTypes);
+	}
+
+	@Override
+	public void setupConfigurationHelper(CertificateConfigurationHelper helper) {
+		helper.addConfigurationDefaultsForTrusts(trustedCertificates);
 	}
 
 	@Override

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/ConnectorHelper.java
@@ -95,6 +95,7 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgor
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedMultiPskStore;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedPskStore;
 import org.eclipse.californium.scandium.dtls.x509.NewAdvancedCertificateVerifier;
+import org.eclipse.californium.scandium.dtls.x509.SingleCertificateProvider;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier.Builder;
 
@@ -106,6 +107,7 @@ import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVe
 public class ConnectorHelper {
 
 	static final String	SERVERNAME							= "my.test.server";
+	static final String	SERVERNAME2							= "my.test.server2";
 	static final String	SCOPED_CLIENT_IDENTITY				= "My_client_identity";
 	static final String	SCOPED_CLIENT_IDENTITY_SECRET		= "mySecretPSK";
 	static final String	CLIENT_IDENTITY						= "Client_identity";
@@ -196,9 +198,11 @@ public class ConnectorHelper {
 
 		ensurePskStore(builder);
 
-		if (incompleteConfig.getPrivateKey() == null) {
-			builder.setIdentity(DtlsTestTools.getPrivateKey(), DtlsTestTools.getServerCertificateChain(),
-					CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509);
+		if (incompleteConfig.getCertificateIdentityProvider() == null) {
+			builder.setCertificateIdentityProvider(
+					new SingleCertificateProvider(
+					DtlsTestTools.getPrivateKey(), DtlsTestTools.getServerCertificateChain(),
+					CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509));
 		}
 
 		if (incompleteConfig.getSupportedCipherSuites() == null) {
@@ -341,7 +345,7 @@ public class ConnectorHelper {
 				.setAddress(bindAddress)
 				.setReceiverThreadCount(1)
 				.setConnectionThreadCount(2)
-				.setIdentity(DtlsTestTools.getClientPrivateKey(), DtlsTestTools.getClientCertificateChain(), CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509)
+				.setCertificateIdentityProvider(new SingleCertificateProvider(DtlsTestTools.getClientPrivateKey(), DtlsTestTools.getClientCertificateChain(), CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509))
 				.setAdvancedCertificateVerifier(clientCertificateVerifier);
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -119,6 +119,7 @@ import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedPskStore;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedSinglePskStore;
 import org.eclipse.californium.scandium.dtls.x509.NewAdvancedCertificateVerifier;
+import org.eclipse.californium.scandium.dtls.x509.SingleCertificateProvider;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier;
 import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
 import org.junit.After;
@@ -183,7 +184,7 @@ public class DTLSConnectorTest {
 						CipherSuite.TLS_PSK_WITH_AES_128_CCM_8,
 						CipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA256,
 						CipherSuite.TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256)
-			.setIdentity(DtlsTestTools.getPrivateKey(), DtlsTestTools.getServerCertificateChain(), CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509)
+			.setCertificateIdentityProvider(new SingleCertificateProvider(DtlsTestTools.getPrivateKey(), DtlsTestTools.getServerCertificateChain(), CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509))
 			.setAdvancedCertificateVerifier(verifier)
 			.setAdvancedPskStore(pskStore)
 			.setClientAuthenticationRequired(true)
@@ -242,7 +243,7 @@ public class DTLSConnectorTest {
 				.setLoggingTag("client")
 				.setReceiverThreadCount(1)
 				.setConnectionThreadCount(2)
-				.setIdentity(DtlsTestTools.getClientPrivateKey(), DtlsTestTools.getClientCertificateChain(), CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509)
+				.setCertificateIdentityProvider(new SingleCertificateProvider(DtlsTestTools.getClientPrivateKey(), DtlsTestTools.getClientCertificateChain(), CertificateType.RAW_PUBLIC_KEY, CertificateType.X_509))
 				.setAdvancedCertificateVerifier(verifier);
 	}
 
@@ -1093,7 +1094,7 @@ public class DTLSConnectorTest {
 			DtlsConnectorConfig.Builder serverConfig = DtlsConnectorConfig.builder()
 					.setAddress(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0))
 					.setLoggingTag("server")
-					.setIdentity(DtlsTestTools.getPrivateKey(), DtlsTestTools.getServerCertificateChain(), CertificateType.RAW_PUBLIC_KEY)
+					.setCertificateIdentityProvider(new SingleCertificateProvider(DtlsTestTools.getPrivateKey(), DtlsTestTools.getServerCertificateChain(), CertificateType.RAW_PUBLIC_KEY))
 					.setClientAuthenticationRequired(false);
 			serverHelper.startServer(serverConfig);
 			serverHelper.givenAnEstablishedSession(client, true);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/AdversaryClientHandshaker.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/AdversaryClientHandshaker.java
@@ -57,7 +57,7 @@ public class AdversaryClientHandshaker extends ClientHandshaker {
 	// Methods ////////////////////////////////////////////////////////
 
 	@Override
-	protected void processServerHelloDone() throws HandshakeException {
+	protected void completeProcessingServerHelloDone() throws HandshakeException {
 
 		DTLSSession session = getSession();
 		if (session.getCipherSuite().isEccBased()) {

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ClientHandshakerTest.java
@@ -44,6 +44,7 @@ import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
+import org.eclipse.californium.scandium.dtls.x509.SingleCertificateProvider;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier.Builder;
 import org.eclipse.californium.scandium.util.ServerName.NameType;
@@ -242,10 +243,10 @@ public class ClientHandshakerTest {
 
 		DtlsConnectorConfig.Builder builder = 
 				DtlsConnectorConfig.builder()
-					.setIdentity(
+					.setCertificateIdentityProvider(new SingleCertificateProvider(
 						DtlsTestTools.getClientPrivateKey(),
 						DtlsTestTools.getClientCertificateChain(),
-						CertificateType.X_509)
+						CertificateType.X_509))
 					.setSniEnabled(sniEnabled);
 
 		Builder verifierBuilder = StaticNewAdvancedCertificateVerifier.builder();
@@ -261,6 +262,7 @@ public class ClientHandshakerTest {
 		DtlsConnectorConfig config = builder.build();
 		Connection connection = new Connection(config.getAddress());
 		connection.setConnectorContext(new SyncExecutor(), null);
+		connection.setConnectionId(ConnectionId.EMPTY);
 		handshaker = new ClientHandshaker(
 				virtualHost,
 				recordLayer,

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/HandshakerTest.java
@@ -486,6 +486,7 @@ public class HandshakerTest {
 
 	private class TestHandshaker extends Handshaker {
 
+
 		private final int[] receivedMessages = new int[10];
 
 		private AtomicBoolean finishedProcessed = new AtomicBoolean(false);
@@ -525,6 +526,10 @@ public class HandshakerTest {
 
 		@Override
 		protected void processCertificateVerified() {
+		}
+
+		@Override
+		protected void processCertificateIdentityAvailable() throws HandshakeException {
 		}
 	}
 }

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/ServerHandshakerTest.java
@@ -56,6 +56,7 @@ import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography;
 import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedSinglePskStore;
 import org.eclipse.californium.scandium.dtls.x509.NewAdvancedCertificateVerifier;
+import org.eclipse.californium.scandium.dtls.x509.SingleCertificateProvider;
 import org.eclipse.californium.scandium.dtls.x509.StaticNewAdvancedCertificateVerifier;
 import org.eclipse.californium.scandium.util.ServerName.NameType;
 import org.eclipse.californium.scandium.util.ServerNames;
@@ -104,7 +105,7 @@ public class ServerHandshakerTest {
 		NewAdvancedCertificateVerifier verifier = StaticNewAdvancedCertificateVerifier.builder().setTrustedCertificates(trustedCertificates).build();
 		config = DtlsConnectorConfig.builder()
 				.setSniEnabled(true)
-				.setIdentity(privateKey, certificateChain, CertificateType.X_509)
+				.setCertificateIdentityProvider(new SingleCertificateProvider(privateKey, certificateChain, CertificateType.X_509))
 				.setAdvancedCertificateVerifier(verifier)
 				.setSupportedCipherSuites(SERVER_CIPHER_SUITE)
 				.setExtendedMasterSecretMode(ExtendedMasterSecretMode.ENABLED)
@@ -224,7 +225,7 @@ public class ServerHandshakerTest {
 		// only as well as a pre-shared key based cipher
 		NewAdvancedCertificateVerifier verifier = StaticNewAdvancedCertificateVerifier.builder().setTrustAllRPKs().build();
 		config = DtlsConnectorConfig.builder()
-				.setIdentity(privateKey, DtlsTestTools.getPublicKey())
+				.setCertificateIdentityProvider(new SingleCertificateProvider(privateKey, DtlsTestTools.getPublicKey()))
 				.setSupportedCipherSuites(
 						CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
 						CipherSuite.TLS_PSK_WITH_AES_128_CCM_8)

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/x509/CertificateConfigurationHelperTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/x509/CertificateConfigurationHelperTest.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Bosch.IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch.IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls.x509;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+
+import org.eclipse.californium.elements.category.Small;
+import org.eclipse.californium.elements.util.SslContextUtil.Credentials;
+import org.eclipse.californium.scandium.dtls.DtlsTestTools;
+import org.eclipse.californium.scandium.dtls.SignatureAndHashAlgorithm;
+import org.eclipse.californium.scandium.dtls.cipher.XECDHECryptography.SupportedGroup;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Small.class)
+public class CertificateConfigurationHelperTest {
+
+	CertificateConfigurationHelper helper;
+
+	@Before
+	public void setUp() throws Exception {
+		helper = new CertificateConfigurationHelper();
+	}
+
+	@Test
+	public void testRawPublicKeySetupSupportsClientAndServer() {
+		helper.addConfigurationDefaultsFor(DtlsTestTools.getClientPublicKey());
+		assertThat(helper.canBeUsedForAuthentication(true), is(true));
+		assertThat(helper.canBeUsedForAuthentication(false), is(true));
+		List<SupportedGroup> defaultSupportedGroups = helper.getDefaultSupportedGroups();
+		assertThat(defaultSupportedGroups.size(), is(1));
+		assertThat(defaultSupportedGroups, hasItem(SupportedGroup.secp256r1));
+		List<SignatureAndHashAlgorithm> defaultSignatureAndHashAlgorithms = helper
+				.getDefaultSignatureAndHashAlgorithms();
+		assertThat(defaultSignatureAndHashAlgorithms.size(), is(1));
+		assertThat(defaultSignatureAndHashAlgorithms, hasItem(SignatureAndHashAlgorithm.SHA256_WITH_ECDSA));
+	}
+
+	@Test
+	public void testCertificateChainWithClientUsageSupportsClientOnly() {
+		Credentials credentials = DtlsTestTools.getCredentials("clientext");
+		helper.addConfigurationDefaultsFor(credentials.getCertificateChainAsList());
+		assertThat(helper.canBeUsedForAuthentication(true), is(true));
+		assertThat(helper.canBeUsedForAuthentication(false), is(false));
+		List<SupportedGroup> defaultSupportedGroups = helper.getDefaultSupportedGroups();
+		assertThat(defaultSupportedGroups.size(), is(1));
+		assertThat(defaultSupportedGroups, hasItem(SupportedGroup.secp256r1));
+		List<SignatureAndHashAlgorithm> defaultSignatureAndHashAlgorithms = helper
+				.getDefaultSignatureAndHashAlgorithms();
+		assertThat(defaultSignatureAndHashAlgorithms.size(), is(1));
+		assertThat(defaultSignatureAndHashAlgorithms, hasItem(SignatureAndHashAlgorithm.SHA256_WITH_ECDSA));
+	}
+
+	@Test
+	public void testRsaCertificateChainWithoutKeyUsageSupportsClientAndServer() {
+		helper.addConfigurationDefaultsFor(DtlsTestTools.getServerRsaCertificateChainAsList());
+		assertThat(helper.canBeUsedForAuthentication(true), is(true));
+		assertThat(helper.canBeUsedForAuthentication(false), is(true));
+		List<SupportedGroup> defaultSupportedGroups = helper.getDefaultSupportedGroups();
+		assertThat(defaultSupportedGroups.size(), is(1));
+		assertThat(defaultSupportedGroups, hasItem(SupportedGroup.secp256r1));
+		List<SignatureAndHashAlgorithm> defaultSignatureAndHashAlgorithms = helper
+				.getDefaultSignatureAndHashAlgorithms();
+		assertThat(defaultSignatureAndHashAlgorithms.size(), is(2));
+		assertThat(defaultSignatureAndHashAlgorithms, hasItem(SignatureAndHashAlgorithm.SHA256_WITH_ECDSA));
+		assertThat(defaultSignatureAndHashAlgorithms, hasItem(SignatureAndHashAlgorithm.SHA256_WITH_RSA));
+	}
+
+	@Test
+	public void testTrustedCertificatesSupportsClientAndServer() {
+		Credentials credentials = DtlsTestTools.getCredentials("clientext");
+		helper.addConfigurationDefaultsForTrusts(credentials.getCertificateChain());
+		assertThat(helper.canBeUsedForAuthentication(true), is(true));
+		assertThat(helper.canBeUsedForAuthentication(false), is(true));
+		List<SupportedGroup> defaultSupportedGroups = helper.getDefaultSupportedGroups();
+		assertThat(defaultSupportedGroups.size(), is(1));
+		assertThat(defaultSupportedGroups, hasItem(SupportedGroup.secp256r1));
+		List<SignatureAndHashAlgorithm> defaultSignatureAndHashAlgorithms = helper
+				.getDefaultSignatureAndHashAlgorithms();
+		assertThat(defaultSignatureAndHashAlgorithms.size(), is(1));
+		assertThat(defaultSignatureAndHashAlgorithms, hasItem(SignatureAndHashAlgorithm.SHA256_WITH_ECDSA));
+	}
+
+	@Test
+	public void testTrustedRsaCertificatesSupportsClientAndServer() {
+		helper.addConfigurationDefaultsForTrusts(DtlsTestTools.getServerRsaCertificateChain());
+		assertThat(helper.canBeUsedForAuthentication(true), is(true));
+		assertThat(helper.canBeUsedForAuthentication(false), is(true));
+		List<SupportedGroup> defaultSupportedGroups = helper.getDefaultSupportedGroups();
+		assertThat(defaultSupportedGroups.size(), is(1));
+		assertThat(defaultSupportedGroups, hasItem(SupportedGroup.secp256r1));
+		List<SignatureAndHashAlgorithm> defaultSignatureAndHashAlgorithms = helper
+				.getDefaultSignatureAndHashAlgorithms();
+		assertThat(defaultSignatureAndHashAlgorithms.size(), is(2));
+		assertThat(defaultSignatureAndHashAlgorithms, hasItem(SignatureAndHashAlgorithm.SHA256_WITH_ECDSA));
+		assertThat(defaultSignatureAndHashAlgorithms, hasItem(SignatureAndHashAlgorithm.SHA256_WITH_RSA));
+	}
+
+}


### PR DESCRIPTION
Introduce a certificate provider.

Supports multiple x509 certificate chains to server for different clients.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>
