### PR TITLE
Remove WipAPI annotation from dtls serialization.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapServer.java
@@ -56,7 +56,6 @@ import org.eclipse.californium.elements.util.ExecutorsUtil;
 import org.eclipse.californium.elements.util.NamedThreadFactory;
 import org.eclipse.californium.elements.util.SerializationUtil;
 import org.eclipse.californium.elements.util.StringUtil;
-import org.eclipse.californium.elements.util.WipAPI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -476,9 +475,8 @@ public class CoapServer implements ServerInterface {
 	 * Each entry contains the {@link #tag}, followed by the
 	 * {@link Endpoint#getUri()} as ASCII string.
 	 * 
-	 * Note: this is "Work In Progress"; the stream will contain not encrypted
-	 * critical credentials. It is required to protect this data before
-	 * exporting it. The encoding of the content may also change in the future.
+	 * Note: the stream will contain not encrypted critical credentials. It is
+	 * required to protect this data before exporting it.
 	 * 
 	 * @param out output stream to write to
 	 * @param maxQuietPeriodInSeconds maximum quiet period of the connections in
@@ -490,7 +488,6 @@ public class CoapServer implements ServerInterface {
 	 * @see PersistentConnector#saveConnections(OutputStream, long)
 	 * @since 3.0
 	 */
-	@WipAPI
 	public int saveAllConnectors(OutputStream out, long maxQuietPeriodInSeconds) throws IOException {
 		stop();
 		int count = 0;
@@ -524,7 +521,6 @@ public class CoapServer implements ServerInterface {
 	 * @see PersistentConnector#loadConnections(InputStream, long)
 	 * @since 3.0
 	 */
-	@WipAPI
 	public static ConnectorIdentifier readConnectorIdentifier(InputStream in) throws IOException {
 		DataStreamReader reader = new DataStreamReader(in);
 		String mark = SerializationUtil.readString(reader, Byte.SIZE);
@@ -566,7 +562,6 @@ public class CoapServer implements ServerInterface {
 	 * @see PersistentConnector#loadConnections(InputStream, long)
 	 * @since 3.0
 	 */
-	@WipAPI
 	public int loadConnector(ConnectorIdentifier identifier, InputStream in, long delta) throws IOException {
 		Endpoint endpoint = getEndpoint(identifier.uri);
 		if (endpoint == null) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/ServersSerializationUtil.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/ServersSerializationUtil.java
@@ -27,7 +27,6 @@ import org.eclipse.californium.elements.PersistentConnector;
 import org.eclipse.californium.elements.util.DataStreamReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.elements.util.SerializationUtil;
-import org.eclipse.californium.elements.util.WipAPI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,13 +35,11 @@ import org.slf4j.LoggerFactory;
  * 
  * Currently only the dtls connections are serialized.
  * 
- * Note: this is "Work In Progress"; the stream will contain not encrypted
- * critical credentials. It is required to protect this data before exporting
- * it. The encoding of the content may also change in the future.
+ * Note: the stream will contain not encrypted critical credentials. It is
+ * required to protect this data before exporting it.
  * 
  * @since 3.0
  */
-@WipAPI
 public class ServersSerializationUtil {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(ServersSerializationUtil.class);
@@ -54,10 +51,6 @@ public class ServersSerializationUtil {
 	 * {@link SerializationUtil#readNanotimeSynchronizationMark(DataStreamReader)}
 	 * ahead in order to synchronize the nano-uptimes.
 	 * 
-	 * Note: this is "Work In Progress"; the stream will contain not encrypted
-	 * critical credentials. The encoding of the content may also change in the
-	 * future.
-	 * 
 	 * @param in input stream to load from
 	 * @param servers servers to load
 	 * @return number of loaded connections.
@@ -67,7 +60,6 @@ public class ServersSerializationUtil {
 	 * @see CoapServer#readConnectorIdentifier(InputStream)
 	 * @see PersistentConnector#loadConnections(InputStream, long)
 	 */
-	@WipAPI
 	public static int loadServers(InputStream in, CoapServer... servers) {
 		return loadServers(in, Arrays.asList(servers));
 	}
@@ -79,10 +71,6 @@ public class ServersSerializationUtil {
 	 * {@link SerializationUtil#readNanotimeSynchronizationMark(DataStreamReader)}
 	 * ahead in order to synchronize the nano-uptimes.
 	 * 
-	 * Note: this is "Work In Progress"; the stream will contain not encrypted
-	 * critical credentials. The encoding of the content may also change in the
-	 * future.
-	 * 
 	 * @param in input stream to load from
 	 * @param servers servers to load
 	 * @return number of loaded connections.
@@ -92,7 +80,6 @@ public class ServersSerializationUtil {
 	 * @see CoapServer#readConnectorIdentifier(InputStream)
 	 * @see PersistentConnector#loadConnections(InputStream, long)
 	 */
-	@WipAPI
 	public static int loadServers(InputStream in, List<CoapServer> servers) {
 		int count = 0;
 		long time = System.nanoTime();
@@ -142,9 +129,8 @@ public class ServersSerializationUtil {
 	 * {@link SerializationUtil#writeNanotimeSynchronizationMark(DatagramWriter)}
 	 * ahead in order to synchronize the nano-uptimes.
 	 * 
-	 * Note: this is "Work In Progress"; the stream will contain not encrypted
-	 * critical credentials. It is required to protect this data before
-	 * exporting it. The encoding of the content may also change in the future.
+	 * Note: the stream will contain not encrypted critical credentials. It is
+	 * required to protect this data before exporting it.
 	 * 
 	 * @param out output stream
 	 * @param maxQuietPeriodInSeconds maximum quiet period of the connections in
@@ -157,7 +143,6 @@ public class ServersSerializationUtil {
 	 * @see CoapServer#saveAllConnectors(OutputStream, long)
 	 * @see PersistentConnector#saveConnections(OutputStream, long)
 	 */
-	@WipAPI
 	public static int saveServers(OutputStream out, long maxQuietPeriodInSeconds, CoapServer... servers)
 			throws IOException {
 		return saveServers(out, maxQuietPeriodInSeconds, Arrays.asList(servers));
@@ -170,9 +155,8 @@ public class ServersSerializationUtil {
 	 * {@link SerializationUtil#writeNanotimeSynchronizationMark(DatagramWriter)}
 	 * ahead in order to synchronize the nano-uptimes.
 	 * 
-	 * Note: this is "Work In Progress"; the stream will contain not encrypted
-	 * critical credentials. It is required to protect this data before
-	 * exporting it. The encoding of the content may also change in the future.
+	 * Note: the stream will contain not encrypted critical credentials. It is
+	 * required to protect this data before exporting it.
 	 * 
 	 * @param out output stream
 	 * @param maxQuietPeriodInSeconds maximum quiet period of the connections in
@@ -185,7 +169,6 @@ public class ServersSerializationUtil {
 	 * @see CoapServer#saveAllConnectors(OutputStream, long)
 	 * @see PersistentConnector#saveConnections(OutputStream, long)
 	 */
-	@WipAPI
 	public static int saveServers(OutputStream out, long maxQuietPeriodInSeconds, List<CoapServer> servers)
 			throws IOException {
 		int count = 0;

--- a/element-connector/src/main/java/org/eclipse/californium/elements/PersistentConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/PersistentConnector.java
@@ -19,18 +19,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import org.eclipse.californium.elements.util.WipAPI;
-
 /**
  * Interface for connector supporting persistent connections.
  * 
- * Note: this is "Work In Progress"; the stream will contain not encrypted
- * critical credentials. It is required to protect this data before exporting
- * it. The encoding of the content may also change in the future.
+ * Note: the stream will contain not encrypted critical credentials. It is
+ * required to protect this data before exporting it.
  * 
  * @since 3.0
  */
-@WipAPI
 public interface PersistentConnector {
 
 	/**
@@ -39,9 +35,8 @@ public interface PersistentConnector {
 	 * Connector must be stopped before saving connections. The connections are
 	 * removed after saving.
 	 * 
-	 * Note: this is "Work In Progress"; the stream will contain not encrypted
-	 * critical credentials. It is required to protect this data before
-	 * exporting it. The encoding of the content may also change in the future.
+	 * Note: the stream will contain not encrypted critical credentials. It is
+	 * required to protect this data before exporting it.
 	 * 
 	 * @param out output stream to save connections
 	 * @param maxQuietPeriodInSeconds maximum quiet period of the connections in
@@ -51,7 +46,6 @@ public interface PersistentConnector {
 	 * @throws IOException if an io-error occurred
 	 * @throws IllegalStateException if connector is running
 	 */
-	@WipAPI
 	int saveConnections(OutputStream out, long maxQuietPeriodInSeconds) throws IOException;
 
 	/**
@@ -73,7 +67,6 @@ public interface PersistentConnector {
 	 *             to load other connection-stores may work, that may be not
 	 *             affected by this error.
 	 */
-	@WipAPI
 	int loadConnections(InputStream in, long delta) throws IOException;
 
 }

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/SerializationUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/SerializationUtil.java
@@ -458,12 +458,9 @@ public class SerializationUtil {
 	/**
 	 * Skip items until "no item" is read.
 	 * 
-	 * Note: this "Work In Progress"; the format may change!
-	 * 
 	 * @param in stream to skip items.
 	 * @param numBits number of bits of the item length.
 	 */
-	@WipAPI
 	public static void skipItems(InputStream in, int numBits) {
 		DataStreamReader reader = new DataStreamReader(in);
 		while ((reader.readNextByte() & 0xff) != NO_VERSION) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -179,7 +179,6 @@ import org.eclipse.californium.elements.util.NetworkInterfacesUtil;
 import org.eclipse.californium.elements.util.NoPublicAPI;
 import org.eclipse.californium.elements.util.SerialExecutor;
 import org.eclipse.californium.elements.util.StringUtil;
-import org.eclipse.californium.elements.util.WipAPI;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.config.DtlsConfig.DtlsRole;
 import org.eclipse.californium.scandium.dtls.AlertMessage;
@@ -1219,7 +1218,6 @@ public class DTLSConnector implements Connector, PersistentConnector, RecordLaye
 		messageHandler = null;
 	}
 
-	@WipAPI
 	@Override
 	public int saveConnections(OutputStream out, long maxQuietPeriodInSeconds) throws IOException {
 		if (isRunning()) {
@@ -1228,13 +1226,11 @@ public class DTLSConnector implements Connector, PersistentConnector, RecordLaye
 		return connectionStore.saveConnections(out, maxQuietPeriodInSeconds);
 	}
 
-	@WipAPI
 	@Override
 	public int loadConnections(InputStream in, long delta) throws IOException {
 		return connectionStore.loadConnections(in, delta);
 	}
 
-	@WipAPI
 	public boolean restoreConnection(Connection connection) {
 		return connectionStore.restore(connection);
 	}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Connection.java
@@ -57,7 +57,6 @@ import org.eclipse.californium.elements.util.SerialExecutor;
 import org.eclipse.californium.elements.util.SerialExecutor.ExecutionListener;
 import org.eclipse.californium.elements.util.SerializationUtil;
 import org.eclipse.californium.elements.util.StringUtil;
-import org.eclipse.californium.elements.util.WipAPI;
 import org.eclipse.californium.scandium.ConnectionListener;
 import org.eclipse.californium.scandium.util.SecretUtil;
 import org.slf4j.Logger;
@@ -942,14 +941,12 @@ public final class Connection {
 	 * Write connection state.
 	 * 
 	 * Note: the stream will contain not encrypted critical credentials. It is
-	 * required to protect this data before exporting it. The encoding of the
-	 * content may also change in the future.
+	 * required to protect this data before exporting it.
 	 * 
 	 * @param writer writer for connection state
 	 * @return {@code true}, if connection is written, {@code false}, if not.
 	 * @since 3.0
 	 */
-	@WipAPI
 	public boolean writeTo(DatagramWriter writer) {
 		if (establishedDtlsContext == null || establishedDtlsContext.isMarkedAsClosed() || rootCause != null) {
 			return false;
@@ -975,16 +972,12 @@ public final class Connection {
 	/**
 	 * Read connection state.
 	 * 
-	 * Note: the stream will contain not encrypted critical credentials. The
-	 * encoding of the content may also change in the future.
-	 * 
 	 * @param reader reader with connection state.
 	 * @param nanoShift adjusting shift for system time in nanoseconds.
 	 * @return read connection.
 	 * @throws IllegalArgumentException if version differs or data is erroneous.
 	 * @since 3.0
 	 */
-	@WipAPI
 	public static Connection fromReader(DataStreamReader reader, long nanoShift) {
 		int length = SerializationUtil.readStartItem(reader, VERSION, Short.SIZE);
 		if (0 < length) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
@@ -30,7 +30,6 @@ import javax.security.auth.Destroyable;
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.elements.util.StringUtil;
-import org.eclipse.californium.elements.util.WipAPI;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.util.SecretIvParameterSpec;
 
@@ -118,16 +117,12 @@ public abstract class DTLSConnectionState implements Destroyable {
 	/**
 	 * Read cipher suite specific connection state from reader.
 	 * 
-	 * Note: the stream will contain not encrypted critical credentials. The
-	 * encoding of the content may also change in the future.
-	 * 
 	 * @param cipherSuite cipher suite
 	 * @param compressionMethod compression method
 	 * @param reader reader with data
 	 * @return connection state
 	 * @since 3.0
 	 */
-	@WipAPI
 	public static DTLSConnectionState fromReader(CipherSuite cipherSuite, CompressionMethod compressionMethod, DatagramReader reader) {
 		switch (cipherSuite.getCipherType()) {
 		case BLOCK:
@@ -209,13 +204,11 @@ public abstract class DTLSConnectionState implements Destroyable {
 	 * Write cipher suite specific connection state to writer.
 	 * 
 	 * Note: the stream will contain not encrypted critical credentials. It is
-	 * required to protect this data before exporting it. The encoding of the
-	 * content may also change in the future.
+	 * required to protect this data before exporting it.
 	 * 
 	 * @param writer writer to write state to.
 	 * @since 3.0
 	 */
-	@WipAPI
 	public abstract void writeTo(DatagramWriter writer);
 
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSContext.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSContext.java
@@ -31,7 +31,6 @@ import org.eclipse.californium.elements.util.SerializationUtil;
 import org.eclipse.californium.elements.util.SerializationUtil.SupportedVersions;
 import org.eclipse.californium.elements.util.SerializationUtil.SupportedVersionsMatcher;
 import org.eclipse.californium.elements.util.StringUtil;
-import org.eclipse.californium.elements.util.WipAPI;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.util.SecretIvParameterSpec;
 import org.eclipse.californium.scandium.util.SecretUtil;
@@ -815,14 +814,12 @@ public final class DTLSContext implements Destroyable {
 	 * Only writes state, if not already marked as closed.
 	 * 
 	 * Note: the stream will contain not encrypted critical credentials. It is
-	 * required to protect this data before exporting it. The encoding of the
-	 * content may also change in the future.
+	 * required to protect this data before exporting it.
 	 * 
 	 * @param writer writer for DTLS context state
 	 * @return {@code true}, if connection was written, {@code false},
 	 *         otherwise, if the dtls context is marked as closed.
 	 */
-	@WipAPI
 	public boolean writeTo(DatagramWriter writer) {
 		if (markedAsclosed) {
 			return false;
@@ -848,15 +845,11 @@ public final class DTLSContext implements Destroyable {
 	/**
 	 * Read DTLS context state.
 	 * 
-	 * Note: the stream will contain not encrypted critical credentials. The
-	 * encoding of the content may also change in the future.
-	 * 
 	 * @param reader reader with DTLS context state.
 	 * @return read DTLS context.
 	 * @throws IllegalArgumentException if version differs or the data is
 	 *             erroneous
 	 */
-	@WipAPI
 	public static DTLSContext fromReader(DatagramReader reader) {
 		SupportedVersionsMatcher matcher = VERSIONS.matcher();
 		int length = SerializationUtil.readStartItem(reader, matcher, Short.SIZE);
@@ -916,7 +909,6 @@ public final class DTLSContext implements Destroyable {
 	 * 
 	 * @param writer writer for DTLS context state
 	 */
-	@WipAPI
 	public void writeSequenceNumbers(DatagramWriter writer) {
 		int position = SerializationUtil.writeStartItem(writer, SEQN_VERSION, Byte.SIZE);
 		writer.writeLong(sequenceNumbers[writeEpoch], 48);
@@ -932,7 +924,6 @@ public final class DTLSContext implements Destroyable {
 	 * @param reader reader with sequence-number state for DTLS context state
 	 * @throws IllegalArgumentException if the data is erroneous
 	 */
-	@WipAPI
 	public void readSequenceNumbers(DatagramReader reader) {
 		int length = SerializationUtil.readStartItem(reader, SEQN_VERSION, Byte.SIZE);
 		if (0 < length) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -60,7 +60,6 @@ import org.eclipse.californium.elements.util.Bytes;
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
 import org.eclipse.californium.elements.util.SerializationUtil;
-import org.eclipse.californium.elements.util.WipAPI;
 import org.eclipse.californium.scandium.auth.PrincipalSerializer;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite.KeyExchangeAlgorithm;
@@ -808,13 +807,11 @@ public final class DTLSSession implements Destroyable {
 	 * Write dtls session state.
 	 * 
 	 * Note: the stream will contain not encrypted critical credentials. It is
-	 * required to protect this data before exporting it. The encoding of the
-	 * content may also change in the future.
+	 * required to protect this data before exporting it.
 	 * 
 	 * @param writer writer for dtls session state
 	 * @since 3.0
 	 */
-	@WipAPI
 	public void writeTo(DatagramWriter writer) {
 		int position = SerializationUtil.writeStartItem(writer, VERSION, Short.SIZE);
 		writer.writeLong(creationTime, Long.SIZE);
@@ -862,16 +859,12 @@ public final class DTLSSession implements Destroyable {
 	/**
 	 * Read dtls session state.
 	 * 
-	 * Note: the stream will contain not encrypted critical credentials. The
-	 * encoding of the content may also change in the future.
-	 * 
 	 * @param reader reader with dtls session state.
 	 * @return read dtls session.
 	 * @throws IllegalArgumentException if version differs or the data is
 	 *             erroneous
 	 * @since 3.0
 	 */
-	@WipAPI
 	public static DTLSSession fromReader(DatagramReader reader) {
 		int length = SerializationUtil.readStartItem(reader, VERSION, Short.SIZE);
 		if (0 < length) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/InMemoryConnectionStore.java
@@ -52,7 +52,6 @@ import org.eclipse.californium.elements.util.LeastRecentlyUsedCache.Timestamped;
 import org.eclipse.californium.elements.util.SerialExecutor;
 import org.eclipse.californium.elements.util.SerializationUtil;
 import org.eclipse.californium.elements.util.StringUtil;
-import org.eclipse.californium.elements.util.WipAPI;
 import org.eclipse.californium.scandium.ConnectionListener;
 import org.eclipse.californium.scandium.util.SecretUtil;
 import org.slf4j.Logger;
@@ -645,7 +644,6 @@ public class InMemoryConnectionStore implements ResumptionSupportingConnectionSt
 		return connections.valuesIterator();
 	}
 
-	@WipAPI
 	@Override
 	public int saveConnections(OutputStream out, long maxQuietPeriodInSeconds) throws IOException {
 		int size = connections.size();
@@ -692,7 +690,6 @@ public class InMemoryConnectionStore implements ResumptionSupportingConnectionSt
 		return count;
 	}
 
-	@WipAPI
 	@Override
 	public int loadConnections(InputStream in, long delta) throws IOException {
 		boolean clear = true;
@@ -725,7 +722,6 @@ public class InMemoryConnectionStore implements ResumptionSupportingConnectionSt
 		return count;
 	}
 
-	@WipAPI
 	@Override
 	public boolean restore(Connection connection) {
 


### PR DESCRIPTION
Adapt javadoc accordingly.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>