### PR TITLE
Fix typo in Credentials.getPublicKey.

### DIFF
--- a/cf-utils/cf-cli/src/main/java/org/eclipse/californium/cli/ClientInitializer.java
+++ b/cf-utils/cf-cli/src/main/java/org/eclipse/californium/cli/ClientInitializer.java
@@ -364,7 +364,7 @@ public class ClientInitializer {
 							identity.getCertificateChain(), certificateTypes));
 				} else if (certificateTypes.contains(CertificateType.RAW_PUBLIC_KEY)) {
 					dtlsConfig.setCertificateIdentityProvider(
-							new SingleCertificateProvider(identity.getPrivateKey(), identity.getPubicKey()));
+							new SingleCertificateProvider(identity.getPrivateKey(), identity.getPublicKey()));
 				}
 			}
 

--- a/cf-utils/cf-cli/src/main/java/org/eclipse/californium/cli/ConnectorConfig.java
+++ b/cf-utils/cf-cli/src/main/java/org/eclipse/californium/cli/ConnectorConfig.java
@@ -172,7 +172,7 @@ public class ConnectorConfig implements Cloneable {
 				} else if (identity.certificate.getPrivateKey() == null) {
 					LOGGER.info("x509 identity from certificate and private key.");
 					credentials = new Credentials(identity.privateKey.getPrivateKey(),
-							identity.certificate.getPubicKey(), identity.certificate.getCertificateChain());
+							identity.certificate.getPublicKey(), identity.certificate.getCertificateChain());
 				} else {
 					LOGGER.info("x509 identity from certificate.");
 					credentials = identity.certificate;
@@ -180,7 +180,7 @@ public class ConnectorConfig implements Cloneable {
 				if (credentials.getPrivateKey() == null) {
 					throw new IllegalArgumentException("Missing private key!");
 				}
-				if (credentials.getPubicKey() == null) {
+				if (credentials.getPublicKey() == null) {
 					throw new IllegalArgumentException("Missing public key or certificate!");
 				}
 			}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/SslContextUtil.java
@@ -1320,7 +1320,7 @@ public class SslContextUtil {
 		 * 
 		 * @return public key
 		 */
-		public PublicKey getPubicKey() {
+		public PublicKey getPublicKey() {
 			return publicKey;
 		}
 

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/SslContextUtilCredentialsTest.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/SslContextUtilCredentialsTest.java
@@ -291,8 +291,8 @@ public class SslContextUtilCredentialsTest {
 		Credentials credentials = SslContextUtil.loadCredentials(SslContextUtil.CLASSPATH_SCHEME + "certs/ec_private.pem", null, null, null);
 		assertThat(credentials, is(notNullValue()));
 		assertThat(credentials.getPrivateKey(), is(notNullValue()));
-		assertThat(credentials.getPubicKey(), is(notNullValue()));
-		assertSigning("PEMv2", credentials.getPrivateKey(), credentials.getPubicKey(), "SHA256withECDSA");
+		assertThat(credentials.getPublicKey(), is(notNullValue()));
+		assertSigning("PEMv2", credentials.getPrivateKey(), credentials.getPublicKey(), "SHA256withECDSA");
 	}
 
 	@Test
@@ -306,7 +306,7 @@ public class SslContextUtilCredentialsTest {
 		assertThat(credentials.getCertificateChain(), is(notNullValue()));
 		assertThat(credentials.getCertificateChain().length, is(greaterThan(0)));
 		assertThat(credentials.getCertificateChain()[0].getPublicKey(), is(notNullValue()));
-		assertSigning("JKS", credentials.getPrivateKey(), credentials.getPubicKey(), "ED25519");
+		assertSigning("JKS", credentials.getPrivateKey(), credentials.getPublicKey(), "ED25519");
 	}
 
 	@Test

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/TestCertificatesTools.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/TestCertificatesTools.java
@@ -295,7 +295,7 @@ public class TestCertificatesTools {
 	 * @since 2.4
 	 */
 	public static KeyPair getServerKeyPair() {
-		return new KeyPair(serverCredentials.getPubicKey(), serverCredentials.getPrivateKey());
+		return new KeyPair(serverCredentials.getPublicKey(), serverCredentials.getPrivateKey());
 	}
 
 	/**

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/SignatureAndHashAlgorithmTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/SignatureAndHashAlgorithmTest.java
@@ -194,7 +194,7 @@ public class SignatureAndHashAlgorithmTest {
 		Credentials credentials = DtlsTestTools.getCredentials("clienteddsa");
 		assumeNotNull("clienteddsa credentials missing!", credentials);
 		List<SignatureAndHashAlgorithm> algorithms = new ArrayList<>();
-		SignatureAndHashAlgorithm.ensureSignatureAlgorithm(algorithms, credentials.getPubicKey());
+		SignatureAndHashAlgorithm.ensureSignatureAlgorithm(algorithms, credentials.getPublicKey());
 		assertThat(algorithms.size(), is(1));
 		assertThat(algorithms, hasItem(SignatureAndHashAlgorithm.INTRINSIC_WITH_ED25519));
 	}


### PR DESCRIPTION
Was Credentials.getPubicKey missing 'l'.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>