### PR TITLE
Adapt calling started of EndpointObserver.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -564,6 +564,9 @@ public class CoapEndpoint implements Endpoint, Executor {
 	@Override
 	public void addObserver(final EndpointObserver observer) {
 		observers.add(observer);
+		if (isStarted()) {
+			observer.started(this);
+		}
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
@@ -100,10 +100,16 @@ public interface Endpoint {
 	void setExecutors(ScheduledExecutorService mainExecutor, ScheduledExecutorService secondaryExecutor);
 
 	/**
-	 * Adds the observer to the list of observers. This has nothing to do with
-	 * CoAP observe relations.
+	 * Adds the observer to the list of observers.
+	 * 
+	 * If the endpoint {@link #isStarted()}, calls
+	 * {@link EndpointObserver#started(Endpoint)}.
+	 * 
+	 * <b>Note:</b> This has nothing to do with CoAP observe relations.
 	 * 
 	 * @param obs the observer
+	 * @since 3.1 (calls {@link EndpointObserver#started(Endpoint)}, if already
+	 *        {@link #isStarted()})
 	 */
 	void addObserver(EndpointObserver obs);
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/CoapEndpointTest.java
@@ -25,6 +25,9 @@ package org.eclipse.californium.core.network;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -113,6 +116,27 @@ public class CoapEndpointTest {
 	@After
 	public void shutDownEndpoint() {
 		endpoint.destroy();
+	}
+
+	@Test
+	public void testAddEndpointObserver() throws IOException {
+		EndpointObserver observer = mock(EndpointObserver.class);
+		endpoint.addObserver(observer);
+		verify(observer, times(1)).started(endpoint);
+		endpoint.stop();
+		verify(observer, times(1)).stopped(endpoint);
+		endpoint.destroy();
+		verify(observer, times(1)).destroyed(endpoint);
+
+		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
+		builder.setConnector(connector);
+		builder.setConfiguration(CONFIG);
+		endpoint = builder.build();
+		observer = mock(EndpointObserver.class);
+		endpoint.addObserver(observer);
+		verify(observer, times(0)).started(endpoint);
+		endpoint.start();
+		verify(observer, times(1)).started(endpoint);
 	}
 
 	@Test


### PR DESCRIPTION
Call EndpointObserver.started in addObserver, if endpoint is already
started.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>