### PR TITLE
Update cloud-init support.

### DIFF
--- a/demo-apps/cf-unix-setup/README.md
+++ b/demo-apps/cf-unix-setup/README.md
@@ -119,8 +119,8 @@ runcmd:
  - [ systemctl, enable, cali ]
  - [ wget, "https://github.com/eclipse/californium/raw/master/demo-apps/cf-unix-setup/src/main/resources/fail2ban/cali2fail.conf", -O, "/etc/fail2ban/jail.d/cali2fail.conf" ]
  - [ wget, "https://github.com/eclipse/californium/raw/master/demo-apps/cf-unix-setup/src/main/resources/fail2ban/cali.conf", -O, "/etc/fail2ban/filter.d/cali.conf" ]
+ - [ sleep, 5 ]
  - [ systemctl, restart, fail2ban ]
-
 ```
 
 [cloud-config.yaml](src/main/resources/cloud-installs/cloud-config.yaml)
@@ -352,3 +352,5 @@ Status for the jail: cali-udp
    |- Total banned:	7
    `- Banned IP list:	
 ```
+
+(If fail2ban is started before the "ban.log" is available, it fails. Just restart it with `sudo systemctl restart fail2ban` should fix it.)

--- a/demo-apps/cf-unix-setup/README.md
+++ b/demo-apps/cf-unix-setup/README.md
@@ -175,6 +175,18 @@ Features: IPv4, Firewall
 
 For further instructions see the comments in that script.
 
+### Installation on AWS
+
+[Amazon Web Service](https://aws.amazon.com)
+
+[deploy_aws.sh](src/main/resources/cloud-installs/deploy_aws.sh)
+
+This script uses the aws API (aws) to create a vm and the [cloud-config.yaml](src/main/resources/cloud-installs/cloud-config.yaml) to configure and install the [Californium Plugtest Server](https://repo.eclipse.org/content/repositories/californium-releases/org/eclipse/californium/cf-plugtest-server/3.2.0/cf-plugtest-server-3.2.0.jar).
+
+Features: IPv4, Firewall
+
+For further instructions see the comments in that script.
+
 ## Handling of the "cali.service"
 
 To start the service, use

--- a/demo-apps/cf-unix-setup/src/main/resources/cloud-installs/cloud-config.yaml
+++ b/demo-apps/cf-unix-setup/src/main/resources/cloud-installs/cloud-config.yaml
@@ -38,5 +38,6 @@ runcmd:
  - [ systemctl, enable, cali ]
  - [ wget, "https://github.com/eclipse/californium/raw/master/demo-apps/cf-unix-setup/src/main/resources/fail2ban/cali2fail.conf", -O, "/etc/fail2ban/jail.d/cali2fail.conf" ]
  - [ wget, "https://github.com/eclipse/californium/raw/master/demo-apps/cf-unix-setup/src/main/resources/fail2ban/cali.conf", -O, "/etc/fail2ban/filter.d/cali.conf" ]
+ - [ sleep, 5 ]
  - [ systemctl, restart, fail2ban ]
 

--- a/demo-apps/cf-unix-setup/src/main/resources/cloud-installs/deploy_aws.sh
+++ b/demo-apps/cf-unix-setup/src/main/resources/cloud-installs/deploy_aws.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+
+#/*******************************************************************************
+# * Copyright (c) 2022 Bosch.IO GmbH and others.
+# * 
+# * All rights reserved. This program and the accompanying materials
+# * are made available under the terms of the Eclipse Public License v2.0
+# * and Eclipse Distribution License v1.0 which accompany this distribution.
+# * 
+# * The Eclipse Public License is available at
+# *    http://www.eclipse.org/legal/epl-v20.html
+# * and the Eclipse Distribution License is available at
+# *    http://www.eclipse.org/org/documents/edl-v10.html.
+# * 
+# * Contributors:
+# *    Achim Kraus (Bosch.IO GmbH) - initial script
+# ******************************************************************************/
+#
+# requirements:
+# 
+# - activate account at https://portal.aws.amazon.com/billing/signup (please obey the resulting costs!)
+# - follow https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html
+# -   Create an IAM user account https://docs.aws.amazon.com/cli/latest/userguide/getting-started-prereqs.html#getting-started-prereqs-iam
+# -   Create an access key ID and secret access key https://docs.aws.amazon.com/cli/latest/userguide/getting-started-prereqs.html#getting-started-prereqs-keys
+# -   install awscli2 https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+#     and configure it https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html
+# - upload your ssh-key (either rsa or ed25519) using the ec2 console using the name "cali" or 
+#      copy a different used name to "ssh_key_id" below.
+#
+# Adapt the the "vmsize" according your requirements and wanted price.
+# See https://aws.amazon.com/ec2/pricing/
+
+name=cali
+ssh_key_id=cali
+vmsize="t2.micro"
+
+get_vm_id() {
+   vm_id=$(aws ec2 describe-instances --filter Name=instance.group-name,Values=${name}-sg --query='Reservations[*].Instances[*].InstanceId' --output text)
+   echo "vm-id: ${vm_id}"
+}
+
+get_ip() {
+   ip=$(aws ec2 describe-instances --filter Name=instance.group-name,Values=${name}-sg --query='Reservations[*].Instances[*].PublicIpAddress' --output text)
+   echo "vm-ip: ${ip}"
+}
+
+wait_vm_ready() {
+   status=$(aws ec2 describe-instances --filter Name=instance.group-name,Values=${name}-sg --query='Reservations[*].Instances[*].State.Name' --output text)
+   while [ "${status}" != "running" ] ; do
+        echo "vm: ${status}, waiting for running"
+        sleep 10
+        status=$(aws ec2 describe-instances --filter Name=instance.group-name,Values=${name}-sg --query='Reservations[*].Instances[*].State.Name' --output text)
+   done
+   echo "vm: ${status}"
+}
+
+wait_vm_terminated() {
+   status=$(aws ec2 describe-instances --filter Name=instance.group-name,Values=${name}-sg --query='Reservations[*].Instances[*].State.Name' --output text)
+   while [ "${status}" = "running" ] || [ "${status}" = "shutting-down" ] ; do
+        echo "vm: ${status}, waiting"
+        sleep 10
+        status=$(aws ec2 describe-instances --filter Name=instance.group-name,Values=${name}-sg --query='Reservations[*].Instances[*].State.Name' --output text)
+   done
+   echo "vm: ${status}"
+}
+
+wait_cloud_init_ready() {
+   status=$(ssh -o "StrictHostKeyChecking=accept-new" root@${ip} "cloud-init status")
+
+   while [ "${status}" != "status: done" ] ; do
+      echo "cloud-init: ${status}, waiting for done"
+      sleep 10
+      status=$(ssh -o "StrictHostKeyChecking=accept-new" root@${ip} "cloud-init status")
+   done
+   echo "cloud-init: ${status}"
+}
+
+if [ "$1" = "create" ]  ; then
+   echo "create aws server ${name}"
+
+   aws ec2 create-security-group --group-name ${name}-sg --description "${name} security group" --output text
+
+   aws ec2 authorize-security-group-ingress --group-name ${name}-sg --ip-permissions \
+      IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges='[{CidrIp=0.0.0.0/0}]' \
+      IpProtocol=udp,FromPort=5684,ToPort=5684,IpRanges='[{CidrIp=0.0.0.0/0}]' \
+      --no-cli-pager
+
+   aws ec2 run-instances --image-id ami-0d527b8c289b4af7f --count 1 --instance-type ${vmsize} \
+      --key-name ${ssh_key_id} --security-groups ${name}-sg --no-cli-pager \
+      --user-data file://cloud-config.yaml
+
+   echo "wait to give vm time to finish the installation!"
+
+   wait_vm_ready
+	
+   get_ip
+
+   wait_cloud_init_ready
+
+   echo "use: ssh root@${ip} to login!"
+
+   exit 0
+fi
+
+if [ "$1" = "delete" ] ; then
+   echo "delete aws server ${name}"
+
+   get_vm_id
+   get_ip
+
+   if [ -n "${vm_id}" ] ; then
+      aws ec2 terminate-instances --instance-ids ${vm_id}
+      wait_vm_terminated
+   fi
+
+   aws ec2 delete-security-group --group-name ${name}-sg
+
+   echo "Please verify the successful deletion via the Web UI."
+
+   if [ -n "${ip}" ] ; then
+      echo "Remove the ssh trust for ${ip} with:"
+      echo "ssh-keygen -f ~/.ssh/known_hosts -R \"${ip}\""
+   fi
+
+   exit 0
+fi
+
+echo "usage: (create|delete)"
+
+
+

--- a/demo-apps/cf-unix-setup/src/main/resources/cloud-installs/deploy_azure.sh
+++ b/demo-apps/cf-unix-setup/src/main/resources/cloud-installs/deploy_azure.sh
@@ -29,20 +29,48 @@
 #
 # Before executing this script, "az login" may be required to refresh the az login credentials.
 
+name=cali
+
 sshkey="ssh-rsa AAAAB3N???"
 
 zone="westeurope"
 vmsize="Standard_B1s"
 
+get_ip() {
+   ip=$(az vm show --resource-group ${name}Resources --name ${name} --show-details --query publicIps --output tsv)
+   echo "vm-ip: ${ip}"
+}
+
+wait_vm_ready() {
+   status=$(az vm show --resource-group ${name}Resources --name ${name} --show-details --query powerState --output tsv)
+   while [ "${status}" != "VM running" ] ; do
+      echo "vm: ${status}, waiting for VM running"
+      sleep 10
+      status=$(az vm show --resource-group ${name}Resources --name ${name} --show-details --query powerState --output tsv)
+   done
+   echo "vm: ${status}"
+}
+
+wait_cloud_init_ready() {
+   status=$(ssh -o "StrictHostKeyChecking=accept-new" root@${ip} "cloud-init status")
+
+   while [ "${status}" != "status: done" ] ; do
+      echo "cloud-init: ${status}, waiting for done"
+      sleep 10
+      status=$(ssh -o "StrictHostKeyChecking=accept-new" root@${ip} "cloud-init status")
+   done
+   echo "cloud-init: ${status}"
+}
+
 if [ "$1" = "create" ]  ; then
-   echo "create azure server"
+   echo "create azure server ${name}"
 
-   az group create --name CaliResources --location ${zone}
+   az group create --name ${name}Resources --location ${zone}
 
-   az sshkey create --resource-group CaliResources --name root --public-key "${sshkey}"
+   az sshkey create --resource-group ${name}Resources --name root --public-key "${sshkey}"
 
-   az vm create --resource-group CaliResources \
-     --name Cali \
+   az vm create --resource-group ${name}Resources \
+     --name ${name} \
      --image UbuntuLTS \
      --ssh-key-name root \
      --size ${vmsize} \
@@ -50,16 +78,19 @@ if [ "$1" = "create" ]  ; then
      --custom-data cloud-config.yaml \
      --verbose
 
-   nsg=$(az network nsg list --resource-group CaliResources --query [].name --output tsv)
+   nsg=$(az network nsg list --resource-group ${name}Resources --query [].name --output tsv)
    echo "Network Security Group: ${nsg}, enable coaps"
 
-   az network nsg rule create --resource-group CaliResources --name coaps --nsg-name "${nsg}" \
+   az network nsg rule create --resource-group ${name}Resources --name ${name}coaps --nsg-name "${nsg}" \
       --priority 800 --access Allow --protocol Udp --destination-port-ranges 5684
 
    echo "wait to give vm time to finish the installation!"
-   sleep 30
 
-   ip=$(az vm show --resource-group CaliResources --name Cali --show-details --query publicIps --output tsv)
+   wait_vm_ready
+
+   get_ip
+
+   wait_cloud_init_ready
 
    echo "use: ssh root@${ip} to login!"
 
@@ -67,13 +98,19 @@ if [ "$1" = "create" ]  ; then
 fi
 
 if [ "$1" = "delete" ]  ; then
-   echo "delete azure server"
-   az vm delete --resource-group CaliResources --name Cali
+   echo "delete azure server ${name}"
+
+   get_ip
+
+   az vm delete --resource-group ${name}Resources --name ${name}
 
    echo "delete azure group"
-   az group delete --name CaliResources
+   az group delete --name ${name}Resources
 
    echo "Please verify the successful deletion via the Web UI."
+
+   echo "Remove the ssh trust for ${ip} with:"
+   echo "ssh-keygen -f ~/.ssh/known_hosts -R \"${ip}\""
 
    exit 0
 fi

--- a/demo-apps/cf-unix-setup/src/main/resources/cloud-installs/deploy_do.sh
+++ b/demo-apps/cf-unix-setup/src/main/resources/cloud-installs/deploy_do.sh
@@ -30,45 +30,80 @@
 # Available regions:
 # run `doctl compute run `doctl compute size list` list`
 
+name=cali
 ssh_key_id="7d:2a:03:72:eb:d6:95:52:1d:7f:77:73:22:35:0f:93"
 vmsize="s-2vcpu-2gb"
 
+get_ip() {
+   ip=$(doctl compute droplet get ${name} --template {{.PublicIPv4}})
+   echo "vm-ip: ${ip}"
+}
+
+wait_vm_ready() {
+   status=$(doctl compute droplet get ${name} --template {{.Status}})
+   while [ "${status}" != "active" ] ; do
+      echo "vm: ${status}, waiting for active"
+      sleep 10
+      status=$(doctl compute droplet get ${name} --template {{.Status}})
+   done
+   echo "vm: ${status}"
+}
+
+wait_cloud_init_ready() {
+   status=$(ssh -o "StrictHostKeyChecking=accept-new" root@${ip} "cloud-init status")
+
+   while [ "${status}" != "status: done" ] ; do
+      echo "cloud-init: ${status}, waiting for done"
+      sleep 10
+      status=$(ssh -o "StrictHostKeyChecking=accept-new" root@${ip} "cloud-init status")
+   done
+   echo "cloud-init: ${status}"
+}
+
 if [ "$1" = "create" ]  ; then
-   echo "create digitalocean server"
+   echo "create digitalocean firewall ${name}"
+
+   doctl compute firewall create \
+     --name ${name} \
+     --tag-names ${name} \
+     --inbound-rules="protocol:tcp,ports:22,address:0.0.0.0/0,address:::/0 protocol:udp,ports:5684,address:0.0.0.0/0,address:::/0" \
+     --outbound-rules="protocol:tcp,ports:all,address:0.0.0.0/0,address:::/0 protocol:udp,ports:all,address:0.0.0.0/0,address:::/0 protocol:icmp,address:0.0.0.0/0,address:::/0"
+
+   echo "create digitalocean server ${name}, may take a couple of minutes to complete."
    
-   doctl compute droplet create cali \
-    --tag-name cali \
+   doctl compute droplet create ${name} \
+    --tag-name ${name} \
     --image "ubuntu-20-04-x64" \
     --enable-ipv6 \
     --region "fra1" \
     --size "${vmsize}" \
     --ssh-keys "${ssh_key_id}" \
-    --user-data-file "cloud-config.yaml" 	
-
-   doctl compute firewall create \
-     --name cali \
-     --tag-names cali \
-     --inbound-rules="protocol:tcp,ports:22,address:0.0.0.0/0,address:::/0 protocol:udp,ports:5684,address:0.0.0.0/0,address:::/0" \
-     --outbound-rules="protocol:tcp,ports:all,address:0.0.0.0/0,address:::/0 protocol:udp,ports:all,address:0.0.0.0/0,address:::/0 protocol:icmp,address:0.0.0.0/0,address:::/0"
+    --user-data-file "cloud-config.yaml" \
+    --wait 	
 
    echo "wait to give vm time to finish the installation!"
-   sleep 30 
-	
-   doctl compute droplet get cali --format ID,PublicIPv4,PublicIPv6
-   
-   ip=$(doctl compute droplet get cali --template {{.PublicIPv4}})
 
+   wait_vm_ready
+
+   doctl compute droplet get ${name} --format ID,PublicIPv4,PublicIPv6
+
+   get_ip
+
+   wait_cloud_init_ready
+	
    echo "use: ssh root@${ip} to login!"
 
    exit 0
 fi
 
 if [ "$1" = "delete" ]  ; then
-   echo "delete digitalocean server"
+   echo "delete digitalocean server ${name}"
 
-   doctl compute droplet delete cali
+   get_ip
 
-   id=$(doctl compute firewall list --format "ID,Name" | grep cali | cut -sd ' ' -f 1)
+   doctl compute droplet delete ${name}
+
+   id=$(doctl compute firewall list --format "ID,Name" | grep ${name} | cut -sd ' ' -f 1)
 
    if [ -n "${id}" ] ; then
       echo "delete digitalocean fw ${id}"
@@ -76,6 +111,9 @@ if [ "$1" = "delete" ]  ; then
    fi
 
    echo "Please verify the successful deletion via the Web UI."
+
+   echo "Remove the ssh trust for ${ip} with:"
+   echo "ssh-keygen -f ~/.ssh/known_hosts -R \"${ip}\""
 
    exit 0
 fi

--- a/demo-apps/cf-unix-setup/src/main/resources/cloud-installs/deploy_exo.sh
+++ b/demo-apps/cf-unix-setup/src/main/resources/cloud-installs/deploy_exo.sh
@@ -28,51 +28,81 @@
 # See https://www.exoscale.com/pricing/ and
 # run `exo compute instance create --help` to see the options.
 
+name=cali
 ssh_key_id="cali"
 vmsize="standard.small"
 
+get_ip() {
+   ip=$(exo compute instance show ${name} -O text --output-template '{{ .IPAddress }}')
+   echo "vm-ip: ${ip}"
+}
+
+wait_vm_ready() {
+   status=$(exo compute instance show ${name} -O text --output-template '{{ .State }}')
+   while [ "${status}" != "running" ] ; do
+      echo "vm: ${status}, waiting for running"
+      sleep 10
+      status=$(exo compute instance show ${name} -O text --output-template '{{ .State }}')
+   done
+   echo "vm: ${status}"
+}
+
+wait_cloud_init_ready() {
+   status=$(ssh -o "StrictHostKeyChecking=accept-new" root@${ip} "cloud-init status")
+
+   while [ "${status}" != "status: done" ] ; do
+      echo "cloud-init: ${status}, waiting for done"
+      sleep 10
+      status=$(ssh -o "StrictHostKeyChecking=accept-new" root@${ip} "cloud-init status")
+   done
+   echo "cloud-init: ${status}"
+}
+
 if [ "$1" = "create" ]  ; then
-   echo "create exoscale server"
+   echo "create exoscale server ${name}"
 
-   exo compute security-group create cali-group
+   exo compute security-group create ${name}-group
 
-   exo compute security-group rule add cali-group \
+   exo compute security-group rule add ${name}-group \
     --description "ssh ipv4" \
     --protocol tcp \
     --network "0.0.0.0/0" \
     --port 22
 
-   exo compute security-group rule add cali-group \
+   exo compute security-group rule add ${name}-group \
     --description "ssh ipv6" \
     --protocol tcp \
     --network "::/0" \
     --port 22
 
-   exo compute security-group rule add cali-group \
+   exo compute security-group rule add ${name}-group \
     --description "coaps ipv4" \
     --protocol udp \
     --network "0.0.0.0/0" \
     --port 5684
 
-   exo compute security-group rule add cali-group \
+   exo compute security-group rule add ${name}-group \
     --description "coaps ipv6" \
     --protocol udp \
     --network "::/0" \
     --port 5684
   
-   exo compute instance create cali \
+   exo compute instance create ${name} \
     --zone de-fra-1 \
     --disk-size 10 \
     --instance-type "${vmsize}" \
     --ipv6 \
     --ssh-key "${ssh_key_id}" \
     --cloud-init cloud-config.yaml \
-    --security-group cali-group
+    --security-group ${name}-group
 
    echo "wait to give vm time to finish the installation!"
-   sleep 30
+
+   wait_vm_ready
 	
-   ip=$(exo compute instance show cali -O text --output-template '{{ .IPAddress }}')
+   get_ip
+
+   wait_cloud_init_ready
 
    echo "use: ssh root@${ip} to login!"
 
@@ -80,12 +110,17 @@ if [ "$1" = "create" ]  ; then
 fi
 
 if [ "$1" = "delete" ]  ; then
-   echo "delete exoscale server"
+   echo "delete exoscale server ${name}"
 
-   exo compute instance delete cali
-   exo compute security-group delete cali-group --force
+   get_ip
+
+   exo compute instance delete ${name}
+   exo compute security-group delete ${name}-group --force
 
    echo "Please verify the successful deletion via the Web UI."
+
+   echo "Remove the ssh trust for ${ip} with:"
+   echo "ssh-keygen -f ~/.ssh/known_hosts -R \"${ip}\""
 
    exit 0
 fi


### PR DESCRIPTION
Extend deploy scripts to monitor the state of the vm during creation.
Add hint to remove ssh trust on deletion.
Add 5s sleep before restart fail2ban to prevent from failing caused by
missing ban.log.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>