### PR TITLE
Remove string list as attribute for endpoint context.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
@@ -36,6 +36,7 @@ import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.elements.DtlsEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.MapBasedEndpointContext;
+import org.eclipse.californium.elements.MapBasedEndpointContext.Attributes;
 import org.eclipse.californium.elements.UdpMulticastConnector;
 
 /**
@@ -533,8 +534,9 @@ public class CoapExchange {
 	private EndpointContext applyHandshakeMode() {
 		EndpointContext context = exchange.getCurrentRequest().getSourceContext();
 		if (handshakeMode != null && context.get(DtlsEndpointContext.KEY_HANDSHAKE_MODE) == null) {
-			context = MapBasedEndpointContext.addEntries(context, DtlsEndpointContext.KEY_HANDSHAKE_MODE,
-					handshakeMode);
+			Attributes attributes = new Attributes();
+			attributes.add(DtlsEndpointContext.KEY_HANDSHAKE_MODE, handshakeMode);
+			context = MapBasedEndpointContext.addEntries(context, attributes);
 		}
 		return context;
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/DeduplicationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/DeduplicationTest.java
@@ -251,8 +251,7 @@ public class DeduplicationTest {
 		builder.ackRandomFactor(1.0F);
 
 		EndpointContext destination = new AddressEndpointContext(server.getSocketAddress());
-		destination = MapBasedEndpointContext.addEntries(destination, DtlsEndpointContext.KEY_HANDSHAKE_MODE,
-				DtlsEndpointContext.HANDSHAKE_MODE_NONE);
+		destination = MapBasedEndpointContext.addEntries(destination, DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_NONE);
 		Request request = createRequest(GET, path, server);
 		request.setDestinationContext(destination);
 		request.setReliabilityLayerParameters(builder.build());
@@ -266,8 +265,7 @@ public class DeduplicationTest {
 		assertThat(request.getEffectiveDestinationContext().getString(DtlsEndpointContext.KEY_HANDSHAKE_MODE), is(DtlsEndpointContext.HANDSHAKE_MODE_NONE));
 
 		destination = new AddressEndpointContext(server.getSocketAddress());
-		destination = MapBasedEndpointContext.addEntries(destination, DtlsEndpointContext.KEY_HANDSHAKE_MODE,
-				DtlsEndpointContext.HANDSHAKE_MODE_FORCE);
+		destination = MapBasedEndpointContext.addEntries(destination, DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_FORCE);
 		request = createRequest(GET, path, server);
 		request.setDestinationContext(destination);
 		request.setReliabilityLayerParameters(builder.build());

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/CaliforniumUtil.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/CaliforniumUtil.java
@@ -226,7 +226,7 @@ public class CaliforniumUtil extends ConnectorUtil {
 	public CoapResponse sendWithFullHandshake(Request request) {
 		EndpointContext destinationContext = request.getDestinationContext();
 		destinationContext = MapBasedEndpointContext.setEntries(destinationContext,
-				DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_FORCE_FULL);
+				DtlsEndpointContext.ATTRIBUE_HANDSHAKE_MODE_FORCE_FULL);
 		request.setDestinationContext(destinationContext);
 		return send(request);
 	}

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreEndpointContextInfo.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreEndpointContextInfo.java
@@ -16,9 +16,6 @@
  ******************************************************************************/
 package org.eclipse.californium.oscore;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
@@ -26,6 +23,7 @@ import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.Exchange.EndpointContextOperator;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.MapBasedEndpointContext;
+import org.eclipse.californium.elements.MapBasedEndpointContext.Attributes;
 
 /**
  * Class that handles setting information in an EndpointContext for OSCORE
@@ -174,28 +172,13 @@ public class OSCoreEndpointContextInfo {
 
 		// Create new MapBasedEndpointContext for this endpoint context with
 		// string values for OSCORE added
-		List<String> attributes = new ArrayList<String>();
-		add(attributes, OSCORE_SENDER_ID, oscoreCtx.getSenderIdString());
-		add(attributes, OSCORE_RECIPIENT_ID, oscoreCtx.getRecipientIdString());
-		add(attributes, OSCORE_CONTEXT_ID, oscoreCtx.getContextIdString());
-		add(attributes, OSCORE_URI, oscoreCtx.getUri());
-		MapBasedEndpointContext newEndpointContext = MapBasedEndpointContext.addEntries(endpointContext,
-				attributes.toArray(new String[attributes.size()]));
+		Attributes attributes = new Attributes();
+		attributes.add(OSCORE_SENDER_ID, oscoreCtx.getSenderIdString());
+		attributes.add(OSCORE_RECIPIENT_ID, oscoreCtx.getRecipientIdString());
+		attributes.add(OSCORE_CONTEXT_ID, oscoreCtx.getContextIdString());
+		attributes.add(OSCORE_URI, oscoreCtx.getUri());
+		MapBasedEndpointContext newEndpointContext = MapBasedEndpointContext.addEntries(endpointContext, attributes);
 
 		return newEndpointContext;
-	}
-
-	/**
-	 * Add values and keys to a list if the value provided is not null.
-	 *
-	 * @param attributes the list to add values and keys to
-	 * @param key the key to add
-	 * @param value the value to add
-	 */
-	private static void add(List<String> attributes, String key, String value) {
-		if (value != null) {
-			attributes.add(key);
-			attributes.add(value);
-		}
 	}
 }

--- a/cf-utils/cf-cluster/src/main/java/org/eclipse/californium/cluster/DtlsClusterManager.java
+++ b/cf-utils/cf-cluster/src/main/java/org/eclipse/californium/cluster/DtlsClusterManager.java
@@ -585,8 +585,7 @@ public class DtlsClusterManager implements Readiness {
 				if (clusterManagementConnector.isRunning()) {
 					EndpointContext context;
 					if (secure) {
-						context = new MapBasedEndpointContext(node, null, DtlsEndpointContext.KEY_HANDSHAKE_MODE,
-								DtlsEndpointContext.HANDSHAKE_MODE_FORCE);
+						context = new MapBasedEndpointContext(node, null, DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_FORCE);
 					} else {
 						context = new AddressEndpointContext(node);
 					}

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
@@ -800,7 +800,7 @@ public class BenchmarkClient {
 					}
 				} else {
 					destinationContext = MapBasedEndpointContext.setEntries(destinationContext,
-							DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_FORCE_FULL);
+							DtlsEndpointContext.ATTRIBUE_HANDSHAKE_MODE_FORCE_FULL);
 					request.setDestinationContext(destinationContext);
 				}
 			}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/DtlsEndpointContext.java
@@ -109,12 +109,47 @@ public class DtlsEndpointContext extends MapBasedEndpointContext {
 
 	/**
 	 * The name of the attribute that contains a auto session resumption timeout
-	 * in milliseconds as number.
+	 * in milliseconds as {@link Number}.
 	 * 
 	 * {@code -1}, disable auto session resumption. None critical attribute, not
 	 * considered for matching.
 	 */
 	public static final String KEY_RESUMPTION_TIMEOUT = KEY_PREFIX_NONE_CRITICAL + "DTLS_RESUMPTION_TIMEOUT";
+	/**
+	 * Attribute to set HANDSHAKE_MODE to {@link #HANDSHAKE_MODE_NONE}.
+	 * 
+	 * @since 3.0
+	 */
+	public static final Attributes ATTRIBUTE_HANDSHAKE_MODE_NONE = new Attributes()
+			.add(KEY_HANDSHAKE_MODE, HANDSHAKE_MODE_NONE).lock();
+	/**
+	 * Attribute to set HANDSHAKE_MODE to {@link #HANDSHAKE_MODE_AUTO}.
+	 * 
+	 * @since 3.0
+	 */
+	public static final Attributes ATTRIBUTE_HANDSHAKE_MODE_AUTO = new Attributes()
+			.add(KEY_HANDSHAKE_MODE, HANDSHAKE_MODE_AUTO).lock();
+	/**
+	 * Attribute to set HANDSHAKE_MODE to {@link #HANDSHAKE_MODE_PROBE}.
+	 * 
+	 * @since 3.0
+	 */
+	public static final Attributes ATTRIBUTE_HANDSHAKE_MODE_PROBE = new Attributes()
+			.add(KEY_HANDSHAKE_MODE, HANDSHAKE_MODE_PROBE).lock();
+	/**
+	 * Attribute to set HANDSHAKE_MODE to {@link #HANDSHAKE_MODE_FORCE}.
+	 * 
+	 * @since 3.0
+	 */
+	public static final Attributes ATTRIBUTE_HANDSHAKE_MODE_FORCE = new Attributes()
+			.add(KEY_HANDSHAKE_MODE, HANDSHAKE_MODE_FORCE).lock();
+	/**
+	 * Attribute to set HANDSHAKE_MODE to {@link #HANDSHAKE_MODE_FORCE_FULL}.
+	 * 
+	 * @since 3.0
+	 */
+	public static final Attributes ATTRIBUE_HANDSHAKE_MODE_FORCE_FULL = new Attributes()
+			.add(KEY_HANDSHAKE_MODE, HANDSHAKE_MODE_FORCE_FULL).lock();
 
 	/**
 	 * Creates a context for DTLS session parameters.

--- a/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContextUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/EndpointContextUtil.java
@@ -40,8 +40,8 @@ public class EndpointContextUtil {
 	 * @param keys set of keys to be matched.
 	 * @param context1 endpoint context to be compared
 	 * @param context2 endpoint context to be compared
-	 * @return true, if all values in the endpoint contexts of the provided
-	 *         keys are equal, false, if not.
+	 * @return true, if all values in the endpoint contexts of the provided keys
+	 *         are equal, false, if not.
 	 */
 	public static boolean match(String name, Set<String> keys, EndpointContext context1, EndpointContext context2) {
 		boolean warn = LOGGER.isWarnEnabled();
@@ -57,7 +57,7 @@ public class EndpointContextUtil {
 			}
 			if (!match) {
 				/* logging differences with warning level */
-				WARN_FILTER.warn("{}, {}: \"{}\" != \"{}\"",  name, key, value1, value2);
+				WARN_FILTER.warn("{}, {}: \"{}\" != \"{}\"", name, key, value1, value2);
 			} else if (trace) {
 				/* logging matches with finest level */
 				LOGGER.trace("{}, {}: \"{}\" == \"{}\"", name, key, value1, value2);
@@ -88,8 +88,7 @@ public class EndpointContextUtil {
 		String mode = messageContext.getString(DtlsEndpointContext.KEY_HANDSHAKE_MODE);
 		if (mode != null && mode.equals(DtlsEndpointContext.HANDSHAKE_MODE_NONE)) {
 			// restore handshake-mode "none"
-			followUpEndpointContext = MapBasedEndpointContext.addEntries(connectionContext,
-					DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_NONE);
+			followUpEndpointContext = MapBasedEndpointContext.addEntries(connectionContext, DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_NONE);
 		} else {
 			followUpEndpointContext = connectionContext;
 		}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/MapBasedEndpointContext.java
@@ -52,45 +52,6 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 	private final Map<String, Object> entries;
 
 	/**
-	 * Creates a context for a socket address, authenticated identity and
-	 * arbitrary key/value pairs.
-	 * 
-	 * @param peerAddress peer address of endpoint context
-	 * @param peerIdentity peer identity of endpoint context
-	 * @param attributes list of attributes (key/value pairs, e.g. key_1,
-	 *            value_1, key_2, value_2 ...)
-	 * @throws NullPointerException if provided peer address is {@code null},
-	 *             the provided attributes is {@code null}, or one of the
-	 *             attributes is {@code null}.
-	 * @throws IllegalArgumentException if provided attributes list has odd size
-	 *             or contains a duplicate key.
-	 */
-	public MapBasedEndpointContext(InetSocketAddress peerAddress, Principal peerIdentity, String... attributes) {
-
-		this(peerAddress, null, peerIdentity, attributes);
-	}
-
-	/**
-	 * Creates a context for a socket address, authenticated identity and
-	 * arbitrary key/value pairs.
-	 * 
-	 * @param peerAddress peer address of endpoint context
-	 * @param virtualHost the name of the virtual host at the peer
-	 * @param peerIdentity peer identity of endpoint context
-	 * @param attributes list of attributes (key/value pairs, e.g. key_1,
-	 *            value_1, key_2, value_2 ...)
-	 * @throws NullPointerException if provided peer address is {@code null},
-	 *             the provided attributes is {@code null}, or one of the
-	 *             attributes is {@code null}.
-	 * @throws IllegalArgumentException if provided attributes list has odd size
-	 *             or contains a duplicate key.
-	 */
-	public MapBasedEndpointContext(InetSocketAddress peerAddress, String virtualHost, Principal peerIdentity,
-			String... attributes) {
-		this(peerAddress, virtualHost, peerIdentity, createAttributes(attributes));
-	}
-
-	/**
 	 * Creates a new endpoint context with correlation context support.
 	 * 
 	 * @param peerAddress peer address of endpoint context
@@ -127,39 +88,6 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 		attributes.lock();
 		this.entries = Collections.unmodifiableMap(attributes.entries);
 		this.hasCriticalEntries = findCriticalEntries(entries);
-	}
-
-	/**
-	 * Create map of attributes.
-	 * 
-	 * @param attributes list of attributes (key/value pairs, e.g. key_1,
-	 *            value_1, key_2, value_2 ...)
-	 * @return create map
-	 * @throws NullPointerException if the provided attributes is {@code null},
-	 *             or one of the critical attributes is {@code null}.
-	 * @throws IllegalArgumentException if provided attributes list has odd size
-	 *             or contains a duplicate key.
-	 */
-	private static final Attributes createAttributes(String... attributes) {
-		if (attributes == null) {
-			throw new NullPointerException("attributes must not null!");
-		}
-		if ((attributes.length & 1) != 0) {
-			throw new IllegalArgumentException("number of attributes must be even, not " + attributes.length + "!");
-		}
-		Attributes entries = new Attributes();
-		for (int index = 0; index < attributes.length; ++index) {
-			try {
-				String key = attributes[index];
-				String value = attributes[++index];
-				entries.add(key, value);
-			} catch (NullPointerException ex) {
-				throw new NullPointerException((index / 2) + ". " + ex.getMessage());
-			} catch (IllegalArgumentException ex) {
-				throw new IllegalArgumentException((index / 2) + ". " + ex.getMessage());
-			}
-		}
-		return entries;
 	}
 
 	/**
@@ -205,23 +133,6 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 	 * Set entries to endpoint context.
 	 * 
 	 * @param context original endpoint context.
-	 * @param attributes list of attributes (key/value pairs, e.g. key_1,
-	 *            value_1, key_2, value_2 ...)..
-	 * @return new endpoint context with attributes.
-	 * @throws NullPointerException if the provided attributes is {@code null},
-	 *             or one of the attributes is {@code null}.
-	 * @throws IllegalArgumentException if provided attributes list has odd size
-	 *             or contains a duplicate key.
-	 *             @since 3.0
-	 */
-	public static MapBasedEndpointContext setEntries(EndpointContext context, String... attributes) {
-		return setEntries(context, createAttributes(attributes));
-	}
-
-	/**
-	 * Set entries to endpoint context.
-	 * 
-	 * @param context original endpoint context.
 	 * @param attributes map of attributes.
 	 * @return new endpoint context with attributes.
 	 * @throws NullPointerException if the provided attributes is {@code null}
@@ -230,23 +141,6 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 	public static MapBasedEndpointContext setEntries(EndpointContext context, Attributes attributes) {
 		return new MapBasedEndpointContext(context.getPeerAddress(), context.getVirtualHost(),
 				context.getPeerIdentity(), attributes);
-	}
-
-	/**
-	 * Add entries to endpoint context.
-	 * 
-	 * @param context original endpoint context.
-	 * @param attributes list of attributes (key/value pairs, e.g. key_1,
-	 *            value_1, key_2, value_2 ...). The provided attributes may
-	 *            overwrite already available ones.
-	 * @return new endpoint context with additional attributes.
-	 * @throws NullPointerException if the provided attributes is {@code null},
-	 *             or one of the attributes is {@code null}.
-	 * @throws IllegalArgumentException if provided attributes list has odd size
-	 *             or contains a duplicate key.
-	 */
-	public static MapBasedEndpointContext addEntries(EndpointContext context, String... attributes) {
-		return addEntries(context, createAttributes(attributes));
 	}
 
 	/**
@@ -339,9 +233,12 @@ public class MapBasedEndpointContext extends AddressEndpointContext {
 
 		/**
 		 * Lock attributes. Protect from further modifications.
+		 * 
+		 * @return this for chaining
 		 */
-		public void lock() {
+		public Attributes lock() {
 			lock = true;
+			return this;
 		}
 
 		/**

--- a/element-connector/src/main/java/org/eclipse/californium/elements/UdpEndpointContext.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/UdpEndpointContext.java
@@ -30,7 +30,7 @@ public class UdpEndpointContext extends MapBasedEndpointContext {
 	 * @param peerAddress The peer's address.
 	 */
 	public UdpEndpointContext(InetSocketAddress peerAddress) {
-		super(peerAddress, null, KEY_PLAIN, "");
+		super(peerAddress, null, new Attributes().add(KEY_PLAIN, ""));
 	}
 
 	@Override

--- a/element-connector/src/test/java/org/eclipse/californium/elements/DtlsEndpointContextMatcherTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/DtlsEndpointContextMatcherTest.java
@@ -21,6 +21,7 @@ import static org.eclipse.californium.elements.DtlsEndpointContext.*;
 
 import java.net.InetSocketAddress;
 
+import org.eclipse.californium.elements.MapBasedEndpointContext.Attributes;
 import org.eclipse.californium.elements.util.Bytes;
 import org.junit.Before;
 import org.junit.Test;
@@ -73,9 +74,10 @@ public class DtlsEndpointContextMatcherTest {
 
 		unsecureMessageContext = new UdpEndpointContext(ADDRESS);
 
-		noneCriticalMessageContext = new MapBasedEndpointContext(ADDRESS, null, KEY_RESUMPTION_TIMEOUT, "30000");
-		scopedNoneCriticalMessageContext = new MapBasedEndpointContext(ADDRESS, SCOPE, null, KEY_RESUMPTION_TIMEOUT,
-				"30000");
+		noneCriticalMessageContext = new MapBasedEndpointContext(ADDRESS, null,
+				new Attributes().add(KEY_RESUMPTION_TIMEOUT, 30000));
+		scopedNoneCriticalMessageContext = new MapBasedEndpointContext(ADDRESS, SCOPE, null,
+				new Attributes().add(KEY_RESUMPTION_TIMEOUT, 30000));
 
 		strictNoneCriticalMessageContext = new MapBasedEndpointContext(ADDRESS, null,
 				new Attributes().add(KEY_SESSION_ID, session).add(KEY_EPOCH, 1).add(KEY_CIPHER, "CIPHER")
@@ -174,28 +176,29 @@ public class DtlsEndpointContextMatcherTest {
 
 	@Test
 	public void testAddNewEntries() {
-		EndpointContext context = MapBasedEndpointContext.addEntries(strictMessageContext, KEY_RESUMPTION_TIMEOUT,
-				"30000");
+		EndpointContext context = MapBasedEndpointContext.addEntries(strictMessageContext,
+				new Attributes().add(KEY_RESUMPTION_TIMEOUT, 30000));
 		assertThat(context.getPeerAddress(), is(strictMessageContext.getPeerAddress()));
 		assertThat(context.getVirtualHost(), is(strictMessageContext.getVirtualHost()));
 		assertThat(context.getPeerIdentity(), is(strictMessageContext.getPeerIdentity()));
-		assertThat(context.getString(KEY_RESUMPTION_TIMEOUT), is("30000"));
+		assertThat(context.getNumber(KEY_RESUMPTION_TIMEOUT).intValue(), is(30000));
 
-		context = MapBasedEndpointContext.addEntries(scopedStrictMessageContext, KEY_RESUMPTION_TIMEOUT, "30000");
+		context = MapBasedEndpointContext.addEntries(scopedStrictMessageContext,
+				new Attributes().add(KEY_RESUMPTION_TIMEOUT, 30000));
 		assertThat(context.getPeerAddress(), is(scopedStrictMessageContext.getPeerAddress()));
 		assertThat(context.getVirtualHost(), is(scopedStrictMessageContext.getVirtualHost()));
 		assertThat(context.getPeerIdentity(), is(scopedStrictMessageContext.getPeerIdentity()));
-		assertThat(context.getString(KEY_RESUMPTION_TIMEOUT), is("30000"));
+		assertThat(context.getNumber(KEY_RESUMPTION_TIMEOUT).intValue(), is(30000));
 	}
 
 	@Test
 	public void testAddContainedEntries() {
-		EndpointContext context = MapBasedEndpointContext.addEntries(noneCriticalMessageContext, KEY_RESUMPTION_TIMEOUT,
-				"60000");
+		EndpointContext context = MapBasedEndpointContext.addEntries(noneCriticalMessageContext,
+				new Attributes().add(KEY_RESUMPTION_TIMEOUT, 60000));
 		assertThat(context.getPeerAddress(), is(noneCriticalMessageContext.getPeerAddress()));
 		assertThat(context.getVirtualHost(), is(noneCriticalMessageContext.getVirtualHost()));
 		assertThat(context.getPeerIdentity(), is(noneCriticalMessageContext.getPeerIdentity()));
-		assertThat(context.getString(KEY_RESUMPTION_TIMEOUT), is("60000"));
+		assertThat(context.getNumber(KEY_RESUMPTION_TIMEOUT).intValue(), is(60000));
 	}
 
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/EndpointContextUtilTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/EndpointContextUtilTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.net.InetSocketAddress;
 import java.util.Set;
 
+import org.eclipse.californium.elements.MapBasedEndpointContext.Attributes;
 import org.eclipse.californium.elements.util.Bytes;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,9 +46,11 @@ public class EndpointContextUtilTest {
 		relaxedMessageContext = new DtlsEndpointContext(ADDRESS, null, null, session, 2, "CIPHER", 200);
 		strictMessageContext = new DtlsEndpointContext(ADDRESS, null, null, session, 1, "CIPHER", 100);
 		differentMessageContext = new DtlsEndpointContext(ADDRESS, null, null, newSession, 1, "CIPHER", 100);
-		MapBasedEndpointContext mapBasedContext = new MapBasedEndpointContext(ADDRESS, null, "ID", "session", "UNKNOWN", "secret");
+		MapBasedEndpointContext mapBasedContext = new MapBasedEndpointContext(ADDRESS, null,
+				new Attributes().add("ID", "session").add("UNKNOWN", "secret"));
 		unsecureMessageContext = mapBasedContext;
-		mapBasedContext = new MapBasedEndpointContext(ADDRESS, null, "ID", "session", "UNKNOWN", "topsecret");
+		mapBasedContext = new MapBasedEndpointContext(ADDRESS, null,
+				new Attributes().add("ID", "session").add("UNKNOWN", "topsecret"));
 		unsecureMessageContext2 = mapBasedContext;
 	}
 
@@ -80,8 +83,8 @@ public class EndpointContextUtilTest {
 	@Test
 	public void testFollowUpEndpointContextStartHandshake() {
 		EndpointContext messageContext = new AddressEndpointContext(ADDRESS);
-		messageContext = MapBasedEndpointContext.addEntries(messageContext, DtlsEndpointContext.KEY_HANDSHAKE_MODE,
-				DtlsEndpointContext.HANDSHAKE_MODE_FORCE);
+		messageContext = MapBasedEndpointContext.addEntries(messageContext,
+				new Attributes().add(DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_FORCE));
 		EndpointContext connectionContext = new AddressEndpointContext(ADDRESS, "myserver", null);
 		EndpointContext followUp = EndpointContextUtil.getFollowUpEndpointContext(messageContext, connectionContext);
 		assertThat(followUp.get(DtlsEndpointContext.KEY_HANDSHAKE_MODE), is(nullValue()));
@@ -90,11 +93,11 @@ public class EndpointContextUtilTest {
 	@Test
 	public void testFollowUpEndpointContextNoneHandshake() {
 		EndpointContext messageContext = new AddressEndpointContext(ADDRESS);
-		messageContext = MapBasedEndpointContext.addEntries(messageContext, DtlsEndpointContext.KEY_HANDSHAKE_MODE,
-				DtlsEndpointContext.HANDSHAKE_MODE_NONE);
+		messageContext = MapBasedEndpointContext.addEntries(messageContext, DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_NONE);
 		EndpointContext connectionContext = new AddressEndpointContext(ADDRESS, "myserver", null);
 		EndpointContext followUp = EndpointContextUtil.getFollowUpEndpointContext(messageContext, connectionContext);
-		assertThat(followUp.getString(DtlsEndpointContext.KEY_HANDSHAKE_MODE), is(DtlsEndpointContext.HANDSHAKE_MODE_NONE));
+		assertThat(followUp.getString(DtlsEndpointContext.KEY_HANDSHAKE_MODE),
+				is(DtlsEndpointContext.HANDSHAKE_MODE_NONE));
 	}
 
 }

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
@@ -799,7 +799,7 @@ public class DTLSConnectorAdvancedTest {
 
 			// force resuming handshake
 			EndpointContext context = new MapBasedEndpointContext(rawServer.getAddress(), null,
-					DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_FORCE);
+					DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_FORCE);
 			data = RawData.outbound("Hello World, Again!".getBytes(), context, null, false);
 			client.send(data);
 
@@ -894,7 +894,7 @@ public class DTLSConnectorAdvancedTest {
 
 			// force resuming handshake
 			EndpointContext context = new MapBasedEndpointContext(rawServer.getAddress(), null,
-					DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_PROBE);
+					DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_PROBE);
 			data = RawData.outbound("Hello World, Again!".getBytes(), context, null, false);
 			client.send(data);
 
@@ -992,7 +992,7 @@ public class DTLSConnectorAdvancedTest {
 
 			// force resuming handshake
 			EndpointContext context = new MapBasedEndpointContext(rawServer.getAddress(), null,
-					DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_PROBE);
+					DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_PROBE);
 			data = RawData.outbound("Hello World, Again!".getBytes(), context, null, false);
 			client.send(data);
 
@@ -1078,7 +1078,7 @@ public class DTLSConnectorAdvancedTest {
 
 			// force resuming handshake
 			EndpointContext context = new MapBasedEndpointContext(rawServer.getAddress(), null,
-					DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_PROBE);
+					DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_PROBE);
 			data = RawData.outbound("Hello World, Again!".getBytes(), context, null, false);
 			client.send(data);
 
@@ -1188,7 +1188,7 @@ public class DTLSConnectorAdvancedTest {
 
 			// force resuming handshake
 			EndpointContext context = new MapBasedEndpointContext(rawServer.getAddress(), null,
-					DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_PROBE);
+					DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_PROBE);
 			data = RawData.outbound("Hello World, Again!".getBytes(), context, null, false);
 			client.send(data);
 
@@ -1275,7 +1275,7 @@ public class DTLSConnectorAdvancedTest {
 
 			// force resuming handshake
 			EndpointContext context = new MapBasedEndpointContext(rawServer.getAddress(), null,
-					DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_PROBE);
+					DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_PROBE);
 			data = RawData.outbound("Hello World, Again!".getBytes(), context, null, false);
 			client.send(data);
 
@@ -1803,7 +1803,7 @@ public class DTLSConnectorAdvancedTest {
 
 			// force resuming handshake
 			EndpointContext context = new MapBasedEndpointContext(rawServer.getAddress(), null,
-					DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_FORCE);
+					DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_FORCE);
 			data = RawData.outbound("Hello World, Again!".getBytes(), context, null, false);
 			client.send(data);
 
@@ -1900,7 +1900,7 @@ public class DTLSConnectorAdvancedTest {
 
 			// force resuming handshake
 			EndpointContext context = new MapBasedEndpointContext(rawServer.getAddress(), null,
-					DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_FORCE);
+					DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_FORCE);
 			data = RawData.outbound("Hello World, Again!".getBytes(), context, null, false);
 			client.send(data);
 
@@ -2311,7 +2311,7 @@ public class DTLSConnectorAdvancedTest {
 
 			// force resuming handshake
 			EndpointContext context = new MapBasedEndpointContext(rawServer.getAddress(), null,
-					DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_FORCE);
+					DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_FORCE);
 			data = RawData.outbound("Hello World, Again!".getBytes(), context, null, false);
 			client.send(data);
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorHandshakeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorHandshakeTest.java
@@ -1698,7 +1698,7 @@ public class DTLSConnectorHandshakeTest {
 		SimpleMessageCallback callback = new SimpleMessageCallback();
 		RawData raw = RawData.outbound(
 				"Hello World, 2!".getBytes(), MapBasedEndpointContext.addEntries(endpointContext,
-						DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_AUTO),
+						DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_AUTO),
 				callback, false);
 		client.send(raw);
 
@@ -1721,7 +1721,7 @@ public class DTLSConnectorHandshakeTest {
 
 		EndpointContext endpointContext = new AddressEndpointContext(serverHelper.serverEndpoint);
 		startClientFailing(builder, MapBasedEndpointContext.addEntries(endpointContext,
-				DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_NONE));
+				DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_NONE));
 
 		SimpleMessageCallback callback = new SimpleMessageCallback();
 		RawData raw = RawData.outbound("Hello World, 2!".getBytes(), endpointContext, callback, false);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
@@ -905,7 +905,7 @@ public class DTLSConnectorResumeTest {
 
 		// send message
 		EndpointContext context = new MapBasedEndpointContext(serverHelper.serverEndpoint, null,
-				DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_FORCE);
+				DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_FORCE);
 		RawData data = RawData.outbound(msg.getBytes(), context, null, false);
 		client.send(data);
 		assertTrue(clientRawDataChannel.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
@@ -938,7 +938,7 @@ public class DTLSConnectorResumeTest {
 
 		// send message
 		EndpointContext context = new MapBasedEndpointContext(serverHelper.serverEndpoint, null,
-				DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_FORCE_FULL);
+				DtlsEndpointContext.ATTRIBUE_HANDSHAKE_MODE_FORCE_FULL);
 		RawData data = RawData.outbound(msg.getBytes(), context, null, false);
 		client.send(data);
 		assertTrue(clientRawDataChannel.await(MAX_TIME_TO_WAIT_SECS, TimeUnit.SECONDS));
@@ -1166,7 +1166,7 @@ public class DTLSConnectorResumeTest {
 		// suppress handshake
 		SimpleMessageCallback callback = new SimpleMessageCallback(1, false);
 		EndpointContext context = new MapBasedEndpointContext(serverHelper.serverEndpoint, null,
-				DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_NONE);
+				DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_NONE);
 		RawData raw = RawData.outbound("Hello World".getBytes(), context, callback, false);
 
 		client.start();
@@ -1190,7 +1190,7 @@ public class DTLSConnectorResumeTest {
 		// suppress handshake
 		SimpleMessageCallback callback = new SimpleMessageCallback(1, false);
 		EndpointContext context = new MapBasedEndpointContext(serverHelper.serverEndpoint, null,
-				DtlsEndpointContext.KEY_HANDSHAKE_MODE, DtlsEndpointContext.HANDSHAKE_MODE_NONE);
+				DtlsEndpointContext.ATTRIBUTE_HANDSHAKE_MODE_NONE);
 		RawData raw = RawData.outbound("Hello World".getBytes(), context, callback, false);
 		client.start();
 		client.send(raw);


### PR DESCRIPTION
Use typed attributes instead.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>