### PR TITLE
Fix java 15-18 ECDSA vulnerability.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,3 +31,11 @@ For more details, please look at https://www.eclipse.org/security/.
 | ------------------- | ---------- | ---------------- | ----- | -------------
 | < 3.3 <br/> < 2.7.2 | com.upokecenter.cbor | 4.0 - 4.5.0 | cf-oscore <br/> demo-apps | [GHSA-fj2w-wfgv-mwq6](https://github.com/peteroupc/CBOR-Java/security/advisories/GHSA-fj2w-wfgv-mwq6)
 | < 3.2 <br/> < 2.7.1 | ch.qos.logback.logback-classic | < 1.2.9 | demo-apps | [CVE-2021-42550](https://cve.report/CVE-2021-42550)
+
+## Known Vulnerabilities Of Runtime Dependencies
+
+| Californium Version | Dependency | Affected Version | Usage | Vulnerability
+| ------------------- | ---------- | ---------------- | ----- | -------------
+| < 3.5 | JDK / JCE | <= 15.0.2? <br/> <= 16.0.2? <br/> < 17.0.3 <br/> < 18.0.1 | execution environment | ECDSA [CVE-2022-21449](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21449)
+
+

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/CertPathUtil.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/CertPathUtil.java
@@ -453,6 +453,9 @@ public class CertPathUtil {
 		// TODO: implement alternative means of revocation checking
 		params.setRevocationEnabled(false);
 		validator.validate(verifyCertPath, params);
+		if (JceProviderUtil.isEcdsaVulnerable()) {
+			Asn1DerDecoder.checkCertificateChain(chain, trust, last);
+		}
 		if (truncated || add) {
 			if (add) {
 				if (!truncated) {

--- a/element-connector/src/main/java/org/eclipse/californium/elements/util/JceNames.java
+++ b/element-connector/src/main/java/org/eclipse/californium/elements/util/JceNames.java
@@ -108,7 +108,7 @@ public interface JceNames {
 	public String OID_X448 = "OID.1.3.101.111";
 
 	/**
-	 * Name of environment variable to specify JCE,.
+	 * Name of environment variable to specify the JCE.
 	 */
 	public String CALIFORNIUM_JCE_PROVIDER = "CALIFORNIUM_JCE_PROVIDER";
 	/**
@@ -140,5 +140,18 @@ public interface JceNames {
 	 * for EdDSA.
 	 */
 	public String JCE_PROVIDER_NET_I2P_CRYPTO = "I2P";
+	/**
+	 * Name of environment variable to specify, if the used JCE is tested for
+	 * the ECDSA vulnerability
+	 * <a href= "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21449"
+	 * target="_blank">ECDSA vulnerability, CVE-2022-21449</a>.
+	 * 
+	 * The default is to test it. If the value of this environment variable is
+	 * set to {@code false}, the test is suppressed and no additional checks for
+	 * such signatures are done.
+	 * 
+	 * @since 3.5
+	 */
+	public String CALIFORNIUM_JCE_ECDSA_FIX = "CALIFORNIUM_JCE_ECDSA_FIX";
 
 }

--- a/element-connector/src/test/java/org/eclipse/californium/elements/util/TestCertificatesTools.java
+++ b/element-connector/src/test/java/org/eclipse/californium/elements/util/TestCertificatesTools.java
@@ -473,11 +473,11 @@ public class TestCertificatesTools {
 			}
 			byte[] data = Bytes.createBytes(random, len);
 			signature.initSign(privateKey);
-			signature.update(data, 0, len);
+			signature.update(data);
 			byte[] sign = signature.sign();
 
 			signature.initVerify(pulbicKey);
-			signature.update(data, 0, len);
+			signature.update(data);
 			if (!signature.verify(sign)) {
 				fail(message + ":" + algorithm + " failed!");
 			}


### PR DESCRIPTION
Add missing check of R and S after successful signature verification.
Applies only to DTLS, not TLS. TLS requires a fixed JCE!

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>