### PR TITLE
Adapt support for deprecated CID.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConfig.java
@@ -707,12 +707,12 @@ public final class DtlsConfig {
 			MODULE + "SIGNATURE_AND_HASH_ALGORITHMS",
 			"DTLS list of signature- and hash-algorihtms.\nValues e.g SHA256withECDSA or ED25519.");
 	/**
-	 * Specify the usage of DTLS CID before version 9 of <a href=
+	 * Specify the usage of DTLS CID before version 09 of <a href=
 	 * "https://datatracker.ietf.org/doc/draft-ietf-tls-dtls-connection-id/"
 	 * target="_blank">Draft dtls-connection-id</a> for the client side.
 	 */
-	public static final BooleanDefinition DTLS_USE_DEPRECATED_CID = new BooleanDefinition(MODULE + "USE_DEPRECATED_CID",
-			"DTLS use deprecated CID for client (before version 9).", false);
+	public static final IntegerDefinition DTLS_USE_DEPRECATED_CID = new IntegerDefinition(MODULE + "USE_DEPRECATED_CID",
+			"DTLS use deprecated CID extension code point for client (before version 09 of RFC-CID).");
 	/**
 	 * Specify the support of DTLS CID before version 9 of <a href=
 	 * "https://datatracker.ietf.org/doc/draft-ietf-tls-dtls-connection-id/"
@@ -786,7 +786,7 @@ public final class DtlsConfig {
 				config.set(DTLS_CIPHER_SUITES, null);
 				config.set(DTLS_CURVES, null);
 				config.set(DTLS_SIGNATURE_AND_HASH_ALGORITHMS, null);
-				config.set(DTLS_USE_DEPRECATED_CID, false);
+				config.set(DTLS_USE_DEPRECATED_CID, null);
 				config.set(DTLS_SUPPORT_DEPRECATED_CID, false);
 			}
 		});

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtensions.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloExtensions.java
@@ -121,11 +121,11 @@ public final class HelloExtensions {
 	 * Gets a hello extension of a particular type.
 	 * 
 	 * @param <T> java-type of extension
-	 * @param type the type of extension
+	 * @param type the type of extension or replacement type
 	 * @return the extension, or {@code null}, if no extension of the given type
-	 *         is present
+	 *         nor replacement type is present
 	 * @throws NullPointerException if type is {@code null}
-	 * @since 3.0 (added NullPointerException)
+	 * @since 3.0 (added NullPointerException and replacement type)
 	 */
 	@SuppressWarnings("unchecked")
 	public <T extends HelloExtension> T getExtension(ExtensionType type) {
@@ -133,7 +133,7 @@ public final class HelloExtensions {
 			throw new NullPointerException("Extension type must not be null!");
 		}
 		for (HelloExtension ext : extensions) {
-			if (type.equals(ext.getType())) {
+			if (type.equals(ext.getType()) || type.equals(ext.getType().getReplacementType())) {
 				return (T) ext;
 			}
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloHandshakeMessage.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/HelloHandshakeMessage.java
@@ -336,11 +336,7 @@ public abstract class HelloHandshakeMessage extends HandshakeMessage {
 	 *         contain the <em>connection id</em> extension.
 	 */
 	public ConnectionIdExtension getConnectionIdExtension() {
-		ConnectionIdExtension extension = extensions.getExtension(ExtensionType.CONNECTION_ID);
-		if (extension == null) {
-			extension = extensions.getExtension(ExtensionType.CONNECTION_ID_DEPRECATED);
-		}
-		return extension;
+		return extensions.getExtension(ExtensionType.CONNECTION_ID);
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -845,7 +845,7 @@ public class ServerHandshaker extends Handshaker {
 				if (!useDeprecatedCid || supportDeprecatedCid) {
 					ConnectionId connectionId = getReadConnectionId();
 					ConnectionIdExtension extension = ConnectionIdExtension.fromConnectionId(connectionId,
-							useDeprecatedCid);
+							connectionIdExtension.getType());
 					serverHello.addExtension(extension);
 					DTLSContext context = getDtlsContext();
 					context.setWriteConnectionId(connectionIdExtension.getConnectionId());

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorHandshakeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorHandshakeTest.java
@@ -82,6 +82,7 @@ import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
 import org.eclipse.californium.scandium.dtls.AlertMessage;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertDescription;
 import org.eclipse.californium.scandium.dtls.AlertMessage.AlertLevel;
+import org.eclipse.californium.scandium.dtls.HelloExtension.ExtensionType;
 import org.eclipse.californium.scandium.dtls.CertificateType;
 import org.eclipse.californium.scandium.dtls.Connection;
 import org.eclipse.californium.scandium.dtls.DTLSSession;
@@ -1067,7 +1068,7 @@ public class DTLSConnectorHandshakeTest {
 				.set(DtlsConfig.DTLS_CONNECTION_ID_LENGTH, 6);
 		startServer();
 		clientBuilder.set(DtlsConfig.DTLS_CONNECTION_ID_LENGTH, 4)
-				.set(DtlsConfig.DTLS_USE_DEPRECATED_CID, true);
+				.set(DtlsConfig.DTLS_USE_DEPRECATED_CID, ExtensionType.CONNECTION_ID_DEPRECATED.getId());
 		startClientPsk(null);
 		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
 		Principal principal = endpointContext.getPeerIdentity();
@@ -1084,7 +1085,7 @@ public class DTLSConnectorHandshakeTest {
 				.set(DtlsConfig.DTLS_CONNECTION_ID_LENGTH, 6);
 		startServer();
 		clientBuilder.set(DtlsConfig.DTLS_CONNECTION_ID_LENGTH, 4)
-				.set(DtlsConfig.DTLS_USE_DEPRECATED_CID, true);
+				.set(DtlsConfig.DTLS_USE_DEPRECATED_CID, ExtensionType.CONNECTION_ID_DEPRECATED.getId());
 		startClientPsk(null);
 		EndpointContext endpointContext = serverHelper.serverRawDataProcessor.getClientEndpointContext();
 		Principal principal = endpointContext.getPeerIdentity();

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSConnectorResumeTest.java
@@ -83,6 +83,7 @@ import org.eclipse.californium.scandium.dtls.ExtendedMasterSecretMode;
 import org.eclipse.californium.scandium.dtls.InMemoryConnectionStore;
 import org.eclipse.californium.scandium.dtls.Record;
 import org.eclipse.californium.scandium.dtls.SessionId;
+import org.eclipse.californium.scandium.dtls.HelloExtension.ExtensionType;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedMultiPskStore;
 import org.eclipse.californium.scandium.dtls.pskstore.AsyncAdvancedPskStore;
@@ -213,7 +214,7 @@ public class DTLSConnectorResumeTest {
 				serverResumptionVerifier.setDelay(100);
 				builder.set(DtlsConfig.DTLS_USE_MULTI_HANDSHAKE_MESSAGE_RECORDS, true)
 						.set(DtlsConfig.DTLS_CONNECTION_ID_LENGTH, 4)
-						.set(DtlsConfig.DTLS_USE_DEPRECATED_CID, true)
+						.set(DtlsConfig.DTLS_USE_DEPRECATED_CID, ExtensionType.CONNECTION_ID_DEPRECATED.getId())
 						.setSupportedCipherSuites(CipherSuite.TLS_PSK_WITH_AES_128_CCM_8)
 						.setAdvancedPskStore(clientPskStore);
 			}


### PR DESCRIPTION
Make it easier to adapt the code for using proprietary code points (e.g.
254 for mbedtls). Just clone the ExtensionType.CONNECTION_ID_DEPRECATED
under a different name, description and the proprietary code point.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>