### PR TITLE
Fix broken encryption on dtls graceful restart.

### DIFF
--- a/californium-core/src/test/java/org/eclipse/californium/core/server/ServerSerializationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/server/ServerSerializationTest.java
@@ -1,0 +1,325 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.core.server;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.DatagramPacket;
+import java.net.InetSocketAddress;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.elements.Connector;
+import org.eclipse.californium.elements.EndpointContextMatcher;
+import org.eclipse.californium.elements.PersistentConnector;
+import org.eclipse.californium.elements.RawData;
+import org.eclipse.californium.elements.RawDataChannel;
+import org.eclipse.californium.elements.UDPConnector;
+import org.eclipse.californium.elements.category.Medium;
+import org.eclipse.californium.elements.config.Configuration;
+import org.eclipse.californium.elements.rule.LoggingRule;
+import org.eclipse.californium.elements.util.DataStreamReader;
+import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.SerializationUtil;
+import org.eclipse.californium.elements.util.StandardCharsets;
+import org.eclipse.californium.rule.CoapNetworkRule;
+import org.eclipse.californium.rule.CoapThreadsRule;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Verifies behavior of {@link ServersSerializationUtil}.
+ */
+@Category(Medium.class)
+public class ServerSerializationTest {
+
+	@ClassRule
+	public static CoapNetworkRule network = new CoapNetworkRule(CoapNetworkRule.Mode.DIRECT,
+			CoapNetworkRule.Mode.NATIVE);
+
+	@Rule
+	public CoapThreadsRule cleanup = new CoapThreadsRule();
+
+	@Rule 
+	public LoggingRule logging = new LoggingRule();
+
+	private DummyConnector connector1 = new DummyConnector(5684);
+	private DummyConnector connector2 = new DummyConnector(5784);
+	private DummyConnector connector3 = new DummyConnector(5884);
+
+	private EncryptedServersSerializationUtil setup(Connector... connectors) {
+		EncryptedServersSerializationUtil util = new EncryptedServersSerializationUtil();
+		Configuration config = network.createStandardTestConfig();
+		CoapServer server = new CoapServer(config);
+		for (Connector connector : connectors) {
+			CoapEndpoint endpoint = CoapEndpoint.builder().setConfiguration(config).setConnector(connector).build();
+			server.addEndpoint(endpoint);
+		}
+		util.add(server);
+		return util;
+	}
+
+	@Test
+	public void testSaveAndLoad() throws IOException {
+		EncryptedServersSerializationUtil util = setup(connector1, connector2);
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		util.saveServers(out, 1000);
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		util.loadServers(in);
+		assertArrayEquals(connector1.mark, connector1.data);
+		assertArrayEquals(connector2.mark, connector2.data);
+	}
+
+	@Test
+	public void testSaveSkipAndLoad() throws IOException {
+		EncryptedServersSerializationUtil util = setup(connector1, connector2);
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		util.saveServers(out, 1000);
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		util = setup(connector2);
+		util.loadServers(in);
+		assertThat(connector1.data, is(nullValue()));
+		assertArrayEquals(connector2.mark, connector2.data);
+	}
+
+	@Test
+	public void testSaveLoadAndSkip() throws IOException {
+		EncryptedServersSerializationUtil util = setup(connector1, connector2);
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		util.saveServers(out, 1000);
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		util = setup(connector1);
+		util.loadServers(in);
+		assertArrayEquals(connector1.mark, connector1.data);
+		assertThat(connector2.data, is(nullValue()));
+	}
+
+	@Test
+	public void testSaveAndLoadWithNonePersistentConnector() throws IOException {
+		EncryptedServersSerializationUtil util = setup(connector1, new UDPConnector(null, network.createStandardTestConfig()));
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		util.saveServers(out, 1000);
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		util.loadServers(in);
+		assertArrayEquals(connector1.mark, connector1.data);
+		assertThat(connector2.data, is(nullValue()));
+	}
+
+	@Test
+	public void testEncryptedSaveAndLoad() throws IOException {
+		EncryptedServersSerializationUtil util = setup(connector1, connector2);
+		SecretKey key = new SecretKeySpec("1234567".getBytes(), "PW");
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		util.saveServers(out, key, 1000);
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		util.loadServers(in, key);
+		assertArrayEquals(connector1.mark, connector1.data);
+		assertArrayEquals(connector2.mark, connector2.data);
+	}
+
+	@Test
+	public void testEncryptedSaveSkipAndLoad() throws IOException {
+		EncryptedServersSerializationUtil util = setup(connector1, connector2);
+		SecretKey key = new SecretKeySpec("1234567".getBytes(), "PW");
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		util.saveServers(out, key, 1000);
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		util = setup(connector2);
+		util.loadServers(in, key);
+		assertThat(connector1.data, is(nullValue()));
+		assertArrayEquals(connector2.mark, connector2.data);
+	}
+
+	@Test
+	public void testEncryptedSaveLoadAndSkip() throws IOException {
+		EncryptedServersSerializationUtil util = setup(connector1, connector2);
+		SecretKey key = new SecretKeySpec("1234567".getBytes(), "PW");
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		util.saveServers(out, key, 1000);
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		util = setup(connector1);
+		util.loadServers(in, key);
+		assertArrayEquals(connector1.mark, connector1.data);
+		assertThat(connector2.data, is(nullValue()));
+	}
+
+	@Test
+	public void testEncryptedSaveLoadSkipAndLoad() throws IOException {
+		EncryptedServersSerializationUtil util = setup(connector1, connector2, connector3);
+		SecretKey key = new SecretKeySpec("1234567".getBytes(), "PW");
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		util.saveServers(out, key, 1000);
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		util = setup(connector1, connector3);
+		util.loadServers(in, key);
+		assertArrayEquals(connector1.mark, connector1.data);
+		assertThat(connector2.data, is(nullValue()));
+	}
+
+	@Test
+	public void testEncryptedSaveAndLoadWrongKey() throws IOException {
+		EncryptedServersSerializationUtil util = setup(connector1, connector2);
+		SecretKey key = new SecretKeySpec("1234567".getBytes(), "PW");
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		util.saveServers(out, key, 1000);
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		key = new SecretKeySpec("01234567".getBytes(), "PW");
+		logging.setLoggingLevel("ERROR", ServersSerializationUtil.class);
+		util.loadServers(in, key);
+		assertThat(connector1.data, is(nullValue()));
+		assertThat(connector2.data, is(nullValue()));
+	}
+
+	@Test
+	public void testEncryptedSaveAndUnencryptedLoad() throws IOException {
+		EncryptedServersSerializationUtil util = setup(connector1, connector2);
+		SecretKey key = new SecretKeySpec("1234567".getBytes(), "PW");
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		util.saveServers(out, key, 1000);
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		logging.setLoggingLevel("ERROR", ServersSerializationUtil.class);
+		util.loadServers(in);
+		assertThat(connector1.data, is(nullValue()));
+		assertThat(connector2.data, is(nullValue()));
+	}
+
+	@Test
+	public void testUnencryptedSaveAndEncryptedLoad() throws IOException {
+		EncryptedServersSerializationUtil util = setup(connector1, connector2);
+		SecretKey key = new SecretKeySpec("1234567".getBytes(), "PW");
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		util.saveServers(out, 1000);
+		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+		logging.setLoggingLevel("ERROR", ServersSerializationUtil.class);
+		util.loadServers(in, key);
+		assertThat(connector1.data, is(nullValue()));
+		assertThat(connector2.data, is(nullValue()));
+	}
+
+	private static class DummyConnector implements Connector, PersistentConnector {
+
+		private InetSocketAddress address;
+
+		private byte[] mark;
+
+		private byte[] data;
+
+		private DummyConnector(int port) {
+			address = new InetSocketAddress(port);
+			mark = String.format("dummy-%05d", port).getBytes(StandardCharsets.UTF_8);
+		}
+
+		@Override
+		public int saveConnections(OutputStream out, long maxQuietPeriodInSeconds) throws IOException {
+			DatagramWriter writer = new DatagramWriter();
+			int pos = SerializationUtil.writeStartItem(writer, 1, Short.SIZE);
+			writer.writeVarBytes(mark, Byte.SIZE);
+			SerializationUtil.writeFinishedItem(writer, pos, Short.SIZE);
+			writer.writeTo(out);
+			pos = SerializationUtil.writeStartItem(writer, 1, Short.SIZE);
+			writer.writeVarBytes(mark, Byte.SIZE);
+			SerializationUtil.writeFinishedItem(writer, pos, Short.SIZE);
+			writer.writeTo(out);
+			pos = SerializationUtil.writeStartItem(writer, 1, Short.SIZE);
+			writer.writeVarBytes(mark, Byte.SIZE);
+			SerializationUtil.writeFinishedItem(writer, pos, Short.SIZE);
+			writer.writeTo(out);
+			SerializationUtil.writeNoItem(out);
+			return 3;
+		}
+
+		@Override
+		public int loadConnections(InputStream in, long delta) throws IOException {
+			DataStreamReader reader = new DataStreamReader(in);
+			SerializationUtil.readStartItem(reader, 1, Short.SIZE);
+			data = reader.readVarBytes(Byte.SIZE);
+			SerializationUtil.readStartItem(reader, 1, Short.SIZE);
+			reader.readVarBytes(Byte.SIZE);
+			SerializationUtil.readStartItem(reader, 1, Short.SIZE);
+			reader.readVarBytes(Byte.SIZE);
+			int version = reader.readNextByte() & 0xff;
+			assertThat(version, is(SerializationUtil.NO_VERSION));
+			return 3;
+		}
+
+		@Override
+		public void start() throws IOException {
+			// dummy
+		}
+
+		@Override
+		public void stop() {
+			// dummy
+		}
+
+		@Override
+		public void destroy() {
+			// dummy
+		}
+
+		@Override
+		public void send(RawData msg) {
+			// dummy
+		}
+
+		@Override
+		public void setRawDataReceiver(RawDataChannel messageHandler) {
+			// dummy
+		}
+
+		@Override
+		public void setEndpointContextMatcher(EndpointContextMatcher matcher) {
+			// dummy
+		}
+
+		@Override
+		public InetSocketAddress getAddress() {
+			// dummy
+			return address;
+		}
+
+		@Override
+		public String getProtocol() {
+			return CoAP.PROTOCOL_DTLS;
+		}
+
+		@Override
+		public boolean isRunning() {
+			// dummy
+			return false;
+		}
+
+		@Override
+		public void processDatagram(DatagramPacket datagram) {
+			// dummy
+		}
+
+	}
+}

--- a/element-connector/src/main/java/org/eclipse/californium/elements/PersistentConnector.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/PersistentConnector.java
@@ -19,11 +19,19 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import org.eclipse.californium.elements.util.SerializationUtil;
+
 /**
  * Interface for connector supporting persistent connections.
  * 
  * Note: the stream will contain not encrypted critical credentials. It is
  * required to protect this data before exporting it.
+ * 
+ * In order to be able to
+ * {@link SerializationUtil#skipItems(org.eclipse.californium.elements.util.DataStreamReader, int)},
+ * on failures, the stream must consist of items with {@code Short.SIZE} length
+ * fields and must be finished with a
+ * {@link SerializationUtil#writeNoItem(org.eclipse.californium.elements.util.DatagramWriter)}.
  * 
  * @since 3.0
  */

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/SerializationUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/SerializationUtil.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import javax.crypto.CipherInputStream;
+
 import org.eclipse.californium.elements.Definition;
 import org.eclipse.californium.elements.Definitions;
 import org.eclipse.californium.elements.EndpointContext;
@@ -494,13 +496,59 @@ public class SerializationUtil {
 	 * 
 	 * @param in stream to skip items.
 	 * @param numBits number of bits of the item length.
+	 * @throws IllegalArgumentException if stream isn't a valid stream of items
 	 */
 	public static void skipItems(InputStream in, int numBits) {
 		DataStreamReader reader = new DataStreamReader(in);
+		skipItems(reader, numBits);
+	}
+
+	/**
+	 * Skip items until "no item" is read.
+	 * 
+	 * @param reader stream reader to skip items.
+	 * @param numBits number of bits of the item length.
+	 * @return number of skipped items.
+	 * @throws IllegalArgumentException if stream isn't a valid stream of items
+	 * @since 3.3.1
+	 */
+	private static int skipItems(DataStreamReader reader, int numBits) {
+		int count = 0;
 		while ((reader.readNextByte() & 0xff) != NO_VERSION) {
 			int len = reader.read(numBits);
-			reader.skip(len);
+			skipBits(reader, len * Byte.SIZE);
+			++count;
 		}
+		return count;
+	}
+
+	/**
+	 * Skip bits.
+	 * 
+	 * If not enough bits are available without blocking, try to read a byte.
+	 * That seems to be required for {@link CipherInputStream}.
+	 * 
+	 * @param reader reader to skip bits.
+	 * @param numBits number of bits to be skipped
+	 * @return number of actual skipped bits
+	 * @throws IllegalArgumentException if not enough bits are available
+	 * @since 3.3.1
+	 */
+	private static long skipBits(DataStreamReader reader, long numBits) {
+		long bits = numBits;
+		while (bits > 0) {
+			long skipped = reader.skip(bits);
+			if (skipped <= 0) {
+				// CipherInputStream seems to require that
+				// readNextByte fails with IllegalArgumentException
+				// at the End Of Stream
+				reader.readNextByte();
+				bits -= Byte.SIZE;
+			} else {
+				bits -= skipped;
+			}
+		}
+		return numBits - bits;
 	}
 
 	/**


### PR DESCRIPTION
Add lost close of CipherOutputStream.
Fix skipItems to skip bits instead of bytes.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>