### PR TITLE
Fix timing issue in unit tests.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/network/GroupedMessageIdTrackerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/GroupedMessageIdTrackerTest.java
@@ -148,7 +148,6 @@ public class GroupedMessageIdTrackerTest {
 
 	public void assertMessageIdRangeRollover(int min, int max) throws Exception {
 		Configuration config = network.createStandardTestConfig();
-		config.set(CoapConfig.EXCHANGE_LIFETIME, 0, TimeUnit.MILLISECONDS);
 		final int range = max - min;
 		final GroupedMessageIdTracker tracker = new GroupedMessageIdTracker(INITIAL_MID + min, min, max, config);
 		final String msg = "not next mid in range[" + min + "..." + max + ") for ";
@@ -171,7 +170,7 @@ public class GroupedMessageIdTrackerTest {
 				maxMid = nextMid;
 			}
 			lastMid = nextMid;
-			time.addTestTimeShift(1, TimeUnit.MILLISECONDS);
+			time.addTestTimeShift(config.getTimeAsInt(CoapConfig.EXCHANGE_LIFETIME, TimeUnit.MILLISECONDS) + 1, TimeUnit.MILLISECONDS);
 		}
 		assertThat("minimun not reached", minMid, is(min));
 		assertThat("maximun not reached", maxMid, is(max - 1));

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageIdProviderMulticastTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageIdProviderMulticastTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.californium.core.config.CoapConfig;
 import org.eclipse.californium.elements.category.Small;
 import org.eclipse.californium.elements.config.Configuration;
+import org.eclipse.californium.elements.rule.TestTimeRule;
 import org.eclipse.californium.rule.CoapNetworkRule;
 import org.eclipse.californium.rule.CoapThreadsRule;
 import org.junit.ClassRule;
@@ -42,6 +43,9 @@ public class InMemoryMessageIdProviderMulticastTest {
 
 	@Rule
 	public CoapThreadsRule cleanup = new CoapThreadsRule();
+
+	@Rule
+	public TestTimeRule time = new TestTimeRule();
 
 	private static final String GROUP = "224.0.1.187";
 	private static final String GROUP2 = "224.0.1.188";
@@ -63,15 +67,11 @@ public class InMemoryMessageIdProviderMulticastTest {
 	public void testMidsWithTwoMulticastGroupsAtOnce() {
 		final int multicastBaseMid = 65515;
 		Configuration config = network.createStandardTestConfig();
-		config.set(CoapConfig.EXCHANGE_LIFETIME, 1, TimeUnit.MILLISECONDS);
 		config.set(CoapConfig.MULTICAST_BASE_MID, multicastBaseMid);
 		InMemoryMessageIdProvider midProvider = new InMemoryMessageIdProvider(config);
 		for (int i = 1; i < 20; i++) {
 			if ((i % 5) == 0) {
-				try {
-					Thread.sleep(1);
-				} catch (InterruptedException e) {
-				}
+				time.addTestTimeShift(config.getTimeAsInt(CoapConfig.EXCHANGE_LIFETIME, TimeUnit.MILLISECONDS) + 1, TimeUnit.MILLISECONDS);
 			}
 			int multicastMidGroup1 = midProvider.getNextMessageId(new InetSocketAddress(GROUP, PORT));
 			int multicastMidGroup2 = midProvider.getNextMessageId(new InetSocketAddress(GROUP2, PORT));

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageIdProviderTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/InMemoryMessageIdProviderTest.java
@@ -156,13 +156,13 @@ public class InMemoryMessageIdProviderTest {
 	public void testGetNextMessageIdIfMaxPeersIsReachedWithStaleEntry() throws InterruptedException {
 
 		int MAX_PEERS = 2;
-		int MAX_PEER_INACTIVITY_PERIOD = 1; // seconds
+		int MAX_PEER_INACTIVITY_PERIOD = 1000; // milliseconds
 		config.set(CoapConfig.MAX_ACTIVE_PEERS, MAX_PEERS);
-		config.set(CoapConfig.MAX_PEER_INACTIVITY_PERIOD, MAX_PEER_INACTIVITY_PERIOD, TimeUnit.SECONDS);
+		config.set(CoapConfig.MAX_PEER_INACTIVITY_PERIOD, MAX_PEER_INACTIVITY_PERIOD, TimeUnit.MILLISECONDS);
 		InMemoryMessageIdProvider provider = new InMemoryMessageIdProvider(config);
 		addPeers(provider, MAX_PEERS);
 
-		time.addTestTimeShift(MAX_PEER_INACTIVITY_PERIOD * 1200, TimeUnit.MILLISECONDS);
+		time.addTestTimeShift(MAX_PEER_INACTIVITY_PERIOD + 200, TimeUnit.MILLISECONDS);
 
 		assertThat(provider.getNextMessageId(getPeerAddress(MAX_PEERS + 1)), is(not(-1)));
 	}

--- a/californium-core/src/test/java/org/eclipse/californium/core/network/MapBasedMessageIdTrackerTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/network/MapBasedMessageIdTrackerTest.java
@@ -139,7 +139,6 @@ public class MapBasedMessageIdTrackerTest {
 	public void assertMessageIdRangeRollover(int min, int max) throws Exception {
 		// GIVEN a tracker with an EXCHANGE_LIFETIME of 0 (MID always expired)
 		Configuration config = network.createStandardTestConfig();
-		config.set(CoapConfig.EXCHANGE_LIFETIME, 0, TimeUnit.MILLISECONDS);
 		final int range = max - min;
 		final MapBasedMessageIdTracker tracker = new MapBasedMessageIdTracker(INITIAL_MID + min, min, max, config);
 		final String msg = "not next mid in range[" + min + "..." + max + ") for ";
@@ -162,7 +161,7 @@ public class MapBasedMessageIdTrackerTest {
 				maxMid = nextMid;
 			}
 			lastMid = nextMid;
-			time.addTestTimeShift(1, TimeUnit.MILLISECONDS);
+			time.addTestTimeShift(config.getTimeAsInt(CoapConfig.EXCHANGE_LIFETIME, TimeUnit.MILLISECONDS) + 1, TimeUnit.MILLISECONDS);
 		}
 		assertThat("minimun not reached", minMid, is(min));
 		assertThat("maximun not reached", maxMid, is(max - 1));


### PR DESCRIPTION
Use TimeRule to adjust time during tests.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>