### PR TITLE
Use endoint context matcher for blockwise follow-up requests.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/ExtendedCoapStackFactory.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/ExtendedCoapStackFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2021 Bosch IO GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -11,7 +11,7 @@
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  * 
  * Contributors:
- *    Bosch Software Innovations GmbH - initial implementation. 
+ *    Bosch IO GmbH - initial implementation
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -19,17 +19,21 @@ import java.util.Map;
 
 import org.eclipse.californium.core.network.stack.CoapStack;
 import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.EndpointContextMatcher;
 import org.eclipse.californium.elements.config.Configuration;
+import org.eclipse.californium.elements.util.PublicAPIExtension;
 
 /**
- * Factory for CoapStack.
+ * Factory for CoapStack supporting blockwise follow-up request matching.
  * 
- * Either provided to the {@link CoapEndpoint.Builder} or set as default
- * {@link CoapEndpoint#setDefaultCoapStackFactory(CoapStackFactory)}.
+ * Either provided to the {@link CoapEndpoint.Builder} or set as
+ * default {@link CoapEndpoint#setDefaultCoapStackFactory(CoapStackFactory)}.
  * 
- * @deprecated use {@link ExtendedCoapStackFactory} instead.
+ * @since 3.1
  */
-public interface CoapStackFactory {
+@SuppressWarnings("deprecation")
+@PublicAPIExtension(type = CoapStackFactory.class)
+public interface ExtendedCoapStackFactory extends CoapStackFactory {
 
 	/**
 	 * Create CoapStack.
@@ -38,6 +42,8 @@ public interface CoapStackFactory {
 	 *            {@link Connector#getProtocol()}.
 	 * @param tag logging tag
 	 * @param config configuration used for this coap stack
+	 * @param matchingStrategy endpoint context matcher to relate responses with
+	 *            requests
 	 * @param outbox outbox to be used for this coap stack
 	 * @param customStackArgument argument for custom stack, if required.
 	 *            {@code null} for standard stacks, or if the custom stack
@@ -46,11 +52,6 @@ public interface CoapStackFactory {
 	 * @return create coap stack-
 	 * @throws NullPointerException if any parameter is {@code null}
 	 * @throws IllegalArgumentException if protocol is not supported.
-	 * @deprecated use
-	 *             {@link ExtendedCoapStackFactory#createCoapStack(String, String, Configuration, org.eclipse.californium.elements.EndpointContextMatcher, Outbox, Object)}
-	 *             instead.
-	 * @since 3.0 (logging tag added, changed parameter to Configuration)
 	 */
-	CoapStack createCoapStack(String protocol, String tag, Configuration config, Outbox outbox,
-			Object customStackArgument);
+	CoapStack createCoapStack(String protocol, String tag, Configuration config, EndpointContextMatcher matchingStrategy, Outbox outbox, Object customStackArgument);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  * The BaseCoapStack passes the messages through the layers configured in the
  * stacks implementations.
  */
-public abstract class BaseCoapStack implements CoapStack {
+public abstract class BaseCoapStack implements CoapStack, ExtendedCoapStack {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(BaseCoapStack.class);
 
@@ -167,6 +167,17 @@ public abstract class BaseCoapStack implements CoapStack {
 	@Override
 	public final boolean hasDeliverer() {
 		return deliverer != null;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T extends Layer> T getLayer(Class<T> type) {
+		for (Layer layer : layers) {
+			if (type.isInstance(layer)) {
+				return (T) layer;
+			}
+		}
+		return null;
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapTcpStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapTcpStack.java
@@ -27,6 +27,7 @@ package org.eclipse.californium.core.network.stack;
 import org.eclipse.californium.core.network.Outbox;
 import org.eclipse.californium.core.server.MessageDeliverer;
 import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.EndpointContextMatcher;
 import org.eclipse.californium.elements.config.Configuration;
 
 /**
@@ -79,20 +80,36 @@ public class CoapTcpStack extends BaseCoapStack {
 	 * 
 	 * @param tag logging tag
 	 * @param config The configuration values to use.
-	 * @param outbox The adapter for submitting outbound messages to the transport.
-	 * @since 3.0 (logging tag added and changed parameter to Configuration)
+	 * @param matchingStrategy endpoint context matcher to relate responses with
+	 *            requests
+	 * @param outbox The adapter for submitting outbound messages to the
+	 *            transport.
+	 * @since 3.1
 	 */
-	public CoapTcpStack(String tag, Configuration config, Outbox outbox) {
+	public CoapTcpStack(String tag, Configuration config, EndpointContextMatcher matchingStrategy, Outbox outbox) {
 		super(outbox);
 
-		Layer layers[] = new Layer[] {
-				new TcpExchangeCleanupLayer(),
-				new TcpObserveLayer(config),
-				new BlockwiseLayer(tag, true, config),
-				new TcpAdaptionLayer() };
+		Layer layers[] = new Layer[] { new TcpExchangeCleanupLayer(), new TcpObserveLayer(config),
+				new BlockwiseLayer(tag, true, config, matchingStrategy), new TcpAdaptionLayer() };
 
 		setLayers(layers);
 
 		// make sure the endpoint sets a MessageDeliverer
+	}
+
+	/**
+	 * Creates a new stack using TCP as the transport.
+	 * 
+	 * @param tag logging tag
+	 * @param config The configuration values to use.
+	 * @param outbox The adapter for submitting outbound messages to the
+	 *            transport.
+	 * @deprecated use
+	 *             {@link #CoapTcpStack(String, Configuration, EndpointContextMatcher, Outbox)}
+	 *             instead.
+	 * @since 3.0 (logging tag added and changed parameter to Configuration)
+	 */
+	public CoapTcpStack(String tag, Configuration config, Outbox outbox) {
+		this(tag, config, null, outbox);
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapUdpStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapUdpStack.java
@@ -24,9 +24,11 @@
  ******************************************************************************/
 package org.eclipse.californium.core.network.stack;
 
+import org.eclipse.californium.core.network.ExtendedCoapStackFactory;
 import org.eclipse.californium.core.network.Outbox;
 import org.eclipse.californium.core.server.MessageDeliverer;
 import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.EndpointContextMatcher;
 import org.eclipse.californium.elements.config.Configuration;
 
 /**
@@ -71,40 +73,105 @@ import org.eclipse.californium.elements.config.Configuration;
  * | {@link Connector}                |
  * +--------------------------+
  * </pre></blockquote><hr>
+ * 
+ * Note: since 3.1 the create-layer methods have been deprecated. If your usage
+ * requires to have custom layers, please implement a own {@link CoapStack} and
+ * use the {@link ExtendedCoapStackFactory} to provide instances of that custom
+ * implementation.
  */
 public class CoapUdpStack extends BaseCoapStack {
 
 	/**
 	 * Creates a new stack for UDP as the transport.
 	 * 
+	 * Note: in order to match blockwise follow up requests, this constructor is
+	 * required. It doesn't longer call the create-layer functions. If that is
+	 * required, please use a own custom implementation of the {@link CoapStack}
+	 * and the {@link ExtendedCoapStackFactory} to provide instances of that
+	 * custom implementation.
+	 * 
 	 * @param tag logging tag
 	 * @param config The configuration values to use.
-	 * @param outbox The adapter for submitting outbound messages to the transport.
+	 * @param matchingStrategy endpoint context matcher to relate responses with
+	 *            requests
+	 * @param outbox The adapter for submitting outbound messages to the
+	 *            transport.
+	 * @since 3.1
+	 */
+	public CoapUdpStack(String tag, Configuration config, EndpointContextMatcher matchingStrategy, Outbox outbox) {
+		super(outbox);
+		Layer[] layers = new Layer[] { new ExchangeCleanupLayer(config), new ObserveLayer(config),
+				new BlockwiseLayer(tag, false, config, matchingStrategy),
+				CongestionControlLayer.newImplementation(tag, config) };
+		setLayers(layers);
+	}
+
+	/**
+	 * Creates a new stack for UDP as the transport.
+	 * 
+	 * @param tag logging tag
+	 * @param config The configuration values to use.
+	 * @param outbox The adapter for submitting outbound messages to the
+	 *            transport.
+	 * @deprecated use
+	 *             {@link #CoapUdpStack(String, Configuration, EndpointContextMatcher, Outbox)}
+	 *             instead
 	 * @since 3.0 (logging tag added and changed parameter to Configuration)
 	 */
 	public CoapUdpStack(String tag, Configuration config, Outbox outbox) {
 		super(outbox);
-		Layer layers[] = new Layer[] {
-				createExchangeCleanupLayer(config),
-				createObserveLayer(config),
-				createBlockwiseLayer(tag, config),
-				createReliabilityLayer(tag, config)};
+		Layer layers[] = new Layer[] { createExchangeCleanupLayer(config), createObserveLayer(config),
+				createBlockwiseLayer(tag, config), createReliabilityLayer(tag, config) };
 
 		setLayers(layers);
 	}
 
+	/**
+	 * Create exchange cleanup layer.
+	 * 
+	 * @param config configuration
+	 * @return exchange cleanup layer
+	 * @deprecated use a custom implementation of the {@link CoapStack} and the
+	 *             {@link ExtendedCoapStackFactory} instead.
+	 */
 	protected Layer createExchangeCleanupLayer(Configuration config) {
 		return new ExchangeCleanupLayer(config);
 	}
 
+	/**
+	 * Create observe layer.
+	 * 
+	 * @param config configuration
+	 * @return observe layer
+	 * @deprecated use a custom implementation of the {@link CoapStack} and the
+	 *             {@link ExtendedCoapStackFactory} instead.
+	 */
 	protected Layer createObserveLayer(Configuration config) {
 		return new ObserveLayer(config);
 	}
 
+	/**
+	 * Create blockwise layer.
+	 * 
+	 * @param tag logging tag
+	 * @param config configuration
+	 * @return blockwise layer
+	 * @deprecated use a custom implementation of the {@link CoapStack} and the
+	 *             {@link ExtendedCoapStackFactory} instead.
+	 */
 	protected Layer createBlockwiseLayer(String tag, Configuration config) {
 		return new BlockwiseLayer(tag, false, config);
 	}
 
+	/**
+	 * Create reliability layer.
+	 * 
+	 * @param tag logging tag
+	 * @param config configuration
+	 * @return reliability layer
+	 * @deprecated use a custom implementation of the {@link CoapStack} and the
+	 *             {@link ExtendedCoapStackFactory} instead.
+	 */
 	protected Layer createReliabilityLayer(String tag, Configuration config) {
 		return CongestionControlLayer.newImplementation(tag, config);
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ExtendedCoapStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ExtendedCoapStack.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.core.network.stack;
+
+import org.eclipse.californium.elements.util.PublicAPIExtension;
+
+/**
+ * CoapStack is what CoapEndpoint uses to send messages through distinct layers.
+ * 
+ * @since 3.1
+ */
+@PublicAPIExtension(type = CoapStack.class)
+public interface ExtendedCoapStack extends CoapStack {
+
+	<T extends Layer> T getLayer(Class<T> type);
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/stack/BlockwiseLayerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/stack/BlockwiseLayerTest.java
@@ -66,7 +66,7 @@ public class BlockwiseLayerTest {
 				.set(CoapConfig.MAX_RESOURCE_BODY_SIZE, 0);
 		Layer appLayer = mock(Layer.class);
 
-		final BlockwiseLayer blockwiseLayer = new BlockwiseLayer("test ", false, config);
+		final BlockwiseLayer blockwiseLayer = new BlockwiseLayer("test ", false, config, null);
 		blockwiseLayer.setUpperLayer(appLayer);
 
 		Request request = newReceivedBlockwiseRequest(256, 64);
@@ -89,7 +89,7 @@ public class BlockwiseLayerTest {
 		Layer outbox = mock(Layer.class);
 		ArgumentCaptor<Response> errorResponse = ArgumentCaptor.forClass(Response.class);
 
-		BlockwiseLayer blockwiseLayer = new BlockwiseLayer("test ", false, config);
+		BlockwiseLayer blockwiseLayer = new BlockwiseLayer("test ", false, config, null);
 		blockwiseLayer.setLowerLayer(outbox);
 
 		Request request = newReceivedBlockwiseRequest(256, 64);
@@ -113,7 +113,7 @@ public class BlockwiseLayerTest {
 				.set(CoapConfig.MAX_MESSAGE_SIZE, 128)
 				.set(CoapConfig.MAX_RESOURCE_BODY_SIZE, 200);
 		MessageObserver requestObserver = mock(MessageObserver.class);
-		BlockwiseLayer blockwiseLayer = new BlockwiseLayer("test ", false, config);
+		BlockwiseLayer blockwiseLayer = new BlockwiseLayer("test ", false, config, null);
 
 		Request request = Request.newGet();
 		request.setURI("coap://127.0.0.1/bigResource");
@@ -139,7 +139,7 @@ public class BlockwiseLayerTest {
 				.set(CoapConfig.MAX_MESSAGE_SIZE, 128)
 				.set(CoapConfig.MAX_RESOURCE_BODY_SIZE, 200);
 		Layer upperLayer = mock(Layer.class);
-		BlockwiseLayer blockwiseLayer = new BlockwiseLayer("test ", false, config);
+		BlockwiseLayer blockwiseLayer = new BlockwiseLayer("test ", false, config, null);
 		blockwiseLayer.setUpperLayer(upperLayer);
 
 		// GIVEN an established observation of a resource with a body requiring blockwise transfer

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MessageExchangeStoreTool.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MessageExchangeStoreTool.java
@@ -28,20 +28,15 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.concurrent.TimeUnit;
 
-import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.config.CoapConfig;
 import org.eclipse.californium.core.network.CoapEndpoint;
-import org.eclipse.californium.core.network.CoapStackFactory;
 import org.eclipse.californium.core.network.InMemoryMessageExchangeStore;
-import org.eclipse.californium.core.network.Outbox;
 import org.eclipse.californium.core.network.RandomTokenGenerator;
 import org.eclipse.californium.core.network.stack.BlockwiseLayer;
-import org.eclipse.californium.core.network.stack.CoapStack;
-import org.eclipse.californium.core.network.stack.CoapUdpStack;
-import org.eclipse.californium.core.network.stack.Layer;
+import org.eclipse.californium.core.network.stack.ExtendedCoapStack;
 import org.eclipse.californium.core.observe.InMemoryObservationStore;
 import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.EndpointContextMatcher;
@@ -167,40 +162,6 @@ public class MessageExchangeStoreTool {
 		return empty;
 	}
 
-	private static final CoapStackFactory COAP_STACK_TEST_FACTORY = new CoapStackFactory() {
-
-		@Override
-		public CoapStack createCoapStack(String protocol, String tag, Configuration config, Outbox outbox, Object customStackArgument) {
-			if (CoAP.isTcpProtocol(protocol)) {
-				throw new IllegalArgumentException("protocol \"" + protocol + "\" is not supported!");
-			}
-			return new CoapUdpTestStack(tag, config, outbox);
-		}
-	};
-
-	public static class CoapUdpTestStack extends CoapUdpStack {
-
-		private BlockwiseLayer blockwiseLayer;
-
-		public CoapUdpTestStack(String tag, Configuration config, Outbox outbox) {
-			super(tag, config, outbox);
-		}
-
-		@Override
-		protected Layer createBlockwiseLayer(String tag, Configuration config) {
-			blockwiseLayer = (BlockwiseLayer) super.createBlockwiseLayer(tag, config);
-			return blockwiseLayer;
-		}
-
-		public BlockwiseLayer getBlockwiseLayer() {
-			return blockwiseLayer;
-		}
-
-		public boolean isEmpty() {
-			return blockwiseLayer == null || blockwiseLayer.isEmpty();
-		}
-	}
-
 	public static class CoapTestEndpoint extends CoapEndpoint {
 
 		private final InMemoryMessageExchangeStore exchangeStore;
@@ -212,7 +173,7 @@ public class MessageExchangeStoreTool {
 				InMemoryObservationStore observationStore, InMemoryMessageExchangeStore exchangeStore,
 				EndpointContextMatcher matcher) {
 			super(connector, config, new RandomTokenGenerator(config), observationStore,
-					exchangeStore, matcher, null, null, null, COAP_STACK_TEST_FACTORY, null);
+					exchangeStore, matcher, null, null, null, null, null);
 			this.exchangeStore = exchangeStore;
 			this.observationStore = observationStore;
 			this.requestChecker = new RequestEventChecker();
@@ -246,12 +207,13 @@ public class MessageExchangeStoreTool {
 			return observationStore;
 		}
 
-		public CoapUdpTestStack getStack() {
-			return (CoapUdpTestStack) coapstack;
+		public ExtendedCoapStack getStack() {
+			return (ExtendedCoapStack) coapstack;
 		}
 
 		public boolean isEmpty() {
-			return exchangeStore.isEmpty() && getStack().isEmpty();
+			BlockwiseLayer layer = getStack().getLayer(BlockwiseLayer.class);
+			return exchangeStore.isEmpty() && layer != null && layer.isEmpty();
 		}
 
 		@Override

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -65,6 +65,7 @@ import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.config.CoapConfig;
+import org.eclipse.californium.core.network.stack.BlockwiseLayer;
 import org.eclipse.californium.core.test.CountingCoapHandler;
 import org.eclipse.californium.core.test.CountingMessageObserver;
 import org.eclipse.californium.core.test.ErrorInjector;
@@ -273,7 +274,7 @@ public class BlockwiseClientSideTest {
 		// We get the response the transfer is complete : BlockwiseLayer should
 		// be empty
 		request.waitForResponse();
-		assertTrue("BlockwiseLayer should be empty", client.getStack().getBlockwiseLayer().isEmpty());
+		assertTrue("BlockwiseLayer should be empty", client.getStack().getLayer(BlockwiseLayer.class).isEmpty());
 
 		clientInterceptor.logNewLine("// next transfer");
 		request = createRequest(GET, path, server);
@@ -296,7 +297,7 @@ public class BlockwiseClientSideTest {
 		// We get the response the transfer is complete : BlockwiseLayer should
 		// be empty
 		request.waitForResponse();
-		assertTrue("BlockwiseLayer should be empty", client.getStack().getBlockwiseLayer().isEmpty());
+		assertTrue("BlockwiseLayer should be empty", client.getStack().getLayer(BlockwiseLayer.class).isEmpty());
 
 		printServerLog(clientInterceptor);
 	}
@@ -1326,7 +1327,7 @@ public class BlockwiseClientSideTest {
 		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 128).go();
 		Thread.sleep((long) (TEST_BLOCKWISE_STATUS_LIFETIME * 0.75));
 
-		assertTrue(!client.getStack().getBlockwiseLayer().isEmpty());
+		assertTrue(!client.getStack().getLayer(BlockwiseLayer.class).isEmpty());
 		// we don't answer to the last request, @after should check is there is
 		// no leak.
 
@@ -1359,7 +1360,7 @@ public class BlockwiseClientSideTest {
 		server.expectRequest(CON, PUT, path).storeBoth("C").block1(2, true, 128).payload(reqtPayload, 256, 384).go();
 		Thread.sleep((long) (TEST_BLOCKWISE_STATUS_LIFETIME * 0.75));
 		
-		assertTrue(!client.getStack().getBlockwiseLayer().isEmpty());
+		assertTrue(!client.getStack().getLayer(BlockwiseLayer.class).isEmpty());
 		// we don't answer to the last request, @after should check is there is
 		// no leak.
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -63,6 +63,7 @@ import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.config.CoapConfig;
 import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.stack.BlockwiseLayer;
 import org.eclipse.californium.core.server.MessageDeliverer;
 import org.eclipse.californium.core.test.CountingMessageObserver;
 import org.eclipse.californium.core.test.ErrorInjector;
@@ -429,7 +430,7 @@ public class ObserveClientSideTest {
 		// ensure client don't ask for block anymore
 		Message message = server.receiveNextMessage(1000, TimeUnit.MILLISECONDS);
 		assertThat("No block2 message expected anymore", message, is(nullValue()));
-		assertTrue("Blockwise layer must be empty", client.getStack().getBlockwiseLayer().isEmpty());
+		assertTrue("Blockwise layer must be empty", client.getStack().getLayer(BlockwiseLayer.class).isEmpty());
 
 		// Send new notif without block
 		notifyPayload = generateRandomPayload(8);

--- a/californium-core/src/test/resources/logback-test.xml
+++ b/californium-core/src/test/resources/logback-test.xml
@@ -20,6 +20,10 @@
 		<appender-ref ref="STDOUT" />
 	</logger>
 
+	<logger name="org.eclipse.californium.core.test.lockstep.IntegrationTestTools" level="INFO" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+
 	<logger name="org.eclipse.californium.core.network.stack.ReliabilityLayer" level="WARN" additivity="false">
 		<appender-ref ref="STDOUT" />
 	</logger>

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreStack.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreStack.java
@@ -25,6 +25,7 @@ import org.eclipse.californium.core.network.stack.CongestionControlLayer;
 import org.eclipse.californium.core.network.stack.ExchangeCleanupLayer;
 import org.eclipse.californium.core.network.stack.Layer;
 import org.eclipse.californium.core.network.stack.ObserveLayer;
+import org.eclipse.californium.elements.EndpointContextMatcher;
 import org.eclipse.californium.elements.config.Configuration;
 
 /**
@@ -33,6 +34,30 @@ import org.eclipse.californium.elements.config.Configuration;
  *
  */
 public class OSCoreStack extends BaseCoapStack {
+	/**
+	 * Creates a new stack for UDP as the transport.
+	 * 
+	 * @param tag logging tag
+	 * @param config The configuration values to use.
+	 * @param matchingStrategy endpoint context matcher to relate responses with
+	 *            requests
+	 * @param outbox The adapter for submitting outbound messages to the
+	 *            transport.
+	 * @param ctxDb context DB.
+	 * @since 3.1
+	 */
+	public OSCoreStack(String tag, Configuration config, EndpointContextMatcher matchingStrategy, Outbox outbox, OSCoreCtxDB ctxDb) {
+		super(outbox);
+
+		Layer layers[] = new Layer[] {
+				new ObjectSecurityContextLayer(ctxDb),
+				new ExchangeCleanupLayer(config),
+				new ObserveLayer(config),
+				new BlockwiseLayer(tag, false, config, matchingStrategy),
+				CongestionControlLayer.newImplementation(tag, config),
+				new ObjectSecurityLayer(ctxDb)};
+		setLayers(layers);
+	}
 
 	/**
 	 * Creates a new stack for UDP as the transport.
@@ -42,18 +67,12 @@ public class OSCoreStack extends BaseCoapStack {
 	 * @param outbox The adapter for submitting outbound messages to the
 	 *            transport.
 	 * @param ctxDb context DB.
+	 * @deprecated use
+	 *             {@link #OSCoreStack(String, Configuration, EndpointContextMatcher, Outbox, OSCoreCtxDB)}
+	 *             instead
 	 * @since 3.0 (logging tag added and changed parameter to Configuration)
 	 */
 	public OSCoreStack(String tag, Configuration config, Outbox outbox, OSCoreCtxDB ctxDb) {
-		super(outbox);
-
-		Layer layers[] = new Layer[] {
-				new ObjectSecurityContextLayer(ctxDb),
-				new ExchangeCleanupLayer(config),
-				new ObserveLayer(config),
-				new BlockwiseLayer(tag, false, config),
-				CongestionControlLayer.newImplementation(tag, config),
-				new ObjectSecurityLayer(ctxDb)};
-		setLayers(layers);
+		this(tag, config, null, outbox, ctxDb);
 	}
 }


### PR DESCRIPTION
Requires to forward the matcher from the endpoint via the coap-stack
into the blockwise layer. Therefore the coap-stack-factory must also be
extended. The old API are deprecated with that, though using them will
not provide protection against unaware endpoint context changes between
blockwise follow up requests.

The create-layer functions in CoapUdpStack have been deprecated. For the
usage in the unit-tests a
get-layer has been added instead. Other usage should implement the
ExtendedCoapStackFactory and use an own custom CoapStack implementation.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>