### PR TITLE
OSCORE: Consider port when storing and retrieving contexts

### DIFF
--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/HashMapCtxDB.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/HashMapCtxDB.java
@@ -32,6 +32,7 @@ import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.elements.util.Bytes;
@@ -292,8 +293,10 @@ public class HashMapCtxDB implements OSCoreCtxDB {
 	 */
 	private static String normalizeServerUri(String uri) throws OSException {
 		String normalized = null;
+		int port = -1;
 
 		try {
+			port = (new URI(uri)).getPort();
 			normalized = (new URI(uri)).getHost();
 		} catch (URISyntaxException e) {
 			// workaround for openjdk bug JDK-8199396.
@@ -341,7 +344,12 @@ public class HashMapCtxDB implements OSCoreCtxDB {
 			LOGGER.error("Error finding host of request URI: " + uri + " message: " + e.getMessage());
 		}
 		if (ipv6Addr instanceof Inet6Address) {
-			normalized = ipv6Addr.getHostAddress();
+			normalized = "[" + ipv6Addr.getHostAddress() + "]";
+		}
+
+		// Consider port, if not default
+		if (port != -1 && port != CoAP.DEFAULT_COAP_PORT) {
+			normalized = normalized + ":" + port;
 		}
 
 		return normalized;

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/HashMapCtxDB.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/HashMapCtxDB.java
@@ -296,8 +296,9 @@ public class HashMapCtxDB implements OSCoreCtxDB {
 		int port = -1;
 
 		try {
-			port = (new URI(uri)).getPort();
-			normalized = (new URI(uri)).getHost();
+			URI serverUri = new URI(uri);
+			port = serverUri.getPort();
+			normalized = serverUri.getHost();
 		} catch (URISyntaxException e) {
 			// workaround for openjdk bug JDK-8199396.
 			// some characters are not supported for the ipv6 scope.

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityContextLayer.java
@@ -111,7 +111,12 @@ public class ObjectSecurityContextLayer extends AbstractLayer {
 	public void sendRequest(final Exchange exchange, final Request request) {
 		if (shouldProtectRequest(request)) {
 			try {
-				final String uri = request.getURI();
+				final String uri;
+				if (request.getOptions().hasProxyUri()) {
+					uri = request.getOptions().getProxyUri();
+				} else {
+					uri = request.getURI();
+				}
 
 				if (uri == null) {
 					LOGGER.error(ErrorDescriptions.URI_NULL);

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityLayer.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ObjectSecurityLayer.java
@@ -131,7 +131,12 @@ public class ObjectSecurityLayer extends AbstractLayer {
 					return;
 				}
 
-				String uri = request.getURI();
+				final String uri;
+				if (request.getOptions().hasProxyUri()) {
+					uri = request.getOptions().getProxyUri();
+				} else {
+					uri = request.getURI();
+				}
 
 				if (uri == null) {
 					LOGGER.error(ErrorDescriptions.URI_NULL);

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestEncryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestEncryptor.java
@@ -47,7 +47,12 @@ public class RequestEncryptor extends Encryptor {
 	 */
 	public static Request encrypt(OSCoreCtxDB db, Request request) throws OSException {
 
-		String uri = request.getURI();
+		final String uri;
+		if (request.getOptions().hasProxyUri()) {
+			uri = request.getOptions().getProxyUri();
+		} else {
+			uri = request.getURI();
+		}
 		OSCoreCtx ctx = db.getContext(uri);
 
 		if (ctx == null) {

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreAlgorithmsTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreAlgorithmsTest.java
@@ -141,7 +141,7 @@ public class OSCoreAlgorithmsTest {
 		byte[] sid = new byte[] { 0x02 };
 		byte[] rid = new byte[] { 0x01 };
 		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, context_id, MAX_UNFRAGMENTED_SIZE);
-		dbClient.addContext("coap://" + serverEndpoint.getAddress().getAddress().getHostAddress(), ctx);
+		dbClient.addContext(TestTools.getUri(serverEndpoint, ""), ctx);
 
 		// send request
 		Request request = new Request(CoAP.Code.POST);

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreObserveTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreObserveTest.java
@@ -77,8 +77,6 @@ public class OSCoreObserveTest {
 
 	private Timer timer;
 	private Endpoint serverEndpoint;
-	private static String serverName = TestTools.LOCALHOST_EPHEMERAL.getAddress().getHostAddress();
-	private static String clientName = TestTools.LOCALHOST_EPHEMERAL.getAddress().getHostAddress();
 	
 	private static boolean withOSCORE = true;
 
@@ -215,7 +213,7 @@ public class OSCoreObserveTest {
 	
 		try {
 			OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, null, MAX_UNFRAGMENTED_SIZE);
-			dbClient.addContext("coap://" + serverName, ctx);
+			dbClient.addContext(TestTools.getUri(serverEndpoint, ""), ctx);
 		}
 		catch(OSException e) {
 			System.err.println("Failed to set client OSCORE Context information!");
@@ -234,7 +232,7 @@ public class OSCoreObserveTest {
 
 		try {
 			OSCoreCtx ctx_B = new OSCoreCtx(master_secret, false, alg, sid, rid, kdf, 32, master_salt, null, MAX_UNFRAGMENTED_SIZE);
-			dbServer.addContext("coap://" + clientName, ctx_B);
+			dbServer.addContext(ctx_B);
 		}
 		catch (OSException e) {
 			System.err.println("Failed to set server OSCORE Context information!");

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreServerClientTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreServerClientTest.java
@@ -103,6 +103,8 @@ public class OSCoreServerClientTest {
 
 	/**
 	 * Tests working OSCORE confirmable request and response.
+	 * 
+	 * @throws Exception on test failure
 	 */
 	@Test
 	public void testConfirmable() throws Exception {	
@@ -112,7 +114,7 @@ public class OSCoreServerClientTest {
 		byte[] sid = new byte[0];
 		byte[] rid = new byte[] { 0x01 };
 		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, context_id, MAX_UNFRAGMENTED_SIZE);
-		dbClient.addContext("coap://" + serverEndpoint.getAddress().getAddress().getHostAddress(), ctx);
+		dbClient.addContext(TestTools.getUri(serverEndpoint, ""), ctx);
 
 		// send request
 		Request request = new Request(CoAP.Code.POST);
@@ -134,9 +136,12 @@ public class OSCoreServerClientTest {
 	}
 
 	/**
-	 * Tests OSCORE functionality when the server replies with a non-OSCORE CoAP error message.
-	 * In this test the client Sender ID is modified to be incorrect.
-	 * The server will reply with an error message with a payload describing the error.
+	 * Tests OSCORE functionality when the server replies with a non-OSCORE CoAP
+	 * error message. In this test the client Sender ID is modified to be
+	 * incorrect. The server will reply with an error message with a payload
+	 * describing the error.
+	 * 
+	 * @throws Exception on test failure
 	 */
 	@Test
 	public void testErrorResponse() throws Exception {	
@@ -146,7 +151,7 @@ public class OSCoreServerClientTest {
 		byte[] sid = new byte[] { 0x77 }; //Modified sender ID to be incorrect
 		byte[] rid = new byte[] { 0x01 };
 		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, context_id, MAX_UNFRAGMENTED_SIZE);
-		dbClient.addContext("coap://" + serverEndpoint.getAddress().getAddress().getHostAddress(), ctx);
+		dbClient.addContext(TestTools.getUri(serverEndpoint, ""), ctx);
 		
 		// send request
 		Request request = new Request(CoAP.Code.POST);
@@ -175,6 +180,8 @@ public class OSCoreServerClientTest {
 	 * many contexts match that RID). The server replies with a non-OSCORE CoAP
 	 * error message. The server will reply with an error message with a payload
 	 * describing the error.
+	 * 
+	 * @throws Exception on test failure
 	 */
 	@Test
 	public void testIncludeContextIDResponse() throws Exception {	
@@ -185,13 +192,13 @@ public class OSCoreServerClientTest {
 		byte[] sid = new byte[] { 0x01 };
 		byte[] rid = new byte[0];
 		OSCoreCtx serverCtxDup = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, Bytes.EMPTY, MAX_UNFRAGMENTED_SIZE);
-		dbServer.addContext("coap://" + TestTools.LOCALHOST_EPHEMERAL.getAddress().getHostName(), serverCtxDup);
+		dbServer.addContext(serverCtxDup);
 
 		//Set up OSCORE context information for request (client)
 		sid = Bytes.EMPTY;
 		rid = new byte[] { 0x01 };
 		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, context_id, MAX_UNFRAGMENTED_SIZE);
-		dbClient.addContext("coap://" + serverEndpoint.getAddress().getAddress().getHostAddress(), ctx);
+		dbClient.addContext(TestTools.getUri(serverEndpoint, ""), ctx);
 		
 		// send request
 		Request request = new Request(CoAP.Code.POST);
@@ -247,7 +254,7 @@ public class OSCoreServerClientTest {
 		byte[] sid = new byte[] { 0x01 };
 		byte[] rid = new byte[0];
 		OSCoreCtx ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, context_id, MAX_UNFRAGMENTED_SIZE);
-		dbServer.addContext("coap://" + TestTools.LOCALHOST_EPHEMERAL.getAddress().getHostName(), ctx);
+		dbServer.addContext(ctx);
 
 		//Create server
 		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();


### PR DESCRIPTION
The PR enables functionality to also consider the port for storage and retrieval of OSCORE contexts. This will enable distinguishing between contexts for the same/IP hostname but with different ports.