### PR TITLE
Update gson to 2.8.9.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,6 +29,7 @@ For more details, please look at https://www.eclipse.org/security/.
 
 | Californium Version | Dependency | Affected Version | Usage | Vulnerability
 | ------------------- | ---------- | ---------------- | ----- | -------------
+| < 3.6 <br/> < 2.7.3 | com.google.code.gson |  < 2.8.8 | demo-apps | [CVE 2022-25647](https://cve.report/CVE-2022-25647)
 | < 3.3 <br/> < 2.7.2 | com.upokecenter.cbor | 4.0 - 4.5.0 | cf-oscore <br/> demo-apps | [GHSA-fj2w-wfgv-mwq6](https://github.com/peteroupc/CBOR-Java/security/advisories/GHSA-fj2w-wfgv-mwq6)
 | < 3.2 <br/> < 2.7.1 | ch.qos.logback.logback-classic | < 1.2.9 | demo-apps | [CVE-2021-42550](https://cve.report/CVE-2021-42550)
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -18,7 +18,7 @@
 
 	<properties>
 		<picocli.version>4.6.2</picocli.version>
-		<gson.version>2.8.8</gson.version>
+		<gson.version>2.8.9</gson.version>
 		<cbor.version>4.5.2</cbor.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<logback.version>1.2.10</logback.version>


### PR DESCRIPTION
Fix CVE-2022-25647.

Signed-off-by: Achim Kraus <achim.kraus@cloudcoap.net>