### PR TITLE
Use connection-store factory for unit tests.

### DIFF
--- a/californium-tests/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/NatTestHelper.java
+++ b/californium-tests/californium-integration-tests/src/test/java/org/eclipse/californium/integration/test/NatTestHelper.java
@@ -47,6 +47,7 @@ import org.eclipse.californium.elements.util.CounterStatisticManager;
 import org.eclipse.californium.elements.util.StringUtil;
 import org.eclipse.californium.integration.test.util.CoapsNetworkRule;
 import org.eclipse.californium.scandium.AlertHandler;
+import org.eclipse.californium.scandium.ConnectorHelper;
 import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.DtlsClusterConnector;
 import org.eclipse.californium.scandium.DtlsClusterHealthLogger;
@@ -243,9 +244,7 @@ public class NatTestHelper {
 					.setConnectionIdGenerator(generator)
 					.setAdvancedPskStore(pskStore).build();
 
-			DebugConnectionStore serverConnectionStore = new DebugConnectionStore(dtlsConfig.getMaxConnections(),
-					dtlsConfig.getStaleConnectionThresholdSeconds(), null);
-			serverConnectionStore.setTag(dtlsConfig.getLoggingTag());
+			DebugConnectionStore serverConnectionStore = ConnectorHelper.createDebugConnectionStore(dtlsConfig);
 			this.serverConnections.add(serverConnectionStore);
 
 			CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
@@ -304,11 +303,9 @@ public class NatTestHelper {
 				.setAsList(DtlsConfig.DTLS_CIPHER_SUITES, CipherSuite.TLS_PSK_WITH_AES_128_CCM_8)
 				.setAdvancedPskStore(new AdvancedSinglePskStore(IDENITITY + "." + size, KEY.getBytes())).build();
 
-		DebugConnectionStore connections = new DebugConnectionStore(clientDtlsConfig.getMaxConnections(),
-				clientDtlsConfig.getStaleConnectionThresholdSeconds(), null);
-		connections.setTag(clientDtlsConfig.getLoggingTag());
+		DebugConnectionStore clientConnectionStore = ConnectorHelper.createDebugConnectionStore(clientDtlsConfig);
 
-		DTLSConnector clientConnector = new MyDtlsConnector(clientDtlsConfig, connections);
+		DTLSConnector clientConnector = new MyDtlsConnector(clientDtlsConfig, clientConnectionStore);
 		clientConnector.setAlertHandler(new MyAlertHandler(clientDtlsConfig.getLoggingTag()));
 		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setConnector(clientConnector);
@@ -318,7 +315,7 @@ public class NatTestHelper {
 		clientCoapStatistics.add(healthLogger);
 		clientEndpoint.addPostProcessInterceptor(healthLogger);
 		clientEndpoint.start();
-		clientConnections.add(connections);
+		clientConnections.add(clientConnectionStore);
 		clientEndpoints.add(clientEndpoint);
 		return clientEndpoint;
 	}

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DTLSEndpointContextTest.java
@@ -44,11 +44,12 @@ import org.eclipse.californium.elements.util.Bytes;
 import org.eclipse.californium.elements.util.SimpleMessageCallback;
 import org.eclipse.californium.scandium.ConnectorHelper.LatchDecrementingRawDataChannel;
 import org.eclipse.californium.scandium.ConnectorHelper.TestContext;
+import org.eclipse.californium.scandium.config.DtlsConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.Connection;
 import org.eclipse.californium.scandium.dtls.DTLSContext;
 import org.eclipse.californium.scandium.dtls.DTLSSession;
-import org.eclipse.californium.scandium.dtls.InMemoryConnectionStore;
+import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
 import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -87,7 +88,7 @@ public class DTLSEndpointContextTest {
 	DtlsConnectorConfig clientConfig;
 	DTLSContext establishedClientContext;
 	DTLSSession establishedClientSession;
-	InMemoryConnectionStore clientConnectionStore;
+	ResumptionSupportingConnectionStore clientConnectionStore;
 
 	/**
 	 * Configures and starts a server side connector for running the tests
@@ -116,8 +117,10 @@ public class DTLSEndpointContextTest {
 
 	@Before
 	public void setUp() throws Exception {
-		clientConnectionStore = new InMemoryConnectionStore(CLIENT_CONNECTION_STORE_CAPACITY, 60);
-		clientConfig = serverHelper.newClientConfigBuilder(network).build();
+		clientConfig = ConnectorHelper.newClientConfigBuilder(network)
+				.set(DtlsConfig.DTLS_MAX_CONNECTIONS, CLIENT_CONNECTION_STORE_CAPACITY)
+				.set(DtlsConfig.DTLS_STALE_CONNECTION_THRESHOLD, 60, TimeUnit.SECONDS).build();
+		clientConnectionStore = ConnectorHelper.createDebugConnectionStore(clientConfig);
 		client = new DTLSConnector(clientConfig, clientConnectionStore);
 	}
 

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/DtlsManagedClusterConnectorTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/DtlsManagedClusterConnectorTest.java
@@ -49,8 +49,8 @@ import org.eclipse.californium.scandium.config.DtlsClusterConnectorConfig;
 import org.eclipse.californium.scandium.config.DtlsConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.Connection;
-import org.eclipse.californium.scandium.dtls.InMemoryConnectionStore;
 import org.eclipse.californium.scandium.dtls.MultiNodeConnectionIdGenerator;
+import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
 import org.eclipse.californium.scandium.dtls.pskstore.AdvancedSinglePskStore;
 import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
 import org.eclipse.californium.scandium.util.SecretUtil;
@@ -118,7 +118,7 @@ public class DtlsManagedClusterConnectorTest {
 	private DtlsClusterHealthLogger health2;
 
 	private DTLSConnector clientConnector;
-	private InMemoryConnectionStore clientConnections;
+	private ResumptionSupportingConnectionStore clientConnections;
 	private LatchDecrementingRawDataChannel clientChannel;
 	private DtlsHealthLogger clientHealth;
 
@@ -201,10 +201,12 @@ public class DtlsManagedClusterConnectorTest {
 				ConnectorHelper.CLIENT_IDENTITY_SECRET.getBytes());
 		DtlsConnectorConfig config = DtlsConnectorConfig.builder(configuration)
 				.set(DtlsConfig.DTLS_CONNECTION_ID_LENGTH, 4)
+				.set(DtlsConfig.DTLS_MAX_CONNECTIONS, 10)
+				.set(DtlsConfig.DTLS_STALE_CONNECTION_THRESHOLD, 6000, TimeUnit.SECONDS)
 				.setAdvancedPskStore(testPskStore)
 				.setHealthHandler(clientHealth)
 				.build();
-		clientConnections = new InMemoryConnectionStore(10, 6000);
+		clientConnections = ConnectorHelper.createDebugConnectionStore(config);
 		clientConnector = new DTLSConnector(config, clientConnections);
 
 		clientChannel = new LatchDecrementingRawDataChannel();

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/HelloExtensionNegotiationTest.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/HelloExtensionNegotiationTest.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.GeneralSecurityException;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.californium.elements.AddressEndpointContext;
 import org.eclipse.californium.elements.RawData;
@@ -44,8 +45,8 @@ import org.eclipse.californium.scandium.ConnectorHelper.TestContext;
 import org.eclipse.californium.scandium.config.DtlsConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig.Builder;
-import org.eclipse.californium.scandium.dtls.InMemoryConnectionStore;
 import org.eclipse.californium.scandium.dtls.MaxFragmentLengthExtension.Length;
+import org.eclipse.californium.scandium.dtls.ResumptionSupportingConnectionStore;
 import org.eclipse.californium.scandium.rule.DtlsNetworkRule;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -74,7 +75,7 @@ public class HelloExtensionNegotiationTest {
 	DtlsConnectorConfig clientConfig;
 	DTLSConnector client;
 	InetSocketAddress clientEndpoint;
-	InMemoryConnectionStore clientConnectionStore;
+	ResumptionSupportingConnectionStore clientConnectionStore;
 
 	/**
 	 * Configures and starts a server side connector for running the tests against.
@@ -111,8 +112,12 @@ public class HelloExtensionNegotiationTest {
 	 */
 	@Before
 	public void setUpClient() throws IOException, GeneralSecurityException {
+		DtlsConnectorConfig config = ConnectorHelper.newClientConfigBuilder(network)
+				.setLoggingTag("client")
+				.set(DtlsConfig.DTLS_MAX_CONNECTIONS, CLIENT_CONNECTION_STORE_CAPACITY)
+				.set(DtlsConfig.DTLS_STALE_CONNECTION_THRESHOLD, 60, TimeUnit.SECONDS).build();
 
-		clientConnectionStore = new InMemoryConnectionStore(CLIENT_CONNECTION_STORE_CAPACITY, 60);
+		clientConnectionStore = ConnectorHelper.createDebugConnectionStore(config);
 		clientEndpoint = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 	}
 
@@ -136,7 +141,7 @@ public class HelloExtensionNegotiationTest {
 	@Test
 	public void testConnectorNegotiatesMaxFragmentLength() throws Exception {
 		// given a constrained client that can only handle fragments of max. 512 bytes
-		Builder builder = serverHelper.newClientConfigBuilder(network)
+		Builder builder = ConnectorHelper.newClientConfigBuilder(network)
 				.set(DtlsConfig.DTLS_MAX_TRANSMISSION_UNIT, 1024)
 				.set(DtlsConfig.DTLS_MAX_FRAGMENT_LENGTH, Length.BYTES_512);
 		clientConfig = builder.build();
@@ -162,7 +167,7 @@ public class HelloExtensionNegotiationTest {
 	public void testConnectorIncludesServerNameIndication() throws Exception {
 
 		// given a client that indicates a virtual host to connect to using SNI
-		clientConfig = serverHelper.newClientConfigBuilder(network)
+		clientConfig = ConnectorHelper.newClientConfigBuilder(network)
 				.set(DtlsConfig.DTLS_USE_SERVER_NAME_INDICATION, true)
 				.build();
 		client = new DTLSConnector(clientConfig, clientConnectionStore);

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DebugConnectionStore.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DebugConnectionStore.java
@@ -16,147 +16,39 @@
 package org.eclipse.californium.scandium.dtls;
 
 import java.net.InetSocketAddress;
-import java.util.concurrent.ConcurrentMap;
-
-import org.eclipse.californium.elements.util.StringUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * An debug {@code ResumptionSupportingConnectionStore} with dump and validate methods.
+ * An debug {@code ResumptionSupportingConnectionStore} with dump and validate
+ * methods.
+ * 
  * Intended to be used for unit tests.
+ * 
+ * @since 3.5
  */
-public final class DebugConnectionStore extends InMemoryConnectionStore {
-	private static final Logger LOG = LoggerFactory.getLogger(DebugConnectionStore.class);
+public interface DebugConnectionStore extends ResumptionSupportingConnectionStore {
 
 	/**
-	 * Creates a store based on given configuration parameters.
+	 * Set logging tag.
 	 * 
-	 * @param capacity the maximum number of connections the store can manage
-	 * @param threshold the period of time of inactivity (in seconds) after
-	 *            which a connection is considered stale and can be evicted from
-	 *            the store if a new connection is to be added to the store
-	 * @param sessionStore a second level store to use for <em>current</em>
-	 *            connection state of established DTLS sessions.
+	 * @param tag logging tag
+	 * @return this connection store
 	 */
-	public DebugConnectionStore(final int capacity, final long threshold, final SessionStore sessionStore) {
-		super(capacity, threshold, sessionStore);
-	}
+	ResumptionSupportingConnectionStore setTag(String tag);
 
 	/**
 	 * Dump connections to logger. Intended to be used for unit tests.
 	 */
-	public synchronized void dump() {
-		if (connections.size() == 0) {
-			LOG.info("  {}connections empty!", tag);
-		} else {
-			LOG.info("  {}connections: {}", tag, connections.size());
-			for (Connection connection : connections.values()) {
-				dump(connection);
-			}
-		}
-	}
+	void dump();
 
 	/**
 	 * Dump connections to logger. Intended to be used for unit tests.
 	 * 
 	 * @param address address of connection to dump
 	 */
-	public boolean dump(InetSocketAddress address) {
-		if (connections.size() == 0) {
-			LOG.info("  {}connections empty!", tag);
-		} else {
-			Connection connection = get(address);
-			if (connection == null) {
-				LOG.info("  {}connection: {} - not available!", tag, StringUtil.toString(address));
-			} else if (connection.equalsPeerAddress(address)) {
-				dump(connection);
-				return true;
-			} else {
-				dump(connection);
-				LOG.info("  {}connection: {} - wrong assigned!", tag, StringUtil.toString(address));
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Dump connection to logger. Intended to be used for unit tests.
-	 * 
-	 * @param connection connection to dump
-	 */
-	private void dump(Connection connection) {
-		if (connection.hasEstablishedDtlsContext()) {
-			LOG.info("  {}connection: {} - {} : {}", tag, connection.getConnectionId(),
-					connection.getPeerAddress(), connection.getEstablishedSession().getSessionIdentifier());
-		} else {
-			LOG.info("  {}connection: {} - {}", tag, connection.getConnectionId(), connection.getPeerAddress());
-		}
-	}
+	boolean dump(InetSocketAddress address);
 
 	/**
 	 * Validate connections. Intended to be used for unit tests.
 	 */
-	public synchronized void validate() {
-		StringBuilder failure = new StringBuilder();
-		if (connections.size() == 0) {
-			if (!connectionsByAddress.isEmpty()) {
-				LOG.warn("  {}connections by address not empty!", tag);
-				dump(connectionsByAddress);
-				failure.append(" connections by address not empty!");
-			}
-			if (connectionsByEstablishedSession != null && !connectionsByEstablishedSession.isEmpty()) {
-				LOG.warn("  {}connections by session not empty!", tag);
-				dump(connectionsByEstablishedSession);
-				failure.append(" connections by sessions not empty!");
-			}
-		} else {
-			for (Connection connection : connections.values()) {
-				InetSocketAddress peerAddress = connection.getPeerAddress();
-				if (peerAddress != null) {
-					Connection peerConnection = connectionsByAddress.get(peerAddress);
-					if (connection != peerConnection && !peerConnection.equalsPeerAddress(peerAddress)) {
-						LOG.warn("  {}connections mixed up peer {} - {} {}", tag, peerAddress, connection,
-								peerConnection);
-						failure.append(" connections by sessions mixed up!");
-					}
-				}
-			}
-			for (InetSocketAddress peerAddress : connectionsByAddress.keySet()) {
-				Connection connection = connectionsByAddress.get(peerAddress);
-				if (!peerAddress.equals(connection.getPeerAddress())) {
-					LOG.warn("  {}connections by address mixed up {} - {}", tag, peerAddress, connection);
-					failure.append(" connections by address mixed up!");
-				}
-				if (connections.get(connection.getConnectionId()) == null) {
-					LOG.warn("  {}connections by address not available by cid! {} - {}", tag, peerAddress, connection);
-					failure.append(" connections by address mixed up!");
-				}
-			}
-			if (connectionsByEstablishedSession != null) {
-				for (SessionId session : connectionsByEstablishedSession.keySet()) {
-					Connection connection = connectionsByEstablishedSession.get(session);
-					if (!session.equals(connection.getEstablishedSession().getSessionIdentifier())) {
-						LOG.warn("  {}connections by session mixed up {} - {}", tag, session,
-								connection.getEstablishedSession().getSessionIdentifier());
-						failure.append(" connections by session mixed up!");
-					}
-					if (connections.get(connection.getConnectionId()) == null) {
-						LOG.warn("  {}connections by session not available by cid! {} - {}", tag, session, connection);
-						failure.append(" connections by session mixed up!");
-					}
-				}
-			}
-		}
-		if (failure.length() > 0) {
-			throw new IllegalStateException(tag + failure);
-		}
-	}
-
-	private <K> void dump(ConcurrentMap<K, Connection> map) {
-		for (K key : map.keySet()) {
-			Connection connection = map.get(key);
-			LOG.warn("  {} connection: {} - {}", tag, key, connection);
-		}
-	}
+	void validate();
 }

--- a/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DebugSynchronizedConnectionStore.java
+++ b/scandium-core/src/test/java/org/eclipse/californium/scandium/dtls/DebugSynchronizedConnectionStore.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Bosch Software Innovations GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Achim Kraus (Bosch Software Innovations GmbH) - Initial creation
+ ******************************************************************************/
+package org.eclipse.californium.scandium.dtls;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.ConcurrentMap;
+
+import org.eclipse.californium.elements.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An debug {@code ResumptionSupportingConnectionStore} with dump and validate
+ * methods.
+ * 
+ * Intended to be used for unit tests.
+ * 
+ * @since 3.5
+ */
+public final class DebugSynchronizedConnectionStore extends InMemoryConnectionStore implements DebugConnectionStore {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DebugSynchronizedConnectionStore.class);
+
+	/**
+	 * Creates a store based on given configuration parameters.
+	 * 
+	 * @param capacity the maximum number of connections the store can manage
+	 * @param threshold the period of time of inactivity (in seconds) after
+	 *            which a connection is considered stale and can be evicted from
+	 *            the store if a new connection is to be added to the store
+	 * @param sessionStore a second level store to use for <em>current</em>
+	 *            connection state of established DTLS sessions.
+	 */
+	public DebugSynchronizedConnectionStore(final int capacity, final long threshold, final SessionStore sessionStore) {
+		super(capacity, threshold, sessionStore);
+	}
+
+	/**
+	 * Dump connections to logger. Intended to be used for unit tests.
+	 */
+	@Override
+	public synchronized void dump() {
+		if (connections.size() == 0) {
+			LOG.info("  {}connections empty!", tag);
+		} else {
+			LOG.info("  {}connections: {}", tag, connections.size());
+			for (Connection connection : connections.values()) {
+				dump(connection);
+			}
+		}
+	}
+
+	/**
+	 * Dump connections to logger. Intended to be used for unit tests.
+	 * 
+	 * @param address address of connection to dump
+	 */
+	@Override
+	public boolean dump(InetSocketAddress address) {
+		if (connections.size() == 0) {
+			LOG.info("  {}connections empty!", tag);
+		} else {
+			Connection connection = get(address);
+			if (connection == null) {
+				LOG.info("  {}connection: {} - not available!", tag, StringUtil.toString(address));
+			} else if (connection.equalsPeerAddress(address)) {
+				dump(connection);
+				return true;
+			} else {
+				dump(connection);
+				LOG.info("  {}connection: {} - wrong assigned!", tag, StringUtil.toString(address));
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Dump connection to logger. Intended to be used for unit tests.
+	 * 
+	 * @param connection connection to dump
+	 */
+	private void dump(Connection connection) {
+		if (connection.hasEstablishedDtlsContext()) {
+			LOG.info("  {}connection: {} - {} : {}", tag, connection.getConnectionId(), connection.getPeerAddress(),
+					connection.getEstablishedSession().getSessionIdentifier());
+		} else {
+			LOG.info("  {}connection: {} - {}", tag, connection.getConnectionId(), connection.getPeerAddress());
+		}
+	}
+
+	/**
+	 * Validate connections. Intended to be used for unit tests.
+	 */
+	@Override
+	public synchronized void validate() {
+		StringBuilder failure = new StringBuilder();
+		if (connections.size() == 0) {
+			if (!connectionsByAddress.isEmpty()) {
+				LOG.warn("  {}connections by address not empty!", tag);
+				dump(connectionsByAddress);
+				failure.append(" connections by address not empty!");
+			}
+			if (connectionsByEstablishedSession != null && !connectionsByEstablishedSession.isEmpty()) {
+				LOG.warn("  {}connections by session not empty!", tag);
+				dump(connectionsByEstablishedSession);
+				failure.append(" connections by sessions not empty!");
+			}
+		} else {
+			for (Connection connection : connections.values()) {
+				InetSocketAddress peerAddress = connection.getPeerAddress();
+				if (peerAddress != null) {
+					Connection peerConnection = connectionsByAddress.get(peerAddress);
+					if (connection != peerConnection && !peerConnection.equalsPeerAddress(peerAddress)) {
+						LOG.warn("  {}connections mixed up peer {} - {} {}", tag, peerAddress, connection,
+								peerConnection);
+						failure.append(" connections by sessions mixed up!");
+					}
+				}
+			}
+			for (InetSocketAddress peerAddress : connectionsByAddress.keySet()) {
+				Connection connection = connectionsByAddress.get(peerAddress);
+				if (!peerAddress.equals(connection.getPeerAddress())) {
+					LOG.warn("  {}connections by address mixed up {} - {}", tag, peerAddress, connection);
+					failure.append(" connections by address mixed up!");
+				}
+				if (connections.get(connection.getConnectionId()) == null) {
+					LOG.warn("  {}connections by address not available by cid! {} - {}", tag, peerAddress, connection);
+					failure.append(" connections by address mixed up!");
+				}
+			}
+			if (connectionsByEstablishedSession != null) {
+				for (SessionId session : connectionsByEstablishedSession.keySet()) {
+					Connection connection = connectionsByEstablishedSession.get(session);
+					if (!session.equals(connection.getEstablishedSession().getSessionIdentifier())) {
+						LOG.warn("  {}connections by session mixed up {} - {}", tag, session,
+								connection.getEstablishedSession().getSessionIdentifier());
+						failure.append(" connections by session mixed up!");
+					}
+					if (connections.get(connection.getConnectionId()) == null) {
+						LOG.warn("  {}connections by session not available by cid! {} - {}", tag, session, connection);
+						failure.append(" connections by session mixed up!");
+					}
+				}
+			}
+		}
+		if (failure.length() > 0) {
+			throw new IllegalStateException(tag + failure);
+		}
+	}
+
+	private <K> void dump(ConcurrentMap<K, Connection> map) {
+		for (K key : map.keySet()) {
+			Connection connection = map.get(key);
+			LOG.warn("  {} connection: {} - {}", tag, key, connection);
+		}
+	}
+}


### PR DESCRIPTION
Prepare for alternative read-write-lock connection-store implementation.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>