### PR TITLE
Adapt datagram parser to be more flexible for customizing.

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAPMessageFormatException.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAPMessageFormatException.java
@@ -22,13 +22,14 @@ import org.eclipse.californium.core.coap.CoAP.ResponseCode;
  * message.
  * <p>
  * The <em>message</em> property contains a description of the problem
- * encountered. The other properties are parsed from the binary representation.
+ * encountered and the <em>error code</em> the intended error response. The
+ * other properties are parsed from the binary representation.
  * </p>
  */
 public class CoAPMessageFormatException extends MessageFormatException {
 
 	private static final long serialVersionUID = 1L;
-	private static final int NO_MID = -1;
+	private static final int NO_MID = Message.NONE;
 	private final int mid;
 	private final int code;
 	private final Token token;
@@ -62,8 +63,10 @@ public class CoAPMessageFormatException extends MessageFormatException {
 	 * @param mid the message ID.
 	 * @param code the message code.
 	 * @param confirmable whether the message has been transferred reliably.
-	 * @param errorCode error response code.
-	 * @since 3.0
+	 * @param errorCode error response code. {@code null} to reject the incoming
+	 *            message, if possible.
+	 * @since 3.0 (since 3.7 supports {@code null} for error code to reject the
+	 *        incoming message)
 	 */
 	public CoAPMessageFormatException(String description, Token token, int mid, int code, boolean confirmable,
 			ResponseCode errorCode) {
@@ -116,8 +119,14 @@ public class CoAPMessageFormatException extends MessageFormatException {
 	/**
 	 * Get the error code for a response.
 	 * 
-	 * @return the error code
-	 * @since 3.0
+	 * Note: only malformed CON-requests are responded with an error message.
+	 * Malformed CON-responses are always rejected and malformed NON-messages
+	 * are always ignored.
+	 * 
+	 * @return the error code, or {@code null}, if the incoming message should
+	 *         be rejected, if possible.
+	 * @since 3.0 (since 3.7 supports {@code null} to reject the incoming
+	 *        message)
 	 */
 	public final ResponseCode getErrorCode() {
 		return errorCode;

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAPOptionException.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAPOptionException.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ ******************************************************************************/
+package org.eclipse.californium.core.coap;
+
+import org.eclipse.californium.core.coap.CoAP.ResponseCode;
+
+/**
+ * Indicates a problem while parsing the binary representation of a CoAP option.
+ * <p>
+ * The <em>message</em> property contains a description of the problem
+ * encountered.
+ * </p>
+ */
+public class CoAPOptionException extends MessageFormatException {
+
+	private static final long serialVersionUID = 1L;
+	private final ResponseCode errorCode;
+
+	/**
+	 * Creates an exception for a description, and error response code.
+	 * 
+	 * @param description a description of the error cause.
+	 * @param errorCode error response code. {@code null} to reject the incoming
+	 *            message, if possible.
+	 */
+	public CoAPOptionException(String description, ResponseCode errorCode) {
+		super(description);
+		this.errorCode = errorCode;
+	}
+
+	/**
+	 * Get the error code for a response.
+	 * 
+	 * Note: only malformed CON-requests are responded with an error message.
+	 * Malformed CON-responses are always rejected and malformed NON-messages
+	 * 
+	 * @return the error code, or {@code null}, if the incoming message should
+	 *         be rejected, if possible.
+	 */
+	public final ResponseCode getErrorCode() {
+		return errorCode;
+	}
+
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/OptionNumberRegistry.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/OptionNumberRegistry.java
@@ -19,6 +19,8 @@
  ******************************************************************************/
 package org.eclipse.californium.core.coap;
 
+import org.eclipse.californium.core.network.CoapEndpoint.Builder;
+
 /**
  * This class describes the CoAP Option Number Registry as defined in RFC 7252,
  * Section 12.2 and other CoAP extensions.
@@ -235,11 +237,52 @@ public final class OptionNumberRegistry {
 	}
 
 	/**
-	 * Checks if is single value.
+	 * Checks whether an option is a custom option.
+	 * 
+	 * CoAP may be extended by custom options. If critical custom option are
+	 * considered, such option numbers must be provided with
+	 * {@link Builder#setCriticalCustomOptions}.
 	 * 
 	 * @param optionNumber
 	 *            the option number
-	 * @return {@code true} if is single value
+	 * @return {@code true} if the option is a custom option
+	 * @since 3.7
+	 */
+	public static boolean isCustomOption(int optionNumber) {
+		switch (optionNumber) {
+		case CONTENT_FORMAT:
+		case MAX_AGE:
+		case PROXY_URI:
+		case PROXY_SCHEME:
+		case URI_HOST:
+		case URI_PORT:
+		case IF_NONE_MATCH:
+		case OBSERVE:
+		case ACCEPT:
+		case OSCORE:
+		case BLOCK1:
+		case BLOCK2:
+		case SIZE1:
+		case SIZE2:
+		case NO_RESPONSE:
+		case ETAG:
+		case IF_MATCH:
+		case URI_PATH:
+		case URI_QUERY:
+		case LOCATION_PATH:
+		case LOCATION_QUERY:
+			return false;
+		default:
+			return true;
+		}
+	}
+
+	/**
+	 * Checks whether an option has a single value.
+	 * 
+	 * @param optionNumber
+	 *            the option number
+	 * @return {@code true} if the option has a single value
 	 */
 	public static boolean isSingleValue(int optionNumber) {
 		switch (optionNumber) {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -1094,7 +1094,7 @@ public class CoapEndpoint implements Endpoint, Executor {
 						// respond with BAD OPTION erroneous reliably
 						// transmitted request as mandated by CoAP spec
 						// https://tools.ietf.org/html/rfc7252#section-4.2
-						responseBadOption(context, e);
+						responseToMalformedRequest(context, e);
 						LOGGER.debug("{}respond malformed request from [{}], reason: {}", tag, context, e.getMessage());
 					} else {
 						// reject erroneous reliably transmitted message as
@@ -1137,7 +1137,7 @@ public class CoapEndpoint implements Endpoint, Executor {
 			}
 		}
 
-		private void responseBadOption(final EndpointContext destination, final CoAPMessageFormatException cause) {
+		private void responseToMalformedRequest(final EndpointContext destination, final CoAPMessageFormatException cause) {
 			Response response = new Response(cause.getErrorCode(), true);
 			response.setDestinationContext(destination);
 			response.setToken(cause.getToken());

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/HealthStatisticLogger.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/HealthStatisticLogger.java
@@ -22,6 +22,7 @@ import org.eclipse.californium.core.coap.CoAP;
 import org.eclipse.californium.core.coap.EmptyMessage;
 import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
+import org.eclipse.californium.elements.RawData;
 import org.eclipse.californium.elements.util.CounterStatisticManager;
 import org.eclipse.californium.elements.util.SimpleCounterStatistic;
 import org.eclipse.californium.elements.util.StringUtil;
@@ -33,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * 
  * @since 2.1
  */
-public class HealthStatisticLogger extends CounterStatisticManager implements MessageInterceptor {
+public class HealthStatisticLogger extends CounterStatisticManager implements MalformedMessageInterceptor {
 
 	/** the logger. */
 	private static final Logger LOGGER = LoggerFactory.getLogger(HealthStatisticLogger.class);
@@ -54,6 +55,12 @@ public class HealthStatisticLogger extends CounterStatisticManager implements Me
 	private final SimpleCounterStatistic duplicateRequests = new SimpleCounterStatistic("duplicate requests", align);
 	private final SimpleCounterStatistic duplicateResponses = new SimpleCounterStatistic("duplicate responses", align);
 	private final SimpleCounterStatistic ignoredMessages = new SimpleCounterStatistic("ignored", align);
+	/**
+	 * Counter for malformed messages.
+	 * 
+	 * @since 3.7
+	 */
+	private final SimpleCounterStatistic malformedMessages = new SimpleCounterStatistic("malformed", align);
 	private final SimpleCounterStatistic offloadedMessages = new SimpleCounterStatistic("offloaded", align);
 
 	/**
@@ -61,6 +68,8 @@ public class HealthStatisticLogger extends CounterStatisticManager implements Me
 	 * tcp.
 	 */
 	private final boolean udp;
+
+	private volatile boolean used;
 
 	/**
 	 * Create passive health logger.
@@ -90,7 +99,8 @@ public class HealthStatisticLogger extends CounterStatisticManager implements Me
 	 * @param executor executor executor to schedule active logging.
 	 * @throws NullPointerException if executor is {@code null}
 	 * @since 3.0 (added unit)
-	 * @deprecated use {@link HealthStatisticLogger#HealthStatisticLogger(String, boolean)}
+	 * @deprecated use
+	 *             {@link HealthStatisticLogger#HealthStatisticLogger(String, boolean)}
 	 *             instead and call {@link #dump()} externally.
 	 */
 	public HealthStatisticLogger(String tag, boolean udp, long interval, TimeUnit unit,
@@ -121,6 +131,7 @@ public class HealthStatisticLogger extends CounterStatisticManager implements Me
 			add("recv-", offloadedMessages);
 		}
 		add("recv-", ignoredMessages);
+		add("recv-", malformedMessages);
 	}
 
 	@Override
@@ -133,7 +144,7 @@ public class HealthStatisticLogger extends CounterStatisticManager implements Me
 		try {
 			if (isEnabled()) {
 				if (LOGGER.isDebugEnabled()) {
-					if (receivedRequests.isUsed() || sentRequests.isUsed() || sendErrors.isUsed()) {
+					if (used) {
 						String eol = StringUtil.lineSeparator();
 						String head = "   " + tag;
 						StringBuilder log = new StringBuilder();
@@ -187,6 +198,7 @@ public class HealthStatisticLogger extends CounterStatisticManager implements Me
 
 	@Override
 	public void sendRequest(Request request) {
+		used = true;
 		if (request.getSendError() != null) {
 			sendErrors.increment();
 		} else if (request.isDuplicate()) {
@@ -198,6 +210,7 @@ public class HealthStatisticLogger extends CounterStatisticManager implements Me
 
 	@Override
 	public void sendResponse(Response response) {
+		used = true;
 		if (response.getOffloadMode() != null) {
 			offloadedMessages.increment();
 		}
@@ -212,6 +225,7 @@ public class HealthStatisticLogger extends CounterStatisticManager implements Me
 
 	@Override
 	public void sendEmptyMessage(EmptyMessage message) {
+		used = true;
 		if (message.getSendError() != null) {
 			sendErrors.increment();
 		} else if (message.getType() == CoAP.Type.ACK) {
@@ -223,6 +237,7 @@ public class HealthStatisticLogger extends CounterStatisticManager implements Me
 
 	@Override
 	public void receiveRequest(Request request) {
+		used = true;
 		if (request.isDuplicate()) {
 			duplicateRequests.increment();
 		} else {
@@ -232,6 +247,7 @@ public class HealthStatisticLogger extends CounterStatisticManager implements Me
 
 	@Override
 	public void receiveResponse(Response response) {
+		used = true;
 		if (response.isCanceled()) {
 			ignoredMessages.increment();
 		} else if (response.isDuplicate()) {
@@ -243,6 +259,7 @@ public class HealthStatisticLogger extends CounterStatisticManager implements Me
 
 	@Override
 	public void receiveEmptyMessage(EmptyMessage message) {
+		used = true;
 		if (message.isCanceled()) {
 			ignoredMessages.increment();
 		} else if (message.getType() == CoAP.Type.ACK) {
@@ -250,5 +267,11 @@ public class HealthStatisticLogger extends CounterStatisticManager implements Me
 		} else {
 			receivedRejects.increment();
 		}
+	}
+
+	@Override
+	public void receivedMalformedMessage(RawData message) {
+		used = true;
+		malformedMessages.increment();
 	}
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/MalformedMessageInterceptor.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/MalformedMessageInterceptor.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ ******************************************************************************/
+package org.eclipse.californium.core.network.interceptors;
+
+import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.elements.RawData;
+
+/**
+ * Counter for malformed messages.
+ * 
+ * Only supported for
+ * {@link CoapEndpoint#addPostProcessInterceptor(MessageInterceptor)}.
+ * 
+ * @since 3.7
+ */
+public interface MalformedMessageInterceptor extends MessageInterceptor {
+
+	/**
+	 * Received malformed message.
+	 * 
+	 * @param message received malformed message.
+	 */
+	void receivedMalformedMessage(RawData message);
+
+}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/MessageTracer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/interceptors/MessageTracer.java
@@ -30,9 +30,10 @@ import org.eclipse.californium.core.coap.Request;
 import org.eclipse.californium.core.coap.Response;
 
 /**
- * The MessageTracer logs all incoming and outgoing messages. MessageInterceptor
- * are located between the serializer/parser and the matcher. Each message comes
- * or goes through a connector is logged.
+ * The MessageTracer logs all incoming and outgoing messages.
+ * 
+ * MessageInterceptor are located between the serializer/parser and the matcher.
+ * Each well-formed message comes or goes through a connector is logged.
  */
 public class MessageTracer implements MessageInterceptor {
 

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/TcpDataParser.java
@@ -36,7 +36,7 @@ import static org.eclipse.californium.core.coap.CoAP.MessageFormat.*;
  * <a href="https://tools.ietf.org/html/draft-ietf-core-coap-tcp-tls-03" target=
  * "_blank">CoAP-over-TCP draft</a>.
  */
-public final class TcpDataParser extends DataParser {
+public class TcpDataParser extends DataParser {
 
 	/**
 	 * Create TCP data parser without checking for critical custom options.

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/UdpDataParser.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/serialization/UdpDataParser.java
@@ -37,7 +37,7 @@ import org.eclipse.californium.core.coap.BlockOption;
 /**
  * A parser for messages encoded following the standard CoAP encoding.
  */
-public final class UdpDataParser extends DataParser {
+public class UdpDataParser extends DataParser {
 
 	private final boolean strictEmptyMessageFormat;
 	

--- a/californium-core/src/test/java/org/eclipse/californium/core/test/MaliciousClientTest.java
+++ b/californium-core/src/test/java/org/eclipse/californium/core/test/MaliciousClientTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.californium.core.test;
 
 import static org.eclipse.californium.core.coap.TestOption.newOption;
+import static org.eclipse.californium.elements.util.TestConditionTools.assertStatisticCounter;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -30,6 +31,7 @@ import org.eclipse.californium.core.CoapServer;
 import org.eclipse.californium.core.coap.BlockOption;
 import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.CoAP.Type;
+import org.eclipse.californium.core.coap.CoAPOptionException;
 import org.eclipse.californium.core.coap.Message;
 import org.eclipse.californium.core.coap.OptionNumberRegistry;
 import org.eclipse.californium.core.coap.Request;
@@ -37,7 +39,10 @@ import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.coap.TestOption;
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.interceptors.HealthStatisticLogger;
 import org.eclipse.californium.core.network.serialization.DataParser;
+import org.eclipse.californium.core.network.serialization.DataParserTest.CustomDataParser;
+import org.eclipse.californium.core.network.serialization.DataParserTest.CustomUdpDataParser;
 import org.eclipse.californium.core.network.serialization.DataSerializer;
 import org.eclipse.californium.core.network.serialization.UdpDataParser;
 import org.eclipse.californium.core.network.serialization.UdpDataSerializer;
@@ -50,6 +55,7 @@ import org.eclipse.californium.elements.category.Small;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.elements.rule.TestNameLoggerRule;
 import org.eclipse.californium.elements.util.Bytes;
+import org.eclipse.californium.elements.util.CounterStatisticManager;
 import org.eclipse.californium.rule.CoapNetworkRule;
 import org.eclipse.californium.rule.CoapThreadsRule;
 import org.junit.After;
@@ -73,7 +79,9 @@ public class MaliciousClientTest {
 	public TestNameLoggerRule name = new TestNameLoggerRule();
 
 	private static Endpoint serverEndpoint;
+	private static CounterStatisticManager healthStatistic;
 	private static Connector clientConnector;
+	private static CustomDataParser serverParser;
 	private static LinkedBlockingQueue<RawData> incoming = new LinkedBlockingQueue<RawData>();
 	private static int mid = 1;
 
@@ -86,9 +94,19 @@ public class MaliciousClientTest {
 
 	@After
 	public void cleanup() throws IOException {
+		serverParser.setIgnoreOptionError(false);
+		serverParser.setOptionException(null);
 		incoming.clear();
+		healthStatistic.reset();
 	}
 
+	/**
+	 * Malformed CON request.
+	 * 
+	 * Standard processing, responds with BAD_OPTION.
+	 * 
+	 * @throws Exception if an error occurs
+	 */
 	@Test
 	public void testConRequestWithTooLongUri() throws Exception {
 		Request get = newGet();
@@ -98,11 +116,88 @@ public class MaliciousClientTest {
 		RawData rawData = serializer.serializeRequest(get);
 		clientConnector.send(rawData);
 
+		assertStatisticCounter(healthStatistic, "recv-malformed", is(1L), 1000, TimeUnit.MILLISECONDS);
 		Response response = waitForResponse(1000);
 		assertThat("expected response", response, is(notNullValue()));
 		assertThat(response.getCode(), is(ResponseCode.BAD_OPTION));
 	}
 
+	/**
+	 * Malformed CON request.
+	 * 
+	 * Ignore malformed option, responds with CONTENT.
+	 * 
+	 * @throws Exception if an error occurs
+	 */
+	@Test
+	public void testConRequestWithTooLongUriIgnored() throws Exception {
+		serverParser.setIgnoreOptionError(true);
+		Request get = newGet();
+		get.getOptions().addOtherOption(newOption(OptionNumberRegistry.URI_PATH, 256));
+
+		DataSerializer serializer = new UdpDataSerializer();
+		RawData rawData = serializer.serializeRequest(get);
+		clientConnector.send(rawData);
+
+		Response response = waitForResponse(1000);
+		assertThat("expected response", response, is(notNullValue()));
+		assertThat(response.getCode(), is(ResponseCode.CONTENT));
+		assertStatisticCounter(healthStatistic, "recv-malformed", is(0L));
+	}
+
+	/**
+	 * Malformed CON request.
+	 * 
+	 * Response with custom response code.
+	 * 
+	 * @throws Exception if an error occurs
+	 */
+	@Test
+	public void testConRequestWithTooLongUriNotFound() throws Exception {
+		serverParser.setOptionException(new CoAPOptionException("too long uri", ResponseCode.NOT_FOUND));
+		Request get = newGet();
+		get.getOptions().addOtherOption(newOption(OptionNumberRegistry.URI_PATH, 256));
+
+		DataSerializer serializer = new UdpDataSerializer();
+		RawData rawData = serializer.serializeRequest(get);
+		clientConnector.send(rawData);
+
+		assertStatisticCounter(healthStatistic, "recv-malformed", is(1L), 1000, TimeUnit.MILLISECONDS);
+		Response response = waitForResponse(1000);
+		assertThat("expected response", response, is(notNullValue()));
+		assertThat(response.getCode(), is(ResponseCode.NOT_FOUND));
+	}
+
+	/**
+	 * Malformed CON request.
+	 * 
+	 * Reject request.
+	 * 
+	 * @throws Exception if an error occurs
+	 */
+	@Test
+	public void testConRequestWithTooLongUriRejected() throws Exception {
+		serverParser.setOptionException(new CoAPOptionException("too long uri, reject", null));
+		Request get = newGet();
+		get.getOptions().addOtherOption(newOption(OptionNumberRegistry.URI_PATH, 256));
+
+		DataSerializer serializer = new UdpDataSerializer();
+		RawData rawData = serializer.serializeRequest(get);
+		clientConnector.send(rawData);
+
+		assertStatisticCounter(healthStatistic, "recv-malformed", is(1L), 1000, TimeUnit.MILLISECONDS);
+		Message reject = waitForMessage(1000);
+		assertThat("expected reject", reject, is(notNullValue()));
+		assertThat(reject.getType(), is(Type.RST));
+	}
+
+	/**
+	 * Malformed NON request.
+	 * 
+	 * Standard processing, ignored.
+	 * 
+	 * @throws Exception if an error occurs
+	 */
 	@Test
 	public void testNonRequestWithTooLongUri() throws Exception {
 		Request get = newGet();
@@ -113,10 +208,89 @@ public class MaliciousClientTest {
 		RawData rawData = serializer.serializeRequest(get);
 		clientConnector.send(rawData);
 
+		assertStatisticCounter(healthStatistic, "recv-malformed", is(1L), 1000, TimeUnit.MILLISECONDS);
 		Message reject = waitForMessage(1000);
 		assertThat("malicous NON not ignored", reject, is(nullValue()));
 	}
 
+	/**
+	 * Malformed NON request.
+	 * 
+	 * Ignore malformed option, responds with CONTENT.
+	 * 
+	 * @throws Exception if an error occurs
+	 */
+	@Test
+	public void testNonRequestWithTooLongUriIgnored() throws Exception {
+		serverParser.setIgnoreOptionError(true);
+		Request get = newGet();
+		get.setConfirmable(false);
+		get.getOptions().addOtherOption(newOption(OptionNumberRegistry.URI_PATH, 256));
+
+		DataSerializer serializer = new UdpDataSerializer();
+		RawData rawData = serializer.serializeRequest(get);
+		clientConnector.send(rawData);
+
+		Response response = waitForResponse(1000);
+		assertThat("expected response", response, is(notNullValue()));
+		assertThat(response.getCode(), is(ResponseCode.CONTENT));
+		assertStatisticCounter(healthStatistic, "recv-malformed", is(0L));
+	}
+
+	/**
+	 * Malformed NON request.
+	 * 
+	 * Custom error code, but NON is ignored anyway.
+	 * 
+	 * @throws Exception if an error occurs
+	 */
+	@Test
+	public void testNonRequestWithTooLongUriNotFoundDiscarded() throws Exception {
+		serverParser.setOptionException(new CoAPOptionException("too long uri", ResponseCode.NOT_FOUND));
+		Request get = newGet();
+		get.setConfirmable(false);
+		get.getOptions().addOtherOption(newOption(OptionNumberRegistry.URI_PATH, 256));
+
+		DataSerializer serializer = new UdpDataSerializer();
+		RawData rawData = serializer.serializeRequest(get);
+		clientConnector.send(rawData);
+
+		assertStatisticCounter(healthStatistic, "recv-malformed", is(1L), 1000, TimeUnit.MILLISECONDS);
+		Message reject = waitForMessage(1000);
+		assertThat("malicous NON not ignored", reject, is(nullValue()));
+	}
+
+	/**
+	 * Malformed NON request.
+	 * 
+	 * Reject, but NON is ignored anyway.
+	 * 
+	 * @throws Exception if an error occurs
+	 */
+	@Test
+	public void testNonRequestWithTooLongUriRejectDiscarded() throws Exception {
+		serverParser.setOptionException(new CoAPOptionException("too long uri", null));
+		Request get = newGet();
+		get.setConfirmable(false);
+		get.getOptions().addOtherOption(newOption(OptionNumberRegistry.URI_PATH, 256));
+
+		DataSerializer serializer = new UdpDataSerializer();
+		RawData rawData = serializer.serializeRequest(get);
+		clientConnector.send(rawData);
+
+		assertStatisticCounter(healthStatistic, "recv-malformed", is(1L), 1000, TimeUnit.MILLISECONDS);
+		Message reject = waitForMessage(1000);
+		assertThat("malicous NON not ignored", reject, is(nullValue()));
+	}
+
+
+	/**
+	 * BERT request with UDP (malformed request).
+	 * 
+	 * Standard processing, responds with BAD_REQUEST.
+	 * 
+	 * @throws Exception if an error occurs
+	 */
 	@Test
 	public void testBertRequest() throws Exception {
 		BlockOption block = new BlockOption(BlockOption.BERT_SZX, false, 0);
@@ -127,11 +301,19 @@ public class MaliciousClientTest {
 		RawData rawData = serializer.serializeRequest(get);
 		clientConnector.send(rawData);
 
+		assertStatisticCounter(healthStatistic, "recv-malformed", is(1L), 1000, TimeUnit.MILLISECONDS);
 		Response response = waitForResponse(1000);
 		assertThat("Response missing", response, is(notNullValue()));
 		assertThat("No BAD_REREQUEST response", response.getCode(), is(ResponseCode.BAD_REQUEST));
 	}
 
+	/**
+	 * Malformed CON response.
+	 * 
+	 * Standard processing, reject.
+	 * 
+	 * @throws Exception if an error occurs
+	 */
 	@Test
 	public void testConResponseWithTooLongLocation() throws Exception {
 		Response response = newResponse(ResponseCode.CONTENT);
@@ -142,11 +324,19 @@ public class MaliciousClientTest {
 		RawData rawData = serializer.serializeResponse(response);
 		clientConnector.send(rawData);
 
+		assertStatisticCounter(healthStatistic, "recv-malformed", is(1L), 1000, TimeUnit.MILLISECONDS);
 		Message reject = waitForMessage(1000);
 		assertThat("expected RST", reject, is(notNullValue()));
 		assertThat(reject.getType(), is(Type.RST));
 	}
 
+	/**
+	 * Malformed NON response.
+	 * 
+	 * Standard processing, ignore.
+	 * 
+	 * @throws Exception if an error occurs
+	 */
 	@Test
 	public void testNonResponseWithTooLongLocation() throws Exception {
 		Response response = newResponse(ResponseCode.CONTENT);
@@ -157,10 +347,18 @@ public class MaliciousClientTest {
 		RawData rawData = serializer.serializeResponse(response);
 		clientConnector.send(rawData);
 
+		assertStatisticCounter(healthStatistic, "recv-malformed", is(1L), 1000, TimeUnit.MILLISECONDS);
 		Message reject = waitForMessage(1000);
 		assertThat("malicous NON response not ignored", reject, is(nullValue()));
 	}
 
+	/**
+	 * Malformed piggy-backed response.
+	 * 
+	 * Standard processing, ignore.
+	 * 
+	 * @throws Exception if an error occurs
+	 */
 	@Test
 	public void testPiggyBackedResponseWithTooLongLocation() throws Exception {
 		Response response = newResponse(ResponseCode.CONTENT);
@@ -171,6 +369,7 @@ public class MaliciousClientTest {
 		RawData rawData = serializer.serializeResponse(response);
 		clientConnector.send(rawData);
 
+		assertStatisticCounter(healthStatistic, "recv-malformed", is(1L), 1000, TimeUnit.MILLISECONDS);
 		Message reject = waitForMessage(1000);
 		assertThat("malicous piggybacked response not ignored", reject, is(nullValue()));
 	}
@@ -213,12 +412,23 @@ public class MaliciousClientTest {
 
 	private static CoapServer createServer() throws IOException {
 		Configuration config = network.getStandardTestConfig();
+
+		CustomUdpDataParser parser = new CustomUdpDataParser(true, null);
+		serverParser = parser;
+
+		
 		CoapEndpoint.Builder builder = new CoapEndpoint.Builder();
 		builder.setConfiguration(config);
 		builder.setInetSocketAddress(TestTools.LOCALHOST_EPHEMERAL);
+		builder.setDataSerializerAndParser(new UdpDataSerializer(), parser);
 		serverEndpoint = builder.build();
 
+		HealthStatisticLogger health = new HealthStatisticLogger("server", true);
+		healthStatistic = health;
+		serverEndpoint.addPostProcessInterceptor(health);
+
 		CoapServer server = new CoapServer(config);
+
 
 		server.addEndpoint(serverEndpoint);
 		server.start();


### PR DESCRIPTION
Allows to skip or fix malformed options.
Supports as null error code to only reject incoming message.

Issue: #2049

Signed-off-by: Achim Kraus <achim.kraus@cloudcoap.net>