### PR TITLE
Use endoint context matcher for blockwise follow-up requests.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/ExtendedCoapStackFactory.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/ExtendedCoapStackFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Bosch Software Innovations GmbH and others.
+ * Copyright (c) 2021 Bosch IO GmbH and others.
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -11,7 +11,7 @@
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  * 
  * Contributors:
- *    Bosch Software Innovations GmbH - initial implementation. 
+ *    Bosch IO GmbH - initial implementation
  ******************************************************************************/
 package org.eclipse.californium.core.network;
 
@@ -20,15 +20,20 @@ import java.util.Map;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.stack.CoapStack;
 import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.EndpointContextMatcher;
+import org.eclipse.californium.elements.util.PublicAPIExtension;
 
 /**
- * Factory for CoapStack.
+ * Factory for CoapStack supporting blockwise follow-up request matching.
  * 
  * Either provided to the {@link CoapEndpoint.Builder} or set as
  * default {@link CoapEndpoint#setDefaultCoapStackFactory(CoapStackFactory)}.
- * @deprecated use {@link ExtendedCoapStackFactory}
+ * 
+ * @since 3.1 (back-ported to 2.7.0)
  */
-public interface CoapStackFactory {
+@SuppressWarnings("deprecation")
+@PublicAPIExtension(type = CoapStackFactory.class)
+public interface ExtendedCoapStackFactory extends CoapStackFactory {
 
 	/**
 	 * Create CoapStack.
@@ -36,6 +41,8 @@ public interface CoapStackFactory {
 	 * @param protocol used protocol, values see
 	 *            {@link Connector#getProtocol()}.
 	 * @param config network configuration used for this coap stack
+	 * @param matchingStrategy endpoint context matcher to relate responses with
+	 *            requests
 	 * @param outbox outbox to be used for this coap stack
 	 * @param customStackArgument argument for custom stack, if required.
 	 *            {@code null} for standard stacks, or if the custom stack
@@ -45,5 +52,5 @@ public interface CoapStackFactory {
 	 * @throws NullPointerException if any parameter is {@code null}
 	 * @throws IllegalArgumentException if protocol is not supported.
 	 */
-	CoapStack createCoapStack(String protocol, NetworkConfig config, Outbox outbox, Object customStackArgument);
+	CoapStack createCoapStack(String protocol, NetworkConfig config, EndpointContextMatcher matchingStrategy, Outbox outbox, Object customStackArgument);
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
@@ -47,7 +47,7 @@ import org.eclipse.californium.core.server.MessageDeliverer;
  * The BaseCoapStack passes the messages through the layers configured in the
  * stacks implementations.
  */
-public abstract class BaseCoapStack implements CoapStack {
+public abstract class BaseCoapStack implements CoapStack, ExtendedCoapStack {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(BaseCoapStack.class);
 
@@ -164,6 +164,17 @@ public abstract class BaseCoapStack implements CoapStack {
 	@Override
 	public final boolean hasDeliverer() {
 		return deliverer != null;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T extends Layer> T getLayer(Class<T> type) {
+		for (Layer layer : layers) {
+			if (type.isInstance(layer)) {
+				return (T) layer;
+			}
+		}
+		return null;
 	}
 
 	@Override

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseStatus.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseStatus.java
@@ -57,7 +57,7 @@ public abstract class BlockwiseStatus {
 	protected EndpointContext followUpEndpointContext;
 
 	private ScheduledFuture<?> cleanUpTask;
-	private Message first;
+	protected Message first;
 	private int currentNum;
 	private int currentSzx;
 	private boolean complete;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapTcpStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapTcpStack.java
@@ -28,6 +28,7 @@ import org.eclipse.californium.core.network.Outbox;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.server.MessageDeliverer;
 import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.EndpointContextMatcher;
 
 /**
  * The CoapTcpStack builds up the stack of CoAP layers that process the CoAP
@@ -73,24 +74,37 @@ import org.eclipse.californium.elements.Connector;
  * </pre></blockquote><hr>
  */
 public class CoapTcpStack extends BaseCoapStack {
+	/**
+	 * Creates a new stack using TCP as the transport.
+	 * 
+	 * @param config The configuration values to use.
+	 * @param matchingStrategy endpoint context matcher to relate responses with
+	 *            requests
+	 * @param outbox The adapter for submitting outbound messages to the transport.
+	 * @since 3.1 (back-ported to 2.7.0)
+	 */
+	public CoapTcpStack(final NetworkConfig config, final EndpointContextMatcher matchingStrategy, final Outbox outbox) {
+		super(outbox);
+
+		Layer layers[] = new Layer[] {
+				new TcpExchangeCleanupLayer(),
+				new TcpObserveLayer(config),
+				new BlockwiseLayer(config, matchingStrategy),
+				new TcpAdaptionLayer() };
+
+		setLayers(layers);
+
+		// make sure the endpoint sets a MessageDeliverer
+	}
 
 	/**
 	 * Creates a new stack using TCP as the transport.
 	 * 
 	 * @param config The configuration values to use.
 	 * @param outbox The adapter for submitting outbound messages to the transport.
+	 * @deprecated use {@link #CoapTcpStack(NetworkConfig, EndpointContextMatcher, Outbox)} instead.
 	 */
 	public CoapTcpStack(final NetworkConfig config, final Outbox outbox) {
-		super(outbox);
-
-		Layer layers[] = new Layer[] {
-				new TcpExchangeCleanupLayer(),
-				new TcpObserveLayer(config),
-				new BlockwiseLayer(config),
-				new TcpAdaptionLayer() };
-
-		setLayers(layers);
-
-		// make sure the endpoint sets a MessageDeliverer
+		this(config, null, outbox);
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ExtendedCoapStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ExtendedCoapStack.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.core.network.stack;
+
+import org.eclipse.californium.elements.util.PublicAPIExtension;
+
+/**
+ * CoapStack is what CoapEndpoint uses to send messages through distinct layers.
+ * 
+ * @since 3.1
+ */
+@PublicAPIExtension(type = CoapStack.class)
+public interface ExtendedCoapStack extends CoapStack {
+
+	<T extends Layer> T getLayer(Class<T> type);
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/BlockwiseClientSideTest.java
@@ -65,6 +65,7 @@ import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.network.stack.BlockwiseLayer;
 import org.eclipse.californium.core.test.CountingCoapHandler;
 import org.eclipse.californium.core.test.CountingMessageObserver;
 import org.eclipse.californium.core.test.ErrorInjector;
@@ -281,7 +282,7 @@ public class BlockwiseClientSideTest {
 		// We get the response the transfer is complete : BlockwiseLayer should
 		// be empty
 		request.waitForResponse();
-		assertTrue("BlockwiseLayer should be empty", client.getStack().getBlockwiseLayer().isEmpty());
+		assertTrue("BlockwiseLayer should be empty", client.getStack().getLayer(BlockwiseLayer.class).isEmpty());
 
 		clientInterceptor.logNewLine("// next transfer");
 		request = createRequest(GET, path, server);
@@ -304,7 +305,7 @@ public class BlockwiseClientSideTest {
 		// We get the response the transfer is complete : BlockwiseLayer should
 		// be empty
 		request.waitForResponse();
-		assertTrue("BlockwiseLayer should be empty", client.getStack().getBlockwiseLayer().isEmpty());
+		assertTrue("BlockwiseLayer should be empty", client.getStack().getLayer(BlockwiseLayer.class).isEmpty());
 
 		printServerLog(clientInterceptor);
 	}
@@ -1370,7 +1371,7 @@ public class BlockwiseClientSideTest {
 		server.expectRequest(CON, GET, path).storeBoth("C").block2(2, false, 128).go();
 		Thread.sleep((long) (TEST_BLOCKWISE_STATUS_LIFETIME * 0.75));
 
-		assertTrue(!client.getStack().getBlockwiseLayer().isEmpty());
+		assertTrue(!client.getStack().getLayer(BlockwiseLayer.class).isEmpty());
 		// we don't answer to the last request, @after should check is there is
 		// no leak.
 
@@ -1404,7 +1405,7 @@ public class BlockwiseClientSideTest {
 		server.expectRequest(CON, PUT, path).storeBoth("C").block1(2, true, 128).payload(reqtPayload, 256, 384).go();
 		Thread.sleep((long) (TEST_BLOCKWISE_STATUS_LIFETIME * 0.75));
 		
-		assertTrue(!client.getStack().getBlockwiseLayer().isEmpty());
+		assertTrue(!client.getStack().getLayer(BlockwiseLayer.class).isEmpty());
 		// we don't answer to the last request, @after should check is there is
 		// no leak.
 

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/lockstep/ObserveClientSideTest.java
@@ -65,6 +65,7 @@ import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.network.config.NetworkConfig;
 import org.eclipse.californium.core.network.config.NetworkConfig.Keys;
+import org.eclipse.californium.core.network.stack.BlockwiseLayer;
 import org.eclipse.californium.core.server.MessageDeliverer;
 import org.eclipse.californium.core.test.CountingMessageObserver;
 import org.eclipse.californium.core.test.ErrorInjector;
@@ -430,9 +431,9 @@ public class ObserveClientSideTest {
 		// ensure client don't ask for block anymore
 		Message message = server.receiveNextMessage(1000, TimeUnit.MILLISECONDS);
 		assertNull("No block2 message expected anymore", message);
-		assertTrue("Blockwise layer must be empty", client.getStack().getBlockwiseLayer().isEmpty());
+		assertTrue("Blockwise layer must be empty", client.getStack().getLayer(BlockwiseLayer.class).isEmpty());
 
-		// Send new notif without block
+		// Send new notify without block
 		notifyPayload = generateRandomPayload(8);
 		server.sendResponse(CON, CONTENT).loadToken("OBS").observe(3).mid(++mid).payload(notifyPayload).go();
 		server.expectEmpty(ACK, mid).go();

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreStack.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreStack.java
@@ -29,6 +29,7 @@ import org.eclipse.californium.core.network.stack.ExchangeCleanupLayer;
 import org.eclipse.californium.core.network.stack.Layer;
 import org.eclipse.californium.core.network.stack.ObserveLayer;
 import org.eclipse.californium.core.network.stack.ReliabilityLayer;
+import org.eclipse.californium.elements.EndpointContextMatcher;
 
 /**
  * 
@@ -49,8 +50,9 @@ public class OSCoreStack extends BaseCoapStack {
 	 * @param outbox The adapter for submitting outbound messages to the
 	 *            transport.
 	 * @param ctxDb context DB.
+	 * @since 3.1 (back-ported to 2.7.0)
 	 */
-	public OSCoreStack(final NetworkConfig config, final Outbox outbox, final OSCoreCtxDB ctxDb) {
+	public OSCoreStack(final NetworkConfig config, final EndpointContextMatcher matchingStrategy, final Outbox outbox, final OSCoreCtxDB ctxDb) {
 		super(outbox);
 		ReliabilityLayer reliabilityLayer;
 		if (config.getBoolean(NetworkConfig.Keys.USE_CONGESTION_CONTROL)) {
@@ -61,8 +63,21 @@ public class OSCoreStack extends BaseCoapStack {
 		}
 
 		Layer layers[] = new Layer[] { new ObjectSecurityContextLayer(ctxDb), new ExchangeCleanupLayer(config),
-				new ObserveLayer(config), new BlockwiseLayer(config), reliabilityLayer,
+				new ObserveLayer(config), new BlockwiseLayer(config, matchingStrategy), reliabilityLayer,
 				new ObjectSecurityLayer(ctxDb), };
 		setLayers(layers);
+	}
+
+	/**
+	 * Creates a new stack for UDP as the transport.
+	 * 
+	 * @param config The configuration values to use.
+	 * @param outbox The adapter for submitting outbound messages to the
+	 *            transport.
+	 * @param ctxDb context DB.
+	 * @deprecated use {@link #OSCoreStack(NetworkConfig, EndpointContextMatcher, Outbox, OSCoreCtxDB)} instead.
+	 */
+	public OSCoreStack(final NetworkConfig config, final Outbox outbox, final OSCoreCtxDB ctxDb) {
+		this(config, null, outbox, ctxDb);
 	}
 }


### PR DESCRIPTION
(back-ported from 3.1)

Requires to forward the matcher from the endpoint via the coap-stack
into the blockwise layer. Therefore the coap-stack-factory must also be
extended. The old API are deprecated with that, though using them will
not provide protection against unaware endpoint context changes between
blockwise follow up requests.

The create-layer functions in CoapUdpStack have been deprecated. For the
usage in the unit-tests a
get-layer has been added instead. Other usage should implement the
ExtendedCoapStackFactory and use an own custom CoapStack implementation.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>