### PR TITLE
Cleanup server-side observe-relation.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/config/CoapConfig.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/config/CoapConfig.java
@@ -310,6 +310,14 @@ public final class CoapConfig {
 	 * The default token size.
 	 */
 	public static final int DEFAULT_TOKEN_SIZE_LIMIT = 8;
+	/**
+	 * The default number of maximum observes supported on the coap-server.
+	 * 
+	 * {@code 0} to disable the server side limitation of observers.
+	 * 
+	 * @since 3.6
+	 */
+	public static final int DEFAULT_MAX_SERVER_OBSERVES = 50000;
 
 	/**
 	 * The maximum number of active peers supported.
@@ -649,6 +657,15 @@ public final class CoapConfig {
 			MODULE + "NOTIFICATION_REREGISTRATION_BACKOFF",
 			"Additional time (backoff) to the max-age option\nfor waiting for the next notification before reregister.",
 			2000L, TimeUnit.MILLISECONDS);
+	/**
+	 * The maximum number of observes supported on the coap-server.
+	 * 
+	 * {@code 0} to disable the server side limitation of observers.
+	 * 
+	 * @since 3.6
+	 */
+	public static final IntegerDefinition MAX_SERVER_OBSERVES = new IntegerDefinition(MODULE + "MAX_SERVER_OBSERVES",
+			"Maximum number of observes on server-side. 0 to disable this limitation.", DEFAULT_MAX_SERVER_OBSERVES);
 
 	/**
 	 * Congestion control algorithm. Still experimental.
@@ -729,8 +746,9 @@ public final class CoapConfig {
 	 * @since 3.5
 	 */
 	public static final BooleanDefinition STRICT_EMPTY_MESSAGE_FORMAT = new BooleanDefinition(
-			MODULE + "STRICT_EMPTY_MESSAGE_FORMAT", "Process empty messages strictly according RFC7252, 4.1 as format error. Disable to ignore additional data as tokens or options.", true);
-
+			MODULE + "STRICT_EMPTY_MESSAGE_FORMAT",
+			"Process empty messages strictly according RFC7252, 4.1 as format error. Disable to ignore additional data as tokens or options.",
+			true);
 
 	public static final ModuleDefinitionsProvider DEFINITIONS = new ModuleDefinitionsProvider() {
 
@@ -795,6 +813,8 @@ public final class CoapConfig {
 
 			config.set(MULTICAST_BASE_MID, DEFAULT_MULTICAST_BASE_MID);
 			config.set(STRICT_EMPTY_MESSAGE_FORMAT, true);
+
+			config.set(MAX_SERVER_OBSERVES, DEFAULT_MAX_SERVER_OBSERVES);
 		}
 	};
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/Exchange.java
@@ -1266,7 +1266,7 @@ public class Exchange {
 				}
 			}
 			notifications.clear();
-			LOGGER.debug("{} removing all remaining NON-notifications of observe relation with {}", this,
+			LOGGER.debug("{} removed all remaining NON-notifications of observe relation with {}", this,
 					relation.getSource());
 		}
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/TcpMatcher.java
@@ -126,7 +126,7 @@ public final class TcpMatcher extends BaseMatcher {
 
 				@Override
 				public void onSendError(Throwable error) {
-					observeRelation.cleanup();
+					observeRelation.cancel();
 				}
 			});
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/BaseCoapStack.java
@@ -39,7 +39,6 @@ import org.eclipse.californium.core.network.ExchangeCompleteException;
 import org.eclipse.californium.core.network.Outbox;
 import org.eclipse.californium.core.network.stack.Layer.TopDownBuilder;
 import org.eclipse.californium.core.observe.ObservationStoreException;
-import org.eclipse.californium.core.observe.ObserveRelation;
 import org.eclipse.californium.core.server.MessageDeliverer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,27 +97,14 @@ public abstract class BaseCoapStack implements CoapStack, ExtendedCoapStack {
 	@Override
 	public void sendResponse(final Exchange exchange, final Response response) {
 		// delegate to top
-		ObserveRelation relation = exchange.getRelation();
-		boolean retransmit = relation != null && relation.isEstablished();
-
 		try {
-			if (retransmit) {
-				// observe- or cancel-observe-requests may have
-				// multiple responses.
-				// when observes are finished, the last response has
-				// no longer an observe option. Therefore check the
-				// request for it.
-				exchange.retransmitResponse();
-			}
 			top.sendResponse(exchange, response);
 		} catch (ExchangeCompleteException ex) {
 			LOGGER.warn("error send response {}", response, ex);
 			response.setSendError(ex);
 		} catch (RuntimeException ex) {
 			LOGGER.warn("error send response {}", response, ex);
-			if (!retransmit) {
-				exchange.sendReject();
-			}
+			exchange.sendReject();
 			response.setSendError(ex);
 		}
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ExchangeCleanupLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/ExchangeCleanupLayer.java
@@ -85,7 +85,7 @@ public class ExchangeCleanupLayer extends AbstractLayer {
 	 */
 	@Override
 	public void sendResponse(final Exchange exchange, final Response response) {
-		if (!response.isNotification()) {
+		if (exchange.getRelation() == null) {
 			Type type = response.getType();
 			if (type == null || type == Type.CON) {
 				// if type is set later, add the cleanup preventive

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveHealth.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveHealth.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.observe;
+
+/**
+ * Observe health interface.
+ * 
+ * Used by the {@link ObserveManager} to report the statistic events.
+ * 
+ * @since 3.6
+ */
+public interface ObserveHealth {
+
+	/**
+	 * Report current number of observe relations.
+	 * 
+	 * @param observeRelations current number of observe relations
+	 */
+	void setObserveRelations(int observeRelations);
+
+	/**
+	 * Report current number of observing endpoints.
+	 * 
+	 * @param observeEndpoints current number of observing endpoints
+	 */
+	void setObserveEndpoints(int observeEndpoints);
+
+	/**
+	 * Report a received observe request.
+	 */
+	void receivingObserveRequest();
+
+	/**
+	 * Report a received cancel-observe request.
+	 */
+	void receivingCancelRequest();
+
+	/**
+	 * Report a received reject for a notification.
+	 */
+	void receivingReject();
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelation.java
@@ -29,41 +29,125 @@ package org.eclipse.californium.core.observe;
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.coap.CoAP.Type;
 import org.eclipse.californium.core.config.CoapConfig;
 import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.KeyToken;
+import org.eclipse.californium.core.server.resources.ObservableResource;
 import org.eclipse.californium.core.server.resources.Resource;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.util.ClockUtil;
-import org.eclipse.californium.elements.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The ObserveRelation is a server-side control structure. It represents a
- * relation between a client endpoint and a resource on this server.
+ * The ObserveRelation is a server-side control structure.
+ * <p>
+ * It represents a relation between a client endpoint and a resource on this
+ * server. It holds the initial {@link Exchange} with the {@link Request}, and
+ * it keeps also track of some states, especially a mechanism to probe
+ * frequently the client's interest by using CON notifies. A mechanism to handle
+ * resource changes while such a CON notification is in transit and may be
+ * required to be retransmitted is also implemented her.
+ * </p>
+ * <p>
+ * The observe-relations a stored in two collections, one per client, the
+ * {@link ObservingEndpoint}, and one per resource, the
+ * {@link ObservableResource}. When receiving an observer request, the observe
+ * relation is first put in {@link State#INIT} and is stored in the
+ * {@link ObservingEndpoint}. With the first response, the observe relation gets
+ * either {@link State#ESTABILSHED}, if the response is
+ * {@link Response#isSuccess()}, or the observe relation gets
+ * {@link State#CANCELED}. When it get's established, the observe relation is
+ * also added to the {@link ObservableResource} and with that changes will be
+ * reported by notifies.
+ * </p>
+ * <p>
+ * If a CON notification is send and times out, the endpoint is considered to be
+ * not longer reachable and all established observe-relations are canceled. If
+ * such a CON notification is rejected by a RST message, only this observe
+ * relation is canceled.
+ * </p>
  */
 public class ObserveRelation {
 
 	/** The logger. */
 	private final static Logger LOGGER = LoggerFactory.getLogger(ObserveRelation.class);
 
+	/**
+	 * State of a {@link ObserveRelation}.
+	 * 
+	 * @since 3.6
+	 */
+	public enum State {
+		/**
+		 * No observe relation.
+		 */
+		NONE,
+		/**
+		 * Observe relation initialized.
+		 * 
+		 * Observe request received, response pending.
+		 */
+		INIT,
+		/**
+		 * Observe relation established.
+		 * 
+		 * Observe request received, response/notify sent.
+		 */
+		ESTABILSHED,
+		/**
+		 * Observe relation canceled.
+		 */
+		CANCELED
+	}
+
 	private final long checkIntervalTime;
 	private final int checkIntervalCount;
 
-	private final ObservingEndpoint endpoint;
+	/**
+	 * Observe manager.
+	 * 
+	 * If used with deprecated
+	 * {@link #ObserveRelation(ObservingEndpoint, Resource, Exchange)}, the
+	 * manager is {@code null}.
+	 * 
+	 * @since 3.6
+	 */
+	private final ObserveManager manager;
 
-	/** The resource that is observed */
-	private final Resource resource;
+	/**
+	 * The resource that is observed.
+	 * 
+	 * @since 3.6 adapted into the new {@link ObservableResource} type
+	 */
+	private final ObservableResource resource;
 
-	/** The exchange that has established the observe relationship */
+	/** The exchange that has initiated the observe relationship */
 	private final Exchange exchange;
+
+	/**
+	 * The request type of the observer request.
+	 * 
+	 * @since 3.6
+	 */
+	private final Type requestType;
+
+	private final InetSocketAddress source;
+
+	/**
+	 * The key token.
+	 * 
+	 * @since 3.6 adapted the type
+	 */
+	private final KeyToken key;
 
 	private Response recentControlNotification;
 	private Response nextControlNotification;
 
-	private final String key;
-
+	private volatile ObservingEndpoint endpoint;
 	/*
 	 * This value is false at first and must be set to true by the resource if
 	 * it accepts the observe relation (the response code must be successful).
@@ -82,23 +166,60 @@ public class ObserveRelation {
 	 * @param endpoint the observing endpoint
 	 * @param resource the observed resource
 	 * @param exchange the exchange that tries to establish the observe relation
+	 * @throws ClassCastException if {@link Resource} does not implement
+	 *             {@link ObservableResource} as well
+	 * @deprecated use
+	 *             {@link #ObserveRelation(ObserveManager, ObservableResource, Exchange)}
+	 *             instead.
 	 */
+	@Deprecated
 	public ObserveRelation(ObservingEndpoint endpoint, Resource resource, Exchange exchange) {
-		if (endpoint == null)
-			throw new NullPointerException();
-		if (resource == null)
-			throw new NullPointerException();
-		if (exchange == null)
-			throw new NullPointerException();
-		this.endpoint = endpoint;
+		this(null, (ObservableResource) resource, exchange);
+		setEndpoint(endpoint);
+	}
+
+	/**
+	 * Constructs a new observe relation.
+	 * 
+	 * @param manager the observe manager
+	 * @param resource the observed resource
+	 * @param exchange the exchange that tries to establish the observe relation
+	 * @since 3.6
+	 */
+	public ObserveRelation(ObserveManager manager, ObservableResource resource, Exchange exchange) {
+		if (manager == null) {
+			throw new NullPointerException("Observe manager must not be null!");
+		} else if (resource == null) {
+			throw new NullPointerException("Observing resource must not be null!");
+		} else if (exchange == null) {
+			throw new NullPointerException("Exchange must not be null!");
+		}
+		this.manager = manager;
 		this.resource = resource;
 		this.exchange = exchange;
+		this.requestType = exchange.getRequest().getType();
 		Configuration config = exchange.getEndpoint().getConfig();
 		checkIntervalTime = config.get(CoapConfig.NOTIFICATION_CHECK_INTERVAL_TIME, TimeUnit.NANOSECONDS);
 		checkIntervalCount = config.get(CoapConfig.NOTIFICATION_CHECK_INTERVAL_COUNT);
-
-		this.key = StringUtil.toString(getSource()) + "#" + exchange.getRequest().getTokenString();
+		Request request = exchange.getRequest();
+		this.source = request.getSourceContext().getPeerAddress();
+		this.key = getKeyToken(exchange);
 		LOGGER.debug("Observe-relation, checks every {}ns or {} notifications.", checkIntervalTime, checkIntervalCount);
+	}
+
+	/**
+	 * Set observing endpoint.
+	 * 
+	 * @param endpoint observing endpoint
+	 * @since 3.6
+	 */
+	public void setEndpoint(ObservingEndpoint endpoint) {
+		if (endpoint == null) {
+			throw new NullPointerException("Observing endpoint must not be null!");
+		}
+		this.endpoint = endpoint;
+		this.endpoint.addObserveRelation(this);
+		this.exchange.setRelation(this);
 	}
 
 	/**
@@ -113,6 +234,8 @@ public class ObserveRelation {
 
 	/**
 	 * Sets the established field.
+	 * 
+	 * Adds this relations to the resource
 	 * 
 	 * @throws IllegalStateException if the relation was already canceled.
 	 */
@@ -146,9 +269,17 @@ public class ObserveRelation {
 	 * {@link #cancel()}, if {@link #isEstablished()}.
 	 * 
 	 * @since 3.0
+	 * @deprecated use {@link #cancel()} also for not established relations
 	 */
+	@Deprecated
 	public void cleanup() {
-		if (isEstablished()) {
+		cancel();
+	}
+
+	public void reject() {
+		if (manager != null) {
+			manager.onRejectedNotification(this);
+		} else {
 			cancel();
 		}
 	}
@@ -180,20 +311,33 @@ public class ObserveRelation {
 	/**
 	 * Notifies the observing endpoint that the resource has been changed. This
 	 * method makes the resource process the same request again.
+	 * 
+	 * Note: the {@link ObservableResource} must implement {@link Resource} as
+	 * well in order to call this method
+	 * 
+	 * @throws ClassCastException if {@link ObservableResource} does not
+	 *             implement {@link Resource} as well
 	 * @deprecated obsolete
 	 */
 	@Deprecated
 	public void notifyObservers() {
-		resource.handleRequest(exchange);
+		((Resource) resource).handleRequest(exchange);
 	}
 
 	/**
 	 * Gets the resource.
 	 *
+	 * Note: the {@link ObservableResource} must implement {@link Resource} as
+	 * well in order to call this method
+	 * 
 	 * @return the resource
+	 * @throws ClassCastException if {@link ObservableResource} does not
+	 *             implement {@link Resource} as well
+	 * @deprecated obsolete
 	 */
+	@Deprecated
 	public Resource getResource() {
-		return resource;
+		return (Resource) resource;
 	}
 
 	/**
@@ -211,11 +355,81 @@ public class ObserveRelation {
 	 * @return the source address
 	 */
 	public InetSocketAddress getSource() {
-		return endpoint.getAddress();
+		return source;
 	}
 
 	/**
-	 * Check, if notification is still requested.
+	 * Gets the source address of the observing endpoint.
+	 *
+	 * @return the source address
+	 */
+	public ObservingEndpoint getEndpoint() {
+		return endpoint;
+	}
+
+	/**
+	 * Get the type of the notifications that will be sent.
+	 * 
+	 * Uses {@link ObservableResource#getObserveType()}, or the request's type,
+	 * if no observe-type is provided. If this results in {@link Type#NON}, then
+	 * {@link #check()} is used, to determine, if the notification is adapted to
+	 * {@link Type#CON} to verify, that the client is still interested.
+	 * 
+	 * @return the type of the notifications
+	 * @since 3.6
+	 */
+	public Type getObserveType() {
+		Type observeType = resource.getObserveType();
+		if (observeType == null) {
+			observeType = requestType;
+		}
+		if (observeType != Type.CON && !check()) {
+			return Type.NON;
+		}
+		return Type.CON;
+	}
+
+	/**
+	 * Process response using this observe relation.
+	 * 
+	 * The first response will {@link #setEstablished()} the relation and
+	 * {@link ObservableResource#addObserveRelation(ObserveRelation)} it. If not
+	 * {@link #isCanceled()}, and the response {@link Response#isSuccess()},
+	 * {@link ObservableResource#getNotificationSequenceNumber()} will be set.
+	 * 
+	 * @param response response
+	 * @return current relation state.
+	 * @since 3.6
+	 */
+	public State onResponse(Response response) {
+		boolean canceled = isCanceled();
+		if (canceled) {
+			return State.CANCELED;
+		} else if (isEstablished()) {
+			exchange.retransmitResponse();
+			if (response.isSuccess()) {
+				response.getOptions().setObserve(resource.getNotificationSequenceNumber());
+			}
+			return State.ESTABILSHED;
+		} else {
+			boolean established = false;
+			if (response.isSuccess()) {
+				setEstablished();
+				resource.addObserveRelation(this);
+				established = !isCanceled();
+			}
+			if (established) {
+				response.getOptions().setObserve(resource.getNotificationSequenceNumber());
+				return State.INIT;
+			} else {
+				return State.CANCELED;
+			}
+		}
+	}
+
+	/**
+	 * Check, if notification is sent to test, if it is still requested by the
+	 * client.
 	 * 
 	 * Send notification as CON response in order to challenge the client to
 	 * acknowledge the message.
@@ -255,7 +469,7 @@ public class ObserveRelation {
 	 * Check, if sending the provided notification is postponed.
 	 * 
 	 * Postponed notification are kept and sent after the current notification.
-	 * Calls {@link #send(Response)}, if not postponed.
+	 * Calls {@link #onSend(Response)}, if not postponed.
 	 * 
 	 * @param response notification to check.
 	 * @return {@code true}, if sending the notification is postponed,
@@ -277,7 +491,7 @@ public class ObserveRelation {
 		} else {
 			recentControlNotification = response;
 			nextControlNotification = null;
-			send(response);
+			onSend(response);
 			return false;
 		}
 	}
@@ -285,7 +499,7 @@ public class ObserveRelation {
 	/**
 	 * Get next notification.
 	 * 
-	 * Calls {@link #send(Response)} for next notification.
+	 * Calls {@link #onSend(Response)} for next notification.
 	 * 
 	 * @param response current notification
 	 * @param acknowledged {@code true}, if the current notification was
@@ -303,7 +517,7 @@ public class ObserveRelation {
 				// next may be null
 				recentControlNotification = next;
 				nextControlNotification = null;
-				send(next);
+				onSend(next);
 			} else if (acknowledged) {
 				// next may be null
 				recentControlNotification = null;
@@ -321,11 +535,38 @@ public class ObserveRelation {
 	 * 
 	 * @param response response to sent.
 	 * @since 3.0
+	 * @deprecated use {@link #onSend(Response)} instead
 	 */
+	@Deprecated
 	public void send(Response response) {
+		onSend(response);
+	}
+
+	/**
+	 * On send response for this relation.
+	 * 
+	 * If the response is no notification, {@link #cancel()} the relation
+	 * internally without completing the exchange.
+	 * 
+	 * @param response response to sent.
+	 * @since 3.6
+	 */
+	public void onSend(Response response) {
 		if (!response.isNotification()) {
 			cancel(false);
 		}
+	}
+
+	/**
+	 * Get key-token, identifying this observer relation.
+	 * 
+	 * Combination of source-address and token.
+	 * 
+	 * @return identifying key
+	 * @since 3.6
+	 */
+	public KeyToken getKeyToken() {
+		return this.key;
 	}
 
 	/**
@@ -334,9 +575,11 @@ public class ObserveRelation {
 	 * Combination of source-address and token.
 	 * 
 	 * @return identifying key
+	 * @deprecated use {@link #getKeyToken()} instead
 	 */
+	@Deprecated
 	public String getKey() {
-		return this.key;
+		return this.key.toString();
 	}
 
 	/**
@@ -350,35 +593,73 @@ public class ObserveRelation {
 	 * @param complete {@code true}, to complete the exchange, {@code false}, to
 	 *            not complete it.
 	 * 
-	 * @throws IllegalStateException if relation wasn't established.
 	 * @since 3.0
 	 */
 	private void cancel(boolean complete) {
-		boolean fail = false;
 		boolean cancel = false;
+		boolean established = false;
 
 		synchronized (this) {
 			if (!canceled) {
-				fail = !established;
-				if (!fail) {
-					canceled = true;
-					established = false;
-					cancel = true;
-				}
+				canceled = true;
+				established = this.established;
+				this.established = false;
+				cancel = true;
 			}
-		}
-		if (fail) {
-			throw new IllegalStateException(String.format("Observe relation %s with %s not established (%s)!", getKey(),
-					resource.getURI(), exchange));
 		}
 		if (cancel) {
 			LOGGER.debug("Canceling observe relation {} with {} ({})", getKey(), resource.getURI(), exchange);
-			resource.removeObserveRelation(this);
-			endpoint.removeObserveRelation(this);
+			if (established) {
+				resource.removeObserveRelation(this);
+			}
+			if (manager != null) {
+				manager.removeObserveRelation(this);
+			} else {
+				endpoint.removeObserveRelation(this);
+			}
 			if (complete) {
 				exchange.executeComplete();
 			}
 		}
+	}
+
+	/**
+	 * Process response using this observe relation.
+	 * 
+	 * The first response will {@link #setEstablished()} the relation and
+	 * {@link ObservableResource#addObserveRelation(ObserveRelation)}. And the
+	 * {@link ObservableResource#getNotificationSequenceNumber()} will be set to
+	 * the options of all responses.
+	 * 
+	 * @param relation the observe relation, or {@code null}, if not available
+	 * @param response response
+	 * @return current relation state.
+	 * @see #onResponse(Response)
+	 * @since 3.6
+	 */
+	public static State onResponse(ObserveRelation relation, Response response) {
+		State result = State.NONE;
+		if (relation != null) {
+			result = relation.onResponse(response);
+		}
+		boolean noNotification = result == State.NONE || result == State.CANCELED;
+		if (response.isNotification() && (!response.isSuccess() || noNotification)) {
+			LOGGER.warn("Application notification, not longer observing, remove observe-option {}", response);
+			response.getOptions().removeObserve();
+		}
+		return result;
+	}
+
+	/**
+	 * Get key token from exchange.
+	 * 
+	 * @param exchange observe- or cancel-request exchange
+	 * @return key token with remote endpoint and request token.
+	 * @since 3.6
+	 */
+	public static KeyToken getKeyToken(Exchange exchange) {
+		Request request = exchange.getRequest();
+		return new KeyToken(request.getToken(), request.getSourceContext().getPeerAddress());
 	}
 
 	/**

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelationContainer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveRelationContainer.java
@@ -33,7 +33,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * their observe relations. When a resource changes it will notify all relations
  * in the container. Each observe relation must only exist once. However, an
  * endpoint could establish more than one observe relation to the same resource.
+ * @deprecated obsolete
  */
+@Deprecated
 public class ObserveRelationContainer implements Iterable<ObserveRelation> {
 
 	/** The set of observe relations */

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveStatisticLogger.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObserveStatisticLogger.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial creation
+ ******************************************************************************/
+package org.eclipse.californium.core.observe;
+
+import org.eclipse.californium.elements.util.CounterStatisticManager;
+import org.eclipse.californium.elements.util.SimpleCounterStatistic;
+import org.eclipse.californium.elements.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Observe health implementation using counter and logging for result.
+ * 
+ * @since 3.6
+ */
+public class ObserveStatisticLogger extends CounterStatisticManager implements ObserveHealth {
+
+	/** the logger. */
+	private static final Logger LOGGER = LoggerFactory.getLogger(ObserveStatisticLogger.class);
+
+	private final SimpleCounterStatistic observes = new SimpleCounterStatistic("observes", align);
+	private final SimpleCounterStatistic endpoints = new SimpleCounterStatistic("observing-endpoints", align);
+	private final SimpleCounterStatistic observeRequests = new SimpleCounterStatistic("observe-request", align);
+	private final SimpleCounterStatistic cancelRequests = new SimpleCounterStatistic("cancel-request", align);
+	private final SimpleCounterStatistic rejectedNotifies = new SimpleCounterStatistic("rejected-notifies", align);
+
+	/**
+	 * Create health logger.
+	 * 
+	 * @param tag logging tag
+	 */
+	public ObserveStatisticLogger(String tag) {
+		super(tag);
+		init();
+	}
+
+	private void init() {
+		add(observes);
+		add(endpoints);
+		add(observeRequests);
+		add(cancelRequests);
+		add(rejectedNotifies);
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return LOGGER.isInfoEnabled();
+	}
+
+	@Override
+	public void dump() {
+		try {
+			if (isEnabled()) {
+				if (LOGGER.isDebugEnabled()) {
+					if (observes.isUsed()) {
+						StringBuilder log = new StringBuilder();
+						String eol = StringUtil.lineSeparator();
+						String head = "   " + tag;
+						log.append(tag).append("observe-statistic:").append(eol);
+						log.append(head).append(observes).append(eol);
+						log.append(head).append(endpoints).append(eol);
+						log.append(head).append(observeRequests).append(eol);
+						log.append(head).append(cancelRequests).append(eol);
+						log.append(tag).append(rejectedNotifies);
+						LOGGER.debug("{}", log);
+					}
+				}
+				transferCounter();
+			}
+		} catch (Throwable e) {
+			LOGGER.error("{}", tag, e);
+		}
+	}
+
+	@Override
+	public void setObserveRelations(int observeRelations) {
+		observes.set(observeRelations);
+	}
+
+	@Override
+	public void setObserveEndpoints(int observeEndpoints) {
+		endpoints.set(observeEndpoints);
+	}
+
+	@Override
+	public void receivingObserveRequest() {
+		observeRequests.increment();
+	}
+
+	@Override
+	public void receivingCancelRequest() {
+		cancelRequests.increment();
+	}
+
+	@Override
+	public void receivingReject() {
+		rejectedNotifies.increment();
+	}
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservingEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/observe/ObservingEndpoint.java
@@ -33,64 +33,86 @@ import org.eclipse.californium.core.coap.Token;
  * reachable and cancels all relations that it has established to resources.
  */
 public class ObservingEndpoint {
-	
+
 	/** The endpoint's address */
 	private final InetSocketAddress address;
 
 	/** The list of relations the endpoint has established with this server */
 	private final List<ObserveRelation> relations;
-	
+
 	/**
 	 * Constructs a new ObservingEndpoint.
+	 * 
 	 * @param address the endpoint's address
+	 * @throws NullPointerException if address is {@code null}.
 	 */
 	public ObservingEndpoint(InetSocketAddress address) {
+		if (address == null) {
+			throw new NullPointerException("Address must not be null!");
+		}
 		this.address = address;
 		this.relations = new CopyOnWriteArrayList<ObserveRelation>();
 	}
-	
+
 	/**
 	 * Adds the specified observe relation.
+	 * 
 	 * @param relation the relation
 	 */
 	public void addObserveRelation(ObserveRelation relation) {
 		relations.add(relation);
 	}
-	
+
 	/**
 	 * Removes the specified observe relations.
+	 * 
 	 * @param relation the relation
 	 */
 	public void removeObserveRelation(ObserveRelation relation) {
 		relations.remove(relation);
 	}
-	
+
 	/**
 	 * Cancels all observe relations that this endpoint has established with
 	 * resources from this server.
 	 */
 	public void cancelAll() {
 		for (ObserveRelation relation : relations) {
-			relation.cancel();
+			if (relation.isEstablished()) {
+				relation.cancel();
+			}
 		}
 	}
 
 	/**
 	 * Returns the address of this endpoint-
+	 * 
 	 * @return the address
 	 */
 	public InetSocketAddress getAddress() {
 		return address;
 	}
 
+	/**
+	 * Get observer relation for provided token.
+	 * 
+	 * @param token observe request's token
+	 * @return observe relation, or {@code null}, if not available.
+	 * @deprecated obsolete
+	 */
+	@Deprecated
 	public ObserveRelation getObserveRelation(Token token) {
 		if (token != null) {
-			for (ObserveRelation relation:relations) {
+			for (ObserveRelation relation : relations) {
 				if (token.equals(relation.getExchange().getRequest().getToken())) {
 					return relation;
 				}
 			}
 		}
 		return null;
+	}
+
+	public boolean isEmpty() {
+		return relations.isEmpty();
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/CoapExchange.java
@@ -50,9 +50,6 @@ public class CoapExchange {
 	private final Exchange exchange;
 	private final Map<String, String> queryParameters;
 
-	/* The destination resource. */
-	private final CoapResource resource;
-
 	/* Response option values. */
 	private String locationPath = null;
 	private String locationQuery = null;
@@ -66,15 +63,27 @@ public class CoapExchange {
 	 * @param exchange The message exchange.
 	 * @param resource The resource.
 	 * @throws NullPointerException if any of the parameters is {@code null}.
+	 * @deprecated use {@link #CoapExchange(Exchange)} instead
 	 */
+	@Deprecated
 	public CoapExchange(final Exchange exchange, final CoapResource resource) {
-		if (exchange == null) {
-			throw new NullPointerException("exchange must not be null");
-		} else if (resource == null) {
+		this(exchange);
+		if (resource == null) {
 			throw new NullPointerException("resource must not be null");
 		}
+	}
+
+	/**
+	 * Creates a new CoAP Exchange object for an exchange.
+	 * 
+	 * @param exchange The message exchange.
+	 * @throws NullPointerException if the message exchange is {@code null}.
+	 */
+	public CoapExchange(Exchange exchange) {
+		if (exchange == null) {
+			throw new NullPointerException("exchange must not be null");
+		}
 		this.exchange = exchange;
-		this.resource = resource;
 		if (getRequestOptions().getURIQueryCount() > 0) {
 			this.queryParameters = new HashMap<>();
 			for (String param : getRequestOptions().getUriQuery()) {
@@ -509,9 +518,9 @@ public class CoapExchange {
 	 * @since 3.0 {@link NoResponseOption} is considered
 	 */
 	public void respond(Response response) {
-		if (response == null)
-			throw new NullPointerException();
-
+		if (response == null) {
+			throw new NullPointerException("Response must not be null!");
+		}
 		// set the response options configured through the CoapExchange API
 		if (locationPath != null)
 			response.getOptions().setLocationPath(locationPath);
@@ -524,7 +533,6 @@ public class CoapExchange {
 			response.getOptions().addETag(eTag);
 		}
 
-		resource.checkObserveRelation(exchange, response);
 		if (response.getDestinationContext() == null) {
 			response.setDestinationContext(applyHandshakeMode());
 		}

--- a/californium-core/src/main/java/org/eclipse/californium/core/server/resources/ObservableResource.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/server/resources/ObservableResource.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.core.server.resources;
+
+import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.observe.ObserveNotificationOrderer;
+import org.eclipse.californium.core.observe.ObserveRelation;
+
+/**
+ * Extension for a {@link Resource} supporting observe notify.
+ * 
+ * @since 3.6
+ */
+public interface ObservableResource {
+
+	/**
+	 * Gets the URI of the resource.
+	 *
+	 * @return the uri
+	 */
+	String getURI();
+
+	/**
+	 * Get the type of the notifications that will be sent.
+	 * 
+	 * @return the type of the notifications, or {@code null}, if the matching
+	 *         type of the request is to be used.
+	 */
+	Type getObserveType();
+
+	/**
+	 * Returns the current notification number.
+	 * 
+	 * @return the current notification number
+	 * @see ObserveNotificationOrderer#getCurrent()
+	 */
+	int getNotificationSequenceNumber();
+
+	/**
+	 * Checks if this resource is observable by remote CoAP clients.
+	 *
+	 * @return {@code true}, if this resource is observable
+	 */
+	boolean isObservable();
+
+	/**
+	 * Adds the specified CoAP observe relation.
+	 * 
+	 * If this resource's state changes, all observer should be notified with a
+	 * new response.
+	 * 
+	 * @param relation the relation
+	 */
+	void addObserveRelation(ObserveRelation relation);
+
+	/**
+	 * Removes the specified CoAP observe relation.
+	 *
+	 * @param relation the relation
+	 */
+	void removeObserveRelation(ObserveRelation relation);
+
+	/**
+	 * Returns the number of observe relations that this resource has to CoAP
+	 * clients.
+	 * 
+	 * @return the observer count
+	 */
+	int getObserverCount();
+
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/observe/ObservationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/observe/ObservationTest.java
@@ -32,8 +32,6 @@ import org.eclipse.californium.core.coap.CoAP.Code;
 import org.eclipse.californium.core.coap.MessageObserverAdapter;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.elements.category.Small;
-import org.eclipse.californium.rule.CoapThreadsRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -43,8 +41,6 @@ import org.junit.experimental.categories.Category;
  */
 @Category(Small.class)
 public class ObservationTest {
-	@Rule
-	public CoapThreadsRule cleanup = new CoapThreadsRule();
 
 	/**
 	 * Verifies that a request with its observe option set to a value != 0 is

--- a/californium-core/src/test/java/org/eclipse/californium/core/observe/ObserveRelationTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/observe/ObserveRelationTest.java
@@ -1,0 +1,244 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Bosch IO GmbH and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Bosch IO GmbH - initial implementation
+ ******************************************************************************/
+package org.eclipse.californium.core.observe;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.californium.TestTools;
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.core.config.CoapConfig;
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.Exchange;
+import org.eclipse.californium.core.network.Exchange.Origin;
+import org.eclipse.californium.core.server.resources.ObservableResource;
+import org.eclipse.californium.elements.category.Small;
+import org.eclipse.californium.elements.config.Configuration;
+import org.eclipse.californium.elements.util.DatagramWriter;
+import org.eclipse.californium.elements.util.TestSynchroneExecutor;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Verifies behavior of {@code ObserveRelation}.
+ */
+@Category(Small.class)
+public class ObserveRelationTest {
+
+	private static final int PEER_PORT = 13000;
+
+	InetSocketAddress address;
+	Endpoint localEndpoint;
+	ObserveManager manager;
+	Exchange exchange;
+	Exchange exchange2;
+
+	Type observeType;
+
+	@Before
+	public void setup() {
+		address = new InetSocketAddress(InetAddress.getLoopbackAddress(), PEER_PORT);
+
+		Configuration config = new Configuration();
+		config.set(CoapConfig.MAX_SERVER_OBSERVES, 10);
+		localEndpoint = mock(Endpoint.class);
+		when(localEndpoint.getConfig()).thenReturn(config);
+
+		manager = new ObserveManager(config);
+
+		exchange = createExchange(0x123);
+		exchange2 = createExchange(0x3210);
+
+	}
+
+	private Exchange createExchange(long token) {
+		DatagramWriter writer = new DatagramWriter(8);
+		writer.writeLong(token, Long.SIZE);
+		Request request = Request.newGet();
+		String uri = TestTools.getUri(address, "obs");
+		request.setURI(uri);
+		request.getOptions().setObserve(0);
+		request.setSourceContext(request.getDestinationContext());
+		request.setToken(writer.toByteArray());
+		Exchange exchange = new Exchange(request, address, Origin.REMOTE, TestSynchroneExecutor.TEST_EXECUTOR);
+		exchange.setEndpoint(localEndpoint);
+		return exchange;
+	}
+
+	private ObserveRelation handleExchange(final Exchange exchange, final ResponseCode code) {
+		exchange.execute(new Runnable() {
+
+			@Override
+			public void run() {
+				manager.addObserveRelation(exchange, resource);
+				Response response = Response.createResponse(exchange.getRequest(), code);
+				exchange.sendResponse(response);
+				exchange.setResponse(response);
+				exchange.setCurrentResponse(response);
+				ObserveRelation relation = exchange.getRelation();
+				if (relation != null) {
+					relation.onResponse(response);
+				}
+			}
+		});
+		return exchange.getRelation();
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testConstructorRejectsNull() {
+		new ObserveRelation(manager, null, null);
+	}
+
+	@Test
+	public void testNotEstablished() {
+		exchange.execute(new Runnable() {
+
+			@Override
+			public void run() {
+				manager.addObserveRelation(exchange, resource);
+			}
+		});
+		assertThat(exchange.getRelation(), is(notNullValue()));
+		assertThat(exchange.getRelation().getEndpoint().isEmpty(), is(false));
+		assertThat(resource.getObserverCount(), is(0));
+		exchange.getRelation().cancel();
+		assertThat(exchange.getRelation().getEndpoint().isEmpty(), is(true));
+	}
+
+	@Test
+	public void testEstablished() {
+		handleExchange(exchange, ResponseCode.CONTENT);
+
+		assertThat(exchange.getRelation(), is(notNullValue()));
+		assertThat(exchange.getRelation().getEndpoint().isEmpty(), is(false));
+		assertThat(exchange.getCurrentResponse().isNotification(), is(true));
+		assertThat(resource.getObserverCount(), is(1));
+		exchange.getRelation().cancel();
+		assertThat(exchange.getRelation().getEndpoint().isEmpty(), is(true));
+		assertThat(resource.getObserverCount(), is(0));
+	}
+
+	@Test
+	public void testNoSuccess() {
+		handleExchange(exchange, ResponseCode.NOT_FOUND);
+
+		assertThat(exchange.getRelation(), is(notNullValue()));
+		assertThat(exchange.getRelation().getEndpoint().isEmpty(), is(false));
+		assertThat(exchange.getCurrentResponse().isNotification(), is(false));
+		assertThat(resource.getObserverCount(), is(0));
+		exchange.getRelation().onSend(exchange.getCurrentResponse());
+		assertThat(exchange.getRelation().getEndpoint().isEmpty(), is(true));
+	}
+
+	@Test
+	public void testTwoObserves() {
+		handleExchange(exchange, ResponseCode.CONTENT);
+		handleExchange(exchange2, ResponseCode.CONTENT);
+
+		assertThat(exchange.getRelation(), is(notNullValue()));
+		assertThat(exchange.getRelation().getEndpoint().isEmpty(), is(false));
+
+		assertThat(resource.getObserverCount(), is(2));
+		exchange.getRelation().getEndpoint().cancelAll();
+		assertThat(exchange.getRelation().getEndpoint().isEmpty(), is(true));
+		assertThat(resource.getObserverCount(), is(0));
+	}
+
+	@Test
+	public void testLimitObserves() {
+		ObserveRelation relation = handleExchange(exchange, ResponseCode.CONTENT);
+		ObserveRelation relation2 = handleExchange(exchange2, ResponseCode.CONTENT);
+		long token = 1;
+		Exchange exchangeN = createExchange(++token);
+		while (handleExchange(exchangeN, ResponseCode.CONTENT) != null) {
+			exchangeN = createExchange(++token);
+		}
+		assertThat(manager.isFull(), is(true));
+		assertThat(exchangeN.getCurrentResponse().isNotification(), is(false));
+
+		// replace
+		Exchange exchangeM = createExchange(0x123);
+		handleExchange(exchangeM, ResponseCode.CONTENT);
+		assertThat(exchangeM.getRelation(), is(notNullValue()));
+		assertThat(relation.isCanceled(), is(true));
+
+		// cancel
+		relation2.cancel();
+
+		assertThat(manager.isFull(), is(false));
+		exchangeN = createExchange(++token);
+		handleExchange(exchangeN, ResponseCode.CONTENT);
+		assertThat(exchangeN.getRelation(), is(notNullValue()));
+
+		// cancel all
+		relation.getEndpoint().cancelAll();
+		assertThat(relation.getEndpoint().isEmpty(), is(true));
+		assertThat(resource.getObserverCount(), is(0));
+	}
+
+	private ObservableResource resource = new ObservableResource() {
+
+		private final List<ObserveRelation> observeRelations = new CopyOnWriteArrayList<>();
+
+		@Override
+		public boolean isObservable() {
+			return true;
+		}
+
+		@Override
+		public String getURI() {
+			return "obs";
+		}
+
+		@Override
+		public Type getObserveType() {
+			return observeType;
+		}
+
+		@Override
+		public int getNotificationSequenceNumber() {
+			return 0;
+		}
+
+		@Override
+		public void addObserveRelation(ObserveRelation relation) {
+			observeRelations.add(relation);
+		}
+
+		@Override
+		public void removeObserveRelation(ObserveRelation relation) {
+			observeRelations.remove(relation);
+		}
+
+		@Override
+		public int getObserverCount() {
+			return observeRelations.size();
+		}
+	};
+
+}

--- a/californium-core/src/test/java/org/eclipse/californium/core/server/ServerMessageDelivererTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/server/ServerMessageDelivererTest.java
@@ -83,7 +83,7 @@ public class ServerMessageDelivererTest {
 
 		// GIVEN a message deliverer subclass which processes all incoming requests
 		// in its preDeliverRequest method
-		final ServerMessageDeliverer deliverer = new ServerMessageDeliverer(rootResource) {
+		final ServerMessageDeliverer deliverer = new ServerMessageDeliverer(rootResource, null) {
 			@Override
 			protected boolean preDeliverRequest(Exchange exchange) {
 				Response response = new Response(ResponseCode.CREATED);
@@ -116,7 +116,7 @@ public class ServerMessageDelivererTest {
 		// GIVEN a message deliverer subclass that adds a custom option to incoming
 		// requests
 		final Option customOption = new Option(200);
-		ServerMessageDeliverer deliverer = new ServerMessageDeliverer(rootResource) {
+		ServerMessageDeliverer deliverer = new ServerMessageDeliverer(rootResource, null) {
 			@Override
 			protected boolean preDeliverRequest(Exchange exchange) {
 				exchange.getRequest().getOptions().addOption(customOption);
@@ -142,7 +142,7 @@ public class ServerMessageDelivererTest {
 	public void testDeliverResponseYieldsToSubclass() {
 
 		// GIVEN a message deliverer subclass that processes all incoming responses
-		ServerMessageDeliverer deliverer = new ServerMessageDeliverer(rootResource) {
+		ServerMessageDeliverer deliverer = new ServerMessageDeliverer(rootResource, null) {
 
 			@Override
 			protected boolean preDeliverResponse(Exchange exchange, Response response) {
@@ -166,7 +166,7 @@ public class ServerMessageDelivererTest {
 
 		// GIVEN a message deliverer subclass that adds a custom option to incoming
 		// responses
-		ServerMessageDeliverer deliverer = new ServerMessageDeliverer(rootResource) {
+		ServerMessageDeliverer deliverer = new ServerMessageDeliverer(rootResource, null) {
 
 			@Override
 			protected boolean preDeliverResponse(Exchange exchange, Response response) {

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/ClientAsynchronousTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/ClientAsynchronousTest.java
@@ -144,25 +144,25 @@ public class ClientAsynchronousTest {
 		// Observe the resource
 		CoapObserveRelation obs1 = client.observe(handler);
 
-		assertTrue("missing notifications", handler.waitOnLoadCalls(1, 2000, TimeUnit.MILLISECONDS));
+		assertTrue("missing first notification", handler.waitOnLoadCalls(1, 2000, TimeUnit.MILLISECONDS));
 
 		LOGGER.info("changed 1");
 		resource.setContent(CONTENT_1 + " - 1");
 		resource.changed();
 
-		assertTrue("missing notifications", handler.waitOnLoadCalls(2, 2000, TimeUnit.MILLISECONDS));
+		assertTrue("missing second notification", handler.waitOnLoadCalls(2, 2000, TimeUnit.MILLISECONDS));
 
 		LOGGER.info("changed 2");
 		resource.setContent(CONTENT_1 + " - 2");
 		resource.changed();
 
-		assertTrue("missing notifications", handler.waitOnLoadCalls(3, 2000, TimeUnit.MILLISECONDS));
+		assertTrue("missing third notification", handler.waitOnLoadCalls(3, 2000, TimeUnit.MILLISECONDS));
 
 		LOGGER.info("changed 3");
 		resource.setContent(CONTENT_1 + " - 3");
 		resource.changed();
 
-		assertTrue("missing notifications", handler.waitOnLoadCalls(4, 2000, TimeUnit.MILLISECONDS));
+		assertTrue("missing fourth notification", handler.waitOnLoadCalls(4, 2000, TimeUnit.MILLISECONDS));
 		obs1.reactiveCancel();
 		resource.changed();
 		Thread.sleep(50);

--- a/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/ForwardProxyMessageDeliverer.java
+++ b/californium-proxy2/src/main/java/org/eclipse/californium/proxy2/resources/ForwardProxyMessageDeliverer.java
@@ -34,6 +34,7 @@ import org.eclipse.californium.core.network.Exchange;
 import org.eclipse.californium.core.server.DelivererException;
 import org.eclipse.californium.core.server.ServerMessageDeliverer;
 import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.util.NetworkInterfacesUtil;
 import org.eclipse.californium.proxy2.CoapUriTranslator;
 import org.eclipse.californium.proxy2.TranslationException;
@@ -122,9 +123,33 @@ public class ForwardProxyMessageDeliverer extends ServerMessageDeliverer {
 	 *            used to determine this destination scheme for forward-proxy
 	 *            implementations. The translator may return {@code null} to
 	 *            bypass the forward-proxy processing for a request.
+	 * @deprecated use
+	 *             {@link #ForwardProxyMessageDeliverer(Resource, CoapUriTranslator, Configuration)}
+	 *             instead
 	 */
+	@Deprecated
 	public ForwardProxyMessageDeliverer(Resource root, CoapUriTranslator translator) {
-		super(root);
+		this(root, translator, null);
+	}
+
+	/**
+	 * Create message deliverer with forward-proxy support.
+	 * 
+	 * @param root root resource of coap-proxy-server. Used for mixed proxies or
+	 *            coap servers, if requests are intended to be also delivered
+	 *            according their uri-path. May be {@code null}, if only used
+	 *            for a forward proxy and requests are no intended to be
+	 *            delivered using their uri path.
+	 * @param translator translator for destination-scheme.
+	 *            {@link CoapUriTranslator#getDestinationScheme(Request)} is
+	 *            used to determine this destination scheme for forward-proxy
+	 *            implementations. The translator may return {@code null} to
+	 *            bypass the forward-proxy processing for a request.
+	 * @param config configuration.
+	 * @since 3.6
+	 */
+	public ForwardProxyMessageDeliverer(Resource root, CoapUriTranslator translator, Configuration config) {
+		super(root, config);
 		this.translator = translator;
 		this.scheme2resource = new HashMap<String, Resource>();
 		this.exposedServices = new HashSet<>();
@@ -141,7 +166,7 @@ public class ForwardProxyMessageDeliverer extends ServerMessageDeliverer {
 	 * @since 2.4
 	 */
 	public ForwardProxyMessageDeliverer(ProxyCoapResource proxyCoapResource) {
-		this(null, proxyCoapResource.getUriTranslater());
+		this(null, proxyCoapResource.getUriTranslater(), null);
 		addProxyCoapResources(proxyCoapResource);
 	}
 
@@ -346,7 +371,7 @@ public class ForwardProxyMessageDeliverer extends ServerMessageDeliverer {
 				LOGGER.debug("Bad proxy request", e);
 			}
 		}
-		if (resource == null && local) {
+		if (resource == null && local && getRootResource() != null) {
 			// try to find local resource
 			resource = super.findResource(exchange);
 		}

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/ExtendedTestServer.java
@@ -52,6 +52,7 @@ import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
 import org.eclipse.californium.core.network.EndpointObserver;
 import org.eclipse.californium.core.network.interceptors.HealthStatisticLogger;
+import org.eclipse.californium.core.observe.ObserveStatisticLogger;
 import org.eclipse.californium.core.server.resources.MyIpResource;
 import org.eclipse.californium.core.server.resources.Resource;
 import org.eclipse.californium.elements.Connector;
@@ -527,9 +528,17 @@ public class ExtendedTestServer extends AbstractTestServer {
 
 			server.addLogger(!config.benchmark);
 
+			List<CounterStatisticManager> statistics = new ArrayList<>();
+			ObserveStatisticLogger obsStatLogger = new ObserveStatisticLogger(server.getTag());
+			if (obsStatLogger.isEnabled()) {
+				statistics.add(obsStatLogger);
+				server.add(obsStatLogger);
+				server.setObserveHealth(obsStatLogger);
+			}
+
 			Resource child = server.getRoot().getChild(Diagnose.RESOURCE_NAME);
 			if (child instanceof Diagnose) {
-				((Diagnose) child).update();
+				((Diagnose) child).update(statistics);
 			}
 
 			PlugtestServer.ActiveInputReader reader = new PlugtestServer.ActiveInputReader();

--- a/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/Diagnose.java
+++ b/demo-apps/cf-extplugtest-server/src/main/java/org/eclipse/californium/extplugtests/resources/Diagnose.java
@@ -96,7 +96,7 @@ public class Diagnose extends CoapResource {
 		getAttributes().addContentType(APPLICATION_CBOR);
 	}
 
-	public void update() {
+	public void update(List<CounterStatisticManager> serverHealth) {
 		if (server != null) {
 			endpointsHealth.clear();
 			for (Resource child : getChildren()) {
@@ -105,14 +105,14 @@ public class Diagnose extends CoapResource {
 			for (Endpoint ep : server.getEndpoints()) {
 				String scheme = ep.getUri().getScheme();
 				if (CoAP.isUdpScheme(scheme)) {
-					addHealth(ep);
+					addHealth(ep, serverHealth);
 				}
 			}
 		}
 	}
 
-	public void addHealth(Endpoint endpoint) {
-		List<CounterStatisticManager> health = new ArrayList<>();
+	public void addHealth(Endpoint endpoint, List<CounterStatisticManager> serverHealth) {
+		List<CounterStatisticManager> health = new ArrayList<>(serverHealth);
 		String protocol = CoAP.getProtocolForScheme(endpoint.getUri().getScheme());
 		InetSocketAddress local = endpoint.getAddress();
 		String key = protocol + ":" + StringUtil.toString(local);

--- a/demo-apps/cf-extplugtest-server/src/main/resources/logback.xml
+++ b/demo-apps/cf-extplugtest-server/src/main/resources/logback.xml
@@ -101,6 +101,9 @@
 	<logger name="org.eclipse.californium.core.network.interceptors.HealthStatisticLogger" level="DEBUG" additivity="false">
 		<appender-ref ref="STDOUT" />
 	</logger>
+	<logger name="org.eclipse.californium.core.observe.ObserveStatisticLogger" level="DEBUG" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
 	<logger name="org.eclipse.californium.unixhealth" level="DEBUG" additivity="false">
 		<appender-ref ref="STDOUT" />
 	</logger>

--- a/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/ExampleCrossProxy2.java
+++ b/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/ExampleCrossProxy2.java
@@ -196,7 +196,7 @@ public class ExampleCrossProxy2 {
 		coapProxyServer = new CoapServer(config, coapPort);
 		MessageDeliverer local = coapProxyServer.getMessageDeliverer();
 		ForwardProxyMessageDeliverer proxyMessageDeliverer = new ForwardProxyMessageDeliverer(coapProxyServer.getRoot(),
-				translater);
+				translater, config);
 		proxyMessageDeliverer.addProxyCoapResources(coap2coap, coap2http);
 		proxyMessageDeliverer.addExposedServiceAddresses(new InetSocketAddress(coapPort));
 		coapProxyServer.setMessageDeliverer(proxyMessageDeliverer);

--- a/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/ExampleSecureProxy2.java
+++ b/demo-apps/cf-proxy2/src/main/java/org/eclipse/californium/examples/ExampleSecureProxy2.java
@@ -161,7 +161,7 @@ public class ExampleSecureProxy2 {
 		// Forwards requests Coap to Coap or Coap to Http server
 		coapProxyServer = new CoapServer(config, coapPort);
 		ForwardProxyMessageDeliverer proxyMessageDeliverer = new ForwardProxyMessageDeliverer(coapProxyServer.getRoot(),
-				translater);
+				translater, config);
 		proxyMessageDeliverer.addProxyCoapResources(coap2coap);
 		proxyMessageDeliverer.addExposedServiceAddresses(new InetSocketAddress(coapPort));
 		coapProxyServer.setMessageDeliverer(proxyMessageDeliverer);


### PR DESCRIPTION
The cleanup redesigns the data model of the server side's observe
relation. The ObserveManager keeps now all observe relations by the
key-token (remote endpoint + token). The other collections are therefore
now only simple lists, obsoletes the ObserveRelationContainer completely.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>