### PR TITLE
Add comment about typo SHA378 in cipher suite names.

### DIFF
--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/PublicAPITypo.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/PublicAPITypo.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.elements.util;
+
+/**
+ * Mark elements, which are part of the public API, but contain typos in their
+ * name.
+ * 
+ * @since 3.3
+ */
+public @interface PublicAPITypo {
+
+	/**
+	 * The (future) name without typo.
+	 * 
+	 * @return (future) name without typo.
+	 */
+	String fixedName();
+}

--- a/scandium-core/README.md
+++ b/scandium-core/README.md
@@ -144,13 +144,13 @@ Also Starting with 3.0.0-RC1, a server may use a `X509KeyManager` in order to pr
 - TLS_ECDHE_PSK_WITH_AES_128_CCM_8_SHA256
 - TLS_ECDHE_PSK_WITH_AES_128_CCM_SHA256
 - TLS_ECDHE_PSK_WITH_AES_128_GCM_SHA256
-- TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA378
+- *TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA378*
 - TLS_PSK_WITH_AES_128_CCM
 - TLS_PSK_WITH_AES_128_CCM_8
 - TLS_PSK_WITH_AES_128_GCM_SHA256
 - TLS_PSK_WITH_AES_256_CCM
 - TLS_PSK_WITH_AES_256_CCM_8
-- TLS_PSK_WITH_AES_256_GCM_SHA378
+- *TLS_PSK_WITH_AES_256_GCM_SHA378*
 - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 
@@ -159,11 +159,13 @@ Also Starting with 3.0.0-RC1, a server may use a `X509KeyManager` in order to pr
 - *TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384*
 - *TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256*
 - *TLS_PSK_WITH_AES_128_CBC_SHA256*
-- *TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-- *TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
-- *TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+- *TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256*
+- *TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384*
+- *TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA*
 
-Note: the *CBC* cipher suite are not longer recommended for new deployments!
+Note: the *CBC* cipher suites are not longer recommended for new deployments!
+
+Note: *SHA378* in the cipher suite names are typos. It must be *SHA384*. The straight forward fix would break the API, therefore the fix is postponed to 4.0 (no schedule for now)!
 
 ## Supported Signature- and Hash-Algorithms
 

--- a/scandium-core/api-changes.json
+++ b/scandium-core/api-changes.json
@@ -350,5 +350,31 @@
 				}
 			]
 		}
-	}
+	},
+	"3.3.0": [
+		{
+			"extension": "revapi.differences",
+			"configuration": {
+				"ignore": true,
+				"differences": [
+					{
+						"ignore": true,
+						"code": "java.annotation.added",
+						"old": "field org.eclipse.californium.scandium.dtls.cipher.CipherSuite.TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA378",
+						"new": "field org.eclipse.californium.scandium.dtls.cipher.CipherSuite.TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA378",
+						"annotation": "@org.eclipse.californium.elements.util.PublicAPITypo(fixedName = \"TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA384\")",
+						"justification": "Annotation is used to announce an API change in the future."
+					},
+					{
+						"ignore": true,
+						"code": "java.annotation.added",
+						"old": "field org.eclipse.californium.scandium.dtls.cipher.CipherSuite.TLS_PSK_WITH_AES_256_GCM_SHA378",
+						"new": "field org.eclipse.californium.scandium.dtls.cipher.CipherSuite.TLS_PSK_WITH_AES_256_GCM_SHA378",
+						"annotation": "@org.eclipse.californium.elements.util.PublicAPITypo(fixedName = \"TLS_PSK_WITH_AES_256_GCM_SHA384\")",
+						"justification": "Annotation is used to announce an API change in the future."
+					}
+				]
+			}
+		}
+	]
 }

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/cipher/CipherSuite.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import org.eclipse.californium.elements.util.Asn1DerDecoder;
 import org.eclipse.californium.elements.util.DatagramReader;
 import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.PublicAPITypo;
 import org.eclipse.californium.scandium.util.ListUtils;
 
 
@@ -94,11 +95,19 @@ public enum CipherSuite {
 	/**See <a href="https://tools.ietf.org/html/rfc8442#section-3" target="_blank">RFC 8442</a> for details*/
 	/**Note: compatibility not tested! openssl 1.1.1 seems not supporting them */
 	TLS_ECDHE_PSK_WITH_AES_128_GCM_SHA256(0xD001, CertificateKeyAlgorithm.NONE, KeyExchangeAlgorithm.ECDHE_PSK, CipherSpec.AES_128_GCM, true),
+	/**
+	 * Wrong cipher suite name! Must be SHA384! Will be changed with the next major version.
+	 */
+	@PublicAPITypo(fixedName="TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA384")
 	TLS_ECDHE_PSK_WITH_AES_256_GCM_SHA378(0xD002, CertificateKeyAlgorithm.NONE, KeyExchangeAlgorithm.ECDHE_PSK, CipherSpec.AES_256_GCM, true, PRFAlgorithm.TLS_PRF_SHA384),
 	TLS_ECDHE_PSK_WITH_AES_128_CCM_8_SHA256(0xD003, CertificateKeyAlgorithm.NONE, KeyExchangeAlgorithm.ECDHE_PSK, CipherSpec.AES_128_CCM_8, true),
 	TLS_ECDHE_PSK_WITH_AES_128_CCM_SHA256(0xD005, CertificateKeyAlgorithm.NONE, KeyExchangeAlgorithm.ECDHE_PSK, CipherSpec.AES_128_CCM, true),
 
 	TLS_PSK_WITH_AES_128_GCM_SHA256(0x00A8, CertificateKeyAlgorithm.NONE, KeyExchangeAlgorithm.PSK, CipherSpec.AES_128_GCM, true),
+	/**
+	 * Wrong cipher suite name! Must be SHA384!
+	 */
+	@PublicAPITypo(fixedName="TLS_PSK_WITH_AES_256_GCM_SHA384")
 	TLS_PSK_WITH_AES_256_GCM_SHA378(0x00A9, CertificateKeyAlgorithm.NONE, KeyExchangeAlgorithm.PSK, CipherSpec.AES_256_GCM, true, PRFAlgorithm.TLS_PRF_SHA384),
 	TLS_PSK_WITH_AES_128_CCM_8(0xC0A8, CertificateKeyAlgorithm.NONE, KeyExchangeAlgorithm.PSK, CipherSpec.AES_128_CCM_8, true),
 	TLS_PSK_WITH_AES_256_CCM_8(0xC0A9, CertificateKeyAlgorithm.NONE, KeyExchangeAlgorithm.PSK, CipherSpec.AES_256_CCM_8, true),


### PR DESCRIPTION
Must be SHA384.
Adds also remark to scandium readme.
Introduce @PublicAPITypo annotation.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>