### PR TITLE
Add support for critical custom options.

### DIFF
--- a/californium-core/api-changes.json
+++ b/californium-core/api-changes.json
@@ -11,5 +11,24 @@
 				}
 			]
 		}
-	}
+	},
+	"3.4.0": [
+		{
+			"extension": "revapi.differences",
+			"configuration": {
+				"ignore": true,
+				"differences": [
+					{
+						"code": "java.method.visibilityReduced",
+						"old": "method void org.eclipse.californium.core.network.serialization.DataParser::<init>()",
+						"new": "method void org.eclipse.californium.core.network.serialization.DataParser::<init>()",
+						"oldVisibility": "public",
+						"newVisibility": "protected",
+						"justification": "abstract class, init is only intended to be called from subclasses"
+					}
+				]
+			}
+		}
+	]
+	
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataParser.java
@@ -33,9 +33,29 @@ import static org.eclipse.californium.core.coap.CoAP.MessageFormat.*;
 
 /**
  * A parser for messages encoded following the encoding defined by the
- * <a href="https://tools.ietf.org/html/draft-ietf-core-coap-tcp-tls-03" target="_blank">CoAP-over-TCP draft</a>.
+ * <a href="https://tools.ietf.org/html/draft-ietf-core-coap-tcp-tls-03" target=
+ * "_blank">CoAP-over-TCP draft</a>.
  */
 public final class TcpDataParser extends DataParser {
+
+	/**
+	 * Create TCP data parser without checking for critical custom options.
+	 */
+	public TcpDataParser() {
+		super();
+	}
+
+	/**
+	 * Create TCP data parser with support for critical custom options.
+	 * 
+	 * @param criticalCustomOptions Array of critical custom options.
+	 *            {@code null}, to not check for critical custom options, empty
+	 *            to fail on custom critical options.
+	 * @since 3.4
+	 */
+	public TcpDataParser(int[] criticalCustomOptions) {
+		super(criticalCustomOptions);
+	}
 
 	@Override
 	protected MessageHeader parseHeader(final DatagramReader reader) {
@@ -61,8 +81,8 @@ public final class TcpDataParser extends DataParser {
 		}
 		int size = lengthSize + 1 + tokenLength;
 		if (!reader.bytesAvailable(size)) {
-			throw new MessageFormatException(
-					"TCP Message too short! " + (reader.bitsLeft() / Byte.SIZE) + " must be at least " + size + " bytes!");
+			throw new MessageFormatException("TCP Message too short! " + (reader.bitsLeft() / Byte.SIZE)
+					+ " must be at least " + size + " bytes!");
 		}
 		reader.readBytes(lengthSize);
 		int code = reader.read(CODE_BITS);

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/UdpDataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/UdpDataParser.java
@@ -38,6 +38,25 @@ import org.eclipse.californium.core.coap.BlockOption;
  */
 public final class UdpDataParser extends DataParser {
 
+	/**
+	 * Create UDP data parser without checking for critical custom options.
+	 */
+	public UdpDataParser() {
+		super();
+	}
+
+	/**
+	 * Create UDP data parser with support for critical custom options.
+	 * 
+	 * @param criticalCustomOptions Array of critical custom options.
+	 *            {@code null}, to not check for critical custom options, empty
+	 *            to fail on custom critical options.
+	 * @since 3.4
+	 */
+	public UdpDataParser(int[] criticalCustomOptions) {
+		super(criticalCustomOptions);
+	}
+
 	@Override
 	protected MessageHeader parseHeader(final DatagramReader reader) {
 		if (!reader.bytesAvailable(4)) {


### PR DESCRIPTION
Reporting critical options in the application layer is rarely done. This
enables to report unknown critical option with 4.02 (BAD OPTION) and to
add custom critical options. Still not checking for critical options is
also possible.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>