### PR TITLE
Fail on sending messages twice.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -657,7 +657,11 @@ public class CoapEndpoint implements Endpoint, Executor {
 			request.setSendError(new IllegalArgumentException(addr + " is a unresolved address!"));
 			return;
 		}
-
+		if (request.isSent()) {
+			LOGGER.warn("{}request was already sent!", tag);
+			request.setSendError(new IllegalArgumentException("Request already sent!"));
+			return;
+		}
 		Object identity;
 		try {
 			identity = identityResolver.getEndpointIdentity(request.getDestinationContext());
@@ -685,6 +689,11 @@ public class CoapEndpoint implements Endpoint, Executor {
 			response.cancel();
 			return;
 		}
+		if (response.isSent()) {
+			LOGGER.warn("{}response was already sent!", tag);
+			response.setSendError(new IllegalArgumentException("Response already sent!"));
+			return;
+		}
 		if (exchange.checkOwner()) {
 			// send response while processing exchange.
 			coapstack.sendResponse(exchange, response);
@@ -703,6 +712,11 @@ public class CoapEndpoint implements Endpoint, Executor {
 	public void sendEmptyMessage(final Exchange exchange, final EmptyMessage message) {
 		if (!started) {
 			message.cancel();
+			return;
+		}
+		if (message.isSent()) {
+			LOGGER.warn("{}empty message was already sent!", tag);
+			message.setSendError(new IllegalArgumentException("Empty message already sent!"));
 			return;
 		}
 		if (exchange.checkOwner()) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Endpoint.java
@@ -203,7 +203,9 @@ public interface Endpoint {
 	/**
 	 * Send the specified request.
 	 * 
-	 * Failures are reported with {@link Request#setSendError(Throwable)}
+	 * Failures are reported with {@link Request#setSendError(Throwable)}.
+	 * 
+	 * Note: since 3.5 sending a request instance twice causes a send error.
 	 *
 	 * @param request the request
 	 */
@@ -212,6 +214,8 @@ public interface Endpoint {
 	/**
 	 * Send the specified response.
 	 *
+	 * Note: since 3.5 sending a response instance twice causes a send error.
+	 * 
 	 * @param exchange the exchange
 	 * @param response the response
 	 */
@@ -220,6 +224,8 @@ public interface Endpoint {
 	/**
 	 * Send the specified empty message.
 	 *
+	 * Note: since 3.5 sending a empty message instance twice causes a send error.
+	 * 
 	 * @param exchange the exchange
 	 * @param message the message
 	 */


### PR DESCRIPTION
Californium is not designed to send messages twice.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>