### PR TITLE
Revert limiting of test unit groups.

### DIFF
--- a/californium-osgi/pom.xml
+++ b/californium-osgi/pom.xml
@@ -128,37 +128,6 @@
 					<type>test-jar</type>
 				</dependency>
 			</dependencies>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<useSystemClassLoader>false</useSystemClassLoader>
-							<systemPropertyVariables>
-								<org.eclipse.californium.junit.socketmode>DIRECT</org.eclipse.californium.junit.socketmode>
-							</systemPropertyVariables>
-							<excludes>
-								<exclude>**/*$*</exclude>
-							</excludes>
-						</configuration>
-						<executions>
-							<execution>
-								<id>medium-tests</id>
-								<phase></phase>
-							</execution>
-							<execution>
-								<id>large-tests</id>
-								<phase></phase>
-							</execution>
-							<execution>
-								<id>native-tests</id>
-								<phase></phase>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
 		</profile>
 	</profiles>
 

--- a/californium-proxy2/pom.xml
+++ b/californium-proxy2/pom.xml
@@ -176,37 +176,6 @@
 					<type>test-jar</type>
 				</dependency>
 			</dependencies>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<useSystemClassLoader>false</useSystemClassLoader>
-							<systemPropertyVariables>
-								<org.eclipse.californium.junit.socketmode>DIRECT</org.eclipse.californium.junit.socketmode>
-							</systemPropertyVariables>
-							<excludes>
-								<exclude>**/*$*</exclude>
-							</excludes>
-						</configuration>
-						<executions>
-							<execution>
-								<id>medium-tests</id>
-								<phase></phase>
-							</execution>
-							<execution>
-								<id>large-tests</id>
-								<phase></phase>
-							</execution>
-							<execution>
-								<id>native-tests</id>
-								<phase></phase>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
 		</profile>
 	</profiles>
 </project>

--- a/californium-tests/californium-integration-tests/pom.xml
+++ b/californium-tests/californium-integration-tests/pom.xml
@@ -53,33 +53,6 @@
 					<scope>test</scope>
 				</dependency>
 			</dependencies>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<useSystemClassLoader>false</useSystemClassLoader>
-							<systemPropertyVariables>
-								<org.eclipse.californium.junit.socketmode>DIRECT</org.eclipse.californium.junit.socketmode>
-							</systemPropertyVariables>
-							<excludes>
-								<exclude>**/*$*</exclude>
-							</excludes>
-						</configuration>
-						<executions>
-							<execution>
-								<id>small-tests</id>
-								<phase></phase>
-							</execution>
-							<execution>
-								<id>large-tests</id>
-								<phase></phase>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
 		</profile>
 	</profiles>
 


### PR DESCRIPTION
The idea, to lower the test time if bouncy castle is used, is not longer
required. The startup of bouncy castle could be improved using a
different (weaker) secure random setup.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>