### PR TITLE
Fix: limit record size limit to 16k.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/DTLSConnector.java
@@ -251,9 +251,8 @@ public class DTLSConnector implements Connector, PersistentConnector, RecordLaye
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(DTLSConnector.class);
 	private static final Logger DROP_LOGGER = LoggerFactory.getLogger(LOGGER.getName() + ".drops");
-	private static final int MAX_PLAINTEXT_FRAGMENT_LENGTH = 16384; // max. DTLSPlaintext.length (2^14 bytes)
 	private static final int MAX_CIPHERTEXT_EXPANSION = CipherSuite.getOverallMaxCiphertextExpansion();
-	private static final int MAX_DATAGRAM_BUFFER_SIZE = MAX_PLAINTEXT_FRAGMENT_LENGTH
+	private static final int MAX_DATAGRAM_BUFFER_SIZE = Record.DTLS_MAX_PLAINTEXT_FRAGMENT_LENGTH
 			+ Record.DTLS_HANDSHAKE_HEADER_LENGTH
 			+ MAX_CIPHERTEXT_EXPANSION;
 
@@ -2472,10 +2471,10 @@ public class DTLSConnector implements Connector, PersistentConnector, RecordLaye
 		if (!running.get()) {
 			connection = null;
 			error = new IllegalStateException("connector must be started before sending messages is possible");
-		} else if (message.getSize() > MAX_PLAINTEXT_FRAGMENT_LENGTH) {
+		} else if (message.getSize() > Record.DTLS_MAX_PLAINTEXT_FRAGMENT_LENGTH) {
 			connection = null;
 			error = new IllegalArgumentException(
-					"Message data must not exceed " + MAX_PLAINTEXT_FRAGMENT_LENGTH + " bytes");
+					"Message data must not exceed " + Record.DTLS_MAX_PLAINTEXT_FRAGMENT_LENGTH + " bytes");
 		} else {
 			boolean create = dtlsRole != DtlsRole.SERVER_ONLY;
 			if (create) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConfig.java
@@ -367,7 +367,7 @@ public final class DtlsConfig {
 	 * 8449</a> for details.
 	 */
 	public static final IntegerDefinition DTLS_RECORD_SIZE_LIMIT = new IntegerDefinition(MODULE + "RECORD_SIZE_LIMIT",
-			"DTLS record size limit (RFC 8449). Between 64 and 65535.", null, 64);
+			"DTLS record size limit (RFC 8449). Between 64 and 16K.", null, 64);
 
 	/**
 	 * Specify the maximum fragment length.

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -67,6 +67,7 @@ import org.eclipse.californium.scandium.dtls.InMemoryConnectionStore;
 import org.eclipse.californium.scandium.dtls.MultiNodeConnectionIdGenerator;
 import org.eclipse.californium.scandium.dtls.MaxFragmentLengthExtension.Length;
 import org.eclipse.californium.scandium.dtls.ProtocolVersion;
+import org.eclipse.californium.scandium.dtls.Record;
 import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
 import org.eclipse.californium.scandium.dtls.SessionListener;
 import org.eclipse.californium.scandium.dtls.SessionStore;
@@ -1977,6 +1978,12 @@ public final class DtlsConnectorConfig {
 					throw new IllegalStateException(
 							"MTU (" + mtu + " bytes) is larger than the limit (" + limit + " bytes)!");
 				}
+			}
+
+			if (config.getRecordSizeLimit() != null
+					&& config.getRecordSizeLimit() > Record.DTLS_MAX_PLAINTEXT_FRAGMENT_LENGTH) {
+				throw new IllegalStateException("Record size limit " + config.getRecordSizeLimit()
+						+ " must be less than " + Record.DTLS_MAX_PLAINTEXT_FRAGMENT_LENGTH + "!");
 			}
 
 			if (config.getDtlsRole() == DtlsRole.SERVER_ONLY) {

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Record.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/Record.java
@@ -90,6 +90,12 @@ public class Record {
 	 */
 	public static final int DTLS_HANDSHAKE_HEADER_LENGTH = RECORD_HEADER_BYTES
 			+ HandshakeMessage.MESSAGE_HEADER_LENGTH_BYTES;
+	/**
+	 * The maximum plaintext fragment size for TLS 1.2
+	 * 
+	 * @since 3.2
+	 */
+	public static final int DTLS_MAX_PLAINTEXT_FRAGMENT_LENGTH = 16384; // 2^14
 
 	public static final long MAX_SEQUENCE_NO = 281474976710655L; // 2^48 - 1
 


### PR DESCRIPTION
Use maximum fragment size of TLS 1.2 as defined in RFC8449.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>