### PR TITLE
Add configurable initial random and timeout scale to DTLS.

### DIFF
--- a/californium-tests/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/NatTestHelper.java
+++ b/californium-tests/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/NatTestHelper.java
@@ -208,7 +208,7 @@ public class NatTestHelper {
 				.set(CoapConfig.EXCHANGE_LIFETIME, RESPONSE_TIMEOUT, TimeUnit.MILLISECONDS)
 				.set(CoapConfig.RESPONSE_MATCHING, mode)
 				.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, ackTimeout, TimeUnit.MILLISECONDS)
-				.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, 4);
+				.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, 4);
 	}
 
 	void createSecureServer(ConnectionIdGenerator... cidGenerators) throws IOException {

--- a/californium-tests/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureTest.java
+++ b/californium-tests/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/SecureTest.java
@@ -229,7 +229,7 @@ public class SecureTest {
 				.set(CoapConfig.EXCHANGE_LIFETIME, TEST_TIMEOUT_EXCHANGE_LIFETIME, TimeUnit.MILLISECONDS)
 				.set(CoapConfig.MARK_AND_SWEEP_INTERVAL, TEST_TIMEOUT_SWEEP_DEDUPLICATOR_INTERVAL, TimeUnit.MILLISECONDS)
 				.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, RETRANSMISSION_TIMEOUT, TimeUnit.MILLISECONDS)
-				.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, NB_RETRANSMISSION);
+				.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, NB_RETRANSMISSION);
 		// setup DTLS Config
 		Builder builder = DtlsConnectorConfig.builder(config)
 				.setAddress(TestTools.LOCALHOST_EPHEMERAL)
@@ -250,7 +250,7 @@ public class SecureTest {
 				.set(CoapConfig.ACK_TIMEOUT, coapTimeout, TimeUnit.MILLISECONDS)
 				.set(CoapConfig.EXCHANGE_LIFETIME, exchangeTimeout, TimeUnit.MILLISECONDS)
 				.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, dtlsTimeout, TimeUnit.MILLISECONDS)
-				.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, TEST_DTLS_RETRANSMISSIONS)
+				.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, TEST_DTLS_RETRANSMISSIONS)
 				.set(DtlsConfig.DTLS_RECEIVER_THREAD_COUNT, 2)
 				.set(DtlsConfig.DTLS_CONNECTOR_THREAD_COUNT, 2);
 		// setup DTLS Config

--- a/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
+++ b/demo-apps/cf-extplugtest-client/src/main/java/org/eclipse/californium/extplugtests/BenchmarkClient.java
@@ -191,7 +191,7 @@ public class BenchmarkClient {
 			config.set(UdpConfig.UDP_SEND_BUFFER_SIZE, 8192);
 			config.set(SystemConfig.HEALTH_STATUS_INTERVAL_IN_SECONDS, 0, TimeUnit.SECONDS);
 			config.set(BENCHMARK_CLIENT_THREADS, 0);
-			config.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, 2);
+			config.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, 2);
 		}
 
 	};

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsManagedClusterConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DtlsManagedClusterConnector.java
@@ -138,7 +138,7 @@ public class DtlsManagedClusterConnector extends DtlsClusterConnector {
 			SecretKey secretkey = clusterConfiguration.getSecretKey();
 			DtlsConnectorConfig.Builder builder = DtlsConnectorConfig.builder(configuration.getConfiguration())
 					.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, 500, TimeUnit.MILLISECONDS)
-					.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, 3)
+					.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, 3)
 					.set(DtlsConfig.DTLS_RETRANSMISSION_BACKOFF, 0)
 					.set(DtlsConfig.DTLS_MAX_CONNECTIONS, 1024)
 					.set(DtlsConfig.DTLS_RECEIVER_THREAD_COUNT, 0)

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConfig.java
@@ -28,6 +28,7 @@ import org.eclipse.californium.elements.config.Configuration.BooleanDefinition;
 import org.eclipse.californium.elements.config.Configuration.DefinitionsProvider;
 import org.eclipse.californium.elements.config.Configuration.EnumDefinition;
 import org.eclipse.californium.elements.config.Configuration.EnumListDefinition;
+import org.eclipse.californium.elements.config.Configuration.FloatDefinition;
 import org.eclipse.californium.elements.config.Configuration.IntegerDefinition;
 import org.eclipse.californium.elements.config.Configuration.StringSetDefinition;
 import org.eclipse.californium.elements.config.Configuration.TimeDefinition;
@@ -159,7 +160,7 @@ public final class DtlsConfig {
 	 */
 	public static final int DEFAULT_ADDITIONAL_TIMEOUT_FOR_ECC_IN_MILLISECONDS = 0;
 	/**
-	 * The default value for {@link #DTLS_RETRANSMISSION_MAX}.
+	 * The default value for {@link #DTLS_MAX_RETRANSMISSIONS}.
 	 */
 	public static final int DEFAULT_MAX_RETRANSMISSIONS = 4;
 	/**
@@ -261,6 +262,18 @@ public final class DtlsConfig {
 			MODULE + "MAX_RETRANSMISSION_TIMEOUT", "DTLS maximum retransmission timeout.",
 			DEFAULT_MAX_RETRANSMISSION_TIMEOUT_IN_MILLISECONDS, TimeUnit.MILLISECONDS);
 	/**
+	 * Random factor applied to the initial retransmission timeout. Harmonize
+	 * CoAP and DTLS.
+	 */
+	public static final FloatDefinition DTLS_RETRANSMISSION_INIT_RANDOM = new FloatDefinition(
+			MODULE + "RETRANSMISSION_INIT_RANDOM", "DTLS random factor for initial retransmission timeout.", 1.0F);
+	/**
+	 * Scale factor applied to the retransmission timeout. Harmonize CoAP and
+	 * DTLS.
+	 */
+	public static final FloatDefinition DTLS_RETRANSMISSION_TIMEOUT_SCALE = new FloatDefinition(
+			MODULE + "RETRANSMISSION_TIMEOUT_SCALE", "DTLS scale factor for retransmission backoff-timeout.", 2.0F);
+	/**
 	 * Specify the additional initial DTLS retransmission timeout, when the
 	 * other peer is expected to perform ECC calculations.
 	 * 
@@ -279,8 +292,9 @@ public final class DtlsConfig {
 	/**
 	 * Specify the maximum number of DTLS retransmissions.
 	 */
-	public static final IntegerDefinition DTLS_RETRANSMISSION_MAX = new IntegerDefinition(MODULE + "RETRANSMISSION_MAX",
-			"DTLS maximum number of flight retransmissions.", DEFAULT_MAX_RETRANSMISSIONS);
+	public static final IntegerDefinition DTLS_MAX_RETRANSMISSIONS = new IntegerDefinition(
+			MODULE + "MAX_RETRANSMISSIONS", "DTLS maximum number of flight retransmissions.",
+			DEFAULT_MAX_RETRANSMISSIONS);
 	/**
 	 * Specify the number of DTLS retransmissions before the attempt to transmit
 	 * a flight in back-off mode.
@@ -709,7 +723,9 @@ public final class DtlsConfig {
 						TimeUnit.MILLISECONDS);
 				config.set(DTLS_ADDITIONAL_ECC_TIMEOUT, DEFAULT_ADDITIONAL_TIMEOUT_FOR_ECC_IN_MILLISECONDS,
 						TimeUnit.MILLISECONDS);
-				config.set(DTLS_RETRANSMISSION_MAX, DEFAULT_MAX_RETRANSMISSIONS);
+				config.set(DTLS_MAX_RETRANSMISSIONS, DEFAULT_MAX_RETRANSMISSIONS);
+				config.set(DTLS_RETRANSMISSION_INIT_RANDOM, 1.0F);
+				config.set(DTLS_RETRANSMISSION_TIMEOUT_SCALE, 2.0F);
 				config.set(DTLS_RETRANSMISSION_BACKOFF, null);
 				config.set(DTLS_CONNECTION_ID_LENGTH, null);
 				config.set(DTLS_CONNECTION_ID_NODE_ID, null);

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -402,6 +402,28 @@ public final class DtlsConnectorConfig {
 	}
 
 	/**
+	 * Gets the random factor for the initial retransmission timeout.
+	 * 
+	 * @return the random factor for the initial retransmission timeout. Values range [1.0 - 2.0]
+	 * @see DtlsConfig#DTLS_RETRANSMISSION_INIT_RANDOM
+	 * @since 3.0
+	 */
+	public Float getRetransmissionRandomFactor() {
+		return configuration.get(DtlsConfig.DTLS_RETRANSMISSION_INIT_RANDOM);
+	}
+
+	/**
+	 * Gets the scale factor for retransmission timeouts back-off.
+	 * 
+	 * @return the scale factor for retransmission timeout. Values range [1.0 - 2.0]
+	 * @see DtlsConfig#DTLS_RETRANSMISSION_TIMEOUT_SCALE
+	 * @since 3.0
+	 */
+	public Float getRetransmissionTimeoutScale() {
+		return configuration.get(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT_SCALE);
+	}
+
+	/**
 	 * Gets the additional (initial) time to wait before a handshake flight of
 	 * messages gets re-transmitted, when the other peer is expected to perform
 	 * ECC calculations.
@@ -462,10 +484,10 @@ public final class DtlsConnectorConfig {
 	 * re-transmitted to a peer.
 	 * 
 	 * @return the maximum number of re-transmissions
-	 * @see DtlsConfig#DTLS_RETRANSMISSION_MAX
+	 * @see DtlsConfig#DTLS_MAX_RETRANSMISSIONS
 	 */
 	public Integer getMaxRetransmissions() {
-		return configuration.get(DtlsConfig.DTLS_RETRANSMISSION_MAX);
+		return configuration.get(DtlsConfig.DTLS_MAX_RETRANSMISSIONS);
 	}
 
 	/**

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorAdvancedTest.java
@@ -322,7 +322,7 @@ public class DTLSConnectorAdvancedTest {
 
 		serverHelper.serverBuilder
 				.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, RETRANSMISSION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-				.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, MAX_RETRANSMISSIONS)
+				.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, MAX_RETRANSMISSIONS)
 				.set(DtlsConfig.DTLS_MAX_TRANSMISSION_UNIT, 1024)
 				.setConnectionIdGenerator(serverCidGenerator)
 				.setHealthHandler(serverHealth)
@@ -418,7 +418,7 @@ public class DTLSConnectorAdvancedTest {
 		clientConfigBuilder = serverHelper.newClientConfigBuilder(network)
 				.set(DtlsConfig.DTLS_MAX_CONNECTIONS, CLIENT_CONNECTION_STORE_CAPACITY)
 				.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, RETRANSMISSION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-				.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, MAX_RETRANSMISSIONS)
+				.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, MAX_RETRANSMISSIONS)
 				.set(DtlsConfig.DTLS_MAX_TRANSMISSION_UNIT, 1024)
 				.setConnectionIdGenerator(clientCidGenerator)
 				.setAdvancedCertificateVerifier(clientCertificateVerifier)
@@ -523,14 +523,14 @@ public class DTLSConnectorAdvancedTest {
 		alternativeServerHelper = new ConnectorHelper(network);
 		alternativeServerHelper.serverBuilder
 				.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, RETRANSMISSION_TIMEOUT_MS * 2, TimeUnit.MILLISECONDS)
-				.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, MAX_RETRANSMISSIONS * 2)
+				.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, MAX_RETRANSMISSIONS * 2)
 				.set(DtlsConfig.DTLS_MAX_DEFERRED_INBOUND_RECORDS_SIZE, 96)
 				.setHealthHandler(serverHealth)
 				.setConnectionIdGenerator(serverCidGenerator);
 
 		clientConfigBuilder
 				.set(DtlsConfig.DTLS_USE_MULTI_RECORD_MESSAGES, false)
-				.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, MAX_RETRANSMISSIONS * 2);
+				.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, MAX_RETRANSMISSIONS * 2);
 
 		// Configure and create UDP connector
 		RecordCollectorDataHandler collector = new RecordCollectorDataHandler(clientCidGenerator);
@@ -1393,7 +1393,7 @@ public class DTLSConnectorAdvancedTest {
 
 		alternativeServerHelper.serverBuilder
 				.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, RETRANSMISSION_TIMEOUT_MS * 2, TimeUnit.MILLISECONDS)
-				.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, MAX_RETRANSMISSIONS * 2)
+				.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, MAX_RETRANSMISSIONS * 2)
 				.set(DtlsConfig.DTLS_USE_MULTI_RECORD_MESSAGES, false)
 				.setHealthHandler(serverHealth)
 				.setConnectionIdGenerator(serverCidGenerator);
@@ -3204,7 +3204,7 @@ public class DTLSConnectorAdvancedTest {
 
 		alternativeServerHelper.serverBuilder
 				.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, RETRANSMISSION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-				.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, MAX_RETRANSMISSIONS)
+				.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, MAX_RETRANSMISSIONS)
 				.set(DtlsConfig.DTLS_USE_HELLO_VERIFY_REQUEST_FOR_PSK, false)
 				.setConnectionIdGenerator(serverCidGenerator)
 				.setHealthHandler(serverHealth);
@@ -3265,7 +3265,7 @@ public class DTLSConnectorAdvancedTest {
 
 		alternativeServerHelper.serverBuilder
 				.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, RETRANSMISSION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-				.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, MAX_RETRANSMISSIONS)
+				.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, MAX_RETRANSMISSIONS)
 				.set(DtlsConfig.DTLS_USE_HELLO_VERIFY_REQUEST_FOR_PSK, false)
 				.setConnectionIdGenerator(serverCidGenerator)
 				.setHealthHandler(serverHealth);
@@ -3327,7 +3327,7 @@ public class DTLSConnectorAdvancedTest {
 
 		alternativeServerHelper.serverBuilder
 				.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, RETRANSMISSION_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-				.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, MAX_RETRANSMISSIONS)
+				.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, MAX_RETRANSMISSIONS)
 				.set(DtlsConfig.DTLS_USE_HELLO_VERIFY_REQUEST, false)
 				.setConnectionIdGenerator(serverCidGenerator)
 				.setHealthHandler(serverHealth);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorTest.java
@@ -186,7 +186,7 @@ public class DTLSConnectorTest {
 
 		serverHelper.serverBuilder.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, 500, TimeUnit.MILLISECONDS)
 				.set(DtlsConfig.DTLS_ADDITIONAL_ECC_TIMEOUT, 2000, TimeUnit.MILLISECONDS)
-				.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, 2)
+				.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, 2)
 				.set(DtlsConfig.DTLS_EXTENDED_MASTER_SECRET_MODE, ExtendedMasterSecretMode.ENABLED)
 				.set(DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, false)
 				.setSupportedCipherSuites(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8,
@@ -1068,7 +1068,7 @@ public class DTLSConnectorTest {
 				.set(DtlsConfig.DTLS_CONNECTOR_THREAD_COUNT, 2)
 				.setLoggingTag("client").setAddress(clientEndpoint)
 				.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, 250, TimeUnit.MILLISECONDS)
-				.set(DtlsConfig.DTLS_RETRANSMISSION_MAX, 1)
+				.set(DtlsConfig.DTLS_MAX_RETRANSMISSIONS, 1)
 				.setAdvancedPskStore(pskStoreWithBadCredentials).build();
 		client = serverHelper.createClient(clientConfig);
 		client.start();


### PR DESCRIPTION
Harmonize coap and dtls settings.
(Rename RETRANSMISSION_MAX into MAX_RETRANSMISIONS)

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>