### PR TITLE
Relax DTLS handshake timeout.

### DIFF
--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/ConnectorUtil.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/ConnectorUtil.java
@@ -55,6 +55,8 @@ public class ConnectorUtil {
 
 	public static final int PORT = 5684;
 
+	public static final long HANDSHAKE_TIMEOUT_MILLIS = 4000;
+
 	private static final char[] KEY_STORE_PASSWORD = "endPass".toCharArray();
 	private static final String KEY_STORE_LOCATION = "certs/keyStore.jks";
 	private static final char[] TRUST_STORE_PASSWORD = "rootPass".toCharArray();
@@ -162,6 +164,7 @@ public class ConnectorUtil {
 			dtlsBuilder = DtlsConnectorConfig.builder(new Configuration());
 		}
 		dtlsBuilder.set(DtlsConfig.DTLS_ADDITIONAL_ECC_TIMEOUT, 1000, TimeUnit.MILLISECONDS)
+				.set(DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT, 1000, TimeUnit.MILLISECONDS)
 				.set(DtlsConfig.DTLS_RECEIVER_THREAD_COUNT, 2)
 				.set(DtlsConfig.DTLS_CONNECTOR_THREAD_COUNT, 2)
 				.set(DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, false)

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/mbedtls/MbedTlsClientAuthenticationInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/mbedtls/MbedTlsClientAuthenticationInteroperabilityTest.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.eclipse.californium.interoperability.test.mbedtls;
 
+import static org.eclipse.californium.interoperability.test.ConnectorUtil.HANDSHAKE_TIMEOUT_MILLIS;
 import static org.eclipse.californium.interoperability.test.CredentialslUtil.CLIENT_RSA_CERTIFICATE;
 import static org.eclipse.californium.interoperability.test.ProcessUtil.TIMEOUT_MILLIS;
 import static org.eclipse.californium.interoperability.test.mbedtls.MbedTlsProcessUtil.AuthenticationMode.CHAIN;
@@ -241,7 +242,7 @@ public class MbedTlsClientAuthenticationInteroperabilityTest {
 	}
 
 	public void connect(String cipher, String... misc) throws Exception {
-		assertTrue("handshake failed!", processUtil.waitConsole("Ciphersuite is ", TIMEOUT_MILLIS));
+		assertTrue("handshake failed!", processUtil.waitConsole("Ciphersuite is ", HANDSHAKE_TIMEOUT_MILLIS));
 		assertTrue("wrong cipher suite!", processUtil.waitConsole("Ciphersuite is " + cipher, TIMEOUT_MILLIS));
 		if (misc != null) {
 			for (String check : misc) {

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/mbedtls/MbedTlsClientInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/mbedtls/MbedTlsClientInteroperabilityTest.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.eclipse.californium.interoperability.test.mbedtls;
 
+import static org.eclipse.californium.interoperability.test.ConnectorUtil.HANDSHAKE_TIMEOUT_MILLIS;
 import static org.eclipse.californium.interoperability.test.ProcessUtil.TIMEOUT_MILLIS;
 import static org.eclipse.californium.interoperability.test.mbedtls.MbedTlsProcessUtil.AuthenticationMode.CHAIN;
 import static org.junit.Assert.assertTrue;
@@ -107,7 +108,7 @@ public class MbedTlsClientInteroperabilityTest {
 		scandiumUtil.start(BIND, null, cipherSuite);
 
 		String cipher = processUtil.startupClient(DESTINATION, ScandiumUtil.PORT, CHAIN, cipherSuite);
-		assertTrue(processUtil.waitConsole("Ciphersuite is " + cipher, TIMEOUT_MILLIS));
+		assertTrue(processUtil.waitConsole("Ciphersuite is " + cipher, HANDSHAKE_TIMEOUT_MILLIS));
 
 		String message = "Hello Scandium!";
 
@@ -135,7 +136,7 @@ public class MbedTlsClientInteroperabilityTest {
 		scandiumUtil.start(BIND, builder, null, cipherSuite);
 
 		String cipher = processUtil.startupClient(DESTINATION, ScandiumUtil.PORT, CHAIN, cipherSuite);
-		assertTrue(processUtil.waitConsole("Ciphersuite is " + cipher, TIMEOUT_MILLIS));
+		assertTrue(processUtil.waitConsole("Ciphersuite is " + cipher, HANDSHAKE_TIMEOUT_MILLIS));
 
 		String message = "Hello Scandium!";
 

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/mbedtls/MbedTlsServerAuthenticationInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/mbedtls/MbedTlsServerAuthenticationInteroperabilityTest.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.eclipse.californium.interoperability.test.mbedtls;
 
+import static org.eclipse.californium.interoperability.test.ConnectorUtil.HANDSHAKE_TIMEOUT_MILLIS;
 import static org.eclipse.californium.interoperability.test.CredentialslUtil.SERVER_CERTIFICATE;
 import static org.eclipse.californium.interoperability.test.CredentialslUtil.SERVER_RSA_CERTIFICATE;
 import static org.eclipse.californium.interoperability.test.CredentialslUtil.SERVER_CA_RSA_CERTIFICATE;
@@ -271,7 +272,7 @@ public class MbedTlsServerAuthenticationInteroperabilityTest {
 
 	public void connect(String cipher, String... misc) throws Exception {
 		String message = "Hello OpenSSL!";
-		scandiumUtil.send(message, DESTINATION, TIMEOUT_MILLIS);
+		scandiumUtil.send(message, DESTINATION, HANDSHAKE_TIMEOUT_MILLIS);
 
 		assertTrue("handshake failed!", processUtil.waitConsole("Ciphersuite is ", TIMEOUT_MILLIS));
 		assertTrue("wrong cipher suite!", processUtil.waitConsole("Ciphersuite is " + cipher, TIMEOUT_MILLIS));

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/mbedtls/MbedTlsServerInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/mbedtls/MbedTlsServerInteroperabilityTest.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.eclipse.californium.interoperability.test.mbedtls;
 
+import static org.eclipse.californium.interoperability.test.ConnectorUtil.HANDSHAKE_TIMEOUT_MILLIS;
 import static org.eclipse.californium.interoperability.test.CredentialslUtil.SERVER_CERTIFICATE;
 import static org.eclipse.californium.interoperability.test.CredentialslUtil.SERVER_RSA_CERTIFICATE;
 import static org.eclipse.californium.interoperability.test.ProcessUtil.TIMEOUT_MILLIS;
@@ -113,7 +114,7 @@ public class MbedTlsServerInteroperabilityTest {
 		scandiumUtil.start(BIND, builder, null, cipherSuite);
 
 		String message = "Hello MbedTLS!";
-		scandiumUtil.send(message, DESTINATION, TIMEOUT_MILLIS);
+		scandiumUtil.send(message, DESTINATION, HANDSHAKE_TIMEOUT_MILLIS);
 
 		assertTrue(processUtil.waitConsole("Ciphersuite is " + cipher, TIMEOUT_MILLIS));
 		assertTrue(processUtil.waitConsole(message, TIMEOUT_MILLIS));
@@ -138,7 +139,7 @@ public class MbedTlsServerInteroperabilityTest {
 		scandiumUtil.start(BIND, builder, null, cipherSuite);
 
 		String message = "Hello MbedTLS!";
-		scandiumUtil.send(message, DESTINATION, TIMEOUT_MILLIS);
+		scandiumUtil.send(message, DESTINATION, HANDSHAKE_TIMEOUT_MILLIS);
 
 		assertTrue(processUtil.waitConsole("Ciphersuite is " + cipher, TIMEOUT_MILLIS));
 		assertTrue(processUtil.waitConsole(message, TIMEOUT_MILLIS));

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/openssl/OpenSslClientAuthenticationInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/openssl/OpenSslClientAuthenticationInteroperabilityTest.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.eclipse.californium.interoperability.test.openssl;
 
+import static org.eclipse.californium.interoperability.test.ConnectorUtil.HANDSHAKE_TIMEOUT_MILLIS;
 import static org.eclipse.californium.interoperability.test.CredentialslUtil.CLIENT_RSA_CERTIFICATE;
 import static org.eclipse.californium.interoperability.test.ProcessUtil.TIMEOUT_MILLIS;
 import static org.eclipse.californium.interoperability.test.openssl.OpenSslProcessUtil.AuthenticationMode.CERTIFICATE;
@@ -259,7 +260,7 @@ public class OpenSslClientAuthenticationInteroperabilityTest {
 	}
 
 	public void connect(String cipher, String... misc) throws Exception {
-		assertTrue("handshake failed!", processUtil.waitConsole("Cipher is ", TIMEOUT_MILLIS));
+		assertTrue("handshake failed!", processUtil.waitConsole("Cipher is ", HANDSHAKE_TIMEOUT_MILLIS));
 		assertTrue("wrong cipher suite!", processUtil.waitConsole("Cipher is " + cipher, TIMEOUT_MILLIS));
 		if (misc != null) {
 			for (String check : misc) {

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/openssl/OpenSslClientInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/openssl/OpenSslClientInteroperabilityTest.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.eclipse.californium.interoperability.test.openssl;
 
+import static org.eclipse.californium.interoperability.test.ConnectorUtil.HANDSHAKE_TIMEOUT_MILLIS;
 import static org.eclipse.californium.interoperability.test.ProcessUtil.TIMEOUT_MILLIS;
 import static org.eclipse.californium.interoperability.test.openssl.OpenSslProcessUtil.AuthenticationMode.CERTIFICATE;
 import static org.junit.Assert.assertTrue;
@@ -108,7 +109,7 @@ public class OpenSslClientInteroperabilityTest {
 		scandiumUtil.start(BIND, null, cipherSuite);
 
 		String cipher = processUtil.startupClient(DESTINATION, CERTIFICATE, cipherSuite);
-		assertTrue(processUtil.waitConsole("Cipher is " + cipher, TIMEOUT_MILLIS));
+		assertTrue(processUtil.waitConsole("Cipher is " + cipher, HANDSHAKE_TIMEOUT_MILLIS));
 
 		String message = "Hello Scandium!";
 		processUtil.send(message);
@@ -136,7 +137,7 @@ public class OpenSslClientInteroperabilityTest {
 		scandiumUtil.start(BIND, builder, null, cipherSuite);
 
 		String cipher = processUtil.startupClient(DESTINATION, CERTIFICATE, cipherSuite);
-		assertTrue(processUtil.waitConsole("Cipher is " + cipher, TIMEOUT_MILLIS));
+		assertTrue(processUtil.waitConsole("Cipher is " + cipher, HANDSHAKE_TIMEOUT_MILLIS));
 
 		String message = "Hello Scandium!";
 		processUtil.send(message);

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/openssl/OpenSslServerAuthenticationInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/openssl/OpenSslServerAuthenticationInteroperabilityTest.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.eclipse.californium.interoperability.test.openssl;
 
+import static org.eclipse.californium.interoperability.test.ConnectorUtil.HANDSHAKE_TIMEOUT_MILLIS;
 import static org.eclipse.californium.interoperability.test.CredentialslUtil.SERVER_CERTIFICATE;
 import static org.eclipse.californium.interoperability.test.CredentialslUtil.SERVER_RSA_CERTIFICATE;
 import static org.eclipse.californium.interoperability.test.CredentialslUtil.SERVER_CA_RSA_CERTIFICATE;
@@ -302,7 +303,7 @@ public class OpenSslServerAuthenticationInteroperabilityTest {
 
 	public void connect(String cipher, String... misc) throws Exception {
 		String message = "Hello OpenSSL!";
-		scandiumUtil.send(message, DESTINATION, TIMEOUT_MILLIS);
+		scandiumUtil.send(message, DESTINATION, HANDSHAKE_TIMEOUT_MILLIS);
 
 		assertTrue("handshake failed!", processUtil.waitConsole("CIPHER is ", TIMEOUT_MILLIS));
 		assertTrue("wrong cipher suite!", processUtil.waitConsole("CIPHER is " + cipher, TIMEOUT_MILLIS));

--- a/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/openssl/OpenSslServerInteroperabilityTest.java
+++ b/californium-tests/californium-interoperability-tests/src/test/java/org/eclipse/californium/interoperability/test/openssl/OpenSslServerInteroperabilityTest.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package org.eclipse.californium.interoperability.test.openssl;
 
+import static org.eclipse.californium.interoperability.test.ConnectorUtil.HANDSHAKE_TIMEOUT_MILLIS;
 import static org.eclipse.californium.interoperability.test.CredentialslUtil.SERVER_CERTIFICATE;
 import static org.eclipse.californium.interoperability.test.CredentialslUtil.SERVER_RSA_CERTIFICATE;
 import static org.eclipse.californium.interoperability.test.ProcessUtil.TIMEOUT_MILLIS;
@@ -119,7 +120,7 @@ public class OpenSslServerInteroperabilityTest {
 		scandiumUtil.start(BIND, builder, null, cipherSuite);
 
 		String message = "Hello OpenSSL!";
-		scandiumUtil.send(message, DESTINATION, TIMEOUT_MILLIS);
+		scandiumUtil.send(message, DESTINATION, HANDSHAKE_TIMEOUT_MILLIS);
 
 		assertTrue(processUtil.waitConsole("CIPHER is " + cipher, TIMEOUT_MILLIS));
 		assertTrue(processUtil.waitConsole(message, TIMEOUT_MILLIS));
@@ -144,7 +145,7 @@ public class OpenSslServerInteroperabilityTest {
 		scandiumUtil.start(BIND, builder, null, cipherSuite);
 
 		String message = "Hello OpenSSL!";
-		scandiumUtil.send(message, DESTINATION, TIMEOUT_MILLIS);
+		scandiumUtil.send(message, DESTINATION, HANDSHAKE_TIMEOUT_MILLIS);
 
 		assertTrue(processUtil.waitConsole("CIPHER is " + cipher, TIMEOUT_MILLIS));
 		assertTrue(processUtil.waitConsole(message, TIMEOUT_MILLIS));


### PR DESCRIPTION
Additionally use shorter dtls retransmission timeout for
interoperability tests.

Signed-off-by: Achim Kraus <achim.kraus@cloudcoap.net>