### PR TITLE
Initialize JceProviderUtil before caching some threadlocal crypto functions.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/ThreadLocalCrypto.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/ThreadLocalCrypto.java
@@ -17,12 +17,18 @@ package org.eclipse.californium.scandium.dtls.cipher;
 
 import java.security.GeneralSecurityException;
 
+import org.eclipse.californium.elements.util.JceProviderUtil;
+
 /**
  * Thread local crypto function.
  * 
  * Uses {@link ThreadLocal} to cache calls to {@link Factory#getInstance()}.
  */
 public class ThreadLocalCrypto<CryptoFunction> {
+
+	static {
+		JceProviderUtil.init();
+	}
 
 	private final Factory<CryptoFunction> factory;
 	private final GeneralSecurityException exception;


### PR DESCRIPTION


Signed-off-by: Achim Kraus <achim.kraus@bosch.io>