### PR TITLE
Update bouncy castĺe for tests to 1.70.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ In that case, it's still possible to use `ed25519-java`, if the [eddsa-0.3.0.jar
 
 ## Run unit tests using Bouncy Castle as alternative JCE provider
 
-With 3.0 a first, experimental support for using Bouncy Castle (1.69, bcprov-jdk15on, bcpkix-jdk15on, and, for tls, bctls-jdk15on) is implemented.
+With 3.0 a first, experimental support for using Bouncy Castle (version 1.69, bcprov-jdk15on, bcpkix-jdk15on, and, for tls, bctls-jdk15on) is implemented. With 3.3 the tests are using the updated version 1.70 (for tls also  bcutil-jdk15on is used additionally).
 
 To demonstrate the basic functions, run the unit-tests using the profile `bc-tests`
 

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsClientConnector.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsClientConnector.java
@@ -45,8 +45,6 @@ import org.eclipse.californium.elements.config.CertificateAuthenticationMode;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.TcpConfig;
 import org.eclipse.californium.elements.util.CertPathUtil;
-import org.eclipse.californium.elements.util.JceProviderUtil;
-import org.eclipse.californium.elements.util.SslContextUtil;
 import org.eclipse.californium.elements.util.StringUtil;
 
 import io.netty.channel.Channel;
@@ -66,7 +64,7 @@ public class TlsClientConnector extends TcpClientConnector {
 	/**
 	 * Weak cipher suites, or {@code null}, if no required.
 	 * 
-	 * @see JceProviderUtil#hasStrongEncryption()
+	 * @see TlsContextUtil#getWeakCipherSuites(SSLContext)
 	 * @since 3.0
 	 */
 	private final String[] weakCipherSuites;
@@ -96,8 +94,7 @@ public class TlsClientConnector extends TcpClientConnector {
 		this.handshakeTimeoutMillis = configuration.getTimeAsInt(TcpConfig.TLS_HANDSHAKE_TIMEOUT,
 				TimeUnit.MILLISECONDS);
 		this.verifyServerSubject = configuration.get(TcpConfig.TLS_VERIFY_SERVER_CERTIFICATES_SUBJECT);
-		this.weakCipherSuites = JceProviderUtil.hasStrongEncryption() ? null
-				: SslContextUtil.getWeakCipherSuites(sslContext);
+		this.weakCipherSuites = TlsContextUtil.getWeakCipherSuites(sslContext);
 	}
 
 	/**

--- a/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsServerConnector.java
+++ b/element-connector-tcp-netty/src/main/java/org/eclipse/californium/elements/tcp/netty/TlsServerConnector.java
@@ -31,8 +31,6 @@ import javax.net.ssl.SSLEngine;
 import org.eclipse.californium.elements.config.CertificateAuthenticationMode;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.config.TcpConfig;
-import org.eclipse.californium.elements.util.JceProviderUtil;
-import org.eclipse.californium.elements.util.SslContextUtil;
 import org.eclipse.californium.elements.util.StringUtil;
 
 import io.netty.channel.Channel;
@@ -54,7 +52,7 @@ public class TlsServerConnector extends TcpServerConnector {
 	/**
 	 * Weak cipher suites, or {@code null}, if no required.
 	 * 
-	 * @see JceProviderUtil#hasStrongEncryption()
+	 * @see TlsContextUtil#getWeakCipherSuites(SSLContext)
 	 * @since 3.0
 	 */
 	private final String[] weakCipherSuites;
@@ -78,8 +76,7 @@ public class TlsServerConnector extends TcpServerConnector {
 		this.sslContext = sslContext;
 		this.clientAuthMode = configuration.get(TcpConfig.TLS_CLIENT_AUTHENTICATION_MODE);
 		this.handshakeTimeoutMillis = configuration.get(TcpConfig.TLS_HANDSHAKE_TIMEOUT, TimeUnit.MILLISECONDS);
-		this.weakCipherSuites = JceProviderUtil.hasStrongEncryption() ? null
-				: SslContextUtil.getWeakCipherSuites(sslContext);
+		this.weakCipherSuites = TlsContextUtil.getWeakCipherSuites(sslContext);
 	}
 
 	@Override

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/JceProviderUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/JceProviderUtil.java
@@ -119,6 +119,7 @@ public class JceProviderUtil {
 	private final boolean ed25519;
 	private final boolean ed448;
 	private final boolean strongEncryption;
+	private final double providerVersion;
 
 	static {
 		setupJce();
@@ -313,6 +314,7 @@ public class JceProviderUtil {
 		} catch (NoSuchAlgorithmException e) {
 		}
 		LOGGER.debug("RSA: {}, EC: {}, strong encryption: {}", rsa, ec, strongEncryption);
+		double version = provider == null ? 0.0 : provider.getVersion();
 		boolean ed25519 = false;
 		boolean ed448 = false;
 		if (found && provider != null) {
@@ -333,7 +335,7 @@ public class JceProviderUtil {
 			provider = null;
 			LOGGER.debug("EdDSA not supported!");
 		}
-		JceProviderUtil newSupport = new JceProviderUtil(isBouncyCastle(provider), rsa, ec, ed25519, ed448, strongEncryption);
+		JceProviderUtil newSupport = new JceProviderUtil(isBouncyCastle(provider), rsa, ec, ed25519, ed448, strongEncryption, version);
 		if (!newSupport.equals(features)) {
 			features = newSupport;
 		}
@@ -391,13 +393,25 @@ public class JceProviderUtil {
 		return false;
 	}
 
-	private JceProviderUtil(boolean useBc, boolean rsa, boolean ec, boolean ed25519, boolean ed448, boolean strongEncryption) {
+	/**
+	 * Get provider version.
+	 * 
+	 * @return provider version. {@code 0.0}, if not available.
+	 * @see Provider#getVersion()
+	 * @since 3.3
+	 */
+	public static double getProviderVersion() {
+		return features.providerVersion;
+	}
+
+	private JceProviderUtil(boolean useBc, boolean rsa, boolean ec, boolean ed25519, boolean ed448, boolean strongEncryption, double providerVersion) {
 		this.useBc = useBc;
 		this.rsa = rsa;
 		this.ec = ec;
 		this.ed25519 = ed25519;
 		this.ed448 = ed448;
 		this.strongEncryption = strongEncryption;
+		this.providerVersion = providerVersion;
 	}
 
 	@Override

--- a/pom.xml
+++ b/pom.xml
@@ -823,7 +823,7 @@
 				<activeByDefault>false</activeByDefault>
 			</activation>
 			<properties>
-				<bc.version>1.69</bc.version>
+				<bc.version>1.70</bc.version>
 				<slf4j.version>1.7.30</slf4j.version>
 			</properties>
 			<dependencies>
@@ -842,6 +842,12 @@
 				<dependency>
 					<groupId>org.bouncycastle</groupId>
 					<artifactId>bctls-jdk15on</artifactId>
+					<version>${bc.version}</version>
+					<scope>test</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.bouncycastle</groupId>
+					<artifactId>bcutil-jdk15on</artifactId>
 					<version>${bc.version}</version>
 					<scope>test</scope>
 				</dependency>

--- a/scandium-core/README.md
+++ b/scandium-core/README.md
@@ -241,6 +241,8 @@ Starting with 3.0.0-RC1 an experimental support for using [Bouncy Castle](https:
 </dependencies>
 ```
 
+(With 3.3 the tests are using the updated version 1.70).
+
 And setup a environment variable `CALIFORNIUM_JCE_PROVIDER` using the value `BC` (see [JceProviderUtil](../element-connector/src/main/java/org/eclipse/californium/elements/util/JceProviderUtil.java) for more details) or use the java `System.property` `CALIFORNIUM_JCE_PROVIDER` to do so.
 
 Supporting Bouncy Castle for the unit test uncovers a couple of differences, which required to adapt the implementation. It is assumed, that more will be found and more adaption will be required. If you find some, don't hesitate to report issues, perhaps research and analysis, and fixes. On the other hand, the project Californium will for now not be able to provide support for Bouncy Castle questions with or without relation to Californium. You may create issues, but it may be not possible for us to answer them.


### PR DESCRIPTION
Use explicit weak cipher suites only for bc before 1.70.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>