### PR TITLE
Improve checking for invalid URIs.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/Request.java
@@ -481,7 +481,6 @@ public class Request extends Message {
 	 */
 	public Request setURI(final URI uri) {
 		checkURI(uri);
-
 		final String host = uri.getHost() == null ? "localhost" : uri.getHost();
 		final String uriScheme = uri.getScheme();
 		final boolean literalIp = IP_PATTERN.matcher(host).matches();
@@ -570,7 +569,9 @@ public class Request extends Message {
 		} else if (!CoAP.isSupportedScheme(uri.getScheme())) {
 			throw new IllegalArgumentException("URI scheme '" + uri.getScheme() + "' is not supported!");
 		} else if (uri.getFragment() != null) {
-			throw new IllegalArgumentException("URI must not contain a fragment");
+			throw new IllegalArgumentException("URI must not contain a fragment '" + uri.getFragment() + "'!");
+		} else if (uri.getSchemeSpecificPart() != null && uri.getHost() == null) {
+			throw new IllegalArgumentException("URI expected host '" + uri.getSchemeSpecificPart() + "' is invalid!");
 		}
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/coap/RequestTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/coap/RequestTest.java
@@ -110,6 +110,18 @@ public class RequestTest {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
+	public void testSetURIMalformedPort() {
+		// space before port
+		Request.newGet().setURI("coap://iot.eclipse.org: 5683");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSetURIMalformedPort2() {
+		// encoded space before port
+		Request.newGet().setURI("coap://iot.eclipse.org:%205683");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
 	public void testSetURIRejectsUnsupportedScheme() {
 		Request.newGet().setURI("unknown://127.0.0.1");
 	}


### PR DESCRIPTION
Issue #1633
Check, if a scheme specific part is contained, but no host.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>