### PR TITLE
Add configurable block1 option for error responses.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/config/CoapConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/config/CoapConfig.java
@@ -170,6 +170,20 @@ public final class CoapConfig {
 	public static final int DEFAULT_BLOCKWISE_STATUS_INTERVAL_IN_SECONDS = 5;
 
 	/**
+	 * The default mode used for error-responds for send blockwise payload.
+	 * <p>
+	 * The default value is {@code false}, which indicate that the server will
+	 * not include the Block1 option in error responses.
+	 * 
+	 * @see <a href="https://github.com/eclipse/californium/issues/1937" target=
+	 *      "_blank"> RFC7959 - Block1 Option in Error Response 4.08 (Request
+	 *      Entity Incomplete)</a>
+	 * 
+	 * @since 3.4
+	 */
+	public static final boolean DEFAULT_BLOCKWISE_STRICT_BLOCK1_OPTION = false;
+
+	/**
 	 * The default mode used to respond for early blockwise negotiation, when
 	 * response can be sent on one packet.
 	 * <p>
@@ -532,6 +546,24 @@ public final class CoapConfig {
 	 */
 	public static final IntegerDefinition TCP_NUMBER_OF_BULK_BLOCKS = new IntegerDefinition(
 			MODULE + "TCP_NUMBER_OF_BULK_BLOCKS", "Number of block per TCP-blockwise bulk transfer.", 1, 1);
+
+	/**
+	 * Property to indicate if the error-response should include the Block1
+	 * option.
+	 * <p>
+	 * The default value of this property is
+	 * {@link #DEFAULT_BLOCKWISE_STRICT_BLOCK1_OPTION}.
+	 * </p>
+	 * 
+	 * @see <a href="https://github.com/eclipse/californium/issues/1937" target=
+	 *      "_blank"> RFC7959 - Block1 Option in Error Response 4.08 (Request
+	 *      Entity Incomplete)</a>
+	 * 
+	 * @since 3.4
+	 */
+	public static final BooleanDefinition BLOCKWISE_STRICT_BLOCK1_OPTION = new BooleanDefinition(
+			MODULE + "BLOCKWISE_STRICT_BLOCK1_OPTION", "Use block1 option strictly, even for error-responses.",
+			DEFAULT_BLOCKWISE_STRICT_BLOCK1_OPTION);
 
 	/**
 	 * Property to indicate if the response should always include the Block2

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BlockwiseLayer.java
@@ -230,6 +230,7 @@ public class BlockwiseLayer extends AbstractLayer {
 	private final int blockTimeout;
 	private final int blockInterval;
 	private final int maxResourceBodySize;
+	private final boolean strictBlock1Option;
 	private final boolean strictBlock2Option;
 	private final long healthStatusInterval;
 	/* @since 2.4 */
@@ -375,6 +376,7 @@ public class BlockwiseLayer extends AbstractLayer {
 				}
 			}
 		});
+		strictBlock1Option = config.get(CoapConfig.BLOCKWISE_STRICT_BLOCK1_OPTION);
 		strictBlock2Option = config.get(CoapConfig.BLOCKWISE_STRICT_BLOCK2_OPTION);
 
 		healthStatusInterval = config.get(SystemConfig.HEALTH_STATUS_INTERVAL, TimeUnit.MILLISECONDS);
@@ -647,6 +649,9 @@ public class BlockwiseLayer extends AbstractLayer {
 			ResponseCode errorCode, String message) {
 
 		Response error = new Response(errorCode, true);
+		if (strictBlock1Option) {
+			error.getOptions().setBlock1(request.getOptions().getBlock1());
+		}
 		error.setDestinationContext(request.getSourceContext());
 		error.setPayload(message);
 		clearBlock1Status(status);


### PR DESCRIPTION
Signed-off-by: Achim Kraus <achim.kraus@bosch.io>