### PR TITLE
Replace the simple trust manager by hostname verifier.

### DIFF
--- a/cf-utils/cf-cluster/src/main/java/org/eclipse/californium/cluster/CredentialsUtil.java
+++ b/cf-utils/cf-cluster/src/main/java/org/eclipse/californium/cluster/CredentialsUtil.java
@@ -44,20 +44,13 @@ public class CredentialsUtil {
 	/**
 	 * Create ssl context for https.
 	 * 
-	 * Supports "simple trust manager", validate certificate chains, but does
-	 * not validate the destination using the subject. Use with care! This
-	 * usually requires, that no public trust root is used!
-	 * 
 	 * @param identity credentials to identify this peer
 	 * @param trust certificates to trust by this peer.
-	 * @param simple {@code true}, to use a "simple trust manager",
-	 *            {@code false}, for regular trust manager.
 	 * @return ssl context.
 	 * @throws GeneralSecurityException if an crypto error occurred.
 	 * @throws IOException if an i/o error occurred
 	 */
-	public static SSLContext getSslContext(String identity, String trust, boolean simple)
-			throws GeneralSecurityException, IOException {
+	public static SSLContext getSslContext(String identity, String trust) throws GeneralSecurityException, IOException {
 		KeyManager[] keyManager;
 		TrustManager[] trustManager;
 		if (identity != null && !identity.isEmpty()) {
@@ -69,11 +62,7 @@ public class CredentialsUtil {
 		}
 		if (trust != null && !trust.isEmpty()) {
 			Certificate[] trustedCertificates = SslContextUtil.loadTrustedCertificates(trust);
-			if (simple) {
-				trustManager = SslContextUtil.createSimpleTrustManager(trustedCertificates);
-			} else {
-				trustManager = SslContextUtil.createTrustManager("https", trustedCertificates);
-			}
+			trustManager = SslContextUtil.createTrustManager("https", trustedCertificates);
 		} else {
 			trustManager = SslContextUtil.createTrustAllManager();
 		}
@@ -103,7 +92,7 @@ public class CredentialsUtil {
 				trusts = "file://" + defaultTrust.getAbsolutePath();
 			}
 			LOGGER.info("https-k8s-client load's trusts from {}.", trusts);
-			return CredentialsUtil.getSslContext(null, trusts, false);
+			return CredentialsUtil.getSslContext(null, trusts);
 		} catch (GeneralSecurityException e) {
 			LOGGER.warn("https-k8s-client:", e);
 		} catch (IOException e) {
@@ -115,16 +104,15 @@ public class CredentialsUtil {
 	/**
 	 * Create ssl context for cluster internal https clients.
 	 * 
-	 * Validate certificate chains, but does not validate the destination using
-	 * the subject. Use with care! This usually requires, that no public trust
-	 * root is used!
+	 * {@link RestoreHttpClient} disables hostname verification. Use with care!
+	 * This usually requires, that no public trust root is used!
 	 * 
 	 * @return ssl context for cluster internal https clients.
 	 */
 	public static SSLContext getClusterInternalHttpsClientContext() {
 		try {
 			return CredentialsUtil.getSslContext("file:///etc/certs/https_client_cert.pem",
-					"file:///etc/certs/https_client_trust.pem", true);
+					"file:///etc/certs/https_client_trust.pem");
 		} catch (GeneralSecurityException e) {
 			LOGGER.warn("https-client:", e);
 		} catch (IOException e) {
@@ -136,15 +124,15 @@ public class CredentialsUtil {
 	/**
 	 * Create ssl context for cluster internal https server.
 	 * 
-	 * Though the client uses a "simple trust manager", ensure, that no public
-	 * trust root is used!
+	 * Though the {@link RestoreHttpClient} disables hostname verification, use
+	 * with care! This usually requires, that no public trust root is used!
 	 * 
 	 * @return ssl context for cluster internal https server.
 	 */
 	public static SSLContext getClusterInternalHttpsServerContext() {
 		try {
 			return CredentialsUtil.getSslContext("file:///etc/certs/https_server_cert.pem",
-					"file:///etc/certs/https_server_trust.pem", false);
+					"file:///etc/certs/https_server_trust.pem");
 		} catch (GeneralSecurityException e) {
 			LOGGER.warn("https-server:", e);
 		} catch (IOException e) {

--- a/cf-utils/cf-cluster/src/main/java/org/eclipse/californium/cluster/K8sManagementDiscoverJdkClient.java
+++ b/cf-utils/cf-cluster/src/main/java/org/eclipse/californium/cluster/K8sManagementDiscoverJdkClient.java
@@ -43,6 +43,6 @@ public class K8sManagementDiscoverJdkClient extends K8sManagementDiscoverClient 
 	public HttpResult executeHttpRequest(String url, String token, SSLContext sslContext)
 			throws IOException, GeneralSecurityException {
 
-		return new JdkHttpClient().get(url, token, sslContext);
+		return new JdkHttpClient().get(url, token, true, sslContext);
 	}
 }

--- a/cf-utils/cf-cluster/src/main/java/org/eclipse/californium/cluster/RestoreHttpClient.java
+++ b/cf-utils/cf-cluster/src/main/java/org/eclipse/californium/cluster/RestoreHttpClient.java
@@ -124,7 +124,11 @@ public class RestoreHttpClient implements Readiness {
 	}
 
 	/**
-	 * Download the state to restore from the pod of the other statefulset,
+	 * Download the state to restore from the pod of the other statefulset.
+	 * 
+	 * <b>Note:</b> though the hostname verification of the x509 certificate is
+	 * not used, be careful and just use private trust-anchors in the related
+	 * trust-store.
 	 * 
 	 * @param restore pod to download the state
 	 * @param port port number of the download service on that pod
@@ -137,7 +141,7 @@ public class RestoreHttpClient implements Readiness {
 		for (int retries = 0; retries < 3; ++retries) {
 			try {
 				JdkHttpClient client = new JdkHttpClient();
-				HttpResult result = client.get(scheme + "://" + restore.address + ":" + port + "/restore", null,
+				HttpResult result = client.get(scheme + "://" + restore.address + ":" + port + "/restore", null, false,
 						sslContext);
 				LOGGER.info("download: {} from {}/{}: {} - {}", scheme, restore.name, restore.address,
 						result.getResponseCode(), result.getResponseMessage());
@@ -170,6 +174,10 @@ public class RestoreHttpClient implements Readiness {
 	 * is only executed, if the double has that label. Though the new pods are
 	 * not labeled with that, a restarting double (failover) will not execute a
 	 * reverse restore.
+	 * 
+	 * <b>Note:</b> though the hostname verification of the x509 certificate is
+	 * not used, be careful and just use private trust-anchors in the related
+	 * trust-store.
 	 * 
 	 * @param k8sClient k8s client to call the k8s management API (get pod).
 	 * @param port port number of https service to restore the servers.


### PR DESCRIPTION
Remove the simple trust manager from ssl context util.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>