### PR TITLE
Add TLS_EMPTY_RENEGOTIATION_INFO_SCSV.

### DIFF
--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/config/DtlsConnectorConfig.java
@@ -1020,12 +1020,12 @@ public final class DtlsConnectorConfig {
 	 * <p>
 	 * The connector will use these cipher suites (in exactly the same order)
 	 * during the DTLS handshake when negotiating a cipher suite with a peer. if
-	 * the given list is empty, contains
-	 * {@link CipherSuite#TLS_NULL_WITH_NULL_NULL}, contains a cipher suite, not
-	 * supported by the JVM, violates the
-	 * {@link DtlsConfig#DTLS_RECOMMENDED_CIPHER_SUITES_ONLY} setting, or the
-	 * use of HELLO_VERIFY_REQUEST is disabled and no PSK cipher suite is
-	 * contained.
+	 * the given list is empty, it will be setup using only
+	 * <ul>
+	 * <li>cipher suites, which are {@link CipherSuite#isValidForNegotiation()}</li>
+	 * <li>cipher suites, supported by the JVM</li>
+	 * <li>cipher suites, not violating the {@link DtlsConfig#DTLS_RECOMMENDED_CIPHER_SUITES_ONLY} setting</li>
+	 * </ul>
 	 * 
 	 * @return the supported cipher suites (ordered by preference)
 	 * @see #getPreselectedCipherSuites()

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHello.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ClientHello.java
@@ -389,7 +389,8 @@ public final class ClientHello extends HelloHandshakeMessage {
 		List<CipherSuite> common = new ArrayList<>();
 		for (CipherSuite cipherSuite : supportedCipherSuites) {
 			// NEVER negotiate NULL cipher suite
-			if (cipherSuite != CipherSuite.TLS_NULL_WITH_NULL_NULL && serverCipherSuite.contains(cipherSuite)) {
+			if (cipherSuite.isValidForNegotiation() &&
+					serverCipherSuite.contains(cipherSuite)) {
 				common.add(cipherSuite);
 			}
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSConnectionState.java
@@ -174,10 +174,10 @@ public abstract class DTLSConnectionState implements Destroyable {
 	/**
 	 * Checks whether the cipher suite is not the <em>NULL_CIPHER</em>.
 	 * 
-	 * @return {@code true} if the suite is not {@link CipherSuite#TLS_NULL_WITH_NULL_NULL}.
+	 * @return {@code true} if the suite is {@link CipherSuite#isValidForNegotiation()}.
 	 */
 	public boolean hasValidCipherSuite() {
-		return !CipherSuite.TLS_NULL_WITH_NULL_NULL.equals(cipherSuite);
+		return cipherSuite.isValidForNegotiation();
 	}
 
 	/**

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/DTLSSession.java
@@ -429,12 +429,18 @@ public final class DTLSSession implements Destroyable {
 	 * <p>
 	 * 
 	 * @param cipherSuite the cipher suite to be used
-	 * @throws IllegalArgumentException if the given cipher suite is
-	 *             {@code null} or {@link CipherSuite#TLS_NULL_WITH_NULL_NULL}
+	 * @throws NullPointerException if the given cipher suite is {@code null}
+	 * @throws IllegalArgumentException if the given cipher suite is not
+	 *             {@link CipherSuite#isValidForNegotiation()}
+	 * @since 3.5 throws NullPointerException and uses
+	 *        {@link CipherSuite#isValidForNegotiation()}
 	 */
 	void setCipherSuite(CipherSuite cipherSuite) {
-		if (cipherSuite == null || CipherSuite.TLS_NULL_WITH_NULL_NULL == cipherSuite) {
-			throw new IllegalArgumentException("Negotiated cipher suite must not be null");
+		if (cipherSuite == null) {
+			throw new NullPointerException("Negotiated cipher suite must not be null!");
+		}
+		if (!cipherSuite.isValidForNegotiation()) {
+			throw new IllegalArgumentException("Negotiated cipher suite must be valid for negotiation!");
 		} else {
 			this.cipherSuite = cipherSuite;
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHandshaker.java
@@ -1037,7 +1037,7 @@ public class ServerHandshaker extends Handshaker {
 	private List<CipherSuite> getCommonCipherSuites(ClientHello clientHello) {
 		List<CipherSuite> supported = supportedCipherSuites;
 		CipherSuite sessionCipherSuite = getSession().getCipherSuite();
-		if (!sessionCipherSuite.equals(CipherSuite.TLS_NULL_WITH_NULL_NULL)) {
+		if (sessionCipherSuite.isValidForNegotiation()) {
 			// resumption, limit handshake to use the same cipher suite
 			supported = Arrays.asList(sessionCipherSuite);
 		}

--- a/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHello.java
+++ b/scandium-core/src/main/java/org/eclipse/californium/scandium/dtls/ServerHello.java
@@ -85,8 +85,8 @@ public final class ServerHello extends HelloHandshakeMessage {
 			throw new HandshakeException(
 					String.format("Server selected unknown cipher suite [%s]", Integer.toHexString(code)),
 					new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE));
-		} else if (cipherSuite == CipherSuite.TLS_NULL_WITH_NULL_NULL) {
-			throw new HandshakeException("Server tries to negotiate NULL cipher suite",
+		} else if (!cipherSuite.isValidForNegotiation()) {
+			throw new HandshakeException("Server tries to negotiate a cipher suite invalid for negotiation",
 					new AlertMessage(AlertLevel.FATAL, AlertDescription.HANDSHAKE_FAILURE));
 		}
 		compressionMethod = CompressionMethod.getMethodByCode(reader.read(CompressionMethod.COMPRESSION_METHOD_BITS));
@@ -115,8 +115,8 @@ public final class ServerHello extends HelloHandshakeMessage {
 	 * @return the object representation
 	 * @throws HandshakeException if the cipher suite code selected by the
 	 *             server is either unknown, i.e. not defined in
-	 *             {@link CipherSuite} at all, or
-	 *             {@link CipherSuite#TLS_NULL_WITH_NULL_NULL}
+	 *             {@link CipherSuite} at all, or not 
+	 *             {@link CipherSuite#isValidForNegotiation()}
 	 */
 	public static HandshakeMessage fromReader(DatagramReader reader) throws HandshakeException {
 		return new ServerHello(reader);


### PR DESCRIPTION
Fix irritations of missing common cipher suite in logging output.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>