### PR TITLE
OSCORE: Improvements to option handling and replay window

### DIFF
--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ContextRederivation.java
@@ -445,7 +445,6 @@ public class ContextRederivation {
 
 			// Generate a new context with the concatenated Context ID
 			OSCoreCtx newCtx = rederiveWithContextID(ctx, protectContextID);
-			newCtx.setReceiverSeq(0);
 
 			// Outgoing response from this context only uses R2 as
 			// Context ID (not concatenated one used to generate the context).

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtxDB.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OSCoreCtxDB.java
@@ -13,6 +13,7 @@
  * Contributors:
  *    Joakim Brorsson
  *    Tobias Andersson (RISE SICS)
+ *    Rikard Höglund (RISE)
  *    
  ******************************************************************************/
 package org.eclipse.californium.oscore;
@@ -84,37 +85,11 @@ public interface OSCoreCtxDB {
 	public OSCoreCtx getContext(String uri) throws OSException;
 
 	/**
-	 * Retrieves the sequence number associated by this token or null
-	 * 
 	 * @param token the token
-	 * @return sequence number for this token or null if not existing
-	 */
-	public Integer getSeqByToken(Token token);
-
-	/**
-	 * Saves the sequence number associated by this token
-	 * 
-	 * @param seq the sequence number
-	 * @param token the token
-	 */
-	public void addSeqByToken(Token token, Integer seq);
-
-	/**
-	 * @param token the token
-	 * @return {@code true}, if an association for this token exists, {@code false}, otherwise
+	 * @return {@code true}, if an association for this token exists,
+	 *         {@code false}, otherwise
 	 */
 	public boolean tokenExist(Token token);
-
-	/**
-	 * @param token the token
-	 */
-	public void removeSeqByToken(Token token);
-
-	/**
-	 * @param token the token
-	 * @param seq the sequence number
-	 */
-	public void updateSeqByToken(Token token, Integer seq);
 
 	/**
 	 * purge all contexts

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OptionJuggle.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OptionJuggle.java
@@ -14,12 +14,12 @@
  *    Joakim Brorsson
  *    Ludwig Seitz (RISE SICS)
  *    Tobias Andersson (RISE SICS)
+ *    Rikard Höglund (RISE)
  *    
  ******************************************************************************/
 package org.eclipse.californium.oscore;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -332,74 +332,4 @@ public class OptionJuggle {
 		}
 		return eOptions;
 	}
-
-	/**
-	 * Retrieve RID value from an OSCORE option.
-	 * 
-	 * @param oscoreOption the OSCORE option
-	 * @return the RID value
-	 */
-	static byte[] getRid(byte[] oscoreOption) {
-		if (oscoreOption.length == 0) {
-			return null;
-		}
-	
-		// Parse the flag byte
-		byte flagByte = oscoreOption[0];
-		int n = flagByte & 0x07;
-		int k = flagByte & 0x08;
-		int h = flagByte & 0x10;
-	
-		byte[] kid = null;
-		int index = 1;
-	
-		// Partial IV
-		index += n;
-	
-		// KID Context
-		if (h != 0) {
-			int s = oscoreOption[index];
-			index += s + 1;
-		}
-	
-		// KID
-		if (k != 0) {
-			kid = Arrays.copyOfRange(oscoreOption, index, oscoreOption.length);
-		}
-	
-		return kid;
-	}
-
-	/**
-	 * Retrieve ID Context value from an OSCORE option.
-	 * 
-	 * @param oscoreOption the OSCORE option
-	 * @return the ID Context value
-	 */
-	static byte[] getIDContext(byte[] oscoreOption) {
-		if (oscoreOption.length == 0) {
-			return null;
-		}
-
-		// Parse the flag byte
-		byte flagByte = oscoreOption[0];
-		int n = flagByte & 0x07;
-		int h = flagByte & 0x10;
-
-		byte[] kidContext = null;
-		int index = 1;
-
-		// Partial IV
-		index += n;
-
-		// KID Context
-		if (h != 0) {
-			int s = oscoreOption[index];
-			kidContext = Arrays.copyOfRange(oscoreOption, index + 1, index + 1 + s);
-			index += s + 1;
-		}
-
-		return kidContext;
-	}
-
 }

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OscoreOptionDecoder.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OscoreOptionDecoder.java
@@ -1,0 +1,223 @@
+/*******************************************************************************
+ * Copyright (c) 2022 RISE and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Rikard Höglund (RISE)
+ *    
+ ******************************************************************************/
+package org.eclipse.californium.oscore;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class for decoding the bytes of an OSCORE CoAP option.
+ * 
+ * See the structure of the option:
+ * https://datatracker.ietf.org/doc/html/rfc8613#section-6.1
+ * 
+ */
+public class OscoreOptionDecoder {
+
+	/**
+	 * The logger
+	 */
+	private static final Logger LOGGER = LoggerFactory.getLogger(OscoreOptionDecoder.class);
+
+	private byte[] encodedBytes;
+
+	private byte[] idContext;
+	private byte[] partialIV;
+	private byte[] kid;
+
+	private int n;
+	private int k;
+	private int h;
+
+	/**
+	 * Initialize the OSCORE option with a certain array of bytes and decode
+	 * them into the parameters of the option.
+	 * 
+	 * @param encodedBytes the encoded bytes of the option
+	 * @throws CoapOSException if the option is malformed
+	 */
+	public OscoreOptionDecoder(byte[] encodedBytes) throws CoapOSException {
+		this.encodedBytes = encodedBytes;
+		decode();
+	}
+
+	/**
+	 * Set the OSCORE option to a certain array of bytes and decode them into
+	 * the parameters of the option.
+	 * 
+	 * @param encodedBytes the encoded bytes of the option
+	 * @throws CoapOSException if the option is malformed
+	 */
+	public void setBytes(byte[] encodedBytes) throws CoapOSException {
+		this.encodedBytes = encodedBytes;
+		decode();
+	}
+
+	/**
+	 * Performs the decoding of the option and stores the resulting parameters
+	 * in this object.
+	 * 
+	 * @throws CoapOSException if the option is malformed
+	 */
+	private void decode() throws CoapOSException {
+		byte[] total = encodedBytes;
+
+		/**
+		 * If the OSCORE option value is a zero length byte array it represents
+		 * a byte array of length 1 with a byte 0x00 See
+		 * https://tools.ietf.org/html/draft-ietf-core-object-security-16#section-2
+		 */
+		if (total.length == 0) {
+			total = new byte[] { 0x00 };
+		}
+
+		byte flagByte = total[0];
+
+		int n = flagByte & 0x07;
+		int k = flagByte & 0x08;
+		int h = flagByte & 0x10;
+
+		byte[] partialIV = null;
+		byte[] kid = null;
+		byte[] kidContext = null;
+		int index = 1;
+
+		try {
+			// Parsing Partial IV
+			if (n > 0) {
+				partialIV = Arrays.copyOfRange(total, index, index + n);
+				index += n;
+			}
+		} catch (Exception e) {
+			LOGGER.error("Failed to parse Partial IV in OSCORE option.");
+			throw new CoapOSException(ErrorDescriptions.FAILED_TO_DECODE_COSE, ResponseCode.BAD_OPTION);
+		}
+
+		try {
+			// Parsing KID Context
+			if (h != 0) {
+				int s = total[index++];
+
+				kidContext = Arrays.copyOfRange(total, index, index + s);
+
+				index += s;
+			}
+		} catch (Exception e) {
+			LOGGER.error("Failed to parse KID Context in OSCORE option.");
+			throw new CoapOSException(ErrorDescriptions.FAILED_TO_DECODE_COSE, ResponseCode.BAD_OPTION);
+		}
+
+		try {
+			// Parsing KID
+			if (k != 0) {
+				kid = Arrays.copyOfRange(total, index, total.length);
+			}
+		} catch (Exception e) {
+			LOGGER.error("Failed to parse KID in OSCORE option.");
+			throw new CoapOSException(ErrorDescriptions.FAILED_TO_DECODE_COSE, ResponseCode.BAD_OPTION);
+		}
+
+		// Check option length consistency
+		if (k == 0 && index != total.length) {
+			// If KID is not present there should be no further data
+			LOGGER.error("Extranous data at end of OSCORE option.");
+			throw new CoapOSException(ErrorDescriptions.FAILED_TO_DECODE_COSE, ResponseCode.BAD_OPTION);
+		}
+
+		// Store parsed data in this object
+		this.n = n;
+		this.k = k;
+		this.h = h;
+		this.partialIV = partialIV;
+		this.kid = kid;
+		this.idContext = kidContext;
+	}
+
+	/**
+	 * Retrieve the ID Context
+	 * 
+	 * @return the ID Context (kid context)
+	 */
+	public byte[] getIdContext() {
+		return idContext;
+	}
+
+	/**
+	 * Retrieve the Partial IV
+	 * 
+	 * @return the Partial IV
+	 */
+	public byte[] getPartialIV() {
+		return partialIV;
+	}
+
+	/**
+	 * Retrieve the sequence number
+	 * 
+	 * @return the sequence number (based on the Partial IV)
+	 */
+	public int getSequenceNumber() {
+		if (partialIV == null) {
+			return 0;
+		}
+
+		byte[] partialIvInt = Arrays.copyOf(partialIV, Integer.SIZE / Byte.SIZE);
+
+		return ByteBuffer.wrap(partialIvInt).getInt();
+	}
+
+	/**
+	 * Retrieve the KID
+	 * 
+	 * @return the KID
+	 */
+	public byte[] getKid() {
+		return kid;
+	}
+
+	/**
+	 * Retrieve the n flag bit
+	 * 
+	 * @return the n bit (length of Partial IV)
+	 */
+	public int getN() {
+		return n;
+	}
+
+	/**
+	 * Retrieve the k flag bit
+	 * 
+	 * @return the k bit (if KID is present)
+	 */
+	public int getK() {
+		return k;
+	}
+
+	/**
+	 * Retrieve the h flag bit
+	 * 
+	 * @return the h bit (if ID Context is present)
+	 */
+	public int getH() {
+		return h;
+	}
+
+}

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/OscoreOptionEncoder.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/OscoreOptionEncoder.java
@@ -1,0 +1,190 @@
+/*******************************************************************************
+ * Copyright (c) 2022 RISE and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Rikard Höglund (RISE)
+ *    
+ ******************************************************************************/
+package org.eclipse.californium.oscore;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.eclipse.californium.elements.util.Bytes;
+
+/**
+ * Class for encoding the bytes of an OSCORE CoAP option.
+ * 
+ * See the structure of the option:
+ * https://datatracker.ietf.org/doc/html/rfc8613#section-6.1
+ * 
+ */
+public class OscoreOptionEncoder {
+
+	private boolean encoded;
+	private byte[] encodedBytes;
+
+	private byte[] idContext;
+	private byte[] partialIV;
+	private byte[] kid;
+
+	/**
+	 * Retrieve the encoded bytes of the OSCORE option.
+	 * 
+	 * @return the encoded OSCORE option bytes
+	 */
+	public byte[] getBytes() {
+		if (!encoded) {
+			encodedBytes = encode();
+		}
+
+		return encodedBytes;
+	}
+
+	/**
+	 * Encode the set parameters into the bytes of the OSCORE option.
+	 * 
+	 * @return the bytes of the OSCORE option
+	 */
+	private byte[] encode() {
+		int firstByte = 0x00;
+		ByteArrayOutputStream bRes = new ByteArrayOutputStream();
+
+		boolean hasContextID = this.idContext != null;
+		boolean hasPartialIV = this.partialIV != null;
+		boolean hasKid = this.kid != null;
+
+		// If the Context ID should be included, set its bit
+		if (hasContextID) {
+			firstByte = firstByte | 0x10;
+		}
+
+		// If the KID should be included, set its bit
+		if (hasKid) {
+			firstByte = firstByte | 0x08; // Set the KID bit
+		}
+
+		// If the Partial IV should be included, encode it
+		if (hasPartialIV) {
+			byte[] partialIV = this.partialIV;
+			firstByte = firstByte | (partialIV.length & 0x07);
+
+			bRes.write(firstByte);
+			try {
+				bRes.write(partialIV);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		} else {
+			bRes.write(firstByte);
+		}
+
+		// Encode the Context ID length and value if to be included
+		if (hasContextID) {
+			try {
+				bRes.write(this.idContext.length);
+				bRes.write(this.idContext);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+
+		// Encode Sender ID (KID)
+		if (hasKid) {
+			try {
+				bRes.write(this.kid);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+
+		// Set the option as encoded
+		encoded = true;
+
+		// If the OSCORE option is length 1 and 0x00, it should be empty
+		// https://tools.ietf.org/html/draft-ietf-core-object-security-16#section-2
+		byte[] optionBytes = bRes.toByteArray();
+		if (optionBytes.length == 1 && optionBytes[0] == 0x00) {
+			return Bytes.EMPTY;
+		} else {
+			return optionBytes;
+		}
+	}
+
+	/**
+	 * Retrieve the set ID Context
+	 * 
+	 * @return the ID Context (kid context)
+	 */
+	public byte[] getIdContext() {
+		return idContext;
+	}
+
+	/**
+	 * Set the ID Context
+	 * 
+	 * @param idContext the ID Context (kid context) to set
+	 */
+	public void setIdContext(byte[] idContext) {
+		encoded = false;
+		this.idContext = idContext;
+	}
+
+	/**
+	 * Retrieve the set Partial IV
+	 * 
+	 * @return the Partial IV
+	 */
+	public byte[] getPartialIV() {
+		return partialIV;
+	}
+
+	/**
+	 * Set the Partial IV
+	 * 
+	 * @param partialIV the Partial IV to set
+	 */
+	public void setPartialIV(byte[] partialIV) {
+		encoded = false;
+		this.partialIV = partialIV;
+	}
+
+	/**
+	 * Set the Partial IV (based on an integer sequence number)
+	 * 
+	 * @param senderSeq the sequence number to set as Partial IV
+	 */
+	public void setPartialIV(int senderSeq) {
+		encoded = false;
+		this.partialIV = OSSerializer.processPartialIV(senderSeq);
+	}
+
+	/**
+	 * Retrieve the set KID
+	 * 
+	 * @return the KID
+	 */
+	public byte[] getKid() {
+		return kid;
+	}
+
+	/**
+	 * Set the KID
+	 * 
+	 * @param kid the KID to set
+	 */
+	public void setKid(byte[] kid) {
+		encoded = false;
+		this.kid = kid;
+	}
+
+}

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestEncryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/RequestEncryptor.java
@@ -74,7 +74,7 @@ public class RequestEncryptor extends Encryptor {
 		OptionSet options = request.getOptions();
 		byte[] confidential = OSSerializer.serializeConfidentialData(options, request.getPayload(), realCode);
 		Encrypt0Message enc = prepareCOSEStructure(confidential);
-		byte[] cipherText = encryptAndEncode(enc, ctx, request, false);
+		byte[] cipherText = encryptAndEncode(enc, ctx, request, false, null);
 		compression(ctx, cipherText, request, false);
 
 		request.setOptions(OptionJuggle.prepareUoptions(request.getOptions()));

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseDecryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseDecryptor.java
@@ -50,13 +50,15 @@ public class ResponseDecryptor extends Decryptor {
 	 *
 	 * @param db the context database used
 	 * @param response the response
+	 * @param requestSequenceNr sequence number (Partial IV) from the request
+	 *            (if encrypting a response)
 	 * 
 	 * @return the decrypted response
 	 * 
 	 * @throws OSException when decryption fails
 	 * 
 	 */
-	public static Response decrypt(OSCoreCtxDB db, Response response) throws OSException {
+	public static Response decrypt(OSCoreCtxDB db, Response response, int requestSequenceNr) throws OSException {
 
 		LOGGER.info("Removes E options from outer options which are not allowed there");
 		discardEOptions(response);
@@ -96,7 +98,7 @@ public class ResponseDecryptor extends Decryptor {
 
 		//Check if parsing of response plaintext succeeds
 		try {
-			byte[] plaintext = decryptAndDecode(enc, response, ctx, db.getSeqByToken(token));
+			byte[] plaintext = decryptAndDecode(enc, response, ctx, requestSequenceNr);
 	
 			DatagramReader reader = new DatagramReader(new ByteArrayInputStream(plaintext));
 			

--- a/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseEncryptor.java
+++ b/cf-oscore/src/main/java/org/eclipse/californium/oscore/ResponseEncryptor.java
@@ -42,15 +42,19 @@ public class ResponseEncryptor extends Encryptor {
 	 * @param db the context DB
 	 * @param response the response
 	 * @param ctx the OSCore context
-	 * @param newPartialIV boolean to indicate whether to use a new partial IV or not
-	 * @param outerBlockwise boolean to indicate whether the block-wise options should be encrypted or not
+	 * @param newPartialIV boolean to indicate whether to use a new partial IV
+	 *            or not
+	 * @param outerBlockwise boolean to indicate whether the block-wise options
+	 *            should be encrypted or not
+	 * @param requestSequenceNr sequence number (Partial IV) from the request
+	 *            (if encrypting a response)
 	 * 
 	 * @return the response with the encrypted OSCore option
 	 * 
 	 * @throws OSException when encryption fails
 	 */
 	public static Response encrypt(OSCoreCtxDB db, Response response, OSCoreCtx ctx, final boolean newPartialIV,
-			boolean outerBlockwise) throws OSException {
+			boolean outerBlockwise, int requestSequenceNr) throws OSException {
 		if (ctx == null) {
 			LOGGER.error(ErrorDescriptions.CTX_NULL);
 			throw new OSException(ErrorDescriptions.CTX_NULL);
@@ -78,7 +82,7 @@ public class ResponseEncryptor extends Encryptor {
 
 		byte[] confidential = OSSerializer.serializeConfidentialData(options, response.getPayload(), realCode);
 		Encrypt0Message enc = prepareCOSEStructure(confidential);
-		byte[] cipherText = encryptAndEncode(enc, ctx, response, newPartialIV);
+		byte[] cipherText = encryptAndEncode(enc, ctx, response, newPartialIV, requestSequenceNr);
 		compression(ctx, cipherText, response, newPartialIV);
 
 		options = response.getOptions();

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/DecryptorTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/DecryptorTest.java
@@ -129,10 +129,9 @@ public class DecryptorTest {
 		//Set up some state information simulating the original outgoing request
 		OSCoreCtxDB db = new HashMapCtxDB();
 		db.addContext(r.getToken(), ctx);
-		db.addSeqByToken(r.getToken(), seq);
 		
 		//Decrypt the response message
-		Response decrypted = ResponseDecryptor.decrypt(db, r);
+		Response decrypted = ResponseDecryptor.decrypt(db, r, seq);
 		decrypted.getOptions().removeOscore();
 		
 		//Check the decrypted response payload

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/EncryptorTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/EncryptorTest.java
@@ -120,7 +120,7 @@ public class EncryptorTest {
 		
 		ctx = new OSCoreCtx(master_secret, true, alg, sid, rid, kdf, 32, master_salt, null, MAX_UNFRAGMENTED_SIZE);
 		ctx.setSenderSeq(0);
-		ctx.setReceiverSeq(seq);
+		ctx.setRecipientSeq(seq);
 
 		//Create response message from raw byte array
 		byte[] responseBytes = new byte[] { 0x64, 0x45, 0x5d, 0x1f, 0x00, 0x00, 0x39, 0x74,
@@ -136,7 +136,7 @@ public class EncryptorTest {
 
 		//Encrypt the response message
 		boolean newPartialIV = true;
-		Response encrypted = ResponseEncryptor.encrypt(null, r, ctx, newPartialIV, false);
+		Response encrypted = ResponseEncryptor.encrypt(null, r, ctx, newPartialIV, false, seq);
 		
 		//Check the OSCORE option value
 		byte[] predictedOSCoreOption = { 0x01, 0x00 };

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/HashMapCtxDBTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/HashMapCtxDBTest.java
@@ -12,14 +12,13 @@
  * 
  * Contributors:
  *    Tobias Andersson (RISE SICS)
+ *    Rikard Höglund (RISE)
  *    
  ******************************************************************************/
 package org.eclipse.californium.oscore;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import org.eclipse.californium.core.coap.Token;
 import org.eclipse.californium.cose.AlgorithmID;
@@ -46,7 +45,6 @@ public class HashMapCtxDBTest {
 	private final byte[] modifiedRid = new byte[] { 0x01, 0x65, 0x72, 0x76, 0x65, 0x72 };
 	private final byte[] context_id = { 0x74, 0x65, 0x73, 0x74, 0x74, 0x65, 0x73, 0x74 };
 	private final byte[] context_id_2 = {  0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11 };
-	private final Integer seq = 42;
 	private final static int MAX_UNFRAGMENTED_SIZE = 4096;
 
 	@Rule
@@ -86,7 +84,7 @@ public class HashMapCtxDBTest {
 	 * Get a context using both RID and ID Context. Only a single context is
 	 * added to the context DB.
 	 * 
-	 * @throws OSException
+	 * @throws OSException on test failure
 	 */
 	@Test
 	public void testAddGetContextRidIDContext() throws OSException {
@@ -105,7 +103,7 @@ public class HashMapCtxDBTest {
 	 * Get a context using both RID and ID Context. Multiple contexts are added
 	 * to the context DB.
 	 * 
-	 * @throws OSException
+	 * @throws OSException on test failure
 	 */
 	@Test
 	public void testAddGetContextRidIDContextMultiple() throws OSException {
@@ -128,7 +126,7 @@ public class HashMapCtxDBTest {
 	 * Get a context using only RID. Multiple contexts are added to the context
 	 * DB. But since only one matches the RID it is returned.
 	 * 
-	 * @throws OSException
+	 * @throws OSException on test failure
 	 */
 	@Test
 	public void testAddGetContextRidMultipleSuccess() throws OSException {
@@ -152,7 +150,7 @@ public class HashMapCtxDBTest {
 	 * DB. Since both of them have the same RID, the retrieval fails since it's
 	 * not unique and the ID Context is not used to disambiguate.
 	 * 
-	 * @throws OSException
+	 * @throws OSException on test failure
 	 */
 	@Test
 	public void testAddGetContextRidMultipleFail() throws OSException {
@@ -179,6 +177,8 @@ public class HashMapCtxDBTest {
 	 * Test retrieving a context using the getContext method that only takes a
 	 * RID. In such case this RID must be unique. If a RID is used that is not
 	 * unique an exception should be thrown.
+	 * 
+	 * @throws OSException on test failure
 	 * 
 	 */
 	@Test
@@ -226,68 +226,4 @@ public class HashMapCtxDBTest {
 		assertNull(db.getContextByToken(modifiedToken));
 	}
 
-	@Test
-	public void testNullSeqByToken() throws OSException {
-		HashMapCtxDB db = new HashMapCtxDB();
-		exception.expect(NullPointerException.class);
-
-		db.addSeqByToken(token, null);
-	}
-
-	@Test
-	public void testSeqByNullToken() throws OSException {
-		HashMapCtxDB db = new HashMapCtxDB();
-		exception.expect(NullPointerException.class);
-
-		db.addSeqByToken(null, seq);
-	}
-
-	@Test
-	public void testSeqBytToken() throws OSException {
-		HashMapCtxDB db = new HashMapCtxDB();
-		db.addSeqByToken(token, seq);
-
-		assertEquals(seq, db.getSeqByToken(token));
-		assertNull(db.getSeqByToken(modifiedToken));
-	}
-
-	@Test
-	public void testRemoveSeqBytToken() throws OSException {
-		HashMapCtxDB db = new HashMapCtxDB();
-		db.addSeqByToken(token, seq);
-		db.removeSeqByToken(token);
-
-		assertNull(db.getSeqByToken(token));
-		assertFalse(db.tokenExist(token));
-	}
-
-	@Test
-	public void testUpdateNonExistentSeqByToken() {
-		HashMapCtxDB db = new HashMapCtxDB();
-
-		try {
-			db.updateSeqByToken(null, seq);
-			db.updateSeqByToken(token, 44);
-		} catch (NullPointerException e) {
-			assertEquals(ErrorDescriptions.TOKEN_NULL, e.getMessage());
-		}
-
-		try {
-			db.updateSeqByToken(token, -5);
-		} catch (Exception e) {
-			assertEquals(ErrorDescriptions.SEQ_NBR_INVALID, e.getMessage());
-		}
-
-		assertFalse(db.tokenExist(token));
-		assertNull(db.getSeqByToken(token));
-	}
-
-	@Test
-	public void testTokenExists() throws OSException {
-		HashMapCtxDB db = new HashMapCtxDB();
-		db.addSeqByToken(token, seq);
-
-		assertTrue(db.tokenExist(token));
-		assertFalse(db.tokenExist(modifiedToken));
-	}
 }

--- a/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreCtxTest.java
+++ b/cf-oscore/src/test/java/org/eclipse/californium/oscore/OSCoreCtxTest.java
@@ -81,7 +81,7 @@ public class OSCoreCtxTest {
 		assertEquals(this.kdf, ctx.getKdf());
 		assertEquals(13, ctx.getIVLength());
 		assertTrue(Arrays.equals(this.master_secret, ctx.getMasterSecret()));
-		assertEquals(-1, ctx.getReceiverSeq());
+		assertEquals(0, ctx.getLowestRecipientSeq());
 		assertTrue(Arrays.equals(this.rid, ctx.getRecipientId()));
 		assertTrue(Arrays.equals(this.sid, ctx.getSenderId()));
 		assertEquals(0, ctx.getSenderSeq());


### PR DESCRIPTION
This pull request updates the handling of the OSCORE option, including separate option encoder/decoder classes, and now stores the entire OSCORE option in the exchange. This avoids using a separate map to keep track of the sequence number to use for processing incoming or outgoing responses. It also enables improvements to the replay window functionality.