### PR TITLE
Fix precedence of cipher-suites.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHello.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHello.java
@@ -479,9 +479,9 @@ public final class ClientHello extends HandshakeMessage {
 	 */
 	public List<CipherSuite> getCommonCipherSuites(List<CipherSuite> serverCipherSuite) {
 		List<CipherSuite> common = new ArrayList<>();
-		for (CipherSuite cipherSuite : serverCipherSuite) {
+		for (CipherSuite cipherSuite : supportedCipherSuites) {
 			// NEVER negotiate NULL cipher suite
-			if (cipherSuite != CipherSuite.TLS_NULL_WITH_NULL_NULL && supportedCipherSuites.contains(cipherSuite)) {
+			if (cipherSuite != CipherSuite.TLS_NULL_WITH_NULL_NULL && serverCipherSuite.contains(cipherSuite)) {
 				common.add(cipherSuite);
 			}
 		}


### PR DESCRIPTION
Use order of CLIENT_HELLO.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>