### PR TITLE
Use EndpointIdentityResolver also for blockwise.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/config/CoapConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/config/CoapConfig.java
@@ -21,11 +21,14 @@ import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.network.GroupedMessageIdTracker;
+import org.eclipse.californium.core.network.KeyMID;
+import org.eclipse.californium.core.network.KeyToken;
 import org.eclipse.californium.core.network.TokenGenerator;
 import org.eclipse.californium.core.network.deduplication.CropRotation;
 import org.eclipse.californium.core.network.deduplication.NoDeduplicator;
 import org.eclipse.californium.core.network.deduplication.SweepDeduplicator;
 import org.eclipse.californium.core.network.deduplication.SweepPerPeerDeduplicator;
+import org.eclipse.californium.core.network.stack.KeyUri;
 import org.eclipse.californium.core.observe.ObserveRelation;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.Configuration.BooleanDefinition;
@@ -66,8 +69,9 @@ public final class CoapConfig {
 		 */
 		PRINCIPAL,
 		/**
-		 * Principal based matching using the principal also as identity.
-		 * Requires unique principals.
+		 * Principal based matching using the principal also as identity for
+		 * {@link KeyMID}, {@link KeyToken} and {@link KeyUri}. Requires unique
+		 * principals and incoming initiated traffic.
 		 */
 		PRINCIPAL_IDENTITY,
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -52,6 +52,7 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
 import java.util.List;
@@ -178,6 +179,14 @@ public class Exchange {
 	 * Mark exchange as notification.
 	 */
 	private final boolean notification;
+	/**
+	 * The other peer's identity.
+	 * 
+	 * Usually that's the peer's {@link InetSocketAddress}.
+	 * 
+	 * @since 3.0
+	 */
+	private final Object peersIdentity;
 	// indicates where the request of this exchange has been initiated.
 	// (as suggested by effective Java, item 40.)
 	private final Origin origin;
@@ -309,12 +318,16 @@ public class Exchange {
 	 * Creates a new exchange with the specified request and origin.
 	 * 
 	 * @param request the request that starts the exchange
+	 * @param peersIdentity peer's identity. Usually that's the peer's
+	 *            {@link InetSocketAddress}.
 	 * @param origin the origin of the request (LOCAL or REMOTE)
-	 * @param executor executor to be used for exchanges. Maybe {@code null} for unit tests.
+	 * @param executor executor to be used for exchanges. Maybe {@code null} for
+	 *            unit tests.
 	 * @throws NullPointerException if request is {@code null}
+	 * @since 3.0 (added peersIdentity)
 	 */
-	public Exchange(Request request, Origin origin, Executor executor) {
-		this(request, origin, executor, null, false);
+	public Exchange(Request request, Object peersIdentity, Origin origin, Executor executor) {
+		this(request, peersIdentity, origin, executor, null, false);
 	}
 
 	/**
@@ -322,14 +335,17 @@ public class Exchange {
 	 * notification marker.
 	 * 
 	 * @param request the request that starts the exchange
+	 * @param peersIdentity peer's identity. Usually that's the peer's
+	 *            {@link InetSocketAddress}.
 	 * @param origin the origin of the request (LOCAL or REMOTE)
 	 * @param executor executor to be used for exchanges. Maybe {@code null} for unit tests.
 	 * @param ctx the endpoint context of this exchange
 	 * @param notification {@code true} for notification exchange, {@code false}
 	 *            otherwise
 	 * @throws NullPointerException if request is {@code null}
+	 * @since 3.0 (added peersIdentity)
 	 */
-	public Exchange(Request request, Origin origin, Executor executor, EndpointContext ctx, boolean notification) {
+	public Exchange(Request request, Object peersIdentity, Origin origin, Executor executor, EndpointContext ctx, boolean notification) {
 		// might only be the first block of the whole request
 		if (request == null) {
 			throw new NullPointerException("request must not be null!");
@@ -339,6 +355,7 @@ public class Exchange {
 		this.currentRequest = request;
 		this.request = request;
 		this.origin = origin;
+		this.peersIdentity = peersIdentity;
 		this.endpointContext.set(ctx);
 		this.keepRequestInStore = !notification && request.isObserve() && origin == Origin.LOCAL;
 		this.notification = notification;
@@ -702,6 +719,16 @@ public class Exchange {
 	 */
 	public void setEndpoint(Endpoint endpoint) {
 		this.endpoint = endpoint;
+	}
+
+	/**
+	 * Returns the other peer's identity.
+	 * 
+	 * @return the other peer's identity
+	 * @since 3.0
+	 */
+	public Object getPeersIdentity() {
+		return peersIdentity;
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/KeyMID.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/KeyMID.java
@@ -42,7 +42,7 @@ public final class KeyMID {
 	 * @throws IllegalArgumentException if mid is &lt; 0 or &gt; 65535.
 	 * 
 	 */
-	public KeyMID(int mid,  Object peer) {
+	public KeyMID(int mid, Object peer) {
 		if (mid < 0 || mid > Message.MAX_MID) {
 			throw new IllegalArgumentException("MID must be a 16 bit unsigned int: " + mid);
 		} else if (peer == null) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -88,16 +88,16 @@ public final class TcpMatcher extends BaseMatcher {
 	 *            observations created by the endpoint this matcher is part of.
 	 * @param exchangeStore The store to use for keeping track of message
 	 *            exchanges.
-	 * @param executor executor to be used for exchanges.
 	 * @param endpointContextMatcher endpoint context matcher to relate
 	 *            responses with requests
-	 * @throws NullPointerException if one of the parameters is {@code null}.
-	 * @since 3.0 (changed parameter to Configuration)
+	 * @param executor executor to be used for exchanges.
+	 * @throws NullPointerException if any of the parameters is {@code null} (except the executor).
+	 * @since 3.0 (changed parameter to Configuration, moved executor to end of parameter list)
 	 */
 	public TcpMatcher(Configuration config, NotificationListener notificationListener, TokenGenerator tokenGenerator,
-			ObservationStore observationStore, MessageExchangeStore exchangeStore, Executor executor,
-			EndpointContextMatcher endpointContextMatcher) {
-		super(config, notificationListener, tokenGenerator, observationStore, exchangeStore, executor);
+			ObservationStore observationStore, MessageExchangeStore exchangeStore, EndpointContextMatcher endpointContextMatcher,
+			Executor executor) {
+		super(config, notificationListener, tokenGenerator, observationStore, exchangeStore, endpointContextMatcher, executor);
 		this.endpointContextMatcher = endpointContextMatcher;
 	}
 
@@ -147,7 +147,8 @@ public final class TcpMatcher extends BaseMatcher {
 	@Override
 	public void receiveRequest(final Request request, final EndpointReceiver receiver) {
 
-		final Exchange exchange = new Exchange(request, Exchange.Origin.REMOTE, executor);
+		Object peer = endpointContextMatcher.getEndpointIdentity(request.getSourceContext());
+		final Exchange exchange = new Exchange(request, peer, Exchange.Origin.REMOTE, executor);
 		exchange.setRemoveHandler(exchangeRemoveHandler);
 		exchange.execute(new Runnable() {
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -407,7 +407,7 @@ public class BlockwiseLayer extends AbstractLayer {
 				// by means of
 				// a transparent blockwise transfer.
 			} else {
-				KeyUri key = KeyUri.getKey(exchange, request);
+				KeyUri key = KeyUri.getKey(exchange);
 				Block2BlockwiseStatus status = getBlock2Status(key);
 				if (status != null) {
 					// Receiving a blockwise response in transparent mode
@@ -471,7 +471,7 @@ public class BlockwiseLayer extends AbstractLayer {
 			BlockOption block2 = request.getOptions().getBlock2();
 			if (block2 != null && block2.getNum() > 0) {
 				// follow up block, respond from status?
-				KeyUri key = KeyUri.getKey(exchange, request);
+				KeyUri key = KeyUri.getKey(exchange);
 				Block2BlockwiseStatus status = getBlock2Status(key);
 				if (status != null) {
 					// The peer wants to retrieve the next block
@@ -503,7 +503,7 @@ public class BlockwiseLayer extends AbstractLayer {
 
 			BlockOption block1 = request.getOptions().getBlock1();
 			LOGGER.debug("{}inbound request contains block1 option {}", tag, block1);
-			KeyUri key = KeyUri.getKey(exchange, request);
+			KeyUri key = KeyUri.getKey(exchange);
 			Block1BlockwiseStatus status = getInboundBlock1Status(key, exchange, request, false);
 			int blockOffset = block1.getOffset();
 
@@ -658,7 +658,7 @@ public class BlockwiseLayer extends AbstractLayer {
 				// has included a block2 option with num = 0 (early negotiation
 				// of block size)
 
-				KeyUri key = KeyUri.getKey(exchange, response);
+				KeyUri key = KeyUri.getKey(exchange);
 				// We can not handle several block2 transfer for the same
 				// client/resource.
 				// So we clean previous transfer (priority to the new one)
@@ -726,7 +726,7 @@ public class BlockwiseLayer extends AbstractLayer {
 					}
 
 					// server is not able to process the payload we included
-					KeyUri key = KeyUri.getKey(exchange, exchange.getCurrentRequest());
+					KeyUri key = KeyUri.getKey(exchange);
 					Block1BlockwiseStatus status = getBlock1Status(key);
 					if (status != null) {
 						clearBlock1Status(status);
@@ -768,7 +768,7 @@ public class BlockwiseLayer extends AbstractLayer {
 			}
 
 			if (!isRandomAccess(exchange)) {
-				KeyUri key = KeyUri.getKey(exchange, response);
+				KeyUri key = KeyUri.getKey(exchange);
 				Block2BlockwiseStatus status = getBlock2Status(key);
 				if (discardBlock2(key, status, exchange, response)) {
 					return;
@@ -807,7 +807,7 @@ public class BlockwiseLayer extends AbstractLayer {
 	 */
 	private boolean handleEntityTooLarge(Exchange exchange, Response response) {
 		if (enableAutoFailoverOn413) {
-			final KeyUri key = KeyUri.getKey(exchange, exchange.getRequest());
+			final KeyUri key = KeyUri.getKey(exchange);
 			try {
 				Request initialRequest = exchange.getRequest();
 				if (response.getOptions().hasBlock1()) {
@@ -907,7 +907,7 @@ public class BlockwiseLayer extends AbstractLayer {
 		LOGGER.debug("{}received response acknowledging block1 {}", tag, block1);
 
 		// Block1 transfer has been originally created for an outbound request
-		final KeyUri key = KeyUri.getKey(exchange, exchange.getRequest());
+		final KeyUri key = KeyUri.getKey(exchange);
 
 		Block1BlockwiseStatus status = getBlock1Status(key);
 
@@ -1070,7 +1070,7 @@ public class BlockwiseLayer extends AbstractLayer {
 	private void handleBlock2Response(final Exchange exchange, final Response response) {
 
 		BlockOption block2 = response.getOptions().getBlock2();
-		KeyUri key = KeyUri.getKey(exchange, response);
+		KeyUri key = KeyUri.getKey(exchange);
 
 		if (exchange.getRequest().isCanceled()) {
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageExchangeStoreTest.java
@@ -126,13 +126,7 @@ public class InMemoryMessageExchangeStoreTest {
 	@Test(expected = NullPointerException.class)
 	public void testShouldNotCreateInMemoryMessageExchangeStoreWithoutTokenProvider() {
 		// WHEN trying to create new InMemoryMessageExchangeStore without TokenProvider
-		store = new InMemoryMessageExchangeStore(config, null, null);
-	}
-
-	@Test(expected = NullPointerException.class)
-	public void testShouldNotCreateInMemoryMessageExchangeStoreWithoutResolver() {
-		// WHEN trying to create new InMemoryMessageExchangeStore without TokenProvider
-		store = new InMemoryMessageExchangeStore(config, new RandomTokenGenerator(config), null);
+		store = new InMemoryMessageExchangeStore(config, null);
 	}
 
 	public void testRegisterOutboundRequestAcceptsRetransmittedRequest() {
@@ -156,7 +150,7 @@ public class InMemoryMessageExchangeStoreTest {
 		Request request = Request.newGet();
 		String uri = TestTools.getUri(InetAddress.getLoopbackAddress(), PEER_PORT, "test");
 		request.setURI(uri);
-		Exchange exchange = new Exchange(request, Origin.LOCAL, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
+		Exchange exchange = new Exchange(request, request.getDestinationContext().getPeerAddress(), Origin.LOCAL, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
 		return exchange;
 	}
 }

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTestUtils.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/MatcherTestUtils.java
@@ -66,7 +66,7 @@ public final class MatcherTestUtils {
 	static TcpMatcher newTcpMatcher(Configuration config, EndpointContextMatcher correlationContextMatcher, ScheduledExecutorService scheduler) {
 		InMemoryMessageExchangeStore exchangeStore = new InMemoryMessageExchangeStore(config);
 		TcpMatcher matcher = new TcpMatcher(config, notificationListener, new RandomTokenGenerator(config),
-				new InMemoryObservationStore(config), exchangeStore, TEST_EXCHANGE_EXECUTOR, correlationContextMatcher);
+				new InMemoryObservationStore(config), exchangeStore, correlationContextMatcher, TEST_EXCHANGE_EXECUTOR);
 		exchangeStore.setExecutor(scheduler);
 		matcher.start();
 		return matcher;
@@ -90,7 +90,7 @@ public final class MatcherTestUtils {
 	static Exchange sendRequest(InetSocketAddress dest, Matcher matcher, EndpointContext exchangeContext) {
 		Request request = Request.newGet();
 		request.setDestinationContext(new AddressEndpointContext(dest));
-		Exchange exchange = new Exchange(request, Origin.LOCAL, TEST_EXCHANGE_EXECUTOR);
+		Exchange exchange = new Exchange(request, dest, Origin.LOCAL, TEST_EXCHANGE_EXECUTOR);
 		matcher.sendRequest(exchange);
 		exchange.setEndpointContext(exchangeContext);
 		return exchange;
@@ -100,7 +100,7 @@ public final class MatcherTestUtils {
 		Request request = Request.newGet();
 		request.setDestinationContext(new AddressEndpointContext(dest));
 		request.setObserve();
-		Exchange exchange = new Exchange(request, Origin.LOCAL, TEST_EXCHANGE_EXECUTOR);
+		Exchange exchange = new Exchange(request, dest, Origin.LOCAL, TEST_EXCHANGE_EXECUTOR);
 		matcher.sendRequest(exchange);
 		exchange.setEndpointContext(exchangeContext);
 		return exchange;
@@ -109,7 +109,7 @@ public final class MatcherTestUtils {
 	static Exchange sendRequest(InetSocketAddress dest, Matcher matcher, Exchange.EndpointContextOperator preoperator, EndpointContext exchangeContext) {
 		Request request = Request.newGet();
 		request.setDestinationContext(new AddressEndpointContext(dest));
-		Exchange exchange = new Exchange(request, Origin.LOCAL, TEST_EXCHANGE_EXECUTOR);
+		Exchange exchange = new Exchange(request, dest, Origin.LOCAL, TEST_EXCHANGE_EXECUTOR);
 		exchange.setEndpointContextPreOperator(preoperator);
 		matcher.sendRequest(exchange);
 		exchange.setEndpointContext(exchangeContext);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherMulticastTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherMulticastTest.java
@@ -93,7 +93,7 @@ public class UdpMatcherMulticastTest {
 		Request request = Request.newGet();
 		request.setType(Type.NON);
 		request.setDestinationContext(new AddressEndpointContext(multicast_dest));
-		Exchange exchange = new Exchange(request, Origin.LOCAL, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
+		Exchange exchange = new Exchange(request, multicast_dest, Origin.LOCAL, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
 		exchange.setRequest(request);
 		matcher.sendRequest(exchange);
 		exchange.setEndpointContext(exchangeEndpointContext);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/UdpMatcherTest.java
@@ -49,7 +49,6 @@ import org.eclipse.californium.core.observe.InMemoryObservationStore;
 import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.EndpointContext;
 import org.eclipse.californium.elements.EndpointContextMatcher;
-import org.eclipse.californium.elements.UdpEndpointContextMatcher;
 import org.eclipse.californium.elements.category.Small;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.rule.CoapNetworkRule;
@@ -90,7 +89,7 @@ public class UdpMatcherTest {
 		scheduler = MatcherTestUtils.newScheduler();
 		cleanup.add(scheduler);
 		tokenProvider = new RandomTokenGenerator(config);
-		messageExchangeStore = new InMemoryMessageExchangeStore(config, tokenProvider, new UdpEndpointContextMatcher());
+		messageExchangeStore = new InMemoryMessageExchangeStore(config, tokenProvider);
 		observationStore =  new InMemoryObservationStore(config);
 		exchangeEndpointContext = mock(EndpointContext.class);
 		responseEndpointContext = mock(EndpointContext.class);
@@ -207,7 +206,7 @@ public class UdpMatcherTest {
 		// GIVEN a request that has not been sent yet
 		Request request = Request.newGet();
 		request.setDestinationContext(new AddressEndpointContext(dest));
-		Exchange exchange = new Exchange(request, Origin.LOCAL, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
+		Exchange exchange = new Exchange(request, dest, Origin.LOCAL, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
 
 		MessageExchangeStore exchangeStore = mock(MessageExchangeStore.class);
 		when(exchangeStore.registerOutboundRequest(exchange)).thenReturn(false);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/deduplication/DeduplicatorTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/deduplication/DeduplicatorTest.java
@@ -75,12 +75,12 @@ public class DeduplicatorTest {
 		incoming.setMID(10);
 		incoming.setSourceContext(new AddressEndpointContext(PEER));
 		key = new KeyMID(incoming.getMID(), PEER);
-		exchange1 = new Exchange(incoming, Exchange.Origin.REMOTE, null);
-		exchange2 = new Exchange(incoming, Exchange.Origin.REMOTE, null);
+		exchange1 = new Exchange(incoming, PEER, Exchange.Origin.REMOTE, null);
+		exchange2 = new Exchange(incoming, PEER, Exchange.Origin.REMOTE, null);
 		incoming = Request.newGet();
 		incoming.setMID(10);
 		incoming.setSourceContext(new AddressEndpointContext(PEER));
-		exchange3 = new Exchange(incoming, Exchange.Origin.REMOTE, null);
+		exchange3 = new Exchange(incoming, PEER, Exchange.Origin.REMOTE, null);
 	}
 
 	@Test

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/deduplication/PeersBasedDeduplicatorTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/deduplication/PeersBasedDeduplicatorTest.java
@@ -157,7 +157,7 @@ public class PeersBasedDeduplicatorTest {
 		Request incoming = Request.newGet();
 		incoming.setMID(mid);
 		incoming.setSourceContext(new AddressEndpointContext(peer));
-		Exchange exchange = new Exchange(incoming, Exchange.Origin.REMOTE, null);
+		Exchange exchange = new Exchange(incoming, peer, Exchange.Origin.REMOTE, null);
 		KeyMID key = new KeyMID(incoming.getMID(), peer);
 		return deduplicator.findPrevious(key, exchange);
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapStackTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapStackTest.java
@@ -84,8 +84,7 @@ public class CoapStackTest {
 	@Test public void cancelledMessageExpectExchangeComplete() {
 		Request request = new Request(CoAP.Code.GET);
 		request.setDestinationContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
-		Exchange exchange = new Exchange(request, Origin.LOCAL, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
-
+		Exchange exchange = new Exchange(request, request.getDestinationContext().getPeerAddress(), Origin.LOCAL, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
 		ArgumentCaptor<Exchange> exchangeCaptor = ArgumentCaptor.forClass(Exchange.class);
 		doNothing().when(outbox).sendRequest(exchangeCaptor.capture(), eq(request));
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapTcpStackTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapTcpStackTest.java
@@ -77,7 +77,8 @@ public class CoapTcpStackTest {
 
 	@Test public void sendRstExpectNotSend() {
 		Request request = new Request(CoAP.Code.GET);
-		Exchange exchange = new Exchange(request, Origin.REMOTE, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
+		request.setSourceContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
+		Exchange exchange = new Exchange(request, request.getSourceContext().getPeerAddress(), Origin.REMOTE, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
 		EmptyMessage message = new EmptyMessage(CoAP.Type.RST);
 		stack.sendEmptyMessage(exchange, message);
 
@@ -87,7 +88,7 @@ public class CoapTcpStackTest {
 	@Test public void sendRequestExpectSent() {
 		Request message = new Request(CoAP.Code.GET);
 		message.setDestinationContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
-		Exchange exchange = new Exchange(message, Origin.LOCAL, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
+		Exchange exchange = new Exchange(message, message.getDestinationContext().getPeerAddress(), Origin.LOCAL, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
 		stack.sendRequest(exchange, message);
 
 		verify(outbox).sendRequest(any(Exchange.class), eq(message));
@@ -96,7 +97,8 @@ public class CoapTcpStackTest {
 
 	@Test public void sendResponseExpectSent() {
 		Request request = new Request(CoAP.Code.GET);
-		Exchange exchange = new Exchange(request, Exchange.Origin.REMOTE, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
+		request.setSourceContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
+		Exchange exchange = new Exchange(request, request.getSourceContext().getPeerAddress(), Exchange.Origin.REMOTE, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
 		exchange.setRequest(request);
 
 		Response response = new Response(CoAP.ResponseCode.CONTENT);

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapUdpStackTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/CoapUdpStackTest.java
@@ -74,18 +74,19 @@ public class CoapUdpStackTest {
 	}
 
 	@Test public void sendRequestExpectSent() {
-		Request message = new Request(CoAP.Code.GET);
-		message.setDestinationContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
-		Exchange exchange = new Exchange(message, Origin.LOCAL, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
-		stack.sendRequest(exchange, message);
+		Request request = new Request(CoAP.Code.GET);
+		request.setDestinationContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
+		Exchange exchange = new Exchange(request, request.getDestinationContext().getPeerAddress(), Origin.LOCAL, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
+		stack.sendRequest(exchange, request);
 
-		verify(outbox).sendRequest(any(Exchange.class), eq(message));
+		verify(outbox).sendRequest(any(Exchange.class), eq(request));
 	}
 
 
 	@Test public void sendResponseExpectSent() {
 		Request request = new Request(CoAP.Code.GET);
-		Exchange exchange = new Exchange(request, Exchange.Origin.REMOTE, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
+		request.setSourceContext(new AddressEndpointContext(InetAddress.getLoopbackAddress(), CoAP.DEFAULT_COAP_PORT));
+		Exchange exchange = new Exchange(request, request.getSourceContext().getPeerAddress(), Origin.REMOTE, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
 		exchange.setRequest(request);
 
 		Response response = new Response(CoAP.ResponseCode.CONTENT);

--- a/californium-core/src/test/java/org/eclipse/californium/core/server/ServerMessageDelivererTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/server/ServerMessageDelivererTest.java
@@ -25,6 +25,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
 import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.Option;
@@ -61,13 +64,14 @@ public class ServerMessageDelivererTest {
 	 */
 	@Before
 	public void setUp() {
+		InetSocketAddress dest = new InetSocketAddress(InetAddress.getLoopbackAddress(), 5683);
 		rootResource = mock(Resource.class);
 		when(rootResource.getChild(anyString())).thenReturn(rootResource);
 		when(rootResource.getExecutor()).thenReturn(null);
-		incomingRequest = new Exchange(new Request(Code.POST), Exchange.Origin.REMOTE, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
+		incomingRequest = new Exchange(new Request(Code.POST), dest, Exchange.Origin.REMOTE, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
 		incomingRequest.setRequest(incomingRequest.getCurrentRequest());
 		incomingResponse = new Response(ResponseCode.CONTENT);
-		outboundRequest = new Exchange(new Request(Code.GET), Origin.LOCAL, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
+		outboundRequest = new Exchange(new Request(Code.GET), dest, Origin.LOCAL, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
 		outboundRequest.setRequest(outboundRequest.getCurrentRequest());
 	}
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceAttributesTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ResourceAttributesTest.java
@@ -115,12 +115,11 @@ public class ResourceAttributesTest {
 		Request request = Request.newGet();
 		request.setURI("coap://localhost/.well-known/core?rt=light-lux&rt=temprature-cel");
 	
-		Exchange exchange = new Exchange(request, Origin.REMOTE, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
-		exchange.setRequest(request);
+		Exchange exchange = new Exchange(request, request.getDestinationContext().getPeerAddress(), Origin.REMOTE, MatcherTestUtils.TEST_EXCHANGE_EXECUTOR);
 		exchange.setEndpoint(new DummyEndpoint());
-		
+
 		DiscoveryResource discovery = new DiscoveryResource(root);
-		
+
 		discovery.handleRequest(exchange);
 		System.out.println(exchange.getResponse().getPayloadString());
 		Assert.assertEquals(ResponseCode.BAD_OPTION, exchange.getResponse().getCode());

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/http/server/HttpStack.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/http/server/HttpStack.java
@@ -248,7 +248,7 @@ public class HttpStack {
 				// keep the receiving interface.
 				coapRequest.setLocalAddress(endpoint);
 				// handle the request
-				Exchange exchange = new Exchange(coapRequest, Origin.REMOTE, null) {
+				Exchange exchange = new Exchange(coapRequest, source, Origin.REMOTE, null) {
 
 					@Override
 					public void sendAccept() {

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
@@ -197,7 +197,7 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 					});
 					// send start rederivation request
 					LOGGER.info("Auxiliary Request: " + exchange.getRequest().toString());
-					final Exchange newExchange = new Exchange(startRederivation, Origin.LOCAL, executor);
+					final Exchange newExchange = new Exchange(startRederivation, exchange.getPeersIdentity(), Origin.LOCAL, executor);
 					newExchange.execute(new Runnable() {
 
 						@Override


### PR DESCRIPTION
Resolve identity once and keep it in Exchange.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>