### PR TITLE
Fix cli tls config.

### DIFF
--- a/cf-utils/cf-cli-tcp-netty/src/main/java/org/eclipse/californium/cli/tcp/netty/TlsConnectorFactory.java
+++ b/cf-utils/cf-cli-tcp-netty/src/main/java/org/eclipse/californium/cli/tcp/netty/TlsConnectorFactory.java
@@ -26,6 +26,8 @@ import javax.net.ssl.TrustManager;
 
 import org.eclipse.californium.cli.CliConnectorFactory;
 import org.eclipse.californium.cli.ClientBaseConfig;
+import org.eclipse.californium.cli.ConnectorConfig.Authentication;
+import org.eclipse.californium.cli.ConnectorConfig.Trust;
 import org.eclipse.californium.core.config.CoapConfig;
 import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.config.Configuration;
@@ -55,6 +57,10 @@ public class TlsConnectorFactory implements CliConnectorFactory {
 		SSLContext clientSslContext = null;
 		try {
 			KeyManager[] keyManager;
+			if (clientConfig.authentication == null) {
+				clientConfig.authentication = new Authentication();
+			}
+			clientConfig.authentication.defaults(clientConfig.defaultEcCredentials);
 			if (clientConfig.authentication.anonymous) {
 				keyManager = SslContextUtil.createAnonymousKeyManager();
 			} else {
@@ -63,6 +69,10 @@ public class TlsConnectorFactory implements CliConnectorFactory {
 						clientConfig.authentication.credentials.getCertificateChain());
 			}
 			TrustManager[] trustManager;
+			if (clientConfig.trust == null) {
+				clientConfig.trust = new Trust();
+			}
+			clientConfig.trust.defaults(clientConfig.defaultEcTrusts);
 			if (clientConfig.trust.trustall) {
 				trustManager = SslContextUtil.createTrustAllManager();
 			} else {

--- a/cf-utils/cf-cli/src/main/java/org/eclipse/californium/cli/ConnectorConfig.java
+++ b/cf-utils/cf-cli/src/main/java/org/eclipse/californium/cli/ConnectorConfig.java
@@ -202,6 +202,21 @@ public class ConnectorConfig implements Cloneable {
 				}
 			}
 		}
+
+		public void defaults(String defaultEcCredentials) {
+			if (!anonymous && identity == null) {
+				try {
+					identity = new Identity();
+					identity.certificate = SslContextUtil.loadCredentials(defaultEcCredentials);
+					LOGGER.info("x509 default identity.");
+				} catch (GeneralSecurityException e) {
+					e.printStackTrace();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
+			defaults();
+		}
 	}
 
 	/**
@@ -444,18 +459,7 @@ public class ConnectorConfig implements Cloneable {
 			if (authentication == null) {
 				authentication = new Authentication();
 			}
-			if (!authentication.anonymous && authentication.identity == null) {
-				try {
-					authentication.identity = new Identity();
-					authentication.identity.certificate = SslContextUtil.loadCredentials(defaultEcCredentials);
-					LOGGER.info("x509 default identity.");
-				} catch (GeneralSecurityException e) {
-					e.printStackTrace();
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
-			}
-			authentication.defaults();
+			authentication.defaults(defaultEcCredentials);
 		}
 		if (cipherHelpRequested || authHelpRequested) {
 			helpRequested = true;


### PR DESCRIPTION
Add lacy initialization to support later selection of tls, e.g. for
cf-browser.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>