### PR TITLE
Deprecate ObserveRelation.notifyObservers.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapResource.java
@@ -925,7 +925,7 @@ public class CoapResource implements Resource {
 		notificationOrderer.getNextObserveNumber();
 		for (ObserveRelation relation : observeRelations) {
 			if (null == filter || filter.accept(relation)) {
-				relation.notifyObservers();
+				handleRequest(relation.getExchange());
 			}
 		}
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
@@ -180,7 +180,9 @@ public class ObserveRelation {
 	/**
 	 * Notifies the observing endpoint that the resource has been changed. This
 	 * method makes the resource process the same request again.
+	 * @deprecated obsolete
 	 */
+	@Deprecated
 	public void notifyObservers() {
 		resource.handleRequest(exchange);
 	}


### PR DESCRIPTION
Obsolete, call handleRequest directly.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>